### PR TITLE
feat: add UTC time utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,7 @@ uv run mypy src tests
 ## Continuous integration
 
 Pull requests targeting `main` and pushes to `main` automatically run CI. The workflow runs pytest, Ruff lint, Ruff format checking, and mypy. Use the equivalent local commands in the existing Development environment section above.
+
+## UTC time handling
+
+Internal datetimes must be timezone-aware and use UTC as the standard timezone. Naive datetimes are explicitly rejected. Time utilities are provided by `quant_system.core.time`.

--- a/src/quant_system/core/__init__.py
+++ b/src/quant_system/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core project primitives."""

--- a/src/quant_system/core/time.py
+++ b/src/quant_system/core/time.py
@@ -1,0 +1,38 @@
+"""UTC datetime validation, conversion, parsing, and formatting."""
+
+from datetime import UTC, datetime, timedelta
+
+__all__ = ["UTC", "ensure_aware", "format_utc", "is_utc", "parse_utc", "to_utc"]
+
+_AWARE_REQUIRED_MESSAGE = "datetime must be timezone-aware"
+
+
+def ensure_aware(value: datetime) -> datetime:
+    """Return an aware datetime unchanged; raise ValueError for a naive value."""
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError(_AWARE_REQUIRED_MESSAGE)
+    return value
+
+
+def to_utc(value: datetime) -> datetime:
+    """Convert an aware datetime to UTC; raise ValueError for a naive value."""
+    return ensure_aware(value).astimezone(UTC)
+
+
+def is_utc(value: datetime) -> bool:
+    """Return whether a datetime has a zero offset, or False if it is naive."""
+    if value.tzinfo is None:
+        return False
+    offset = value.utcoffset()
+    return offset is not None and offset == timedelta(0)
+
+
+def parse_utc(value: str) -> datetime:
+    """Parse ISO 8601 to UTC; raise ValueError if its datetime is naive."""
+    return to_utc(datetime.fromisoformat(value))
+
+
+def format_utc(value: datetime) -> str:
+    """Format an aware datetime in UTC with Z; raise ValueError if it is naive."""
+    formatted = to_utc(value).isoformat()
+    return f"{formatted.removesuffix('+00:00')}Z"

--- a/tests/core/test_time.py
+++ b/tests/core/test_time.py
@@ -1,0 +1,221 @@
+from datetime import UTC, datetime, timedelta, timezone, tzinfo
+
+import pytest
+
+from quant_system.core.time import (
+    ensure_aware,
+    format_utc,
+    is_utc,
+    parse_utc,
+    to_utc,
+)
+
+
+class _IndeterminateTimezone(tzinfo):
+    def utcoffset(self, dt: datetime | None) -> None:
+        return None
+
+    def dst(self, dt: datetime | None) -> None:
+        return None
+
+    def tzname(self, dt: datetime | None) -> str:
+        return "indeterminate"
+
+
+def test_ensure_aware_returns_same_aware_datetime() -> None:
+    value = datetime(2026, 7, 19, 7, 1, 20, tzinfo=UTC)
+
+    assert ensure_aware(value) is value
+
+
+def test_ensure_aware_rejects_naive_datetime_with_clear_message() -> None:
+    value = datetime(2026, 7, 19, 7, 1, 20)
+
+    with pytest.raises(ValueError, match="^datetime must be timezone-aware$"):
+        ensure_aware(value)
+
+
+def test_ensure_aware_rejects_timezone_with_no_offset() -> None:
+    value = datetime(2026, 7, 19, 7, 1, 20, tzinfo=_IndeterminateTimezone())
+
+    with pytest.raises(ValueError, match="^datetime must be timezone-aware$"):
+        ensure_aware(value)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (
+            datetime(2026, 7, 19, 7, 1, 20, tzinfo=timezone(timedelta(hours=8))),
+            datetime(2026, 7, 18, 23, 1, 20, tzinfo=UTC),
+        ),
+        (
+            datetime(2026, 7, 19, 22, 1, 20, tzinfo=timezone(timedelta(hours=-5))),
+            datetime(2026, 7, 20, 3, 1, 20, tzinfo=UTC),
+        ),
+    ],
+)
+def test_to_utc_converts_offsets_across_date_boundaries(
+    value: datetime, expected: datetime
+) -> None:
+    assert to_utc(value) == expected
+
+
+def test_to_utc_handles_utc_input_and_preserves_microseconds() -> None:
+    value = datetime(2026, 7, 19, 7, 1, 20, 123456, tzinfo=UTC)
+
+    result = to_utc(value)
+
+    assert result == value
+    assert result.tzinfo is UTC
+    assert result.microsecond == 123456
+
+
+def test_to_utc_does_not_modify_input() -> None:
+    value = datetime(2026, 7, 19, 7, 1, 20, tzinfo=timezone(timedelta(hours=8)))
+    original = value
+
+    to_utc(value)
+
+    assert value is original
+    assert value.utcoffset() == timedelta(hours=8)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        datetime(2026, 7, 19, 7, 1, 20),
+        datetime(2026, 7, 19, 7, 1, 20, tzinfo=_IndeterminateTimezone()),
+    ],
+)
+def test_to_utc_rejects_datetime_without_valid_offset(value: datetime) -> None:
+    with pytest.raises(ValueError, match="^datetime must be timezone-aware$"):
+        to_utc(value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        datetime(2026, 7, 19, 7, 1, 20, tzinfo=UTC),
+        datetime(2026, 7, 19, 7, 1, 20, tzinfo=timezone.utc),  # noqa: UP017
+        datetime(
+            2026,
+            7,
+            19,
+            7,
+            1,
+            20,
+            tzinfo=timezone(timedelta(0), name="zero offset"),
+        ),
+    ],
+)
+def test_is_utc_accepts_any_valid_zero_offset(value: datetime) -> None:
+    assert is_utc(value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        datetime(2026, 7, 19, 7, 1, 20, tzinfo=timezone(timedelta(hours=8))),
+        datetime(2026, 7, 19, 7, 1, 20, tzinfo=timezone(timedelta(hours=-5))),
+        datetime(2026, 7, 19, 7, 1, 20),
+        datetime(2026, 7, 19, 7, 1, 20, tzinfo=_IndeterminateTimezone()),
+    ],
+)
+def test_is_utc_rejects_nonzero_or_missing_offset(value: datetime) -> None:
+    assert not is_utc(value)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("2026-07-19T07:01:20Z", datetime(2026, 7, 19, 7, 1, 20, tzinfo=UTC)),
+        (
+            "2026-07-19T07:01:20+00:00",
+            datetime(2026, 7, 19, 7, 1, 20, tzinfo=UTC),
+        ),
+        (
+            "2026-07-19T07:01:20+08:00",
+            datetime(2026, 7, 18, 23, 1, 20, tzinfo=UTC),
+        ),
+        (
+            "2026-07-19T22:01:20-05:00",
+            datetime(2026, 7, 20, 3, 1, 20, tzinfo=UTC),
+        ),
+        (
+            "2026-07-19T07:01:20.123456Z",
+            datetime(2026, 7, 19, 7, 1, 20, 123456, tzinfo=UTC),
+        ),
+    ],
+)
+def test_parse_utc_parses_and_normalizes_iso_8601_offsets(
+    value: str, expected: datetime
+) -> None:
+    result = parse_utc(value)
+
+    assert result == expected
+    assert result.tzinfo is UTC
+
+
+def test_parse_utc_rejects_iso_string_without_timezone() -> None:
+    with pytest.raises(ValueError, match="^datetime must be timezone-aware$"):
+        parse_utc("2026-07-19T07:01:20")
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        "2026-02-30T07:01:20Z",
+        "2026-07-19T25:01:20Z",
+    ],
+)
+def test_parse_utc_rejects_empty_or_invalid_iso_string(value: str) -> None:
+    with pytest.raises(ValueError):
+        parse_utc(value)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (datetime(2026, 7, 19, 7, 1, 20, tzinfo=UTC), "2026-07-19T07:01:20Z"),
+        (
+            datetime(2026, 7, 19, 7, 1, 20, tzinfo=timezone(timedelta(hours=8))),
+            "2026-07-18T23:01:20Z",
+        ),
+        (
+            datetime(2026, 7, 19, 22, 1, 20, tzinfo=timezone(timedelta(hours=-5))),
+            "2026-07-20T03:01:20Z",
+        ),
+        (
+            datetime(2026, 7, 19, 7, 1, 20, 123456, tzinfo=UTC),
+            "2026-07-19T07:01:20.123456Z",
+        ),
+    ],
+)
+def test_format_utc_converts_to_utc_with_z_suffix(
+    value: datetime, expected: str
+) -> None:
+    assert format_utc(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        datetime(2026, 7, 19, 7, 1, 20),
+        datetime(2026, 7, 19, 7, 1, 20, tzinfo=_IndeterminateTimezone()),
+    ],
+)
+def test_format_utc_rejects_datetime_without_valid_offset(value: datetime) -> None:
+    with pytest.raises(ValueError, match="^datetime must be timezone-aware$"):
+        format_utc(value)
+
+
+def test_format_utc_does_not_modify_input() -> None:
+    value = datetime(2026, 7, 19, 7, 1, 20, tzinfo=timezone(timedelta(hours=8)))
+    original = value
+
+    format_utc(value)
+
+    assert value is original
+    assert value.utcoffset() == timedelta(hours=8)


### PR DESCRIPTION
﻿# Pull Request

## 关联 Issue

Closes #9

## 实现摘要

建立统一 UTC 时间工具，明确拒绝 naive datetime，并提供 timezone-aware datetime 的 UTC 转换、判断、ISO 8601 解析和稳定 Z 格式化能力。

## 修改范围

- 新增 src/quant_system/core/__init__.py
- 新增 src/quant_system/core/time.py
- 新增 tests/core/test_time.py
- 更新 README.md，增加简短 UTC 时间规范

## 关键设计决定

### 公开 API

- UTC
- ensure_aware(value: datetime) -> datetime
- to_utc(value: datetime) -> datetime
- is_utc(value: datetime) -> bool
- parse_utc(value: str) -> datetime
- format_utc(value: datetime) -> str

### 关键行为

- 使用 Python 3.11 datetime.UTC
- 同时依据 tzinfo 和 utcoffset() 判断是否 aware
- naive datetime 明确抛出 ValueError
- 错误消息为 datetime must be timezone-aware
- to_utc 使用 astimezone(UTC)
- is_utc 根据有效 offset 是否等于零判断
- parse_utc 使用 datetime.fromisoformat()
- 支持 Z 和显式正负 UTC offset
- format_utc 只将末尾 +00:00 转换为 Z
- 保留微秒，不为无微秒输入增加 .000000
- 不依赖系统本地时区或当前时间

### 测试覆盖

- 新增 32 个时间工具测试
- 总测试数为 33
- 覆盖 aware/naive
- 覆盖无有效 utcoffset() 的自定义 tzinfo
- 覆盖正负 offset
- 覆盖跨日期转换
- 覆盖其他零 offset 时区对象
- 覆盖 Z、+00:00、正负 offset 解析
- 覆盖空字符串、无时区和非法日期时间
- 覆盖微秒保留和输入不变性

## 验证结果

| 命令 | 结果 | 说明 |
| --- | --- | --- |
| uv sync --dev --python 3.11 | 通过 | 开发依赖同步成功 |
| uv lock --check | 通过 | 锁文件有效 |
| uv run --python 3.11 pytest | 通过 | 33 passed |
| uv run --python 3.11 ruff check . | 通过 | lint 通过 |
| uv run --python 3.11 ruff format --check . | 通过 | 8 files already formatted |
| uv run --python 3.11 mypy src tests | 通过 | 4 source files |
| git diff --check | 通过 | 无空白错误 |
| 独立 Codex 审查 | 通过 | 可以提交 |

## 从 Issue 复制的验收标准

- [x] 存在 src/quant_system/core/time.py
- [x] 存在 src/quant_system/core/__init__.py
- [x] 使用 Python 3.11 的 datetime.UTC
- [x] 所有公开函数具有完整类型标注
- [x] naive datetime 会被明确拒绝
- [x] aware datetime 可正确转换为 UTC
- [x] is_utc 能区分 UTC、非 UTC和 naive datetime
- [x] parse_utc 支持 Z
- [x] parse_utc 支持显式 UTC offset
- [x] parse_utc 拒绝没有时区的字符串
- [x] format_utc 输出以 Z 结尾
- [x] 微秒能够稳定保留
- [x] 不依赖系统本地时区
- [x] 正常路径和失败路径均有测试
- [x] uv lock --check 通过
- [x] pytest 通过
- [x] Ruff lint 通过
- [x] Ruff format check 通过
- [x] mypy strict 通过
- [x] GitHub Actions CI 通过
- [x] README 包含简短 UTC 时间规范
- [x] 未增加新的运行时依赖
- [x] 未增加数据、回测、模型或交易功能
- [x] git diff --check 通过

## 风险检查

- [x] 未静默接受 naive datetime
- [x] 未依赖系统本地时区
- [x] 未调用 datetime.now() 或 datetime.today()
- [x] 未增加运行时或开发依赖
- [x] 未修改 pyproject.toml 或 uv.lock
- [x] 未修改 CI 工作流
- [x] 未引入凭据、网络、数据库或研究数据
- [x] 未增加数据、回测、模型或交易能力

## 范围外内容

未实现：

- 当前时间 API
- Clock 抽象
- Unix 时间戳
- 交易所时间同步
- NTP
- 市场日历
- K 线时间窗口
- pandas 或 NumPy 时间类型
- 配置和日志
- 数据、因子、回测、机器学习或交易功能

## 已知限制

- 无

