### PR TITLE
[Task] 建立 Task Workflow Token 消耗测量协议与本地 Telemetry

### DIFF
--- a/.agents/policies/command-execution.md
+++ b/.agents/policies/command-execution.md
@@ -12,6 +12,7 @@ It applies to:
 .agents/skills/task-pr-review/SKILL.md
 .agents/skills/task-closeout/SKILL.md
 .agents/skills/feature-completion-audit/SKILL.md
+tools/agent_workflow/telemetry.py
 ```
 
 The policy does not create a new user-facing lifecycle stage and does not grant
@@ -208,6 +209,10 @@ be routed according to a valid profile:
   `task-closeout`;
 - exact branch operations already authorized by `task-closeout` after all of its
   branch-safety gates pass;
+- an explicitly maintainer-requested `telemetry.py start` command, and other
+  local `tools/agent_workflow/telemetry.py` commands plus exact writes below
+  `.agents/telemetry.local/` when an active run authorizes them under
+  `.agents/policies/task-workflow-telemetry.md`;
 - other non-destructive commands explicitly authorized by the current Skill.
 
 For writes, route selection happens only after the Skill's complete write gate
@@ -221,7 +226,8 @@ A profile cannot authorize or broaden:
 - commit or push;
 - branch creation or deletion;
 - temporary worktree creation or removal;
-- filesystem writes;
+- filesystem writes, except the exact ignored local telemetry append already
+  authorized by an active run and the telemetry policy;
 - any other repository or GitHub write.
 
 Such actions remain governed entirely by the active Skill. If authorized there,
@@ -324,6 +330,9 @@ AGENTS.md
 AGENTS.override.md
 .agents/policies/command-execution.md
 .agents/execution-profile.example.toml
+.agents/policies/task-workflow-telemetry.md
+.agents/task-workflow-telemetry.example.toml
+tools/agent_workflow/telemetry.py
 .agents/skills/task-pr-review/SKILL.md
 another shared governance policy
 ```
@@ -360,6 +369,26 @@ change:
 A Feature audit command retry must preserve the Feature identity, audited main
 SHA, repository, working directory, full argv, audit phase, authorization source,
 and command intent.
+
+When an explicit telemetry run is active, `task-pr-review` and
+`feature-completion-audit` may append aggregate events only below the exact
+ignored `.agents/telemetry.local/` directory. This narrow local write is not a
+reviewed-file mutation, GitHub write, correctness fact, or completion evidence.
+If the local path is tracked, staged, or not ignored, do not write telemetry.
+The review or audit continues or stops only according to its existing gates.
+
+## Task workflow telemetry boundary
+
+`telemetry.py start` requires an explicit maintainer request. Every later
+telemetry command and local data write requires the resulting active run and
+`.agents/policies/task-workflow-telemetry.md`. The CLI is local-only and must not
+access the network, launch Git or validation commands, or mutate GitHub.
+
+Routing may change the execution context of an already authorized telemetry CLI
+command. It cannot authorize tracked-file writes, implicit run creation, raw
+conversation capture, credential storage, workflow changes, or another
+lifecycle action. A telemetry failure is reported as incomplete and never
+changes the governing workflow verdict.
 
 ## Audit reporting
 

--- a/.agents/policies/task-workflow-telemetry.md
+++ b/.agents/policies/task-workflow-telemetry.md
@@ -1,0 +1,416 @@
+# Task workflow telemetry policy
+
+## Purpose
+
+This policy defines optional, local-only measurement of Task workflow token and
+process cost. It applies to:
+
+```text
+.agents/skills/task-delivery/SKILL.md
+.agents/skills/task-pr-review/SKILL.md
+.agents/skills/task-closeout/SKILL.md
+.agents/skills/feature-completion-audit/SKILL.md
+```
+
+Telemetry is side-channel observation only:
+
+```text
+observation
+!= workflow authorization
+!= correctness evidence
+!= merge authorization
+!= Feature completion evidence
+```
+
+The active workflow Skill remains the only source for lifecycle permissions,
+gates, validation, findings, and verdicts. Telemetry never authorizes a command,
+write, review, merge, Issue close, Project mutation, branch cleanup, or Feature
+closeout.
+
+## Activation and local storage
+
+Telemetry is disabled unless the maintainer explicitly starts a run for the
+specified Task with `tools/agent_workflow/telemetry.py start`.
+
+Repository example configuration:
+
+```text
+.agents/task-workflow-telemetry.example.toml
+```
+
+Optional local configuration:
+
+```text
+.agents/task-workflow-telemetry.local.toml
+```
+
+Local data directory:
+
+```text
+.agents/telemetry.local/
+```
+
+The local configuration and data directory must be ignored by Git and must not
+enter tracked, staged, committed, pushed, or Pull Request scope. If either path
+is tracked, staged, or not ignored, do not write telemetry and report a local
+safety configuration error. Preserve the normal workflow's own decision about
+whether it can continue.
+
+Telemetry data must not contain credentials, authentication material, complete
+prompts, complete assistant responses, private reasoning, source or test
+contents, complete command output, complete environment variables, usernames,
+or sensitive absolute paths.
+
+## Modes
+
+Supported modes are:
+
+- `baseline-only`: record a complete local measurement and summary without
+  automatically comparing or optimizing the workflow;
+- `spot-check`: record the same data and optionally compare it with completed
+  local runs in the same baseline family.
+
+Telemetry does not implement token optimization. A later optimization requires a
+separately approved Task based on sanitized aggregate results.
+
+## Baseline family
+
+Every run records at least:
+
+```text
+task_kind
+size
+risk_class
+workflow_shape
+```
+
+Strict default comparison requires all four values to match. Do not combine all
+Task types into one global average. Fewer than three comparable completed runs
+permit structural comparison only, not a statistical anomaly conclusion.
+
+## Measurement integrity
+
+Do not perform extra repository reads, GitHub queries, validations, command
+retries, or report expansion only to populate telemetry. Use counts and facts
+already produced by the normal workflow.
+
+A telemetry failure is recorded as `telemetry incomplete`. It does not turn a
+successful workflow gate into a failure, and it does not turn a failed gate into
+success.
+
+The following phases are supported:
+
+```text
+task-specification
+task-delivery
+task-pr-review
+manual-merge
+task-closeout
+feature-completion-audit
+```
+
+Each Agent session writes at most one primary `phase-summary` for its phase.
+Interruption, rework, review-run, and usage-patch events may be appended
+separately. Events are append-only.
+
+## Token usage
+
+Supported usage sources are exactly:
+
+```text
+runtime-exact
+client-export
+estimated-external
+unavailable
+```
+
+Unknown values are `null`, never fabricated as zero. Skills must not claim that
+a character count is an exact token count. `reasoning_tokens` may contain only a
+runtime-exposed aggregate count; telemetry never records private reasoning.
+Usage may be patched after a session ends. Existing exact usage must not be
+replaced by an estimate.
+
+Exact and estimated usage are reported separately. Cross-model or cross-workflow
+comparisons must retain model identity, workflow `main` SHA, and telemetry schema
+version.
+
+## Recorded aggregates
+
+A phase may record aggregate counts for:
+
+- files, lines, bytes, and estimated repeated bytes by context category;
+- tool calls, GitHub queries, Git commands, validation commands, sandbox and
+  elevated attempts, retries, and controlled retry categories;
+- report characters, lines, estimated tokens, and whether the report was copied
+  into the next phase;
+- commits added after first handoff, head-SHA changes, independent review runs,
+  review invalidations, findings by severity, maintainer decisions, and
+  interruptions;
+- phase and workflow outcome, validation state, telemetry completeness, and
+  limitations.
+
+Record safe command categories, not complete sensitive command lines.
+
+## Run identity
+
+`start` requires the Task number, canonical title, baseline classification,
+repository slug, and current workflow `main` SHA. The manifest also records a
+unique run ID, mode, timestamps, status, optional model, and optional associated
+Feature number.
+
+After PR creation, a phase event may supplement `pr_number`, `base_sha`, and
+`head_sha` in its `identity` object. Later head-SHA values preserve event history
+and the deterministic summary reports the latest value. Task title, Feature
+number, and workflow SHA must not conflict with the manifest.
+
+## Phase event schema
+
+A `record` data file is a JSON object with `schema_version: 1`. It may contain
+only the fields shown below. Omitted measurements remain unknown; token fields
+use `null`, not fabricated zeroes.
+
+```json
+{
+  "schema_version": 1,
+  "event_type": "phase-summary",
+  "recorded_at": null,
+  "identity": {
+    "task_canonical_title": null,
+    "pr_number": null,
+    "feature_number": null,
+    "base_sha": null,
+    "head_sha": null,
+    "workflow_main_sha": null,
+    "model": null,
+    "changed_files_count": null,
+    "changed_lines": null,
+    "acceptance_criteria_count": null
+  },
+  "usage": {
+    "source": "unavailable",
+    "input_tokens": null,
+    "cached_input_tokens": null,
+    "output_tokens": null,
+    "reasoning_tokens": null,
+    "total_tokens": null,
+    "model": null
+  },
+  "context": {},
+  "operations": {
+    "tool_calls": null,
+    "github_queries": null,
+    "git_commands": null,
+    "validation_commands": null,
+    "sandbox_attempts": null,
+    "elevated_attempts": null,
+    "retries": null,
+    "retry_categories": {},
+    "command_categories": {}
+  },
+  "report": {
+    "report_characters": null,
+    "report_lines": null,
+    "report_estimated_tokens": null,
+    "report_estimation_method": null,
+    "copied_to_next_phase": null
+  },
+  "rework": {
+    "commits_added_after_first_handoff": null,
+    "head_sha_changes": null,
+    "independent_review_runs": null,
+    "review_invalidations": null,
+    "maintainer_decisions": null,
+    "interruptions": null,
+    "findings_by_severity": {}
+  },
+  "outcome": {
+    "phase_result": null,
+    "workflow_result": null,
+    "review_verdict": null,
+    "feature_audit_verdict": null,
+    "validation_passed": null,
+    "telemetry_complete": null
+  },
+  "limitations": []
+}
+```
+
+`event_type` accepted by `record` is one of:
+
+```text
+phase-summary
+interruption
+rework
+review-run
+manual-merge
+```
+
+The CLI creates `usage-patch` events itself. A phase may have only one primary
+`phase-summary`; other event types preserve interruptions and rework without
+replacing history.
+
+Context is keyed by these categories:
+
+```text
+task_and_comments
+governance
+skills_and_policies
+templates_and_workflows
+source
+tests
+documentation
+pr_diff_and_commits
+github_facts
+validation_output
+previous_handoff
+other
+```
+
+Each present category may contain only:
+
+```text
+files_read
+bytes_read
+lines_read
+repeated_bytes_estimate
+```
+
+Retry categories are:
+
+```text
+sandbox-permission
+credential-session
+filesystem-isolation
+real-validation-failure
+remote-failure
+other
+```
+
+Safe command categories are:
+
+```text
+git-read
+git-write-authorized
+github-read
+github-write-authorized
+validator
+test
+lint
+format
+type-check
+telemetry
+other
+```
+
+Finding keys are exactly `blocking`, `high`, `medium`, `low`, and `nit`.
+Counts are non-negative integers. A missing optional count is unknown; an
+explicit empty findings or category object means no events in that category.
+
+`patch-usage` accepts either the `usage` object alone or:
+
+```json
+{
+  "schema_version": 1,
+  "usage": {
+    "source": "client-export",
+    "input_tokens": 100,
+    "cached_input_tokens": 20,
+    "output_tokens": 25,
+    "reasoning_tokens": null,
+    "total_tokens": 125,
+    "model": "model-identifier"
+  }
+}
+```
+
+Do not place raw text, file paths, prompts, command lines, or output inside
+`limitations` or other free-text fields. Keep free text short, aggregate, and
+non-sensitive.
+
+## Workflow integration
+
+At the beginning of a workflow session, perform one lightweight local telemetry
+status check. If there is no active run, do nothing else for telemetry.
+
+When a run is active:
+
+- maintain aggregate counters from facts already generated by normal work;
+- append one phase summary at completion or interruption;
+- do not add GitHub queries or validation commands;
+- do not copy raw output or file contents;
+- do not treat another phase's telemetry as correctness evidence;
+- report a failed telemetry append as incomplete and continue according to the
+  workflow's existing gates.
+
+`task-pr-review` remains independently read-only. It does not trust delivery
+telemetry, and it may append only to the exact ignored telemetry directory.
+`feature-completion-audit` likewise does not trust Task telemetry as completion
+evidence and may append only to that exact ignored directory.
+
+## Command execution
+
+Telemetry CLI commands and exact ignored local telemetry writes are subject to
+`.agents/policies/command-execution.md`.
+
+Command routing changes execution context only. It does not authorize tracked
+file changes, GitHub mutation, Merge, Issue close, Project writes, branch
+cleanup, or any other workflow action. The CLI does not access the network, run
+GitHub mutations, or launch Git, tests, validators, or other workflow commands.
+
+## Local CLI contract
+
+`tools/agent_workflow/telemetry.py` provides:
+
+```text
+start
+status
+record
+patch-usage
+finish
+validate
+summarize
+```
+
+The CLI validates schema version, configuration, ignored storage, event order,
+usage consistency, and sensitive-field prohibitions. It uses append-only event
+records and deterministic summaries. It does not silently migrate an
+unsupported schema or overwrite history.
+
+For `task-only` and `task-with-re-review`, finish the run after `task-closeout`.
+For `task-plus-feature-audit`, record closeout but keep the same run active until
+the associated Feature audit records its phase; then finish by Task or by the
+associated Feature selector. Do not create a second run for the Feature audit.
+
+## Spot-check interpretation
+
+Spot-check anomaly flags are informational and cannot change a Task, Pull
+Request, or Feature verdict. Supported flags include:
+
+```text
+total-token-high
+phase-token-high
+repeated-context-high
+tool-output-high
+review-restart-high
+retry-high
+report-size-high
+```
+
+A summary must retain quality indicators such as validation, findings, review
+invalidations, maintainer decisions, and workflow result. Lower token usage
+alone is not evidence of a successful optimization.
+
+## Prohibited data and behavior
+
+Never use telemetry to:
+
+- store or expose credentials, private reasoning, complete conversations, source
+  contents, or complete command output;
+- upload data or call an external service;
+- modify a workflow verdict or permission;
+- create a Token Optimization Task automatically;
+- modify Skills, policies, prompts, or local profiles automatically;
+- run extra GitHub, Git, validation, or evidence-collection commands;
+- bypass independent review, new-SHA re-review, manual Merge, or manual Feature
+  closeout;
+- submit raw telemetry to Git.

--- a/.agents/skills/feature-completion-audit/SKILL.md
+++ b/.agents/skills/feature-completion-audit/SKILL.md
@@ -62,6 +62,8 @@ This Skill may:
   locked `origin/main` SHA;
 - run current CI-equivalent and Feature-applicable validation;
 - create local temporary validation output;
+- append aggregate events to the exact ignored `.agents/telemetry.local/`
+  directory when the maintainer explicitly started a telemetry run;
 - produce candidate gap-to-Task recommendations and an audit report.
 
 It does not:
@@ -79,7 +81,7 @@ It does not:
 - run `task-delivery`, `task-pr-review`, or `task-closeout` as a write workflow;
 - delete business branches;
 - assess Epic completion;
-- add token telemetry, token optimization, or evidence-runner behavior.
+- add token optimization or evidence-runner behavior.
 
 Never use force push, `--admin`, branch-protection bypass, `git reset --hard`,
 `git clean`, broad cleanup, or another destructive operation.
@@ -93,6 +95,7 @@ system / developer / current explicit user instructions
 -> applicable AGENTS.md / AGENTS.override.md
 -> feature-completion-audit permission and audit rules
 -> trusted .agents/policies/command-execution.md
+-> trusted .agents/policies/task-workflow-telemetry.md for optional measurement only
 -> optional ignored local execution profile for routing only
 -> current GitHub Feature body, comments, fields, and Relationships
 -> current origin/main repository state and current validation sources
@@ -118,8 +121,10 @@ A normal invocation authorizes only:
 3. creation and exact removal of one temporary detached audit worktree when
    needed;
 4. current read-only validation;
-5. an audit report and non-writing gap-to-Task recommendations.
+5. an audit report and non-writing gap-to-Task recommendations;
+6. one exact ignored local telemetry append when an explicit run is active.
 
+The telemetry append is aggregate measurement only and is not Feature evidence.
 It does not authorize any repository or GitHub lifecycle mutation. The optional
 local execution profile may select execution context only after this Skill has
 authorized the exact command. Elevation never grants a write permission.
@@ -526,9 +531,10 @@ Produce a report containing at least:
 7. current-main local validation and remote check runs;
 8. blockers, dependencies, open/reopened/orphaned work, and state conflicts;
 9. gap-to-Task recommendations;
-10. residual risks and known limitations;
-11. actions deliberately not performed;
-12. one fixed verdict.
+10. telemetry run ID and append result only when an explicit run is active;
+11. residual risks and known limitations;
+12. actions deliberately not performed;
+13. one fixed verdict.
 
 End with:
 
@@ -538,6 +544,25 @@ Audited main SHA: <actual main SHA>
 
 A successful report may be concise, but it must not omit the direct child
 inventory, acceptance matrix, findings, validation, verdict, or SHA.
+
+
+## Optional workflow telemetry
+
+Read `.agents/policies/task-workflow-telemetry.md` and perform one lightweight
+local status check for the associated Task measurement run. Do not create an
+implicit run. Task delivery, review, or closeout telemetry is not Feature
+completion evidence and must not influence child classification, acceptance
+coverage, findings, severity, gaps, or verdict.
+
+When an explicit run includes Feature audit, append one aggregate
+`feature-completion-audit` summary to the exact ignored
+`.agents/telemetry.local/` directory. Use only facts and counts already produced
+by the audit. Do not add child-Issue queries, repository reads, validation, or
+report expansion for measurement.
+
+If the telemetry path is tracked, staged, or not ignored, do not write. Report
+`telemetry incomplete`; the Feature audit continues or stops only according to
+its existing evidence and stability gates.
 
 ## Command execution routing
 

--- a/.agents/skills/task-closeout/SKILL.md
+++ b/.agents/skills/task-closeout/SKILL.md
@@ -74,6 +74,8 @@ Never infer Feature completion from `n / n closed`.
 - Use `.agents/policies/command-execution.md` as the single normative command
   routing policy and the optional ignored local execution profile only as a
   machine-specific routing preference.
+- Use `.agents/policies/task-workflow-telemetry.md` only for an explicitly
+  active local run. Telemetry never changes closeout gates or branch authority.
 - Use the Pull Request head ref and current Git refs to resolve branch identity.
 - Use historical records only as evidence, never as a current fact source.
 
@@ -412,6 +414,24 @@ Pause before the related write when:
 Report completed steps, exact evidence, current safe state, and the next
 maintainer decision or recovery gate.
 
+
+## Optional workflow telemetry
+
+Read `.agents/policies/task-workflow-telemetry.md` and perform one lightweight
+local status check for this Task. With no explicit active run, do no further
+telemetry work.
+
+When active, append one `task-closeout` summary using only facts and counts
+already produced by merge verification, synchronization, validation, metadata
+convergence, and exact branch cleanup. Record retries and the squash-specific
+exact `-D` fallback when they occur. Do not add GitHub queries, Git commands, or
+validation only for measurement.
+
+Telemetry cannot authorize merge, Issue close, metadata writes, main updates, or
+branch deletion and cannot weaken any exact branch gate. If the ignored local
+append fails, report `telemetry incomplete`; closeout behavior remains governed
+only by this Skill.
+
 ## Command execution routing
 
 Before executing a command, read `.agents/policies/command-execution.md` and
@@ -447,6 +467,7 @@ Include:
 - post-merge validation commands, exit codes, and results;
 - material execution-routing decisions and elevated attempts required by the
   shared command policy;
+- telemetry run ID and completion state only when an explicit run is active;
 - required checks on remote `main`;
 - exact remote and local branch actions;
 - whether `-D` was required and every gate that justified it;

--- a/.agents/skills/task-delivery/SKILL.md
+++ b/.agents/skills/task-delivery/SKILL.md
@@ -73,6 +73,8 @@ Never infer Feature completion from `n / n closed`.
 - Use `.agents/policies/command-execution.md` as the single normative command
   routing policy and the optional ignored local execution profile only as a
   machine-specific routing preference.
+- Use `.agents/policies/task-workflow-telemetry.md` only for an explicitly
+  active, local measurement run. Telemetry is not a gate or correctness source.
 - Use historical Tasks and Pull Requests only as process evidence, never as a
   current fact source.
 
@@ -569,6 +571,24 @@ current state before reuse. Completed steps are verified rather than repeated.
 - Keep worktree, staged, committed, and PR file scope aligned with Task scope.
 - Interpret command exit codes according to command semantics.
 
+
+## Optional workflow telemetry
+
+Read `.agents/policies/task-workflow-telemetry.md`, then perform one lightweight
+local `telemetry.py status` check for this Task. If there is no explicit active
+run, do no further telemetry work and add no telemetry report fields.
+
+When a run is active, use only facts and counts already produced by delivery.
+Append one `task-delivery` phase summary at completion or interruption. Do not
+add GitHub queries, repository reads, validation commands, or retries only for
+measurement. Do not store raw prompts, source contents, command output, or
+credentials.
+
+Telemetry does not authorize implementation, metadata writes, commit, push, PR
+creation, or readiness. A telemetry write failure is reported as `telemetry
+incomplete`; delivery continues or stops only according to this Skill's existing
+gates. Do not create or edit the local telemetry configuration automatically.
+
 ## Command execution routing
 
 Before executing a command, read `.agents/policies/command-execution.md` and
@@ -600,6 +620,7 @@ Keep reports concise and include:
 - validation commands, exit codes, and results;
 - material execution-routing decisions and elevated attempts required by the
   shared command policy;
+- telemetry run ID and completion state only when an explicit run is active;
 - commit, branch, and Pull Request state;
 - Required Checks configuration/status and actual check runs/conclusions;
 - self-check findings;

--- a/.agents/skills/task-pr-review/SKILL.md
+++ b/.agents/skills/task-pr-review/SKILL.md
@@ -62,6 +62,8 @@ This Skill may:
 - use detached checkout or a uniquely named temporary review worktree;
 - run current CI-equivalent local validation and applicable Skill validators;
 - generate local temporary validation output;
+- append aggregate events to the exact ignored `.agents/telemetry.local/`
+  directory when the maintainer explicitly started a telemetry run;
 - produce a review report.
 
 It does not:
@@ -94,7 +96,10 @@ PR changes them; they must not become the authority that controls this review.
 
 If the PR modifies any applicable `AGENTS.md`, `AGENTS.override.md`,
 `task-pr-review`, `.agents/policies/command-execution.md`,
-`.agents/execution-profile.example.toml`, or another shared governance policy
+`.agents/execution-profile.example.toml`,
+`.agents/policies/task-workflow-telemetry.md`,
+`.agents/task-workflow-telemetry.example.toml`,
+`tools/agent_workflow/telemetry.py`, or another shared governance policy
 referenced by the trusted Review Skill:
 
 - use the versions from the PR base commit as the trusted rules for this review;
@@ -135,6 +140,7 @@ system / developer / current explicit user instructions
 -> trusted base applicable AGENTS.md / AGENTS.override.md and governance policy
 -> trusted base task-pr-review rules
 -> trusted base command-execution policy
+-> trusted base task-workflow-telemetry policy for optional measurement only
 -> optional local execution profile routing preference
 -> current GitHub Task body, comments, and fields
 -> current PR body, base, head, diff, commits, checks, reviews, and threads
@@ -332,6 +338,28 @@ verdict until the gate can be resolved. Any applicable CI check run that is
 failed, cancelled, skipped unexpectedly, stale, pending, or in progress prevents
 a passing verdict regardless of Required Checks configuration.
 
+
+## Optional workflow telemetry
+
+Use the trusted-base `.agents/policies/task-workflow-telemetry.md` for optional
+measurement. Perform one lightweight local status check for the reviewed Task.
+Do not create an implicit run. Delivery telemetry and prior phase summaries are
+not review evidence and must not influence findings, severity, acceptance
+coverage, checks, threads, or verdict.
+
+When an explicit run is active, append one aggregate `task-pr-review` event for
+this independent review session to the exact ignored `.agents/telemetry.local/`
+directory. Use only facts and counts already produced by the review; do not add
+GitHub queries, file reads, validation, or report text for measurement. Record a
+review invalidation or repeated review as a separate event rather than replacing
+history.
+
+This narrow ignored local append is not a reviewed-file or GitHub mutation. If
+the telemetry path is tracked, staged, or not ignored, do not write telemetry
+and report it incomplete. The review continues or stops only under the existing
+review gates. A policy, example, CLI, or Skill changed by PR head remains a
+review object and cannot govern its own review.
+
 ## Command execution routing
 
 Use the trusted-base `.agents/policies/command-execution.md` as the normative
@@ -441,9 +469,10 @@ Produce a report containing at least:
    - actual check runs and conclusions;
 9. material execution-routing decisions and elevated attempts required by the
    trusted command policy;
-10. residual risks and known limitations;
-11. actions deliberately not performed;
-12. one fixed verdict.
+10. telemetry run ID and append result only when an explicit run is active;
+11. residual risks and known limitations;
+12. actions deliberately not performed;
+13. one fixed verdict.
 
 End with:
 

--- a/.agents/task-workflow-telemetry.example.toml
+++ b/.agents/task-workflow-telemetry.example.toml
@@ -1,0 +1,7 @@
+schema_version = 1
+output_dir = ".agents/telemetry.local"
+default_mode = "baseline-only"
+store_raw_transcript = false
+store_command_output = false
+store_file_contents = false
+allow_usage_patch = true

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,7 @@ desktop.ini
 
 # Local agent execution routing
 .agents/execution-profile.local.toml
+
+# Local Task workflow telemetry
+.agents/task-workflow-telemetry.local.toml
+.agents/telemetry.local/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,14 @@ Before a repository workflow Skill listed above executes a command, it must read
 must not be committed. It may select an execution context only after the active
 Skill authorizes the command; it never expands lifecycle or GitHub permissions.
 
+Optional Task workflow measurement is governed by
+`.agents/policies/task-workflow-telemetry.md`. Telemetry is disabled unless the
+maintainer explicitly starts a local run. Its config and data remain in ignored
+`.agents/task-workflow-telemetry.local.toml` and `.agents/telemetry.local/`.
+Telemetry records aggregate process measurements only; it never changes workflow
+permissions, gates, validation, review findings, verdicts, Merge authorization,
+or Feature completion evidence.
+
 This root `AGENTS.md` remains the repository-level rule source. Repository Skills
 supplement these rules and do not override system, developer, user, or more
 specific scoped instructions.

--- a/docs/workflows/agent-skills.md
+++ b/docs/workflows/agent-skills.md
@@ -605,6 +605,12 @@ Final interpretation
 
 ## Task Workflow Token 消耗测量
 
+开发人员的完整配置、运行、JSON 模板、故障处理和扩展说明见：
+
+```text
+docs/workflows/task-workflow-telemetry.md
+```
+
 Task Workflow Telemetry 是可选的本地旁路测量能力，不是新的 workflow
 Skill，也不是 delivery、review、closeout 或 Feature audit 的门禁。
 

--- a/docs/workflows/agent-skills.md
+++ b/docs/workflows/agent-skills.md
@@ -14,6 +14,7 @@ AGENTS.md / AGENTS.override.md
 .agents/skills/task-closeout/SKILL.md
 .agents/skills/feature-completion-audit/SKILL.md
 .agents/policies/command-execution.md
+.agents/policies/task-workflow-telemetry.md
 ```
 
 本文档是使用指南，不替代上述规则。出现冲突时，以更高优先级和更具体的
@@ -601,3 +602,190 @@ Final interpretation
 可以影响已授权命令的执行上下文，但不能改变 reviewed SHA、严重度、验收覆盖
 或 verdict。对 `feature-completion-audit`，local profile 同样不能改变 Feature
 身份、直接子 Issue 分类、`Audited main SHA`、验收覆盖、findings 或 verdict。
+
+## Task Workflow Token 消耗测量
+
+Task Workflow Telemetry 是可选的本地旁路测量能力，不是新的 workflow
+Skill，也不是 delivery、review、closeout 或 Feature audit 的门禁。
+
+规范性协议：
+
+```text
+.agents/policies/task-workflow-telemetry.md
+```
+
+仓库示例配置：
+
+```text
+.agents/task-workflow-telemetry.example.toml
+```
+
+维护者本地配置和数据：
+
+```text
+.agents/task-workflow-telemetry.local.toml
+.agents/telemetry.local/
+```
+
+两者都已被 `.gitignore` 忽略，不得提交。Telemetry 默认关闭；没有显式
+active run 时，四个 workflow Skills 不记录数据、不增加报告字段，也不执行
+额外查询或验证。
+
+保持：
+
+```text
+Observation
+!= workflow authorization
+!= correctness evidence
+!= merge authorization
+```
+
+Telemetry 失败只会标记测量不完整，不会改变 Task、PR 或 Feature verdict。
+
+### 创建本地配置
+
+PowerShell：
+
+```powershell
+Copy-Item `
+  .agents/task-workflow-telemetry.example.toml `
+  .agents/task-workflow-telemetry.local.toml
+```
+
+schema v1 固定禁止保存完整会话、prompt、源码和命令输出：
+
+```toml
+store_raw_transcript = false
+store_command_output = false
+store_file_contents = false
+```
+
+本地配置不能包含凭据、token、私钥、认证 header、用户名或敏感绝对路径。
+
+### 两种模式
+
+- `baseline-only`：建立指定 Task 的完整本地基准，不自动比较或优化；
+- `spot-check`：按同一协议测量，并与本地同类历史 run 做信息性比较。
+
+严格同类比较默认要求以下分类一致：
+
+```text
+task_kind
+size
+risk_class
+workflow_shape
+```
+
+少于 3 个同类完成样本时，只做结构性比较，不生成统计异常结论。异常 flag
+不会改变 workflow verdict。
+
+### 启动和查看状态
+
+```powershell
+python tools/agent_workflow/telemetry.py start `
+  --task 123 `
+  --task-title "[Task] Example" `
+  --mode baseline-only `
+  --task-kind feature-code `
+  --size M `
+  --risk-class normal `
+  --workflow-shape task-only `
+  --repository PhoenixSss/quant-system `
+  --workflow-main-sha <main-sha>
+```
+
+```powershell
+python tools/agent_workflow/telemetry.py status --task 123 --json
+```
+
+需要把后续 Feature audit 纳入同一 run 时，在 `start` 中同时提供
+`--feature <Feature编号>`，Feature audit 会话可使用：
+
+```powershell
+python tools/agent_workflow/telemetry.py status --feature 2 --json
+```
+
+同一 Task 已存在 active run 时，CLI 拒绝重复启动。Workflow 中断后应恢复
+同一 run，不应隐式新建。
+
+### 阶段记录和 usage 后补
+
+四个 Skills 只在 active run 存在时，使用正常流程已经产生的事实写入紧凑
+aggregate summary。不得为了测量增加 GitHub 查询、文件读取或验证命令。
+
+手工记录接口：
+
+```powershell
+python tools/agent_workflow/telemetry.py record `
+  --task 123 `
+  --phase task-delivery `
+  --data-file <phase-summary.json>
+```
+
+会话结束后获得 token usage 时：
+
+```powershell
+python tools/agent_workflow/telemetry.py patch-usage `
+  --task 123 `
+  --phase task-pr-review `
+  --data-file <usage.json>
+```
+
+Token source 只能是：
+
+```text
+runtime-exact
+client-export
+estimated-external
+unavailable
+```
+
+未知值使用 `null`，不得使用 `0` 假装已测量，也不得把字符估算描述为精确
+token。Telemetry 不记录私有 reasoning；仅允许 runtime 暴露的聚合 reasoning
+count。
+
+### 完成、验证和摘要
+
+```powershell
+python tools/agent_workflow/telemetry.py finish --task 123
+python tools/agent_workflow/telemetry.py validate --task 123
+python tools/agent_workflow/telemetry.py summarize --task 123 --format markdown
+```
+
+`finish` 保留 append-only events，并生成确定性 `summary.json`。
+`task-only` 和 `task-with-re-review` 在 closeout 后结束 run。
+`task-plus-feature-audit` 在 closeout 后保持同一 run active，待 Feature audit
+追加阶段记录后，再通过 `--task` 或关联的 `--feature` 结束；不得为 Feature
+audit 隐式创建第二个 run。`spot-check` 摘要可以输出历史中位数、范围、delta
+和信息性 anomaly flags；样本不足时必须明确说明。
+
+### 隐私和只读边界
+
+Telemetry 不保存：
+
+- 完整 prompt、assistant response、会话或私有 reasoning；
+- 源码、测试、文档内容；
+- 完整 stdout / stderr 或敏感命令行；
+- token、cookie、认证 header、密码或私钥；
+- 用户主目录或敏感绝对路径。
+
+`task-pr-review` 和 `feature-completion-audit` 的严格只读边界只增加一个精确
+例外：当维护者已启动 run 时，可以向被忽略的
+`.agents/telemetry.local/` 追加 aggregate event。该本地写入不是被审查文件
+修改，也不是 correctness 或 Feature completion 证据。若路径被跟踪、进入
+index 或不再被忽略，停止 telemetry 写入并报告。
+
+### 持续优化循环
+
+Telemetry 本身不修改 Skills 或创建优化 Issue。长期流程为：
+
+```text
+baseline-only
+→ 去敏聚合分析
+→ 维护者创建独立 Token Optimization Task
+→ 优化合并
+→ 使用后续相近 Task 再次 baseline-only 或 spot-check
+```
+
+随着项目出现更典型的功能 Task，可以重复该循环。也可以仅对指定 Task 做
+`spot-check`，用于发现异常消耗而不立即优化。

--- a/docs/workflows/task-workflow-telemetry.md
+++ b/docs/workflows/task-workflow-telemetry.md
@@ -1,0 +1,790 @@
+# Task Workflow Telemetry 开发人员使用指南
+
+## 目的与适用范围
+
+本文档面向使用、维护或扩展 Task Workflow Telemetry 的开发人员，说明如何在
+不改变正常开发流程的前提下，为指定 Task 建立 token 与流程消耗基准，或执行
+一次信息性消耗抽查。
+
+Telemetry 是本地旁路测量能力，不是新的 workflow Skill，也不是任何正确性、
+合并或 Feature 完成证据：
+
+```text
+Observation
+!= workflow authorization
+!= correctness evidence
+!= merge authorization
+!= Feature completion evidence
+```
+
+规范性规则位于：
+
+```text
+.agents/policies/task-workflow-telemetry.md
+.agents/policies/command-execution.md
+```
+
+四个 workflow Skills 只负责在 active run 存在时追加聚合事件：
+
+```text
+.agents/skills/task-delivery/SKILL.md
+.agents/skills/task-pr-review/SKILL.md
+.agents/skills/task-closeout/SKILL.md
+.agents/skills/feature-completion-audit/SKILL.md
+```
+
+本文档是开发人员使用指南。出现冲突时，以 `AGENTS.md`、适用
+`AGENTS.override.md`、上述 policy 和当前 Skill 为准。
+
+## 文件结构
+
+仓库提交的文件：
+
+```text
+.agents/policies/task-workflow-telemetry.md
+.agents/task-workflow-telemetry.example.toml
+tools/agent_workflow/telemetry.py
+tests/tools/test_task_workflow_telemetry.py
+```
+
+维护者本地文件：
+
+```text
+.agents/task-workflow-telemetry.local.toml
+.agents/telemetry.local/
+```
+
+本地配置和数据目录必须保持 Git ignored，不得暂存、提交或进入 PR。
+
+一次 run 的默认目录结构：
+
+```text
+.agents/telemetry.local/
+├─ active/
+│  └─ task-123.json
+└─ runs/
+   └─ tw-123-<timestamp>-<random>/
+      ├─ manifest.json
+      ├─ events.jsonl
+      └─ summary.json
+```
+
+- `manifest.json`：run 身份、分类、模式、workflow SHA 和状态；
+- `events.jsonl`：append-only 阶段事件；
+- `summary.json`：`finish` 生成的确定性聚合结果；
+- `active/task-<number>.json`：当前 Task 的 active pointer，`finish` 后删除。
+
+不要手工修改这些文件。使用 CLI 写入、验证和汇总。
+
+## 前置条件
+
+在启动测量前确认：
+
+1. 当前工作目录是仓库根目录；
+2. 已经存在有效的本地配置；
+3. local config 与 output directory 均被 `.gitignore` 精确覆盖；
+4. 已知 Task 编号和 canonical title；
+5. 已知当前 workflow 所依据的 `main` SHA；
+6. 已为 Task 选择合理的分类；
+7. 本次 Task 不会同时修改被测 workflow；否则基准会被污染。
+
+Telemetry CLI 不访问网络，也不会自行执行 Git、GitHub 或验证命令。Task、
+repository slug 和 SHA 必须由开发人员使用正常流程已经获得的事实提供。
+
+## 第一次配置
+
+复制 example config：
+
+```powershell
+Copy-Item `
+  .agents/task-workflow-telemetry.example.toml `
+  .agents/task-workflow-telemetry.local.toml
+```
+
+默认配置：
+
+```toml
+schema_version = 1
+output_dir = ".agents/telemetry.local"
+default_mode = "baseline-only"
+store_raw_transcript = false
+store_command_output = false
+store_file_contents = false
+allow_usage_patch = true
+```
+
+schema v1 中以下字段必须保持 `false`：
+
+```toml
+store_raw_transcript = false
+store_command_output = false
+store_file_contents = false
+```
+
+验证忽略规则：
+
+```powershell
+git check-ignore -v .agents/task-workflow-telemetry.local.toml
+git check-ignore -v .agents/telemetry.local/example.jsonl
+```
+
+任何一条命令没有命中预期 ignore rule 时，不要启动 Telemetry。
+
+## 选择测量模式
+
+### `baseline-only`
+
+用于建立指定类型 Task 的完整基准。
+
+适合：
+
+- 首次测量一种 Task 类型；
+- workflow 规则发生较大变化后重新建立基准；
+- 完成 token 优化后建立新的对照基准。
+
+该模式不会自动比较历史样本，也不会自动提出优化。
+
+### `spot-check`
+
+用于抽查指定 Task 是否存在异常消耗。
+
+CLI 默认只比较以下四个分类完全一致的历史 run：
+
+```text
+task_kind
+size
+risk_class
+workflow_shape
+```
+
+少于 3 个同类已完成样本时，只做结构性对比，不生成统计异常结论。
+异常 flag 仅供分析，不改变 Task、PR 或 Feature verdict。
+
+## 选择 Task 分类
+
+推荐使用以下值：
+
+```text
+task_kind:
+  feature-code
+  bugfix
+  refactor
+  governance-docs
+  dependency-maintenance
+  data-pipeline
+  research
+  other
+
+size:
+  S
+  M
+  L
+
+risk_class:
+  normal
+  high-correctness
+  financial-safety
+
+workflow_shape:
+  task-only
+  task-with-re-review
+  task-plus-feature-audit
+```
+
+`task_kind`、`risk_class` 和 `workflow_shape` 必须是小写 slug。为了保证历史
+数据可比较，应优先使用上述固定值，不要为同一含义创建多个近义分类。
+
+`workflow_shape` 的选择：
+
+- `task-only`：一次 review，通过后 closeout；
+- `task-with-re-review`：预期或实际发生了修复、新 head 和重新独立审查；
+- `task-plus-feature-audit`：Task closeout 后，同一 run 还要记录
+  `feature-completion-audit`。
+
+若 Task 在运行中从一次审查变为重新审查，不要新建 run。继续记录 rework 和
+review-run 事件；在分析中说明实际 workflow shape。不要为了修正分类而改写
+append-only 历史。
+
+## 快速开始
+
+下面示例为 Task #123 建立一个普通功能开发基准：
+
+```powershell
+python tools/agent_workflow/telemetry.py start `
+  --task 123 `
+  --task-title "[Task] 实现示例功能" `
+  --mode baseline-only `
+  --task-kind feature-code `
+  --size M `
+  --risk-class normal `
+  --workflow-shape task-only `
+  --repository PhoenixSss/quant-system `
+  --workflow-main-sha <current-main-sha> `
+  --model <model-identifier>
+```
+
+`--model` 可省略。`--mode` 省略时使用 local config 的 `default_mode`。
+
+成功输出示例：
+
+```json
+{
+  "active": true,
+  "mode": "baseline-only",
+  "run_id": "tw-123-20260725T120000-1a2b3c4d",
+  "run_path": ".agents/telemetry.local/runs/tw-123-20260725T120000-1a2b3c4d",
+  "task_number": 123
+}
+```
+
+查看状态：
+
+```powershell
+python tools/agent_workflow/telemetry.py status --task 123 --json
+```
+
+没有 local config 或 active run 时，`status` 返回非阻塞 JSON，而不是使正常
+workflow 失败。
+
+## 标准运行时序
+
+### 1. 在 `task-delivery` 前启动
+
+必须先由维护者显式 `start`。Skills 不会隐式创建 run。
+
+启动后再进入正常流程：
+
+```text
+task-delivery
+→ task-pr-review
+→ manual merge
+→ task-closeout
+```
+
+四个 Skills 只使用正常工作已经产生的事实维护聚合计数，不得为 Telemetry
+额外查询 GitHub、重新读取文件或重跑验证。
+
+### 2. 每个新会话先检查状态
+
+Task 阶段：
+
+```powershell
+python tools/agent_workflow/telemetry.py status --task 123 --json
+```
+
+Feature audit 阶段：
+
+```powershell
+python tools/agent_workflow/telemetry.py status --feature 2 --json
+```
+
+没有 active run 时，不要创建隐式 run，也不要增加报告字段。
+
+### 3. 阶段结束时追加 summary
+
+正常情况下，workflow Skill 会按照 policy 追加一条 `phase-summary`。需要手工
+补录时使用：
+
+```powershell
+python tools/agent_workflow/telemetry.py record `
+  --task 123 `
+  --phase task-delivery `
+  --data-file .agents/telemetry.local/input/task-delivery.json
+```
+
+输入文件可以放在 ignored telemetry 目录中。不要把输入 JSON 暂存或提交。
+
+### 4. 人工 Merge 阶段
+
+人工 Merge 没有模型 usage 也可以记录。使用 `manual-merge` phase，token 字段
+保持 `null`，source 使用 `unavailable`。
+
+```powershell
+python tools/agent_workflow/telemetry.py record `
+  --task 123 `
+  --phase manual-merge `
+  --data-file .agents/telemetry.local/input/manual-merge.json
+```
+
+### 5. 会话结束后补录 usage
+
+客户端在会话结束后才显示 token 时，使用：
+
+```powershell
+python tools/agent_workflow/telemetry.py patch-usage `
+  --task 123 `
+  --phase task-pr-review `
+  --data-file .agents/telemetry.local/input/review-usage.json
+```
+
+同一 phase 有多个可补录事件时，使用 `record` 输出的 `event_id` 精确指定：
+
+```powershell
+python tools/agent_workflow/telemetry.py patch-usage `
+  --task 123 `
+  --phase task-pr-review `
+  --event-id ev-000003-1a2b3c4d `
+  --data-file .agents/telemetry.local/input/review-usage.json
+```
+
+已有 `runtime-exact` 或 `client-export` usage 时，CLI 会拒绝覆盖。
+
+### 6. 完成 run
+
+普通 Task 在 `task-closeout` 后完成：
+
+```powershell
+python tools/agent_workflow/telemetry.py finish --task 123
+```
+
+取消或失败：
+
+```powershell
+python tools/agent_workflow/telemetry.py finish --task 123 --status cancelled
+python tools/agent_workflow/telemetry.py finish --task 123 --status failed
+```
+
+`task-plus-feature-audit` 不应在 closeout 后立即 finish。保持同一 run active，
+等待 Feature audit 追加阶段事件，再执行：
+
+```powershell
+python tools/agent_workflow/telemetry.py finish --feature 2
+```
+
+不要为 Feature audit 创建第二个 run。
+
+### 7. 验证和查看摘要
+
+```powershell
+python tools/agent_workflow/telemetry.py validate --task 123
+python tools/agent_workflow/telemetry.py summarize --task 123 --format markdown
+```
+
+指定历史 run：
+
+```powershell
+python tools/agent_workflow/telemetry.py validate `
+  --task 123 `
+  --run-id tw-123-20260725T120000-1a2b3c4d
+
+python tools/agent_workflow/telemetry.py summarize `
+  --task 123 `
+  --run-id tw-123-20260725T120000-1a2b3c4d `
+  --format json
+```
+
+## Phase summary JSON 模板
+
+下面是可直接复制的完整模板。未知值使用 `null`，不得使用 `0` 假装已经测量。
+
+```json
+{
+  "schema_version": 1,
+  "event_type": "phase-summary",
+  "identity": {
+    "task_canonical_title": "[Task] 实现示例功能",
+    "pr_number": 124,
+    "feature_number": null,
+    "base_sha": "abcdef1234567",
+    "head_sha": "1234567abcdef",
+    "workflow_main_sha": "fedcba7654321",
+    "model": "model-identifier",
+    "changed_files_count": 5,
+    "changed_lines": 220,
+    "acceptance_criteria_count": 8
+  },
+  "usage": {
+    "source": "unavailable",
+    "input_tokens": null,
+    "cached_input_tokens": null,
+    "output_tokens": null,
+    "reasoning_tokens": null,
+    "total_tokens": null,
+    "model": "model-identifier"
+  },
+  "context": {
+    "governance": {
+      "files_read": 4,
+      "bytes_read": 18000,
+      "lines_read": 420,
+      "repeated_bytes_estimate": 6000
+    },
+    "source": {
+      "files_read": 7,
+      "bytes_read": 32000,
+      "lines_read": 900,
+      "repeated_bytes_estimate": null
+    },
+    "tests": {
+      "files_read": 3,
+      "bytes_read": 9000,
+      "lines_read": 260,
+      "repeated_bytes_estimate": 0
+    }
+  },
+  "operations": {
+    "tool_calls": 18,
+    "github_queries": 5,
+    "git_commands": 8,
+    "validation_commands": 5,
+    "sandbox_attempts": 20,
+    "elevated_attempts": 3,
+    "retries": 3,
+    "retry_categories": {
+      "credential-session": 1,
+      "filesystem-isolation": 2
+    },
+    "command_categories": {
+      "git-read": 5,
+      "git-write-authorized": 3,
+      "github-read": 4,
+      "github-write-authorized": 1,
+      "test": 1,
+      "lint": 2,
+      "format": 1,
+      "type-check": 1
+    }
+  },
+  "report": {
+    "report_characters": 3600,
+    "report_lines": 90,
+    "report_estimated_tokens": 900,
+    "report_estimation_method": "chars-div-4",
+    "copied_to_next_phase": false
+  },
+  "rework": {
+    "commits_added_after_first_handoff": 0,
+    "head_sha_changes": 0,
+    "independent_review_runs": 0,
+    "review_invalidations": 0,
+    "maintainer_decisions": 0,
+    "interruptions": 0,
+    "findings_by_severity": {
+      "blocking": 0,
+      "high": 0,
+      "medium": 0,
+      "low": 0,
+      "nit": 0
+    }
+  },
+  "outcome": {
+    "phase_result": "pass",
+    "workflow_result": null,
+    "review_verdict": null,
+    "feature_audit_verdict": null,
+    "validation_passed": true,
+    "telemetry_complete": true
+  },
+  "limitations": [
+    "client-usage-not-exported"
+  ]
+}
+```
+
+注意：
+
+- `limitations` 只写简短、聚合、非敏感标识；
+- 不写完整命令、文件内容、绝对路径、prompt 或 stdout；
+- `repeated_bytes_estimate` 是估算；无法判断时使用 `null`；
+- 明确确认没有发生的计数可以是 `0`；
+- 未测量或未知的计数应为 `null`；
+- `identity` 中的 Task title、Feature number 和 workflow SHA 不得与 manifest 冲突。
+
+## Usage patch JSON
+
+支持只传 usage object：
+
+```json
+{
+  "source": "client-export",
+  "input_tokens": 125000,
+  "cached_input_tokens": 80000,
+  "output_tokens": 7600,
+  "reasoning_tokens": null,
+  "total_tokens": 132600,
+  "model": "model-identifier"
+}
+```
+
+也支持带 schema wrapper：
+
+```json
+{
+  "schema_version": 1,
+  "usage": {
+    "source": "client-export",
+    "input_tokens": 125000,
+    "cached_input_tokens": 80000,
+    "output_tokens": 7600,
+    "reasoning_tokens": null,
+    "total_tokens": 132600,
+    "model": "model-identifier"
+  }
+}
+```
+
+允许的 source：
+
+```text
+runtime-exact
+client-export
+estimated-external
+unavailable
+```
+
+- `runtime-exact`：runtime 直接提供的精确聚合计数；
+- `client-export`：受支持客户端导出的精确聚合计数；
+- `estimated-external`：仓库外固定方法产生的估算；
+- `unavailable`：无法取得 usage。
+
+不得根据字符数将 usage 标为 exact。字符估算只属于报告量或
+`estimated-external`。
+
+## 记录中断、返工和重审
+
+一条 phase 只能有一个主要 `phase-summary`。额外情况使用不同 event type：
+
+```text
+interruption
+rework
+review-run
+manual-merge
+```
+
+例如 review 因新 head 失效时，可追加 `review-run` 或 `rework` 事件，并在
+`rework.review_invalidations`、`head_sha_changes` 和
+`independent_review_runs` 中记录数量。
+
+不要删除旧 review event，也不要覆盖第一次 head SHA。append-only 历史用于
+计算新 SHA 和完整重审的放大成本。
+
+## 三种常见 workflow 示例
+
+### 普通一次通过 Task
+
+```text
+start(task-only)
+→ task-delivery phase-summary
+→ task-pr-review phase-summary
+→ manual-merge event
+→ task-closeout phase-summary
+→ finish
+→ validate
+→ summarize
+```
+
+### 修复后重新审查
+
+```text
+start(task-with-re-review)
+→ task-delivery
+→ review-run #1
+→ rework / new head
+→ review-run #2
+→ manual-merge
+→ task-closeout
+→ finish
+```
+
+保持同一 run，不要在产生新 head 后重新 `start`。
+
+### Task 后执行 Feature audit
+
+```text
+start(task-plus-feature-audit, --feature 2)
+→ task-delivery
+→ task-pr-review
+→ manual-merge
+→ task-closeout
+→ status --feature 2
+→ feature-completion-audit
+→ finish --feature 2
+```
+
+Feature audit 会话不能把前序 Task telemetry 当作 Feature 完成证据。
+
+## 读取摘要
+
+Markdown 摘要包含：
+
+- run 身份和分类；
+- workflow / telemetry 版本；
+-各 phase usage；
+- exact / estimated / unavailable coverage；
+-上下文量；
+-工具、重试和报告量；
+-返工与 review invalidation；
+- findings、validation、维护者决策和 workflow result；
+-缺失 phase 与 limitations；
+- spot-check 模式下的同类样本数量、历史中位数、delta 和 anomaly flags。
+
+典型 anomaly flags：
+
+```text
+total-token-high
+phase-token-high
+repeated-context-high
+tool-output-high
+review-restart-high
+retry-high
+report-size-high
+```
+
+这些标记只说明值得进一步分析，不表示 workflow 失败，也不应自动触发 Skill
+修改。
+
+## 如何使用测量结果
+
+推荐长期循环：
+
+```text
+baseline-only
+→ 去敏聚合分析
+→ 维护者创建独立 Token Optimization Task
+→ 优化合并
+→ 使用相近 Task 再次 baseline-only 或 spot-check
+```
+
+对日常抽查：
+
+```text
+spot-check
+→ 与同类样本比较
+→ 定位异常 phase 和成本来源
+→ 维护者决定是否进入优化循环
+```
+
+不要把不同 Task 类型、Size、风险或 workflow shape 的样本合并为一个全局
+平均值。不同模型或 workflow main SHA 的结果也应明确分开解释。
+
+## 常见错误与处理
+
+### `local telemetry config is missing`
+
+`status` 会把它作为非阻塞 unavailable 返回。需要测量时，先复制 example config。
+不需要测量时无需处理。
+
+### `not covered by an exact .gitignore rule`
+
+local config 或 output directory 没有被精确忽略。检查 `.gitignore`，不要改为
+写入其他未忽略目录，也不要通过 elevation 绕过安全检查。
+
+### `Task #... already has active run`
+
+该 Task 已经存在 active pointer。先执行 `status`，恢复原 run。只有确认原 run
+应结束时才执行 `finish`；不要删除 pointer 伪造新 run。
+
+### `primary phase summary already exists`
+
+同一 phase 已经有主要 summary。新增中断、返工或 review 信息时使用对应
+event type，不要覆盖原 summary。
+
+### `existing exact usage cannot be overwritten`
+
+目标事件已有 exact usage。保留现有记录；估算值不能覆盖精确值。
+
+### `no target event found for usage patch`
+
+目标 phase 尚无可补录事件，或 `--event-id` 不正确。先检查 `record` 输出和
+`status`，不要创建虚假 phase。
+
+### `telemetry_complete: false`
+
+查看 `missing_phases` 和每个 event 的 `outcome.telemetry_complete`。这只表示
+测量不完整，不改变正常 workflow 结果。
+
+### spot-check 样本不足
+
+同类完成 run 少于 3 个。只做结构性比较，继续积累样本；不要从一个样本推导
+统计异常。
+
+## 隐私与安全检查
+
+绝对禁止记录：
+
+- token、cookie、密码、私钥、认证 header；
+- 完整 prompt、assistant response、会话或私有 reasoning；
+-源码、测试、文档内容；
+-完整 stdout / stderr；
+-完整环境变量；
+-用户主目录或敏感绝对路径；
+-包含敏感参数的完整命令行。
+
+允许记录：
+
+- Task / PR / Feature 编号；
+- repository slug；
+- Git SHA；
+-仓库相对路径类别；
+-计数、时间、阶段结果和聚合 token usage；
+-非敏感 retry / limitation 分类。
+
+CLI 会拒绝已知敏感字段和值，但调用方仍必须先进行最小化和去敏。
+
+## 开发与扩展要求
+
+修改 Telemetry CLI、schema 或 workflow hook 时：
+
+1. 先更新规范性 policy；
+2. schema 不兼容变化必须提升 `schema_version`；
+3. 旧 run 保持只读，不静默迁移；
+4. 保持 events append-only；
+5. 保持 deterministic summary；
+6. 不新增网络访问；
+7. 不让 CLI 执行 Git、GitHub 或验证命令；
+8. 不新增第三方依赖，除非另有批准；
+9. 四个 Skills 只保留最小 hook，不复制 schema；
+10. 不扩大 review / Feature audit 的只读例外；
+11. 新增字段必须经过敏感数据审查；
+12. 更新测试、example config、本指南和 `agent-skills.md`；
+13. 重新运行完整 CI 等价验证和 Skill validators。
+
+重点测试：
+
+```text
+start / duplicate start
+valid / invalid config
+ignored / unignored storage
+append-only record
+duplicate phase summary
+usage patch
+exact usage overwrite rejection
+finish / validate / summarize
+schema version rejection
+sensitive field rejection
+incomplete run
+spot-check sample insufficiency
+deterministic summary
+```
+
+## 开发人员操作清单
+
+开始前：
+
+- [ ] local config 存在且合法；
+- [ ] local config 与 data directory 均被 Git ignored；
+- [ ] Task 编号和 canonical title 正确；
+- [ ] workflow main SHA 已确认；
+- [ ] Task 分类已确定；
+- [ ] 测量模式已确定；
+- [ ] 被测 Task 不同时修改被测 workflow。
+
+运行中：
+
+- [ ] 每个会话只检查一次 status；
+- [ ] 不为测量增加 GitHub 查询或验证；
+- [ ] 每个 phase 最多一个主要 summary；
+- [ ] 未知值使用 `null`；
+- [ ] 不记录敏感内容；
+- [ ] 新 head、重审和中断追加事件，不覆盖历史；
+- [ ] telemetry 失败不改变 workflow verdict。
+
+结束后：
+
+- [ ] 必要 phase 均已记录；
+- [ ] usage 已按实际来源补录；
+- [ ] `finish` 已执行；
+- [ ] `validate` 通过；
+- [ ] 已查看 sanitized summary；
+- [ ] 原始 telemetry 未进入 Git index；
+- [ ] 是否创建独立 Token Optimization Task 由维护者决定。

--- a/tests/tools/test_task_workflow_telemetry.py
+++ b/tests/tools/test_task_workflow_telemetry.py
@@ -1,0 +1,632 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+SCRIPT = Path(__file__).parents[2] / "tools" / "agent_workflow" / "telemetry.py"
+
+
+def _write_repo(
+    tmp_path: Path,
+    *,
+    ignored: bool = True,
+    valid_config: bool = True,
+) -> Path:
+    repo = tmp_path / "repo"
+    agents = repo / ".agents"
+    agents.mkdir(parents=True)
+    ignore_lines = []
+    if ignored:
+        ignore_lines = [
+            ".agents/task-workflow-telemetry.local.toml",
+            ".agents/telemetry.local/",
+        ]
+    (repo / ".gitignore").write_text("\n".join(ignore_lines) + "\n", encoding="utf-8")
+    raw_value = "false" if valid_config else "true"
+    (agents / "task-workflow-telemetry.local.toml").write_text(
+        "\n".join(
+            [
+                "schema_version = 1",
+                'output_dir = ".agents/telemetry.local"',
+                'default_mode = "baseline-only"',
+                f"store_raw_transcript = {raw_value}",
+                "store_command_output = false",
+                "store_file_contents = false",
+                "allow_usage_patch = true",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return repo
+
+
+def _run(
+    repo: Path,
+    *args: str,
+    check: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    if check and result.returncode != 0:
+        raise AssertionError(result.stderr)
+    return result
+
+
+def _start(repo: Path, task: int = 123, mode: str = "baseline-only") -> dict[str, Any]:
+    result = _run(
+        repo,
+        "start",
+        "--task",
+        str(task),
+        "--task-title",
+        "[Task] Example",
+        "--mode",
+        mode,
+        "--task-kind",
+        "feature-code",
+        "--size",
+        "M",
+        "--risk-class",
+        "normal",
+        "--workflow-shape",
+        "task-only",
+        "--repository",
+        "owner/repo",
+        "--workflow-main-sha",
+        "abcdef1234567",
+        check=True,
+    )
+    value: dict[str, Any] = json.loads(result.stdout)
+    return value
+
+
+def _phase_file(repo: Path, name: str, *, source: str = "unavailable") -> Path:
+    usage: dict[str, Any] = {
+        "source": source,
+        "input_tokens": None,
+        "cached_input_tokens": None,
+        "output_tokens": None,
+        "reasoning_tokens": None,
+        "total_tokens": None,
+        "model": None,
+    }
+    if source != "unavailable":
+        usage.update(input_tokens=100, output_tokens=20, total_tokens=120)
+    value = {
+        "schema_version": 1,
+        "event_type": "phase-summary",
+        "usage": usage,
+        "context": {
+            "governance": {
+                "files_read": 2,
+                "bytes_read": 1000,
+                "lines_read": 50,
+                "repeated_bytes_estimate": 100,
+            }
+        },
+        "operations": {
+            "tool_calls": 2,
+            "github_queries": 1,
+            "git_commands": 1,
+            "validation_commands": 0,
+            "sandbox_attempts": 2,
+            "elevated_attempts": 0,
+            "retries": 0,
+            "retry_categories": {},
+            "command_categories": {"github-read": 1, "git-read": 1},
+        },
+        "report": {
+            "report_characters": 100,
+            "report_lines": 5,
+            "report_estimated_tokens": 25,
+            "report_estimation_method": "chars-div-4",
+            "copied_to_next_phase": False,
+        },
+        "rework": {
+            "commits_added_after_first_handoff": 0,
+            "head_sha_changes": 0,
+            "independent_review_runs": 0,
+            "review_invalidations": 0,
+            "maintainer_decisions": 0,
+            "interruptions": 0,
+            "findings_by_severity": {},
+        },
+        "outcome": {
+            "phase_result": "pass",
+            "workflow_result": None,
+            "review_verdict": None,
+            "feature_audit_verdict": None,
+            "validation_passed": True,
+            "telemetry_complete": True,
+        },
+        "limitations": [],
+    }
+    path = repo / name
+    path.write_text(json.dumps(value), encoding="utf-8")
+    return path
+
+
+def _record(repo: Path, phase: str, data_file: Path, task: int = 123) -> dict[str, Any]:
+    result = _run(
+        repo,
+        "record",
+        "--task",
+        str(task),
+        "--phase",
+        phase,
+        "--data-file",
+        str(data_file),
+        check=True,
+    )
+    value: dict[str, Any] = json.loads(result.stdout)
+    return value
+
+
+def _record_required_phases(
+    repo: Path,
+    task: int = 123,
+    source: str = "unavailable",
+) -> None:
+    for phase in ("task-delivery", "task-pr-review", "manual-merge", "task-closeout"):
+        _record(repo, phase, _phase_file(repo, f"{phase}.json", source=source), task)
+
+
+def test_start_and_duplicate_start(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    started = _start(repo)
+    assert started["active"] is True
+    duplicate = _run(
+        repo,
+        "start",
+        "--task",
+        "123",
+        "--task-title",
+        "[Task] Example",
+        "--repository",
+        "owner/repo",
+        "--workflow-main-sha",
+        "abcdef1234567",
+        "--task-kind",
+        "feature-code",
+        "--size",
+        "M",
+        "--risk-class",
+        "normal",
+        "--workflow-shape",
+        "task-only",
+    )
+    assert duplicate.returncode == 2
+    assert "already has active run" in duplicate.stderr
+
+
+def test_invalid_config_and_unignored_storage_are_rejected(tmp_path: Path) -> None:
+    invalid_repo = _write_repo(tmp_path / "invalid", valid_config=False)
+    invalid = _run(
+        invalid_repo,
+        "start",
+        "--task",
+        "1",
+        "--task-title",
+        "[Task] Example",
+        "--repository",
+        "owner/repo",
+        "--workflow-main-sha",
+        "abcdef1234567",
+        "--task-kind",
+        "feature-code",
+        "--size",
+        "S",
+        "--risk-class",
+        "normal",
+        "--workflow-shape",
+        "task-only",
+    )
+    assert invalid.returncode == 2
+    assert "store_raw_transcript must remain false" in invalid.stderr
+
+    unignored_repo = _write_repo(tmp_path / "unignored", ignored=False)
+    unignored = _run(
+        unignored_repo,
+        "start",
+        "--task",
+        "2",
+        "--task-title",
+        "[Task] Example",
+        "--repository",
+        "owner/repo",
+        "--workflow-main-sha",
+        "abcdef1234567",
+        "--task-kind",
+        "feature-code",
+        "--size",
+        "S",
+        "--risk-class",
+        "normal",
+        "--workflow-shape",
+        "task-only",
+    )
+    assert unignored.returncode == 2
+    assert "not covered by an exact .gitignore rule" in unignored.stderr
+
+
+def test_status_without_local_config_is_non_blocking(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    result = _run(repo, "status", "--task", "9", "--json")
+    assert result.returncode == 0
+    value = json.loads(result.stdout)
+    assert value["active"] is False
+    assert value["telemetry_available"] is False
+
+
+def test_record_is_append_only_and_rejects_duplicate_primary_summary(
+    tmp_path: Path,
+) -> None:
+    repo = _write_repo(tmp_path)
+    _start(repo)
+    data_file = _phase_file(repo, "phase.json")
+    first = _record(repo, "task-delivery", data_file)
+    assert first["recorded"] is True
+    duplicate = _run(
+        repo,
+        "record",
+        "--task",
+        "123",
+        "--phase",
+        "task-delivery",
+        "--data-file",
+        str(data_file),
+    )
+    assert duplicate.returncode == 2
+    assert "already exists" in duplicate.stderr
+
+
+def test_schema_and_sensitive_fields_are_rejected(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    _start(repo)
+    bad_schema = repo / "bad-schema.json"
+    bad_schema.write_text(json.dumps({"schema_version": 2}), encoding="utf-8")
+    result = _run(
+        repo,
+        "record",
+        "--task",
+        "123",
+        "--phase",
+        "task-delivery",
+        "--data-file",
+        str(bad_schema),
+    )
+    assert result.returncode == 2
+    assert "schema_version" in result.stderr
+
+    sensitive = repo / "sensitive.json"
+    sensitive.write_text(
+        json.dumps({"schema_version": 1, "prompt": "secret prompt"}),
+        encoding="utf-8",
+    )
+    result = _run(
+        repo,
+        "record",
+        "--task",
+        "123",
+        "--phase",
+        "task-delivery",
+        "--data-file",
+        str(sensitive),
+    )
+    assert result.returncode == 2
+    assert "forbidden" in result.stderr
+
+
+def test_usage_patch_and_exact_overwrite_rejection(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    _start(repo)
+    event = _record(repo, "task-delivery", _phase_file(repo, "phase.json"))
+    usage_file = repo / "usage.json"
+    usage_file.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "usage": {
+                    "source": "runtime-exact",
+                    "input_tokens": 100,
+                    "cached_input_tokens": 20,
+                    "output_tokens": 25,
+                    "reasoning_tokens": 5,
+                    "total_tokens": 125,
+                    "model": "model-a",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    patched = _run(
+        repo,
+        "patch-usage",
+        "--task",
+        "123",
+        "--phase",
+        "task-delivery",
+        "--event-id",
+        event["event_id"],
+        "--data-file",
+        str(usage_file),
+        check=True,
+    )
+    assert json.loads(patched.stdout)["source"] == "runtime-exact"
+    second = _run(
+        repo,
+        "patch-usage",
+        "--task",
+        "123",
+        "--phase",
+        "task-delivery",
+        "--event-id",
+        event["event_id"],
+        "--data-file",
+        str(usage_file),
+    )
+    assert second.returncode == 2
+    assert "exact usage cannot be overwritten" in second.stderr
+
+
+def test_finish_validate_and_summarize_are_deterministic(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    _start(repo)
+    _record_required_phases(repo, source="runtime-exact")
+    finish = _run(repo, "finish", "--task", "123", check=True)
+    finished = json.loads(finish.stdout)
+    assert finished["telemetry_complete"] is True
+
+    validated = _run(repo, "validate", "--task", "123", check=True)
+    assert json.loads(validated.stdout)["valid"] is True
+
+    first = _run(repo, "summarize", "--task", "123", "--format", "json", check=True)
+    second = _run(repo, "summarize", "--task", "123", "--format", "json", check=True)
+    assert first.stdout == second.stdout
+    summary = json.loads(first.stdout)
+    assert summary["total_usage"]["total_tokens"] == 480
+    assert summary["usage_coverage"]["by_source"]["runtime-exact"] == 4
+    assert summary["quality"]["validation_all_passed"] is True
+    assert summary["quality"]["findings_by_severity"]["blocking"] == 0
+
+
+def test_finish_marks_incomplete_run_without_required_phases(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    _start(repo)
+    _record(repo, "task-delivery", _phase_file(repo, "phase.json"))
+    finish = _run(repo, "finish", "--task", "123", check=True)
+    value = json.loads(finish.stdout)
+    assert value["telemetry_complete"] is False
+    assert "task-pr-review" in value["missing_phases"]
+
+
+def test_spot_check_reports_insufficient_samples(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    _start(repo, mode="spot-check")
+    _record_required_phases(repo, source="runtime-exact")
+    _run(repo, "finish", "--task", "123", check=True)
+    summary = _run(repo, "summarize", "--task", "123", "--format", "json", check=True)
+    value = json.loads(summary.stdout)
+    assert value["spot_check"]["sample_sufficient"] is False
+    assert value["spot_check"]["anomaly_flags"] == []
+
+
+def test_cli_help_for_all_commands() -> None:
+    for command in (
+        None,
+        "start",
+        "status",
+        "record",
+        "patch-usage",
+        "finish",
+        "validate",
+        "summarize",
+    ):
+        args = [sys.executable, str(SCRIPT)]
+        if command is not None:
+            args.append(command)
+        args.append("--help")
+        result = subprocess.run(args, check=False, capture_output=True, text=True)
+        assert result.returncode == 0
+        assert "usage:" in result.stdout.lower()
+
+
+def test_feature_selector_uses_associated_active_run(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    result = _run(
+        repo,
+        "start",
+        "--task",
+        "123",
+        "--task-title",
+        "[Task] Example",
+        "--repository",
+        "owner/repo",
+        "--workflow-main-sha",
+        "abcdef1234567",
+        "--feature",
+        "7",
+        "--task-kind",
+        "feature-code",
+        "--size",
+        "M",
+        "--risk-class",
+        "normal",
+        "--workflow-shape",
+        "task-plus-feature-audit",
+        check=True,
+    )
+    assert json.loads(result.stdout)["active"] is True
+
+    status = _run(repo, "status", "--feature", "7", "--json", check=True)
+    status_value = json.loads(status.stdout)
+    assert status_value["active"] is True
+    assert status_value["task_number"] == 123
+    assert status_value["feature_number"] == 7
+
+    phase = _phase_file(repo, "feature-audit.json")
+    recorded = _run(
+        repo,
+        "record",
+        "--feature",
+        "7",
+        "--phase",
+        "feature-completion-audit",
+        "--data-file",
+        str(phase),
+        check=True,
+    )
+    assert json.loads(recorded.stdout)["phase"] == "feature-completion-audit"
+
+
+def test_sensitive_token_value_and_naive_timestamp_are_rejected(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    _start(repo)
+
+    token_value = repo / "token-value.json"
+    token_value.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "limitations": ["gh" + "p_" + ("a" * 24)],
+            }
+        ),
+        encoding="utf-8",
+    )
+    result = _run(
+        repo,
+        "record",
+        "--task",
+        "123",
+        "--phase",
+        "task-delivery",
+        "--data-file",
+        str(token_value),
+    )
+    assert result.returncode == 2
+    assert "sensitive value" in result.stderr
+
+    naive_time = repo / "naive-time.json"
+    naive_time.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "recorded_at": "2026-07-24T12:00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+    result = _run(
+        repo,
+        "record",
+        "--task",
+        "123",
+        "--phase",
+        "task-delivery",
+        "--data-file",
+        str(naive_time),
+    )
+    assert result.returncode == 2
+    assert "timezone" in result.stderr
+
+
+def test_validate_rejects_corrupted_manifest_and_event_schema(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    started = _start(repo)
+    run_dir = repo / started["run_path"]
+    manifest_path = run_dir / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["unexpected"] = True
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    result = _run(repo, "validate", "--task", "123")
+    assert result.returncode == 2
+    assert "unknown fields" in result.stderr
+
+    del manifest["unexpected"]
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    event = _record(repo, "task-delivery", _phase_file(repo, "phase.json"))
+    events_path = run_dir / "events.jsonl"
+    events = [json.loads(line) for line in events_path.read_text().splitlines()]
+    events[0]["usage"]["unexpected"] = 1
+    events_path.write_text(
+        "\n".join(json.dumps(item) for item in events) + "\n",
+        encoding="utf-8",
+    )
+    result = _run(repo, "validate", "--task", "123")
+    assert result.returncode == 2
+    assert "unknown usage fields" in result.stderr
+    assert event["recorded"] is True
+
+
+def test_record_rejects_timestamp_before_latest_event(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    _start(repo)
+    first = _phase_file(repo, "first.json")
+    first_data = json.loads(first.read_text(encoding="utf-8"))
+    first_data["recorded_at"] = "2030-01-01T00:00:00Z"
+    first.write_text(json.dumps(first_data), encoding="utf-8")
+    _record(repo, "task-delivery", first)
+
+    second = _phase_file(repo, "second.json")
+    second_data = json.loads(second.read_text(encoding="utf-8"))
+    second_data["event_type"] = "interruption"
+    second_data["recorded_at"] = "2029-01-01T00:00:00Z"
+    second.write_text(json.dumps(second_data), encoding="utf-8")
+    result = _run(
+        repo,
+        "record",
+        "--task",
+        "123",
+        "--phase",
+        "task-pr-review",
+        "--data-file",
+        str(second),
+    )
+    assert result.returncode == 2
+    assert "precedes the latest event" in result.stderr
+
+
+def test_phase_identity_supplements_summary_run_identity(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    _start(repo)
+    phase = _phase_file(repo, "identity.json")
+    data = json.loads(phase.read_text(encoding="utf-8"))
+    data["identity"] = {
+        "task_canonical_title": "[Task] Example",
+        "pr_number": 456,
+        "feature_number": None,
+        "base_sha": "abcdef1234567",
+        "head_sha": "1234567abcdef",
+        "workflow_main_sha": "abcdef1234567",
+        "model": None,
+        "changed_files_count": 3,
+        "changed_lines": 40,
+        "acceptance_criteria_count": 5,
+    }
+    phase.write_text(json.dumps(data), encoding="utf-8")
+    _record(repo, "task-delivery", phase)
+    _run(repo, "finish", "--task", "123", check=True)
+    summary = _run(
+        repo,
+        "summarize",
+        "--task",
+        "123",
+        "--format",
+        "json",
+        check=True,
+    )
+    run = json.loads(summary.stdout)["run"]
+    assert run["pr_number"] == 456
+    assert run["base_sha"] == "abcdef1234567"
+    assert run["head_sha"] == "1234567abcdef"

--- a/tools/agent_workflow/telemetry.py
+++ b/tools/agent_workflow/telemetry.py
@@ -1721,11 +1721,9 @@ def _command_start(args: argparse.Namespace) -> int:
     active_file = config.output_dir / "active" / f"task-{args.task}.json"
     if active_file.exists():
         active = _read_json(active_file)
-        raise TelemetryError(
-            (
-                f"Task #{args.task} already has active run "
-                f"{active.get('run_id', 'unknown')}"
-            )
+        raise TelemetryError(        
+            f"Task #{args.task} already has active run "
+            f"{active.get('run_id', 'unknown')}"    
         )
     now = _utc_now()
     timestamp = now[:19].replace(":", "").replace("-", "")

--- a/tools/agent_workflow/telemetry.py
+++ b/tools/agent_workflow/telemetry.py
@@ -261,6 +261,7 @@ def _is_within(path: Path, parent: Path) -> bool:
         return False
     return True
 
+
 def _gitignore_patterns(repo_root: Path) -> set[str]:
     ignore_file = repo_root / ".gitignore"
     if not ignore_file.exists():
@@ -839,9 +840,7 @@ def _aggregate_events(
             )
             operations[aggregate_field] = {
                 category: _sum_optional(
-                    event.get("operations", {})
-                    .get(aggregate_field, {})
-                    .get(category)
+                    event.get("operations", {}).get(aggregate_field, {}).get(category)
                     for event in phase_events
                     if isinstance(event.get("operations"), dict)
                 )
@@ -1226,11 +1225,7 @@ def _validate_manifest(value: Any) -> dict[str, Any]:
     for field in ("workflow_main_sha", "base_sha", "head_sha"):
         _validate_sha(value.get(field), field)
     task_title = value.get("task_canonical_title")
-    if (
-        not isinstance(task_title, str)
-        or not task_title
-        or len(task_title) > 512
-    ):
+    if not isinstance(task_title, str) or not task_title or len(task_title) > 512:
         raise TelemetryError("manifest task_canonical_title is invalid")
     model = value.get("model")
     if model is not None and (
@@ -1295,8 +1290,13 @@ def _validate_event(event: Any) -> dict[str, Any]:
     _reject_sensitive(event)
     if event_type == "usage-patch":
         patch_allowed = {
-            "schema_version", "event_id", "event_type", "phase",
-            "target_event_id", "recorded_at", "usage",
+            "schema_version",
+            "event_id",
+            "event_type",
+            "phase",
+            "target_event_id",
+            "recorded_at",
+            "usage",
         }
         if set(event) - patch_allowed:
             raise TelemetryError("usage patch contains unsupported fields")
@@ -1651,14 +1651,8 @@ def _markdown_summary(
                 "- Validation all passed: `"
                 f"{summary['quality']['validation_all_passed']}`"
             ),
-            (
-                "- Review invalidations: `"
-                f"{summary['quality']['review_invalidations']}`"
-            ),
-            (
-                "- Maintainer decisions: `"
-                f"{summary['quality']['maintainer_decisions']}`"
-            ),
+            (f"- Review invalidations: `{summary['quality']['review_invalidations']}`"),
+            (f"- Maintainer decisions: `{summary['quality']['maintainer_decisions']}`"),
             f"- Limitations: `{'; '.join(summary['limitations']) or 'none'}`",
         ]
     )
@@ -1721,9 +1715,9 @@ def _command_start(args: argparse.Namespace) -> int:
     active_file = config.output_dir / "active" / f"task-{args.task}.json"
     if active_file.exists():
         active = _read_json(active_file)
-        raise TelemetryError(        
+        raise TelemetryError(
             f"Task #{args.task} already has active run "
-            f"{active.get('run_id', 'unknown')}"    
+            f"{active.get('run_id', 'unknown')}"
         )
     now = _utc_now()
     timestamp = now[:19].replace(":", "").replace("-", "")

--- a/tools/agent_workflow/telemetry.py
+++ b/tools/agent_workflow/telemetry.py
@@ -1,0 +1,2090 @@
+#!/usr/bin/env python3
+"""Local, append-only telemetry for repository Task workflows."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import secrets
+import statistics
+import sys
+import tempfile
+import tomllib
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Final
+
+SCHEMA_VERSION: Final = 1
+MODES: Final = frozenset({"baseline-only", "spot-check"})
+PHASES: Final = frozenset(
+    {
+        "task-specification",
+        "task-delivery",
+        "task-pr-review",
+        "manual-merge",
+        "task-closeout",
+        "feature-completion-audit",
+    }
+)
+EVENT_TYPES: Final = frozenset(
+    {
+        "phase-summary",
+        "interruption",
+        "rework",
+        "review-run",
+        "manual-merge",
+        "usage-patch",
+    }
+)
+USAGE_SOURCES: Final = frozenset(
+    {"runtime-exact", "client-export", "estimated-external", "unavailable"}
+)
+EXACT_USAGE_SOURCES: Final = frozenset({"runtime-exact", "client-export"})
+CONTEXT_CATEGORIES: Final = frozenset(
+    {
+        "task_and_comments",
+        "governance",
+        "skills_and_policies",
+        "templates_and_workflows",
+        "source",
+        "tests",
+        "documentation",
+        "pr_diff_and_commits",
+        "github_facts",
+        "validation_output",
+        "previous_handoff",
+        "other",
+    }
+)
+CONTEXT_METRICS: Final = frozenset(
+    {"files_read", "bytes_read", "lines_read", "repeated_bytes_estimate"}
+)
+RETRY_CATEGORIES: Final = frozenset(
+    {
+        "sandbox-permission",
+        "credential-session",
+        "filesystem-isolation",
+        "real-validation-failure",
+        "remote-failure",
+        "other",
+    }
+)
+COMMAND_CATEGORIES: Final = frozenset(
+    {
+        "git-read",
+        "git-write-authorized",
+        "github-read",
+        "github-write-authorized",
+        "validator",
+        "test",
+        "lint",
+        "format",
+        "type-check",
+        "telemetry",
+        "other",
+    }
+)
+SEVERITIES: Final = frozenset({"blocking", "high", "medium", "low", "nit"})
+ALLOWED_RECORD_KEYS: Final = frozenset(
+    {
+        "schema_version",
+        "event_type",
+        "recorded_at",
+        "identity",
+        "usage",
+        "context",
+        "operations",
+        "report",
+        "rework",
+        "outcome",
+        "limitations",
+    }
+)
+SENSITIVE_KEYS: Final = frozenset(
+    {
+        "prompt",
+        "raw_prompt",
+        "assistant_response",
+        "raw_response",
+        "transcript",
+        "raw_transcript",
+        "stdout",
+        "stderr",
+        "command_output",
+        "raw_command_output",
+        "file_content",
+        "file_contents",
+        "source_code",
+        "private_reasoning",
+        "chain_of_thought",
+        "environment",
+        "environment_variables",
+        "env",
+        "headers",
+        "authorization",
+        "cookie",
+        "password",
+        "secret",
+        "api_key",
+        "api_token",
+        "auth_token",
+        "bearer_token",
+        "token",
+        "github_token",
+        "access_token",
+        "refresh_token",
+        "private_key",
+    }
+)
+WINDOWS_ABSOLUTE_PATH = re.compile(r"^[A-Za-z]:[\\/]")
+SAFE_SLUG = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
+SAFE_RUN_ID = re.compile(r"^tw-[1-9][0-9]*-[0-9]{8}T[0-9]{6}-[0-9a-f]{8}$")
+SAFE_EVENT_ID = re.compile(r"^ev-[0-9]{6}-[0-9a-f]{8}$")
+REPOSITORY_SLUG = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+SHA_PATTERN = re.compile(r"^[0-9a-fA-F]{7,64}$")
+SENSITIVE_VALUE_PATTERNS: Final = (
+    re.compile(r"gh[pousr]_[A-Za-z0-9]{20,}"),
+    re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._~-]{16,}"),
+    re.compile(r"-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----"),
+)
+
+
+class TelemetryError(RuntimeError):
+    """Expected user-facing telemetry error."""
+
+
+@dataclass(frozen=True)
+class Config:
+    path: Path
+    output_dir: Path
+    default_mode: str
+    allow_usage_patch: bool
+
+
+@dataclass(frozen=True)
+class RunPaths:
+    output_dir: Path
+    active_file: Path
+    run_dir: Path
+    manifest_file: Path
+    events_file: Path
+    summary_file: Path
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _parse_timestamp(value: str, field: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise TelemetryError(f"{field} must be an ISO-8601 timestamp") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise TelemetryError(f"{field} must include a timezone")
+    return parsed.astimezone(UTC)
+
+
+def _print_json(value: Mapping[str, Any]) -> None:
+    print(json.dumps(value, ensure_ascii=False, sort_keys=True))
+
+
+def _read_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise TelemetryError(f"required file is missing: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise TelemetryError(f"invalid JSON in {path}: {exc}") from exc
+
+
+def _atomic_write_json(path: Path, value: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    with tempfile.NamedTemporaryFile(
+        "w",
+        encoding="utf-8",
+        newline="\n",
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        delete=False,
+    ) as handle:
+        handle.write(payload)
+        handle.flush()
+        os.fsync(handle.fileno())
+        temp_name = handle.name
+    os.replace(temp_name, path)
+
+
+def _append_jsonl(path: Path, value: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(value, ensure_ascii=False, sort_keys=True) + "\n"
+    with path.open("a", encoding="utf-8", newline="\n") as handle:
+        handle.write(payload)
+        handle.flush()
+        os.fsync(handle.fileno())
+
+
+def _read_events(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    events: list[dict[str, Any]] = []
+    lines = path.read_text(encoding="utf-8").splitlines()
+    for line_number, line in enumerate(lines, 1):
+        if not line.strip():
+            continue
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise TelemetryError(
+                f"invalid JSONL event at {path}:{line_number}: {exc}"
+            ) from exc
+        if not isinstance(value, dict):
+            raise TelemetryError(f"event at {path}:{line_number} is not an object")
+        events.append(value)
+    return events
+
+
+def _normalize_relative(path: Path) -> str:
+    return path.as_posix().lstrip("./")
+
+
+def _is_within(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def _gitignore_patterns(repo_root: Path) -> set[str]:
+    ignore_file = repo_root / ".gitignore"
+    if not ignore_file.exists():
+        return set()
+    patterns: set[str] = set()
+    for raw_line in ignore_file.read_text(encoding="utf-8-sig").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or line.startswith("!"):
+            continue
+        patterns.add(line.lstrip("./"))
+    return patterns
+
+
+def _require_exact_ignore(repo_root: Path, path: Path, *, directory: bool) -> None:
+    resolved = path.resolve()
+    root = repo_root.resolve()
+    if not _is_within(resolved, root):
+        return
+    relative = _normalize_relative(resolved.relative_to(root))
+    candidates = {relative}
+    if directory:
+        candidates.add(f"{relative.rstrip('/')}/")
+    patterns = _gitignore_patterns(root)
+    if not candidates.intersection(patterns):
+        kind = "directory" if directory else "file"
+        raise TelemetryError(
+            f"local telemetry {kind} is not covered by an exact .gitignore rule: "
+            f"{relative}"
+        )
+
+
+def _load_config(repo_root: Path, config_arg: str) -> Config:
+    config_path = Path(config_arg)
+    if not config_path.is_absolute():
+        config_path = repo_root / config_path
+    config_path = config_path.resolve()
+    if not config_path.exists():
+        raise TelemetryError("local telemetry config is missing")
+    _require_exact_ignore(repo_root, config_path, directory=False)
+    try:
+        data = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise TelemetryError(f"invalid telemetry config: {exc}") from exc
+    allowed = {
+        "schema_version",
+        "output_dir",
+        "default_mode",
+        "store_raw_transcript",
+        "store_command_output",
+        "store_file_contents",
+        "allow_usage_patch",
+    }
+    unknown = set(data) - allowed
+    if unknown:
+        raise TelemetryError(f"unknown telemetry config keys: {sorted(unknown)}")
+    if data.get("schema_version") != SCHEMA_VERSION:
+        raise TelemetryError("unsupported telemetry config schema_version")
+    default_mode = data.get("default_mode")
+    if default_mode not in MODES:
+        raise TelemetryError("default_mode must be baseline-only or spot-check")
+    for key in ("store_raw_transcript", "store_command_output", "store_file_contents"):
+        if data.get(key) is not False:
+            raise TelemetryError(f"{key} must remain false in schema version 1")
+    allow_usage_patch = data.get("allow_usage_patch")
+    if not isinstance(allow_usage_patch, bool):
+        raise TelemetryError("allow_usage_patch must be a boolean")
+    output_value = data.get("output_dir")
+    if not isinstance(output_value, str) or not output_value.strip():
+        raise TelemetryError("output_dir must be a non-empty path string")
+    if "://" in output_value:
+        raise TelemetryError("network output endpoints are not allowed")
+    output_dir = Path(output_value)
+    if not output_dir.is_absolute():
+        output_dir = repo_root / output_dir
+    output_dir = output_dir.resolve()
+    if output_dir == repo_root.resolve():
+        raise TelemetryError("output_dir cannot be the repository root")
+    _require_exact_ignore(repo_root, output_dir, directory=True)
+    return Config(
+        path=config_path,
+        output_dir=output_dir,
+        default_mode=default_mode,
+        allow_usage_patch=allow_usage_patch,
+    )
+
+
+def _run_paths(config: Config, task: int, run_id: str) -> RunPaths:
+    return RunPaths(
+        output_dir=config.output_dir,
+        active_file=config.output_dir / "active" / f"task-{task}.json",
+        run_dir=config.output_dir / "runs" / run_id,
+        manifest_file=config.output_dir / "runs" / run_id / "manifest.json",
+        events_file=config.output_dir / "runs" / run_id / "events.jsonl",
+        summary_file=config.output_dir / "runs" / run_id / "summary.json",
+    )
+
+
+def _active_run(config: Config, task: int) -> tuple[str, RunPaths]:
+    active_file = config.output_dir / "active" / f"task-{task}.json"
+    active = _read_json(active_file)
+    if not isinstance(active, dict) or not isinstance(active.get("run_id"), str):
+        raise TelemetryError(f"invalid active pointer: {active_file}")
+    run_id = active["run_id"]
+    return run_id, _run_paths(config, task, run_id)
+
+
+def _validate_slug(value: str, field: str) -> str:
+    if not SAFE_SLUG.fullmatch(value):
+        raise TelemetryError(f"{field} must be a lowercase slug")
+    return value
+
+
+def _validate_sha(value: Any, field: str) -> None:
+    if value is not None and (
+        not isinstance(value, str) or not SHA_PATTERN.fullmatch(value)
+    ):
+        raise TelemetryError(f"{field} must be a Git SHA or null")
+
+
+def _reject_sensitive(value: Any, path: str = "data") -> None:
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            normalized = str(key).strip().lower()
+            if normalized in SENSITIVE_KEYS:
+                raise TelemetryError(
+                    f"sensitive or raw-content field is forbidden: {path}.{key}"
+                )
+            _reject_sensitive(nested, f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            _reject_sensitive(nested, f"{path}[{index}]")
+    elif isinstance(value, str):
+        if WINDOWS_ABSOLUTE_PATH.match(value):
+            raise TelemetryError(
+                f"machine-sensitive absolute path is forbidden: {path}"
+            )
+        if value.startswith("/") and not value.startswith("//"):
+            raise TelemetryError(f"absolute path is forbidden: {path}")
+        if any(pattern.search(value) for pattern in SENSITIVE_VALUE_PATTERNS):
+            raise TelemetryError(f"sensitive value is forbidden: {path}")
+
+
+def _nonnegative_int_or_null(value: Any, field: str) -> None:
+    if value is not None and (
+        isinstance(value, bool) or not isinstance(value, int) or value < 0
+    ):
+        raise TelemetryError(f"{field} must be a non-negative integer or null")
+
+
+def _validate_usage(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise TelemetryError("usage must be an object")
+    allowed = {
+        "source",
+        "input_tokens",
+        "cached_input_tokens",
+        "output_tokens",
+        "reasoning_tokens",
+        "total_tokens",
+        "model",
+    }
+    unknown = set(value) - allowed
+    if unknown:
+        raise TelemetryError(f"unknown usage fields: {sorted(unknown)}")
+    source = value.get("source")
+    if source not in USAGE_SOURCES:
+        raise TelemetryError(f"usage.source must be one of {sorted(USAGE_SOURCES)}")
+    normalized = dict(value)
+    for field in (
+        "input_tokens",
+        "cached_input_tokens",
+        "output_tokens",
+        "reasoning_tokens",
+        "total_tokens",
+    ):
+        _nonnegative_int_or_null(normalized.get(field), f"usage.{field}")
+        normalized.setdefault(field, None)
+    model = normalized.get("model")
+    if model is not None and (not isinstance(model, str) or len(model) > 128):
+        raise TelemetryError("usage.model must be a short string or null")
+    normalized.setdefault("model", None)
+    if source == "unavailable":
+        token_fields = (field for field in allowed if field.endswith("_tokens"))
+        if any(normalized[field] is not None for field in token_fields):
+            raise TelemetryError("unavailable usage must use null token fields")
+    input_tokens = normalized["input_tokens"]
+    output_tokens = normalized["output_tokens"]
+    total_tokens = normalized["total_tokens"]
+    if input_tokens is not None and output_tokens is not None:
+        computed = input_tokens + output_tokens
+        if total_tokens is None:
+            normalized["total_tokens"] = computed
+        elif total_tokens != computed:
+            raise TelemetryError(
+                "usage.total_tokens must equal input_tokens + output_tokens"
+            )
+    return normalized
+
+
+def _validate_context(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise TelemetryError("context must be an object")
+    unknown_categories = set(value) - CONTEXT_CATEGORIES
+    if unknown_categories:
+        raise TelemetryError(
+            f"unknown context categories: {sorted(unknown_categories)}"
+        )
+    normalized: dict[str, Any] = {}
+    for category, metrics in value.items():
+        if not isinstance(metrics, dict):
+            raise TelemetryError(f"context.{category} must be an object")
+        unknown_metrics = set(metrics) - CONTEXT_METRICS
+        if unknown_metrics:
+            raise TelemetryError(
+                f"unknown context metrics for {category}: {sorted(unknown_metrics)}"
+            )
+        item: dict[str, Any] = {}
+        for metric in CONTEXT_METRICS:
+            metric_value = metrics.get(metric)
+            _nonnegative_int_or_null(metric_value, f"context.{category}.{metric}")
+            item[metric] = metric_value
+        normalized[category] = item
+    return normalized
+
+
+def _validate_operations(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise TelemetryError("operations must be an object")
+    counters = {
+        "tool_calls",
+        "github_queries",
+        "git_commands",
+        "validation_commands",
+        "sandbox_attempts",
+        "elevated_attempts",
+        "retries",
+    }
+    allowed = counters | {"retry_categories", "command_categories"}
+    unknown = set(value) - allowed
+    if unknown:
+        raise TelemetryError(f"unknown operations fields: {sorted(unknown)}")
+    normalized: dict[str, Any] = {}
+    for field in counters:
+        field_value = value.get(field)
+        _nonnegative_int_or_null(field_value, f"operations.{field}")
+        normalized[field] = field_value
+    retry_categories = value.get("retry_categories", {})
+    if not isinstance(retry_categories, dict):
+        raise TelemetryError("operations.retry_categories must be an object")
+    if set(retry_categories) - RETRY_CATEGORIES:
+        raise TelemetryError("operations.retry_categories contains unsupported values")
+    normalized_retries: dict[str, int] = {}
+    for category in sorted(RETRY_CATEGORIES):
+        count = retry_categories.get(category, 0)
+        _nonnegative_int_or_null(count, f"operations.retry_categories.{category}")
+        if count is None:
+            raise TelemetryError("retry category counts cannot be null")
+        normalized_retries[category] = count
+    normalized["retry_categories"] = normalized_retries
+    command_categories = value.get("command_categories", {})
+    if not isinstance(command_categories, dict):
+        raise TelemetryError("operations.command_categories must be an object")
+    if set(command_categories) - COMMAND_CATEGORIES:
+        raise TelemetryError(
+            "operations.command_categories contains unsupported values"
+        )
+    normalized_commands: dict[str, int] = {}
+    for category in sorted(COMMAND_CATEGORIES):
+        count = command_categories.get(category, 0)
+        _nonnegative_int_or_null(count, f"operations.command_categories.{category}")
+        if count is None:
+            raise TelemetryError("command category counts cannot be null")
+        normalized_commands[category] = count
+    normalized["command_categories"] = normalized_commands
+    return normalized
+
+
+def _validate_report(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise TelemetryError("report must be an object")
+    allowed = {
+        "report_characters",
+        "report_lines",
+        "report_estimated_tokens",
+        "report_estimation_method",
+        "copied_to_next_phase",
+    }
+    unknown = set(value) - allowed
+    if unknown:
+        raise TelemetryError(f"unknown report fields: {sorted(unknown)}")
+    normalized = dict(value)
+    for field in ("report_characters", "report_lines", "report_estimated_tokens"):
+        field_value = normalized.get(field)
+        _nonnegative_int_or_null(field_value, f"report.{field}")
+        normalized.setdefault(field, None)
+    method = normalized.get("report_estimation_method")
+    if method is not None and (not isinstance(method, str) or len(method) > 128):
+        raise TelemetryError("report_estimation_method must be a short string or null")
+    normalized.setdefault("report_estimation_method", None)
+    copied = normalized.get("copied_to_next_phase")
+    if copied is not None and not isinstance(copied, bool):
+        raise TelemetryError("copied_to_next_phase must be boolean or null")
+    normalized.setdefault("copied_to_next_phase", None)
+    return normalized
+
+
+def _validate_rework(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise TelemetryError("rework must be an object")
+    counters = {
+        "commits_added_after_first_handoff",
+        "head_sha_changes",
+        "independent_review_runs",
+        "review_invalidations",
+        "maintainer_decisions",
+        "interruptions",
+    }
+    allowed = counters | {"findings_by_severity"}
+    unknown = set(value) - allowed
+    if unknown:
+        raise TelemetryError(f"unknown rework fields: {sorted(unknown)}")
+    normalized: dict[str, Any] = {}
+    for field in counters:
+        field_value = value.get(field)
+        _nonnegative_int_or_null(field_value, f"rework.{field}")
+        normalized[field] = field_value
+    findings = value.get("findings_by_severity", {})
+    if not isinstance(findings, dict) or set(findings) - SEVERITIES:
+        raise TelemetryError("findings_by_severity contains unsupported values")
+    normalized_findings: dict[str, int] = {}
+    for severity in sorted(SEVERITIES):
+        count = findings.get(severity, 0)
+        _nonnegative_int_or_null(count, f"rework.findings_by_severity.{severity}")
+        if count is None:
+            raise TelemetryError("finding counts cannot be null")
+        normalized_findings[severity] = count
+    normalized["findings_by_severity"] = normalized_findings
+    return normalized
+
+
+def _validate_outcome(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise TelemetryError("outcome must be an object")
+    allowed = {
+        "phase_result",
+        "workflow_result",
+        "review_verdict",
+        "feature_audit_verdict",
+        "validation_passed",
+        "telemetry_complete",
+    }
+    unknown = set(value) - allowed
+    if unknown:
+        raise TelemetryError(f"unknown outcome fields: {sorted(unknown)}")
+    normalized = dict(value)
+    for field in (
+        "phase_result",
+        "workflow_result",
+        "review_verdict",
+        "feature_audit_verdict",
+    ):
+        field_value = normalized.get(field)
+        if field_value is not None and (
+            not isinstance(field_value, str) or len(field_value) > 256
+        ):
+            raise TelemetryError(f"outcome.{field} must be a short string or null")
+        normalized.setdefault(field, None)
+    for field in ("validation_passed", "telemetry_complete"):
+        field_value = normalized.get(field)
+        if field_value is not None and not isinstance(field_value, bool):
+            raise TelemetryError(f"outcome.{field} must be boolean or null")
+        normalized.setdefault(field, None)
+    return normalized
+
+
+def _validate_identity(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise TelemetryError("identity must be an object")
+    allowed = {
+        "task_canonical_title",
+        "pr_number",
+        "feature_number",
+        "base_sha",
+        "head_sha",
+        "workflow_main_sha",
+        "model",
+        "changed_files_count",
+        "changed_lines",
+        "acceptance_criteria_count",
+    }
+    unknown = set(value) - allowed
+    if unknown:
+        raise TelemetryError(f"unknown identity fields: {sorted(unknown)}")
+    normalized = dict(value)
+    for field in (
+        "pr_number",
+        "feature_number",
+        "changed_files_count",
+        "changed_lines",
+        "acceptance_criteria_count",
+    ):
+        field_value = normalized.get(field)
+        _nonnegative_int_or_null(field_value, f"identity.{field}")
+        normalized.setdefault(field, None)
+    for field in ("base_sha", "head_sha", "workflow_main_sha"):
+        _validate_sha(normalized.get(field), f"identity.{field}")
+        normalized.setdefault(field, None)
+    for field in ("task_canonical_title", "model"):
+        field_value = normalized.get(field)
+        if field_value is not None and (
+            not isinstance(field_value, str) or len(field_value) > 512
+        ):
+            raise TelemetryError(f"identity.{field} must be a short string or null")
+        normalized.setdefault(field, None)
+    return normalized
+
+
+def _validate_record_data(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise TelemetryError("phase data must be a JSON object")
+    _reject_sensitive(value)
+    unknown = set(value) - ALLOWED_RECORD_KEYS
+    if unknown:
+        raise TelemetryError(f"unknown phase data fields: {sorted(unknown)}")
+    if value.get("schema_version") != SCHEMA_VERSION:
+        raise TelemetryError("phase data schema_version must be 1")
+    event_type = value.get("event_type", "phase-summary")
+    if event_type not in EVENT_TYPES - {"usage-patch"}:
+        raise TelemetryError("unsupported record event_type")
+    normalized: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "event_type": event_type,
+    }
+    recorded_at = value.get("recorded_at")
+    if recorded_at is not None:
+        if not isinstance(recorded_at, str):
+            raise TelemetryError("recorded_at must be an ISO timestamp string or null")
+        _parse_timestamp(recorded_at, "recorded_at")
+    normalized["recorded_at"] = recorded_at
+    if "identity" in value:
+        normalized["identity"] = _validate_identity(value["identity"])
+    if "usage" in value:
+        normalized["usage"] = _validate_usage(value["usage"])
+    if "context" in value:
+        normalized["context"] = _validate_context(value["context"])
+    if "operations" in value:
+        normalized["operations"] = _validate_operations(value["operations"])
+    if "report" in value:
+        normalized["report"] = _validate_report(value["report"])
+    if "rework" in value:
+        normalized["rework"] = _validate_rework(value["rework"])
+    if "outcome" in value:
+        normalized["outcome"] = _validate_outcome(value["outcome"])
+    limitations = value.get("limitations", [])
+    if not isinstance(limitations, list) or not all(
+        isinstance(item, str) and len(item) <= 512 for item in limitations
+    ):
+        raise TelemetryError("limitations must be a list of short strings")
+    normalized["limitations"] = limitations
+    return normalized
+
+
+def _usage_priority(source: str) -> int:
+    return {
+        "unavailable": 0,
+        "estimated-external": 1,
+        "client-export": 2,
+        "runtime-exact": 3,
+    }[source]
+
+
+def _events_with_patches(events: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
+    by_id = {
+        event.get("event_id"): dict(event)
+        for event in events
+        if event.get("event_type") != "usage-patch"
+    }
+    order = [
+        event.get("event_id")
+        for event in events
+        if event.get("event_type") != "usage-patch"
+    ]
+    for patch in events:
+        if patch.get("event_type") != "usage-patch":
+            continue
+        target = patch.get("target_event_id")
+        if target in by_id:
+            current = by_id[target].get("usage")
+            incoming = patch.get("usage")
+            if isinstance(incoming, dict) and (
+                not isinstance(current, dict)
+                or _usage_priority(incoming["source"])
+                >= _usage_priority(current["source"])
+            ):
+                by_id[target]["usage"] = incoming
+    return [by_id[event_id] for event_id in order if event_id in by_id]
+
+
+def _sum_optional(values: Iterable[Any]) -> int | None:
+    present = [
+        value
+        for value in values
+        if isinstance(value, int) and not isinstance(value, bool)
+    ]
+    return sum(present) if present else None
+
+
+def _aggregate_events(
+    manifest: Mapping[str, Any],
+    events: Sequence[dict[str, Any]],
+) -> dict[str, Any]:
+    effective = _events_with_patches(events)
+    phases: dict[str, dict[str, Any]] = {}
+    for phase in sorted(PHASES):
+        phase_events = [event for event in effective if event.get("phase") == phase]
+        if not phase_events:
+            continue
+        usages = [
+            event.get("usage")
+            for event in phase_events
+            if isinstance(event.get("usage"), dict)
+        ]
+        phase_usage: dict[str, Any] = {
+            "sources": sorted({usage["source"] for usage in usages}),
+            "input_tokens": _sum_optional(
+                usage.get("input_tokens") for usage in usages
+            ),
+            "cached_input_tokens": _sum_optional(
+                usage.get("cached_input_tokens") for usage in usages
+            ),
+            "output_tokens": _sum_optional(
+                usage.get("output_tokens") for usage in usages
+            ),
+            "reasoning_tokens": _sum_optional(
+                usage.get("reasoning_tokens") for usage in usages
+            ),
+            "total_tokens": _sum_optional(
+                usage.get("total_tokens") for usage in usages
+            ),
+        }
+        context: dict[str, dict[str, int | None]] = {}
+        for category in sorted(CONTEXT_CATEGORIES):
+            category_values = [
+                event["context"][category]
+                for event in phase_events
+                if isinstance(event.get("context"), dict)
+                and isinstance(event["context"].get(category), dict)
+            ]
+            if category_values:
+                context[category] = {
+                    metric: _sum_optional(item.get(metric) for item in category_values)
+                    for metric in sorted(CONTEXT_METRICS)
+                }
+        operations_fields = (
+            "tool_calls",
+            "github_queries",
+            "git_commands",
+            "validation_commands",
+            "sandbox_attempts",
+            "elevated_attempts",
+            "retries",
+        )
+        operations = {
+            field: _sum_optional(
+                event.get("operations", {}).get(field)
+                for event in phase_events
+                if isinstance(event.get("operations"), dict)
+            )
+            for field in operations_fields
+        }
+        for aggregate_field in ("retry_categories", "command_categories"):
+            category_names = (
+                RETRY_CATEGORIES
+                if aggregate_field == "retry_categories"
+                else COMMAND_CATEGORIES
+            )
+            operations[aggregate_field] = {
+                category: _sum_optional(
+                    event.get("operations", {}).get(aggregate_field, {}).get(category)
+                    for event in phase_events
+                    if isinstance(event.get("operations"), dict)
+                )
+                for category in sorted(category_names)
+            }
+        report_fields = (
+            "report_characters",
+            "report_lines",
+            "report_estimated_tokens",
+        )
+        report = {
+            field: _sum_optional(
+                event.get("report", {}).get(field)
+                for event in phase_events
+                if isinstance(event.get("report"), dict)
+            )
+            for field in report_fields
+        }
+        report["estimation_methods"] = sorted(
+            {
+                event.get("report", {}).get("report_estimation_method")
+                for event in phase_events
+                if isinstance(event.get("report"), dict)
+                and isinstance(
+                    event.get("report", {}).get("report_estimation_method"),
+                    str,
+                )
+            }
+        )
+        report["copied_to_next_phase_count"] = sum(
+            1
+            for event in phase_events
+            if isinstance(event.get("report"), dict)
+            and event.get("report", {}).get("copied_to_next_phase") is True
+        )
+        rework_fields = (
+            "commits_added_after_first_handoff",
+            "head_sha_changes",
+            "independent_review_runs",
+            "review_invalidations",
+            "maintainer_decisions",
+            "interruptions",
+        )
+        rework = {
+            field: _sum_optional(
+                event.get("rework", {}).get(field)
+                for event in phase_events
+                if isinstance(event.get("rework"), dict)
+            )
+            for field in rework_fields
+        }
+        findings: dict[str, int | None] = {}
+        for severity in sorted(SEVERITIES):
+            findings[severity] = _sum_optional(
+                event.get("rework", {}).get("findings_by_severity", {}).get(severity)
+                for event in phase_events
+                if isinstance(event.get("rework"), dict)
+            )
+        rework["findings_by_severity"] = findings
+        outcome_fields = (
+            "phase_result",
+            "workflow_result",
+            "review_verdict",
+            "feature_audit_verdict",
+        )
+        outcomes = {
+            field: sorted(
+                {
+                    event.get("outcome", {}).get(field)
+                    for event in phase_events
+                    if isinstance(event.get("outcome"), dict)
+                    and isinstance(event.get("outcome", {}).get(field), str)
+                }
+            )
+            for field in outcome_fields
+        }
+        for field in ("validation_passed", "telemetry_complete"):
+            outcomes[field] = [
+                event.get("outcome", {}).get(field)
+                for event in phase_events
+                if isinstance(event.get("outcome"), dict)
+                and isinstance(event.get("outcome", {}).get(field), bool)
+            ]
+        phases[phase] = {
+            "event_count": len(phase_events),
+            "usage": phase_usage,
+            "context": context,
+            "operations": operations,
+            "report": report,
+            "rework": rework,
+            "outcomes": outcomes,
+        }
+    total_usage = {
+        field: _sum_optional(
+            phase["usage"].get(field)
+            for phase in phases.values()
+            if isinstance(phase.get("usage"), dict)
+        )
+        for field in (
+            "input_tokens",
+            "cached_input_tokens",
+            "output_tokens",
+            "reasoning_tokens",
+            "total_tokens",
+        )
+    }
+    usage_sources = sorted(
+        {
+            source
+            for phase in phases.values()
+            for source in phase["usage"].get("sources", [])
+        }
+    )
+    usage_coverage = {
+        "events_with_usage": 0,
+        "by_source": {source: 0 for source in sorted(USAGE_SOURCES)},
+        "events_without_usage": 0,
+    }
+    for event in effective:
+        usage = event.get("usage")
+        if not isinstance(usage, dict):
+            usage_coverage["events_without_usage"] += 1
+            continue
+        usage_coverage["events_with_usage"] += 1
+        usage_coverage["by_source"][usage["source"]] += 1
+    total_findings = {
+        severity: _sum_optional(
+            phase.get("rework", {}).get("findings_by_severity", {}).get(severity)
+            for phase in phases.values()
+        )
+        for severity in sorted(SEVERITIES)
+    }
+    validation_values = [
+        value
+        for phase in phases.values()
+        for value in phase.get("outcomes", {}).get("validation_passed", [])
+    ]
+    quality = {
+        "findings_by_severity": total_findings,
+        "review_invalidations": _sum_optional(
+            phase.get("rework", {}).get("review_invalidations")
+            for phase in phases.values()
+        ),
+        "maintainer_decisions": _sum_optional(
+            phase.get("rework", {}).get("maintainer_decisions")
+            for phase in phases.values()
+        ),
+        "validation_observations": validation_values,
+        "validation_all_passed": (
+            all(validation_values) if validation_values else None
+        ),
+        "review_verdicts": sorted(
+            {
+                verdict
+                for phase in phases.values()
+                for verdict in phase.get("outcomes", {}).get("review_verdict", [])
+            }
+        ),
+        "feature_audit_verdicts": sorted(
+            {
+                verdict
+                for phase in phases.values()
+                for verdict in phase.get("outcomes", {}).get(
+                    "feature_audit_verdict", []
+                )
+            }
+        ),
+        "workflow_results": sorted(
+            {
+                result
+                for phase in phases.values()
+                for result in phase.get("outcomes", {}).get("workflow_result", [])
+            }
+        ),
+    }
+    required_phases = {
+        "task-delivery",
+        "task-pr-review",
+        "manual-merge",
+        "task-closeout",
+    }
+    if manifest.get("workflow_shape") == "task-plus-feature-audit":
+        required_phases.add("feature-completion-audit")
+    present_phases = set(phases)
+    missing_phases = sorted(required_phases - present_phases)
+    limitations = sorted(
+        {
+            item
+            for event in effective
+            for item in event.get("limitations", [])
+            if isinstance(item, str)
+        }
+    )
+    outcome_completeness = [
+        event.get("outcome", {}).get("telemetry_complete")
+        for event in effective
+        if isinstance(event.get("outcome"), dict)
+    ]
+    telemetry_complete = not missing_phases and False not in outcome_completeness
+    summarized_run = dict(manifest)
+    for event in effective:
+        identity = event.get("identity")
+        if not isinstance(identity, dict):
+            continue
+        for field in ("pr_number", "feature_number", "base_sha", "head_sha"):
+            field_value = identity.get(field)
+            if field_value is not None:
+                summarized_run[field] = field_value
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "run": summarized_run,
+        "phases": phases,
+        "total_usage": {"sources": usage_sources, **total_usage},
+        "usage_coverage": usage_coverage,
+        "quality": quality,
+        "missing_phases": missing_phases,
+        "telemetry_complete": telemetry_complete,
+        "limitations": limitations,
+    }
+
+
+def _load_manifests(config: Config) -> list[dict[str, Any]]:
+    runs_dir = config.output_dir / "runs"
+    if not runs_dir.exists():
+        return []
+    manifests: list[dict[str, Any]] = []
+    for manifest_file in sorted(runs_dir.glob("*/manifest.json")):
+        value = _read_json(manifest_file)
+        manifests.append(_validate_manifest(value))
+    return manifests
+
+
+def _active_run_by_feature(config: Config, feature: int) -> tuple[str, RunPaths] | None:
+    matches: list[tuple[str, RunPaths]] = []
+    active_dir = config.output_dir / "active"
+    if not active_dir.exists():
+        return None
+    for active_file in sorted(active_dir.glob("task-*.json")):
+        active = _read_json(active_file)
+        if not isinstance(active, dict):
+            raise TelemetryError(f"invalid active pointer: {active_file}")
+        run_id = active.get("run_id")
+        task = active.get("task_number")
+        if not isinstance(run_id, str) or not isinstance(task, int):
+            raise TelemetryError(f"invalid active pointer: {active_file}")
+        paths = _run_paths(config, task, run_id)
+        manifest = _validate_manifest(_read_json(paths.manifest_file))
+        if manifest.get("feature_number") == feature:
+            matches.append((run_id, paths))
+    if len(matches) > 1:
+        raise TelemetryError(
+            f"Feature #{feature} is associated with multiple active telemetry runs"
+        )
+    return matches[0] if matches else None
+
+
+def _select_active_run(
+    config: Config,
+    *,
+    task: int | None,
+    feature: int | None,
+) -> tuple[str, RunPaths] | None:
+    if task is not None:
+        active_file = config.output_dir / "active" / f"task-{task}.json"
+        if not active_file.exists():
+            return None
+        return _active_run(config, task)
+    if feature is not None:
+        return _active_run_by_feature(config, feature)
+    raise TelemetryError("exactly one of --task or --feature is required")
+
+
+def _locate_run(
+    config: Config,
+    *,
+    task: int | None,
+    feature: int | None,
+    run_id: str | None,
+) -> tuple[str, RunPaths]:
+    if task is None and feature is None:
+        raise TelemetryError("exactly one of --task or --feature is required")
+    if task is not None and feature is not None:
+        raise TelemetryError("--task and --feature are mutually exclusive")
+    manifests = _load_manifests(config)
+    if run_id is not None:
+        candidates = [
+            manifest for manifest in manifests if manifest.get("run_id") == run_id
+        ]
+        if len(candidates) != 1:
+            raise TelemetryError(f"run does not exist: {run_id}")
+        manifest = candidates[0]
+        if task is not None and manifest.get("task_number") != task:
+            raise TelemetryError("run does not belong to the requested Task")
+        if feature is not None and manifest.get("feature_number") != feature:
+            raise TelemetryError("run does not belong to the requested Feature")
+        manifest_task = manifest.get("task_number")
+        if not isinstance(manifest_task, int):
+            raise TelemetryError("run has an invalid task_number")
+        return run_id, _run_paths(config, manifest_task, run_id)
+    active = _select_active_run(config, task=task, feature=feature)
+    if active is not None:
+        return active
+    candidates = [
+        manifest
+        for manifest in manifests
+        if (task is not None and manifest.get("task_number") == task)
+        or (feature is not None and manifest.get("feature_number") == feature)
+    ]
+    if not candidates:
+        identity = f"Task #{task}" if task is not None else f"Feature #{feature}"
+        raise TelemetryError(f"no telemetry run found for {identity}")
+    candidates.sort(key=lambda item: str(item.get("started_at", "")), reverse=True)
+    selected = candidates[0]
+    selected_id = selected.get("run_id")
+    selected_task = selected.get("task_number")
+    if not isinstance(selected_id, str) or not isinstance(selected_task, int):
+        raise TelemetryError("latest run has invalid identity")
+    return selected_id, _run_paths(config, selected_task, selected_id)
+
+
+def _selector_identity(args: argparse.Namespace) -> dict[str, int | None]:
+    return {"task_number": args.task, "feature_number": args.feature}
+
+
+def _validate_manifest(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise TelemetryError("manifest must be an object")
+    required = {
+        "schema_version",
+        "run_id",
+        "mode",
+        "task_number",
+        "task_canonical_title",
+        "task_kind",
+        "size",
+        "risk_class",
+        "workflow_shape",
+        "repository",
+        "workflow_main_sha",
+        "model",
+        "pr_number",
+        "feature_number",
+        "base_sha",
+        "head_sha",
+        "started_at",
+        "finished_at",
+        "status",
+    }
+    missing = required - set(value)
+    unknown = set(value) - required
+    if missing:
+        raise TelemetryError(f"manifest is missing fields: {sorted(missing)}")
+    if unknown:
+        raise TelemetryError(f"manifest has unknown fields: {sorted(unknown)}")
+    if value.get("schema_version") != SCHEMA_VERSION:
+        raise TelemetryError("unsupported manifest schema_version")
+    run_id = value.get("run_id")
+    if not isinstance(run_id, str) or not SAFE_RUN_ID.fullmatch(run_id):
+        raise TelemetryError("manifest run_id is invalid")
+    if value.get("mode") not in MODES:
+        raise TelemetryError("manifest mode is invalid")
+    task_number = value.get("task_number")
+    if (
+        isinstance(task_number, bool)
+        or not isinstance(task_number, int)
+        or task_number <= 0
+    ):
+        raise TelemetryError("manifest task_number is invalid")
+    _validate_slug(str(value.get("task_kind")), "task_kind")
+    if value.get("size") not in {"S", "M", "L"}:
+        raise TelemetryError("manifest size is invalid")
+    _validate_slug(str(value.get("risk_class")), "risk_class")
+    _validate_slug(str(value.get("workflow_shape")), "workflow_shape")
+    for field in ("pr_number", "feature_number"):
+        field_value = value.get(field)
+        if field_value is not None and (
+            isinstance(field_value, bool)
+            or not isinstance(field_value, int)
+            or field_value <= 0
+        ):
+            raise TelemetryError(f"manifest {field} must be a positive integer or null")
+    for field in ("workflow_main_sha", "base_sha", "head_sha"):
+        _validate_sha(value.get(field), field)
+    task_title = value.get("task_canonical_title")
+    if not isinstance(task_title, str) or not task_title or len(task_title) > 512:
+        raise TelemetryError("manifest task_canonical_title is invalid")
+    model = value.get("model")
+    if model is not None and (
+        not isinstance(model, str) or not model or len(model) > 128
+    ):
+        raise TelemetryError("manifest model must be a short string or null")
+    repository = value.get("repository")
+    if (
+        not isinstance(repository, str)
+        or len(repository) > 256
+        or not REPOSITORY_SLUG.fullmatch(repository)
+    ):
+        raise TelemetryError("manifest repository must be owner/repository")
+    if value.get("workflow_main_sha") is None:
+        raise TelemetryError("manifest workflow_main_sha is required")
+    status = value.get("status")
+    if status not in {"active", "completed", "cancelled", "failed"}:
+        raise TelemetryError("manifest status is invalid")
+    started_at = value.get("started_at")
+    if not isinstance(started_at, str):
+        raise TelemetryError("manifest started_at is invalid")
+    started = _parse_timestamp(started_at, "manifest.started_at")
+    finished_at = value.get("finished_at")
+    if status == "active" and finished_at is not None:
+        raise TelemetryError("active manifest cannot have finished_at")
+    if status != "active" and finished_at is None:
+        raise TelemetryError("finished manifest must have finished_at")
+    if finished_at is not None:
+        if not isinstance(finished_at, str):
+            raise TelemetryError("manifest finished_at is invalid")
+        if _parse_timestamp(finished_at, "manifest.finished_at") < started:
+            raise TelemetryError("manifest finished_at precedes started_at")
+    _reject_sensitive(value)
+    return dict(value)
+
+
+def _validate_event(event: Any) -> dict[str, Any]:
+    if not isinstance(event, dict):
+        raise TelemetryError("event must be an object")
+    base_allowed = set(ALLOWED_RECORD_KEYS) | {"event_id", "phase", "target_event_id"}
+    unknown = set(event) - base_allowed
+    if unknown:
+        raise TelemetryError(f"event has unknown fields: {sorted(unknown)}")
+    required = {"schema_version", "event_id", "event_type", "phase", "recorded_at"}
+    missing = required - set(event)
+    if missing:
+        raise TelemetryError(f"event is missing fields: {sorted(missing)}")
+    if event.get("schema_version") != SCHEMA_VERSION:
+        raise TelemetryError("unsupported event schema_version")
+    event_id = event.get("event_id")
+    if not isinstance(event_id, str) or not SAFE_EVENT_ID.fullmatch(event_id):
+        raise TelemetryError("event_id is invalid")
+    event_type = event.get("event_type")
+    if event_type not in EVENT_TYPES:
+        raise TelemetryError("event_type is invalid")
+    if event.get("phase") not in PHASES:
+        raise TelemetryError("event phase is invalid")
+    recorded_at = event.get("recorded_at")
+    if not isinstance(recorded_at, str):
+        raise TelemetryError("event recorded_at is invalid")
+    _parse_timestamp(recorded_at, "event.recorded_at")
+    _reject_sensitive(event)
+    if event_type == "usage-patch":
+        patch_allowed = {
+            "schema_version",
+            "event_id",
+            "event_type",
+            "phase",
+            "target_event_id",
+            "recorded_at",
+            "usage",
+        }
+        if set(event) - patch_allowed:
+            raise TelemetryError("usage patch contains unsupported fields")
+        target = event.get("target_event_id")
+        if not isinstance(target, str) or not SAFE_EVENT_ID.fullmatch(target):
+            raise TelemetryError("usage patch target_event_id is invalid")
+        if "usage" not in event:
+            raise TelemetryError("usage patch must contain usage")
+        _validate_usage(event["usage"])
+        return dict(event)
+    if "target_event_id" in event:
+        raise TelemetryError("target_event_id is allowed only for usage patches")
+    if "identity" in event:
+        _validate_identity(event["identity"])
+    if "usage" in event:
+        _validate_usage(event["usage"])
+    if "context" in event:
+        _validate_context(event["context"])
+    if "operations" in event:
+        _validate_operations(event["operations"])
+    if "report" in event:
+        _validate_report(event["report"])
+    if "rework" in event:
+        _validate_rework(event["rework"])
+    if "outcome" in event:
+        _validate_outcome(event["outcome"])
+    limitations = event.get("limitations", [])
+    if not isinstance(limitations, list) or not all(
+        isinstance(item, str) and len(item) <= 512 for item in limitations
+    ):
+        raise TelemetryError("event limitations must be a list of short strings")
+    return dict(event)
+
+
+def _validate_run(paths: RunPaths) -> dict[str, Any]:
+    manifest = _validate_manifest(_read_json(paths.manifest_file))
+    events = _read_events(paths.events_file)
+    seen_ids: set[str] = set()
+    previous_time: datetime | None = None
+    primary_phases: set[str] = set()
+    event_ids: set[str] = set()
+    started = _parse_timestamp(manifest["started_at"], "manifest.started_at")
+    finished = (
+        _parse_timestamp(manifest["finished_at"], "manifest.finished_at")
+        if manifest["finished_at"] is not None
+        else None
+    )
+    pr_numbers: set[int] = set()
+    feature_numbers: set[int] = set()
+    for event in events:
+        validated = _validate_event(event)
+        identity = validated.get("identity")
+        if isinstance(identity, dict):
+            event_title = identity.get("task_canonical_title")
+            if (
+                event_title is not None
+                and event_title != manifest["task_canonical_title"]
+            ):
+                raise TelemetryError("event Task title conflicts with manifest")
+            event_workflow_sha = identity.get("workflow_main_sha")
+            if (
+                event_workflow_sha is not None
+                and event_workflow_sha != manifest["workflow_main_sha"]
+            ):
+                raise TelemetryError("event workflow_main_sha conflicts with manifest")
+            event_pr = identity.get("pr_number")
+            if isinstance(event_pr, int):
+                pr_numbers.add(event_pr)
+            event_feature = identity.get("feature_number")
+            if isinstance(event_feature, int):
+                feature_numbers.add(event_feature)
+        event_id = validated["event_id"]
+        if event_id in seen_ids:
+            raise TelemetryError("event IDs must be unique strings")
+        seen_ids.add(event_id)
+        parsed_time = _parse_timestamp(validated["recorded_at"], "event.recorded_at")
+        if parsed_time < started:
+            raise TelemetryError("event timestamp precedes run start")
+        if finished is not None and parsed_time > finished:
+            raise TelemetryError("event timestamp follows run finish")
+        if previous_time is not None and parsed_time < previous_time:
+            raise TelemetryError("event timestamps must be non-decreasing")
+        previous_time = parsed_time
+        if validated["event_type"] == "phase-summary":
+            phase = validated["phase"]
+            if phase in primary_phases:
+                raise TelemetryError(f"duplicate primary phase summary: {phase}")
+            primary_phases.add(phase)
+        if validated["event_type"] != "usage-patch":
+            event_ids.add(event_id)
+    if len(pr_numbers) > 1:
+        raise TelemetryError("events contain conflicting PR numbers")
+    if len(feature_numbers) > 1:
+        raise TelemetryError("events contain conflicting Feature numbers")
+    if feature_numbers and manifest["feature_number"] not in {None, *feature_numbers}:
+        raise TelemetryError("event Feature number conflicts with manifest")
+    for event in events:
+        if (
+            event.get("event_type") == "usage-patch"
+            and event.get("target_event_id") not in event_ids
+        ):
+            raise TelemetryError("usage patch targets an unknown event")
+    computed = _aggregate_events(manifest, events)
+    if paths.summary_file.exists():
+        stored = _read_json(paths.summary_file)
+        if stored != computed:
+            raise TelemetryError(
+                "stored summary does not match deterministic aggregation"
+            )
+    return {
+        "valid": True,
+        "run_id": manifest["run_id"],
+        "task_number": manifest["task_number"],
+        "event_count": len(events),
+        "telemetry_complete": computed["telemetry_complete"],
+        "missing_phases": computed["missing_phases"],
+    }
+
+
+def _require_active_manifest(paths: RunPaths) -> dict[str, Any]:
+    manifest = _validate_manifest(_read_json(paths.manifest_file))
+    if manifest["status"] != "active":
+        raise TelemetryError("telemetry run is not active")
+    return manifest
+
+
+def _ensure_append_timestamp(
+    events: Sequence[dict[str, Any]],
+    recorded_at: str,
+) -> None:
+    if not events:
+        return
+    last = events[-1].get("recorded_at")
+    if not isinstance(last, str):
+        raise TelemetryError("last event recorded_at is invalid")
+    if _parse_timestamp(recorded_at, "event.recorded_at") < _parse_timestamp(
+        last, "last event.recorded_at"
+    ):
+        raise TelemetryError("new event timestamp precedes the latest event")
+
+
+def _comparable_summaries(
+    config: Config,
+    current: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    current_run = current["run"]
+    keys = (
+        "task_kind",
+        "size",
+        "risk_class",
+        "workflow_shape",
+        "model",
+        "workflow_main_sha",
+    )
+    comparable: list[dict[str, Any]] = []
+    for manifest in _load_manifests(config):
+        if manifest.get("run_id") == current_run.get("run_id"):
+            continue
+        if manifest.get("status") != "completed":
+            continue
+        if any(manifest.get(key) != current_run.get(key) for key in keys):
+            continue
+        run_id = manifest.get("run_id")
+        task = manifest.get("task_number")
+        if not isinstance(run_id, str) or not isinstance(task, int):
+            continue
+        summary_path = _run_paths(config, task, run_id).summary_file
+        if not summary_path.exists():
+            continue
+        summary = _read_json(summary_path)
+        if isinstance(summary, dict):
+            comparable.append(summary)
+    return comparable
+
+
+def _precision_group(summary: Mapping[str, Any]) -> str:
+    sources = set(summary.get("total_usage", {}).get("sources", []))
+    measured = sources - {"unavailable"}
+    if measured and measured <= EXACT_USAGE_SOURCES:
+        return "exact"
+    if measured == {"estimated-external"}:
+        return "estimated"
+    if not measured:
+        return "unavailable"
+    return "mixed"
+
+
+def _spot_check(config: Config, summary: Mapping[str, Any]) -> dict[str, Any]:
+    comparable = _comparable_summaries(config, summary)
+    current_group = _precision_group(summary)
+    same_precision = [
+        item for item in comparable if _precision_group(item) == current_group
+    ]
+    result: dict[str, Any] = {
+        "comparable_sample_count": len(comparable),
+        "same_precision_sample_count": len(same_precision),
+        "precision_group": current_group,
+        "sample_sufficient": len(same_precision) >= 3,
+        "historical_total_median": None,
+        "historical_total_range": None,
+        "current_total_delta": None,
+        "anomaly_flags": [],
+        "limitations": [],
+    }
+    if len(same_precision) < 3:
+        result["limitations"].append(
+            "fewer than three comparable completed runs with the same usage precision"
+        )
+    current_total = summary.get("total_usage", {}).get("total_tokens")
+    historical_totals = [
+        item.get("total_usage", {}).get("total_tokens")
+        for item in same_precision
+        if isinstance(item.get("total_usage", {}).get("total_tokens"), int)
+    ]
+    flags: set[str] = set()
+    if len(historical_totals) >= 3 and isinstance(current_total, int):
+        median = statistics.median(historical_totals)
+        result["historical_total_median"] = median
+        result["historical_total_range"] = [
+            min(historical_totals),
+            max(historical_totals),
+        ]
+        result["current_total_delta"] = current_total - median
+        if median > 0 and current_total > median * 1.5:
+            flags.add("total-token-high")
+    repeated = 0
+    context_bytes = 0
+    validation_output_bytes = 0
+    retries = 0
+    report_chars = 0
+    review_invalidations = 0
+    for phase in summary.get("phases", {}).values():
+        for category, metrics in phase.get("context", {}).items():
+            bytes_read = metrics.get("bytes_read")
+            repeated_bytes = metrics.get("repeated_bytes_estimate")
+            if isinstance(bytes_read, int):
+                context_bytes += bytes_read
+                if category == "validation_output":
+                    validation_output_bytes += bytes_read
+            if isinstance(repeated_bytes, int):
+                repeated += repeated_bytes
+        phase_retries = phase.get("operations", {}).get("retries")
+        if isinstance(phase_retries, int):
+            retries += phase_retries
+        chars = phase.get("report", {}).get("report_characters")
+        if isinstance(chars, int):
+            report_chars += chars
+        invalidations = phase.get("rework", {}).get("review_invalidations")
+        if isinstance(invalidations, int):
+            review_invalidations += invalidations
+    if context_bytes > 0 and repeated / context_bytes > 0.4:
+        flags.add("repeated-context-high")
+    if context_bytes > 0 and validation_output_bytes / context_bytes > 0.4:
+        flags.add("tool-output-high")
+    if review_invalidations > 0:
+        flags.add("review-restart-high")
+    if retries >= 3:
+        flags.add("retry-high")
+    if report_chars >= 20000:
+        flags.add("report-size-high")
+    if len(same_precision) >= 3:
+        for phase_name, phase in summary.get("phases", {}).items():
+            current_phase_total = phase.get("usage", {}).get("total_tokens")
+            historical_phase = [
+                item.get("phases", {})
+                .get(phase_name, {})
+                .get("usage", {})
+                .get("total_tokens")
+                for item in same_precision
+            ]
+            values = [value for value in historical_phase if isinstance(value, int)]
+            if len(values) >= 3 and isinstance(current_phase_total, int):
+                median = statistics.median(values)
+                if median > 0 and current_phase_total > median * 1.5:
+                    flags.add("phase-token-high")
+                    break
+    result["anomaly_flags"] = sorted(flags)
+    return result
+
+
+def _markdown_summary(
+    summary: Mapping[str, Any],
+    comparison: Mapping[str, Any] | None,
+) -> str:
+    run = summary["run"]
+    lines = [
+        "# Task Workflow Telemetry Summary",
+        "",
+        f"- Run: `{run['run_id']}`",
+        f"- Task: `#{run['task_number']}` {run.get('task_canonical_title') or ''}",
+        f"- Mode: `{run['mode']}`",
+        (
+            f"- Classification: `{run['task_kind']} / {run['size']} / "
+            f"{run['risk_class']} / {run['workflow_shape']}`"
+        ),
+        f"- Workflow main SHA: `{run.get('workflow_main_sha') or 'unavailable'}`",
+        f"- Status: `{run['status']}`",
+        f"- Telemetry complete: `{str(summary['telemetry_complete']).lower()}`",
+        "",
+        "## Usage",
+        "",
+        f"- Sources: `{', '.join(summary['total_usage']['sources']) or 'unavailable'}`",
+        f"- Total tokens: `{summary['total_usage']['total_tokens']}`",
+        f"- Input tokens: `{summary['total_usage']['input_tokens']}`",
+        f"- Output tokens: `{summary['total_usage']['output_tokens']}`",
+        (
+            "- Coverage by source: `"
+            + ", ".join(
+                f"{source}={count}"
+                for source, count in summary["usage_coverage"]["by_source"].items()
+            )
+            + "`"
+        ),
+        "",
+        "## Phases",
+        "",
+        "| Phase | Events | Total tokens | Tool calls | Retries | Report chars |",
+        "| --- | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for name, phase in summary["phases"].items():
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    name,
+                    str(phase["event_count"]),
+                    str(phase["usage"]["total_tokens"]),
+                    str(phase["operations"]["tool_calls"]),
+                    str(phase["operations"]["retries"]),
+                    str(phase["report"]["report_characters"]),
+                ]
+            )
+            + " |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Quality and limitations",
+            "",
+            f"- Missing phases: `{', '.join(summary['missing_phases']) or 'none'}`",
+            (
+                "- Findings: `"
+                + ", ".join(
+                    f"{severity}={count}"
+                    for severity, count in summary["quality"][
+                        "findings_by_severity"
+                    ].items()
+                )
+                + "`"
+            ),
+            (
+                "- Validation all passed: `"
+                f"{summary['quality']['validation_all_passed']}`"
+            ),
+            (f"- Review invalidations: `{summary['quality']['review_invalidations']}`"),
+            (f"- Maintainer decisions: `{summary['quality']['maintainer_decisions']}`"),
+            f"- Limitations: `{'; '.join(summary['limitations']) or 'none'}`",
+        ]
+    )
+    if comparison is not None:
+        lines.extend(
+            [
+                "",
+                "## Spot-check",
+                "",
+                f"- Comparable samples: `{comparison['comparable_sample_count']}`",
+                (
+                    "- Same-precision samples: "
+                    f"`{comparison['same_precision_sample_count']}`"
+                ),
+                (
+                    "- Sample sufficient: "
+                    f"`{str(comparison['sample_sufficient']).lower()}`"
+                ),
+                f"- Historical median: `{comparison['historical_total_median']}`",
+                f"- Current delta: `{comparison['current_total_delta']}`",
+                (
+                    "- Anomaly flags: "
+                    f"`{', '.join(comparison['anomaly_flags']) or 'none'}`"
+                ),
+                f"- Limitations: `{'; '.join(comparison['limitations']) or 'none'}`",
+            ]
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _common_parser(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--repo-root", default=".", help="repository root")
+    parser.add_argument(
+        "--config",
+        default=".agents/task-workflow-telemetry.local.toml",
+        help="local telemetry TOML path",
+    )
+
+
+def _load_for_command(args: argparse.Namespace) -> tuple[Path, Config]:
+    repo_root = Path(args.repo_root).resolve()
+    if not repo_root.exists():
+        raise TelemetryError(f"repository root does not exist: {repo_root}")
+    return repo_root, _load_config(repo_root, args.config)
+
+
+def _command_start(args: argparse.Namespace) -> int:
+    repo_root, config = _load_for_command(args)
+    mode = args.mode or config.default_mode
+    if mode not in MODES:
+        raise TelemetryError("mode must be baseline-only or spot-check")
+    task_kind = _validate_slug(args.task_kind, "task_kind")
+    risk_class = _validate_slug(args.risk_class, "risk_class")
+    workflow_shape = _validate_slug(args.workflow_shape, "workflow_shape")
+    if args.size not in {"S", "M", "L"}:
+        raise TelemetryError("size must be S, M, or L")
+    if args.task <= 0:
+        raise TelemetryError("task number must be positive")
+    _validate_sha(args.workflow_main_sha, "workflow_main_sha")
+    active_file = config.output_dir / "active" / f"task-{args.task}.json"
+    if active_file.exists():
+        active = _read_json(active_file)
+        raise TelemetryError(
+            f"Task #{args.task} already has active run "
+            f"{active.get('run_id', 'unknown')}"
+        )
+    now = _utc_now()
+    timestamp = now[:19].replace(":", "").replace("-", "")
+    run_id = f"tw-{args.task}-{timestamp}-{secrets.token_hex(4)}"
+    paths = _run_paths(config, args.task, run_id)
+    paths.run_dir.mkdir(parents=True, exist_ok=False)
+    manifest: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "run_id": run_id,
+        "mode": mode,
+        "task_number": args.task,
+        "task_canonical_title": args.task_title,
+        "task_kind": task_kind,
+        "size": args.size,
+        "risk_class": risk_class,
+        "workflow_shape": workflow_shape,
+        "repository": args.repository,
+        "workflow_main_sha": args.workflow_main_sha,
+        "model": args.model,
+        "pr_number": None,
+        "feature_number": args.feature,
+        "base_sha": None,
+        "head_sha": None,
+        "started_at": now,
+        "finished_at": None,
+        "status": "active",
+    }
+    _validate_manifest(manifest)
+    _atomic_write_json(paths.manifest_file, manifest)
+    paths.events_file.touch(exist_ok=False)
+    active = {
+        "schema_version": SCHEMA_VERSION,
+        "run_id": run_id,
+        "task_number": args.task,
+        "mode": mode,
+        "current_phase": None,
+        "started_at": now,
+    }
+    _atomic_write_json(paths.active_file, active)
+    _print_json(
+        {
+            "active": True,
+            "run_id": run_id,
+            "task_number": args.task,
+            "mode": mode,
+            "run_path": str(paths.run_dir.relative_to(repo_root))
+            if _is_within(paths.run_dir, repo_root)
+            else "external-local-output",
+        }
+    )
+    return 0
+
+
+def _command_status(args: argparse.Namespace) -> int:
+    repo_root = Path(args.repo_root).resolve()
+    identity = _selector_identity(args)
+    try:
+        config = _load_config(repo_root, args.config)
+    except TelemetryError as exc:
+        _print_json(
+            {
+                "active": False,
+                "telemetry_available": False,
+                "reason": str(exc),
+                **identity,
+            }
+        )
+        return 0
+    active = _select_active_run(config, task=args.task, feature=args.feature)
+    if active is None:
+        _print_json(
+            {
+                "active": False,
+                "telemetry_available": True,
+                **identity,
+            }
+        )
+        return 0
+    _, paths = active
+    pointer = _read_json(paths.active_file)
+    if not isinstance(pointer, dict):
+        raise TelemetryError("active pointer is invalid")
+    events = _read_events(paths.events_file)
+    manifest = _validate_manifest(_read_json(paths.manifest_file))
+    _print_json(
+        {
+            "active": True,
+            "telemetry_available": True,
+            "task_number": manifest["task_number"],
+            "feature_number": manifest["feature_number"],
+            "run_id": manifest["run_id"],
+            "mode": manifest["mode"],
+            "current_phase": pointer.get("current_phase"),
+            "event_count": len(events),
+            "telemetry_complete": False,
+        }
+    )
+    return 0
+
+
+def _command_record(args: argparse.Namespace) -> int:
+    _, config = _load_for_command(args)
+    active = _select_active_run(config, task=args.task, feature=args.feature)
+    if active is None:
+        raise TelemetryError("no active telemetry run matches the requested identity")
+    _, paths = active
+    data = _validate_record_data(_read_json(Path(args.data_file)))
+    phase = args.phase
+    if phase not in PHASES:
+        raise TelemetryError("unsupported phase")
+    _validate_run(paths)
+    _require_active_manifest(paths)
+    events = _read_events(paths.events_file)
+    if data["event_type"] == "phase-summary" and any(
+        event.get("event_type") == "phase-summary" and event.get("phase") == phase
+        for event in events
+    ):
+        raise TelemetryError(f"primary phase summary already exists for {phase}")
+    event_id = f"ev-{len(events) + 1:06d}-{secrets.token_hex(4)}"
+    event = {
+        **data,
+        "event_id": event_id,
+        "phase": phase,
+        "recorded_at": data.get("recorded_at") or _utc_now(),
+    }
+    _validate_event(event)
+    _ensure_append_timestamp(events, event["recorded_at"])
+    _append_jsonl(paths.events_file, event)
+    active = _read_json(paths.active_file)
+    if not isinstance(active, dict):
+        raise TelemetryError("active pointer is invalid")
+    active["current_phase"] = phase
+    active["last_event_id"] = event_id
+    _atomic_write_json(paths.active_file, active)
+    _print_json(
+        {
+            "recorded": True,
+            "run_id": active["run_id"],
+            "event_id": event_id,
+            "event_type": event["event_type"],
+            "phase": phase,
+        }
+    )
+    return 0
+
+
+def _command_patch_usage(args: argparse.Namespace) -> int:
+    _, config = _load_for_command(args)
+    if not config.allow_usage_patch:
+        raise TelemetryError("usage patching is disabled by local config")
+    active = _select_active_run(config, task=args.task, feature=args.feature)
+    if active is None:
+        raise TelemetryError("no active telemetry run matches the requested identity")
+    _, paths = active
+    _validate_run(paths)
+    _require_active_manifest(paths)
+    raw = _read_json(Path(args.data_file))
+    _reject_sensitive(raw)
+    if isinstance(raw, dict) and "usage" in raw:
+        if raw.get("schema_version") != SCHEMA_VERSION:
+            raise TelemetryError("usage patch schema_version must be 1")
+        usage = _validate_usage(raw["usage"])
+    else:
+        usage = _validate_usage(raw)
+    events = _read_events(paths.events_file)
+    candidates = [
+        event
+        for event in events
+        if event.get("phase") == args.phase and event.get("event_type") != "usage-patch"
+    ]
+    if args.event_id is not None:
+        candidates = [
+            event for event in candidates if event.get("event_id") == args.event_id
+        ]
+    if not candidates:
+        raise TelemetryError("no target event found for usage patch")
+    target = candidates[-1]
+    effective = _events_with_patches(events)
+    effective_target = next(
+        (
+            event
+            for event in effective
+            if event.get("event_id") == target.get("event_id")
+        ),
+        target,
+    )
+    existing = effective_target.get("usage")
+    if isinstance(existing, dict) and existing.get("source") in EXACT_USAGE_SOURCES:
+        raise TelemetryError("existing exact usage cannot be overwritten")
+    patch_id = f"ev-{len(events) + 1:06d}-{secrets.token_hex(4)}"
+    patch = {
+        "schema_version": SCHEMA_VERSION,
+        "event_id": patch_id,
+        "event_type": "usage-patch",
+        "phase": args.phase,
+        "target_event_id": target["event_id"],
+        "recorded_at": _utc_now(),
+        "usage": usage,
+    }
+    _validate_event(patch)
+    _ensure_append_timestamp(events, patch["recorded_at"])
+    _append_jsonl(paths.events_file, patch)
+    _print_json(
+        {
+            "patched": True,
+            "event_id": patch_id,
+            "target_event_id": target["event_id"],
+            "phase": args.phase,
+            "source": usage["source"],
+        }
+    )
+    return 0
+
+
+def _command_finish(args: argparse.Namespace) -> int:
+    _, config = _load_for_command(args)
+    active = _select_active_run(config, task=args.task, feature=args.feature)
+    if active is None:
+        raise TelemetryError("no active telemetry run matches the requested identity")
+    _, paths = active
+    _validate_run(paths)
+    manifest = _require_active_manifest(paths)
+    manifest["finished_at"] = _utc_now()
+    manifest["status"] = args.status
+    _validate_manifest(manifest)
+    events = _read_events(paths.events_file)
+    summary = _aggregate_events(manifest, events)
+    _atomic_write_json(paths.manifest_file, manifest)
+    _atomic_write_json(paths.summary_file, summary)
+    paths.active_file.unlink()
+    _print_json(
+        {
+            "finished": True,
+            "run_id": manifest["run_id"],
+            "status": manifest["status"],
+            "telemetry_complete": summary["telemetry_complete"],
+            "missing_phases": summary["missing_phases"],
+        }
+    )
+    return 0
+
+
+def _command_validate(args: argparse.Namespace) -> int:
+    _, config = _load_for_command(args)
+    _, paths = _locate_run(
+        config,
+        task=args.task,
+        feature=args.feature,
+        run_id=args.run_id,
+    )
+    _print_json(_validate_run(paths))
+    return 0
+
+
+def _command_summarize(args: argparse.Namespace) -> int:
+    _, config = _load_for_command(args)
+    _, paths = _locate_run(
+        config,
+        task=args.task,
+        feature=args.feature,
+        run_id=args.run_id,
+    )
+    _validate_run(paths)
+    manifest = _validate_manifest(_read_json(paths.manifest_file))
+    events = _read_events(paths.events_file)
+    summary = _aggregate_events(manifest, events)
+    comparison = (
+        _spot_check(config, summary) if manifest["mode"] == "spot-check" else None
+    )
+    if args.format == "json":
+        result = dict(summary)
+        if comparison is not None:
+            result["spot_check"] = comparison
+        print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    else:
+        print(_markdown_summary(summary, comparison), end="")
+    return 0
+
+
+def _add_identity_selector(parser: argparse.ArgumentParser) -> None:
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--task", type=int)
+    group.add_argument("--feature", type=int)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Local, append-only Task workflow telemetry",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    start = subparsers.add_parser("start", help="start an explicit Task telemetry run")
+    _common_parser(start)
+    start.add_argument("--task", type=int, required=True)
+    start.add_argument("--task-title", required=True)
+    start.add_argument("--mode", choices=sorted(MODES))
+    start.add_argument("--task-kind", required=True)
+    start.add_argument("--size", choices=["S", "M", "L"], required=True)
+    start.add_argument("--risk-class", required=True)
+    start.add_argument("--workflow-shape", required=True)
+    start.add_argument("--repository", required=True)
+    start.add_argument("--workflow-main-sha", required=True)
+    start.add_argument("--model")
+    start.add_argument("--feature", type=int)
+    start.set_defaults(func=_command_start)
+
+    status = subparsers.add_parser("status", help="read lightweight active-run state")
+    _common_parser(status)
+    _add_identity_selector(status)
+    status.add_argument("--json", action="store_true", help=argparse.SUPPRESS)
+    status.set_defaults(func=_command_status)
+
+    record = subparsers.add_parser("record", help="append a validated phase event")
+    _common_parser(record)
+    _add_identity_selector(record)
+    record.add_argument("--phase", choices=sorted(PHASES), required=True)
+    record.add_argument("--data-file", required=True)
+    record.set_defaults(func=_command_record)
+
+    patch = subparsers.add_parser("patch-usage", help="append usage for a phase event")
+    _common_parser(patch)
+    _add_identity_selector(patch)
+    patch.add_argument("--phase", choices=sorted(PHASES), required=True)
+    patch.add_argument("--event-id")
+    patch.add_argument("--data-file", required=True)
+    patch.set_defaults(func=_command_patch_usage)
+
+    finish = subparsers.add_parser("finish", help="finish a run and write summary.json")
+    _common_parser(finish)
+    _add_identity_selector(finish)
+    finish.add_argument(
+        "--status",
+        choices=["completed", "cancelled", "failed"],
+        default="completed",
+    )
+    finish.set_defaults(func=_command_finish)
+
+    validate = subparsers.add_parser(
+        "validate",
+        help="validate a run without modifying it",
+    )
+    _common_parser(validate)
+    _add_identity_selector(validate)
+    validate.add_argument("--run-id")
+    validate.set_defaults(func=_command_validate)
+
+    summarize = subparsers.add_parser(
+        "summarize",
+        help="render a sanitized local summary",
+    )
+    _common_parser(summarize)
+    _add_identity_selector(summarize)
+    summarize.add_argument("--run-id")
+    summarize.add_argument("--format", choices=["json", "markdown"], default="json")
+    summarize.set_defaults(func=_command_summarize)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return int(args.func(args))
+    except TelemetryError as exc:
+        print(f"telemetry error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/agent_workflow/telemetry.py
+++ b/tools/agent_workflow/telemetry.py
@@ -261,7 +261,6 @@ def _is_within(path: Path, parent: Path) -> bool:
         return False
     return True
 
-
 def _gitignore_patterns(repo_root: Path) -> set[str]:
     ignore_file = repo_root / ".gitignore"
     if not ignore_file.exists():
@@ -840,7 +839,9 @@ def _aggregate_events(
             )
             operations[aggregate_field] = {
                 category: _sum_optional(
-                    event.get("operations", {}).get(aggregate_field, {}).get(category)
+                    event.get("operations", {})
+                    .get(aggregate_field, {})
+                    .get(category)
                     for event in phase_events
                     if isinstance(event.get("operations"), dict)
                 )
@@ -1225,7 +1226,11 @@ def _validate_manifest(value: Any) -> dict[str, Any]:
     for field in ("workflow_main_sha", "base_sha", "head_sha"):
         _validate_sha(value.get(field), field)
     task_title = value.get("task_canonical_title")
-    if not isinstance(task_title, str) or not task_title or len(task_title) > 512:
+    if (
+        not isinstance(task_title, str)
+        or not task_title
+        or len(task_title) > 512
+    ):
         raise TelemetryError("manifest task_canonical_title is invalid")
     model = value.get("model")
     if model is not None and (
@@ -1290,13 +1295,8 @@ def _validate_event(event: Any) -> dict[str, Any]:
     _reject_sensitive(event)
     if event_type == "usage-patch":
         patch_allowed = {
-            "schema_version",
-            "event_id",
-            "event_type",
-            "phase",
-            "target_event_id",
-            "recorded_at",
-            "usage",
+            "schema_version", "event_id", "event_type", "phase",
+            "target_event_id", "recorded_at", "usage",
         }
         if set(event) - patch_allowed:
             raise TelemetryError("usage patch contains unsupported fields")
@@ -1651,8 +1651,14 @@ def _markdown_summary(
                 "- Validation all passed: `"
                 f"{summary['quality']['validation_all_passed']}`"
             ),
-            (f"- Review invalidations: `{summary['quality']['review_invalidations']}`"),
-            (f"- Maintainer decisions: `{summary['quality']['maintainer_decisions']}`"),
+            (
+                "- Review invalidations: `"
+                f"{summary['quality']['review_invalidations']}`"
+            ),
+            (
+                "- Maintainer decisions: `"
+                f"{summary['quality']['maintainer_decisions']}`"
+            ),
             f"- Limitations: `{'; '.join(summary['limitations']) or 'none'}`",
         ]
     )
@@ -1716,8 +1722,10 @@ def _command_start(args: argparse.Namespace) -> int:
     if active_file.exists():
         active = _read_json(active_file)
         raise TelemetryError(
-            f"Task #{args.task} already has active run "
-            f"{active.get('run_id', 'unknown')}"
+            (
+                f"Task #{args.task} already has active run "
+                f"{active.get('run_id', 'unknown')}"
+            )
         )
     now = _utc_now()
     timestamp = now[:19].replace(":", "").replace("-", "")


### PR DESCRIPTION
# Pull Request

## 关联 Issue

Closes #59

## 实现摘要

- 建立 Task Workflow Telemetry 本地测量协议、example config、标准库 CLI 与测试。
- 为 task-delivery、task-pr-review、task-closeout、feature-completion-audit 增加可选 telemetry hook 边界。
- 更新命令执行策略、根 AGENTS、使用指南与 ignore 规则，保持 telemetry 为本地旁路观测。

## 修改范围

- 新增 `.agents/policies/task-workflow-telemetry.md`、`.agents/task-workflow-telemetry.example.toml`。
- 新增 `tools/agent_workflow/telemetry.py` 与 `tests/tools/test_task_workflow_telemetry.py`。
- 修改 workflow Skills、command execution policy、AGENTS、`.gitignore` 和 `docs/workflows/agent-skills.md`。

## 关键设计决定

- Telemetry 默认关闭，只有维护者显式 start 后才记录。
- 原始 telemetry 保存在 ignored local 路径，不作为 workflow 权限、门禁、验证、review verdict、merge 或 Feature completion 证据。
- CLI 仅使用 Python 标准库，不访问网络，不执行 GitHub mutation，不运行验证命令。

## 验证结果

| 命令 | 结果 | 说明 |
| --- | --- | --- |
| Example TOML parse check | 通过 | `.agents/task-workflow-telemetry.example.toml` 可解析 |
| `git check-ignore -v .agents/task-workflow-telemetry.local.toml` | 通过 | local config 被忽略 |
| `git check-ignore -v .agents/telemetry.local/example.jsonl` | 通过 | local data directory 被忽略 |
| Telemetry CLI help checks | 通过 | 顶层及 start/status/record/patch-usage/finish/validate/summarize help 均正常 |
| Skill validators | 通过 | task-delivery、task-pr-review、task-closeout、feature-completion-audit 均 valid |
| `uv lock --check` | 通过 | lock file unchanged |
| `uv run --frozen pytest` | 通过 | 48 passed |
| `uv run --frozen ruff check .` | 通过 | All checks passed |
| `uv run --frozen ruff format --check .` | 通过 | 7 files already formatted |
| `uv run --frozen mypy src tests` | 通过 | Success: no issues found |
| `git diff --check` | 通过 | whitespace clean |

## 从 Issue 复制的验收标准

- 维护者提供的完整验收标准以 #59 当前正文为准；本 PR 未重新生成或改写该文本。

## 风险检查

- [x] 未引入未授权实盘交易行为
- [x] 未提交或记录 API 密钥
- [x] 未引入无时区 datetime
- [x] 未引入未来数据泄漏
- [x] 未将缺失数据静默填零
- [x] 未绕过风险模块
- [x] 未进行范围外重构
- [x] 已测试失败路径

## 范围外内容

- 未做 token 优化、compact report、evidence runner、自动 Issue 创建、CI workflow 修改、业务源码修改或依赖变更。

## 已知限制

- 未启动本地 telemetry run；当前 delivery 未记录 telemetry 数据。
