### PR TITLE
[Task] 修复 Telemetry closeout 完整性判定与事件身份校验

### DIFF
--- a/.agents/policies/task-workflow-telemetry.md
+++ b/.agents/policies/task-workflow-telemetry.md
@@ -109,6 +109,26 @@ task-closeout
 feature-completion-audit
 ```
 
+Telemetry completeness requires only Agent-executed phases:
+
+```text
+task-only / task-with-re-review:
+  task-delivery
+  task-pr-review
+  task-closeout
+
+task-plus-feature-audit:
+  task-delivery
+  task-pr-review
+  task-closeout
+  feature-completion-audit
+```
+
+Maintainer manual Merge remains a mandatory business workflow gate, but it is
+not a required telemetry phase. `manual-merge` remains a legal optional phase
+and event type for compatibility with existing local runs; its absence does not
+make an otherwise complete run incomplete.
+
 Each Agent session writes at most one primary `phase-summary` for its phase.
 Interruption, rework, review-run, and usage-patch events may be appended
 separately. Events are append-only.
@@ -162,6 +182,11 @@ After PR creation, a phase event may supplement `pr_number`, `base_sha`, and
 `head_sha` in its `identity` object. Later head-SHA values preserve event history
 and the deterministic summary reports the latest value. Task title, Feature
 number, and workflow SHA must not conflict with the manifest.
+
+`workflow_main_sha` is the immutable workflow baseline captured by `start`. It
+is not the PR base SHA, PR head SHA, Squash merge commit, or post-merge current
+`main` SHA. A closeout event that includes this field must copy it from the
+active run manifest rather than recomputing it from Git.
 
 ## Phase event schema
 
@@ -375,6 +400,14 @@ The CLI validates schema version, configuration, ignored storage, event order,
 usage consistency, and sensitive-field prohibitions. It uses append-only event
 records and deterministic summaries. It does not silently migrate an
 unsupported schema or overwrite history.
+
+`record` validates manifest-bound event identity before appending. A conflicting
+Task title, Feature number, or `workflow_main_sha` is rejected without changing
+the event stream, manifest, summary, or active pointer.
+
+`summarize` deterministically recomputes derived output from the manifest and
+append-only events. For a finished run it may atomically refresh `summary.json`;
+it never edits the manifest or event history.
 
 For `task-only` and `task-with-re-review`, finish the run after `task-closeout`.
 For `task-plus-feature-audit`, record closeout but keep the same run active until

--- a/.agents/skills/task-closeout/SKILL.md
+++ b/.agents/skills/task-closeout/SKILL.md
@@ -427,6 +427,12 @@ convergence, and exact branch cleanup. Record retries and the squash-specific
 exact `-D` fallback when they occur. Do not add GitHub queries, Git commands, or
 validation only for measurement.
 
+When the summary identity includes `workflow_main_sha`, copy the immutable value
+from the active Telemetry run manifest. Do not derive it from current `main`,
+`origin/main`, the PR base or head SHA, or the Squash merge commit. Maintainer
+manual Merge remains a closeout prerequisite but does not require a separate
+Telemetry event.
+
 Telemetry cannot authorize merge, Issue close, metadata writes, main updates, or
 branch deletion and cannot weaken any exact branch gate. If the ignored local
 append fails, report `telemetry incomplete`; closeout behavior remains governed

--- a/docs/workflows/agent-skills.md
+++ b/docs/workflows/agent-skills.md
@@ -765,6 +765,15 @@ python tools/agent_workflow/telemetry.py summarize --task 123 --format markdown
 audit 隐式创建第二个 run。`spot-check` 摘要可以输出历史中位数、范围、delta
 和信息性 anomaly flags；样本不足时必须明确说明。
 
+维护者人工 Merge 仍是 `task-pr-review` 与 `task-closeout` 之间的业务硬门禁，
+但不是必需 Telemetry phase，也不需要手工 `record`。标准 Task Run 的完整性只
+要求 `task-delivery`、`task-pr-review` 和 `task-closeout`；Feature audit workflow
+再额外要求 `feature-completion-audit`。历史 `manual-merge` event 仍可兼容读取。
+
+任何 phase summary 中的 `workflow_main_sha` 都表示 `start` 时写入 manifest 的
+不可变工作流基线。closeout 不得使用合并后的当前 `main`、PR base/head 或 merge
+commit 替代。CLI 会在事件追加前拒绝与 manifest 冲突的身份字段。
+
 ### 隐私和只读边界
 
 Telemetry 不保存：

--- a/docs/workflows/task-workflow-telemetry.md
+++ b/docs/workflows/task-workflow-telemetry.md
@@ -261,6 +261,9 @@ task-delivery
 → task-closeout
 ```
 
+这里的 manual merge 是业务工作流中的维护者门禁，不是必需 Telemetry phase。
+Telemetry 完整性只要求实际由 Agent/Codex 执行的阶段。
+
 四个 Skills 只使用正常工作已经产生的事实维护聚合计数，不得为 Telemetry
 额外查询 GitHub、重新读取文件或重跑验证。
 
@@ -294,17 +297,11 @@ python tools/agent_workflow/telemetry.py record `
 
 输入文件可以放在 ignored telemetry 目录中。不要把输入 JSON 暂存或提交。
 
-### 4. 人工 Merge 阶段
+### 4. 可选的历史 `manual-merge` 事件
 
-人工 Merge 没有模型 usage 也可以记录。使用 `manual-merge` phase，token 字段
-保持 `null`，source 使用 `unavailable`。
-
-```powershell
-python tools/agent_workflow/telemetry.py record `
-  --task 123 `
-  --phase manual-merge `
-  --data-file .agents/telemetry.local/input/manual-merge.json
-```
+人工 Merge 不在 Codex 会话中发生，不产生模型 usage，也不需要为了完整性手工
+记录。`manual-merge` 仍保留为合法的可选 phase/event type，仅用于兼容已经包含
+该事件的历史本地 Run；有无该事件均不影响标准 Task Run 的完整性。
 
 ### 5. 会话结束后补录 usage
 
@@ -373,9 +370,18 @@ python tools/agent_workflow/telemetry.py summarize `
   --format json
 ```
 
+`summarize` 会从 manifest 与 append-only events 重新计算确定性摘要。对于已经
+结束的 Run，它会原子刷新派生的 `summary.json`，但不会修改 manifest 或 event
+stream。这样在完整性规则修复后，旧 Run 可以直接重新汇总并随后通过
+`validate`，无需伪造或编辑历史 event。
+
 ## Phase summary JSON 模板
 
 下面是可直接复制的完整模板。未知值使用 `null`，不得使用 `0` 假装已经测量。
+
+`workflow_main_sha` 必须复制自本次 Run 的 manifest，是 `start` 时锁定的不可变
+工作流基线。它不是 PR base、PR head、Squash merge commit，也不是 closeout 时
+当前的 `main`。`record` 会在追加前拒绝与 manifest 冲突的值。
 
 ```json
 {
@@ -551,6 +557,9 @@ review-run
 manual-merge
 ```
 
+`manual-merge` 只是向后兼容的可选事件，不属于完整性必需阶段，也不应被当作
+模型 Token 消耗。
+
 例如 review 因新 head 失效时，可追加 `review-run` 或 `rework` 事件，并在
 `rework.review_invalidations`、`head_sha_changes` 和
 `independent_review_runs` 中记录数量。
@@ -566,7 +575,7 @@ manual-merge
 start(task-only)
 → task-delivery phase-summary
 → task-pr-review phase-summary
-→ manual-merge event
+→ 维护者人工 Merge（业务门禁，不要求 Telemetry event）
 → task-closeout phase-summary
 → finish
 → validate
@@ -581,7 +590,7 @@ start(task-with-re-review)
 → review-run #1
 → rework / new head
 → review-run #2
-→ manual-merge
+→ 维护者人工 Merge（业务门禁，不要求 Telemetry event）
 → task-closeout
 → finish
 ```
@@ -594,7 +603,7 @@ start(task-with-re-review)
 start(task-plus-feature-audit, --feature 2)
 → task-delivery
 → task-pr-review
-→ manual-merge
+→ 维护者人工 Merge（业务门禁，不要求 Telemetry event）
 → task-closeout
 → status --feature 2
 → feature-completion-audit
@@ -693,6 +702,10 @@ event type，不要覆盖原 summary。
 查看 `missing_phases` 和每个 event 的 `outcome.telemetry_complete`。这只表示
 测量不完整，不改变正常 workflow 结果。
 
+标准 `task-only` 与 `task-with-re-review` 只要求 `task-delivery`、
+`task-pr-review` 和 `task-closeout`。`task-plus-feature-audit` 额外要求
+`feature-completion-audit`。`manual-merge` 缺失不是不完整原因。
+
 ### spot-check 样本不足
 
 同类完成 run 少于 3 个。只做结构性比较，继续积累样本；不要从一个样本推导
@@ -753,6 +766,8 @@ finish / validate / summarize
 schema version rejection
 sensitive field rejection
 incomplete run
+pre-append identity conflict rejection
+optional manual-merge compatibility
 spot-check sample insufficiency
 deterministic summary
 ```

--- a/tests/tools/test_task_workflow_telemetry.py
+++ b/tests/tools/test_task_workflow_telemetry.py
@@ -177,7 +177,7 @@ def _record_required_phases(
     task: int = 123,
     source: str = "unavailable",
 ) -> None:
-    for phase in ("task-delivery", "task-pr-review", "manual-merge", "task-closeout"):
+    for phase in ("task-delivery", "task-pr-review", "task-closeout"):
         _record(repo, phase, _phase_file(repo, f"{phase}.json", source=source), task)
 
 
@@ -291,6 +291,60 @@ def test_record_is_append_only_and_rejects_duplicate_primary_summary(
     assert "already exists" in duplicate.stderr
 
 
+def test_record_rejects_conflicting_workflow_sha_before_append(
+    tmp_path: Path,
+) -> None:
+    repo = _write_repo(tmp_path)
+    started = _start(repo)
+    run_dir = repo / started["run_path"]
+    events_path = run_dir / "events.jsonl"
+    manifest_path = run_dir / "manifest.json"
+    active_path = repo / ".agents" / "telemetry.local" / "active" / "task-123.json"
+    summary_path = run_dir / "summary.json"
+
+    before_events = events_path.read_bytes()
+    before_manifest = manifest_path.read_bytes()
+    before_active = active_path.read_bytes()
+
+    data_file = _phase_file(repo, "conflicting-closeout.json")
+    data = json.loads(data_file.read_text(encoding="utf-8"))
+    data["identity"] = {
+        "task_canonical_title": "[Task] Example",
+        "pr_number": 456,
+        "base_sha": "1111111",
+        "head_sha": "2222222",
+        "workflow_main_sha": "7654321fedcba",
+    }
+    data_file.write_text(json.dumps(data), encoding="utf-8")
+
+    rejected = _run(
+        repo,
+        "record",
+        "--task",
+        "123",
+        "--phase",
+        "task-closeout",
+        "--data-file",
+        str(data_file),
+    )
+    assert rejected.returncode == 2
+    assert "workflow_main_sha conflicts with manifest" in rejected.stderr
+    assert events_path.read_bytes() == before_events
+    assert manifest_path.read_bytes() == before_manifest
+    assert active_path.read_bytes() == before_active
+    assert not summary_path.exists()
+
+    data["identity"]["workflow_main_sha"] = "abcdef1234567"
+    data_file.write_text(json.dumps(data), encoding="utf-8")
+    recorded = _record(repo, "task-closeout", data_file)
+    assert recorded["recorded"] is True
+
+    stored_event = json.loads(events_path.read_text(encoding="utf-8").splitlines()[-1])
+    assert stored_event["identity"]["workflow_main_sha"] == "abcdef1234567"
+    assert stored_event["identity"]["base_sha"] == "1111111"
+    assert stored_event["identity"]["head_sha"] == "2222222"
+
+
 def test_schema_and_sensitive_fields_are_rejected(tmp_path: Path) -> None:
     repo = _write_repo(tmp_path)
     _start(repo)
@@ -395,10 +449,82 @@ def test_finish_validate_and_summarize_are_deterministic(tmp_path: Path) -> None
     second = _run(repo, "summarize", "--task", "123", "--format", "json", check=True)
     assert first.stdout == second.stdout
     summary = json.loads(first.stdout)
-    assert summary["total_usage"]["total_tokens"] == 480
-    assert summary["usage_coverage"]["by_source"]["runtime-exact"] == 4
+    assert summary["total_usage"]["total_tokens"] == 360
+    assert summary["usage_coverage"]["by_source"]["runtime-exact"] == 3
     assert summary["quality"]["validation_all_passed"] is True
     assert summary["quality"]["findings_by_severity"]["blocking"] == 0
+
+
+def test_summarize_refreshes_stale_derived_summary(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    started = _start(repo)
+    _record_required_phases(repo)
+    _run(repo, "finish", "--task", "123", check=True)
+
+    summary_path = repo / started["run_path"] / "summary.json"
+    stale = json.loads(summary_path.read_text(encoding="utf-8"))
+    stale["missing_phases"] = ["manual-merge"]
+    stale["telemetry_complete"] = False
+    summary_path.write_text(json.dumps(stale), encoding="utf-8")
+
+    invalid = _run(repo, "validate", "--task", "123")
+    assert invalid.returncode == 2
+    assert "stored summary does not match" in invalid.stderr
+
+    summarized = _run(
+        repo,
+        "summarize",
+        "--task",
+        "123",
+        "--format",
+        "json",
+        check=True,
+    )
+    value = json.loads(summarized.stdout)
+    assert value["missing_phases"] == []
+    assert value["telemetry_complete"] is True
+    assert json.loads(summary_path.read_text(encoding="utf-8")) == value
+
+    validated = _run(repo, "validate", "--task", "123", check=True)
+    assert json.loads(validated.stdout)["valid"] is True
+
+
+def test_optional_manual_merge_event_remains_compatible(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    _start(repo)
+    _record_required_phases(repo, source="runtime-exact")
+
+    manual_merge_file = _phase_file(repo, "manual-merge.json")
+    manual_merge = json.loads(manual_merge_file.read_text(encoding="utf-8"))
+    manual_merge["event_type"] = "manual-merge"
+    manual_merge["usage"] = {
+        "source": "unavailable",
+        "input_tokens": None,
+        "cached_input_tokens": None,
+        "output_tokens": None,
+        "reasoning_tokens": None,
+        "total_tokens": None,
+        "model": None,
+    }
+    manual_merge_file.write_text(json.dumps(manual_merge), encoding="utf-8")
+    _record(repo, "manual-merge", manual_merge_file)
+
+    finished = _run(repo, "finish", "--task", "123", check=True)
+    assert json.loads(finished.stdout)["telemetry_complete"] is True
+    summary = _run(
+        repo,
+        "summarize",
+        "--task",
+        "123",
+        "--format",
+        "json",
+        check=True,
+    )
+    value = json.loads(summary.stdout)
+    assert value["missing_phases"] == []
+    assert value["total_usage"]["total_tokens"] == 360
+    assert value["usage_coverage"]["by_source"]["runtime-exact"] == 3
+    assert value["usage_coverage"]["by_source"]["unavailable"] == 1
 
 
 def test_finish_marks_incomplete_run_without_required_phases(tmp_path: Path) -> None:
@@ -488,6 +614,87 @@ def test_feature_selector_uses_associated_active_run(tmp_path: Path) -> None:
         check=True,
     )
     assert json.loads(recorded.stdout)["phase"] == "feature-completion-audit"
+
+
+def test_feature_workflow_requires_audit_but_not_manual_merge(
+    tmp_path: Path,
+) -> None:
+    repo = _write_repo(tmp_path)
+    _run(
+        repo,
+        "start",
+        "--task",
+        "123",
+        "--task-title",
+        "[Task] Example",
+        "--repository",
+        "owner/repo",
+        "--workflow-main-sha",
+        "abcdef1234567",
+        "--feature",
+        "7",
+        "--task-kind",
+        "feature-code",
+        "--size",
+        "M",
+        "--risk-class",
+        "normal",
+        "--workflow-shape",
+        "task-plus-feature-audit",
+        check=True,
+    )
+    _record_required_phases(repo)
+
+    before_audit = _run(repo, "status", "--feature", "7", "--json", check=True)
+    assert json.loads(before_audit.stdout)["active"] is True
+
+    _run(
+        repo,
+        "record",
+        "--feature",
+        "7",
+        "--phase",
+        "feature-completion-audit",
+        "--data-file",
+        str(_phase_file(repo, "feature-audit-complete.json")),
+        check=True,
+    )
+    finished = _run(repo, "finish", "--feature", "7", check=True)
+    value = json.loads(finished.stdout)
+    assert value["missing_phases"] == []
+    assert value["telemetry_complete"] is True
+
+
+def test_feature_workflow_reports_missing_audit(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    _run(
+        repo,
+        "start",
+        "--task",
+        "123",
+        "--task-title",
+        "[Task] Example",
+        "--repository",
+        "owner/repo",
+        "--workflow-main-sha",
+        "abcdef1234567",
+        "--feature",
+        "7",
+        "--task-kind",
+        "feature-code",
+        "--size",
+        "M",
+        "--risk-class",
+        "normal",
+        "--workflow-shape",
+        "task-plus-feature-audit",
+        check=True,
+    )
+    _record_required_phases(repo)
+    finished = _run(repo, "finish", "--task", "123", check=True)
+    value = json.loads(finished.stdout)
+    assert value["telemetry_complete"] is False
+    assert value["missing_phases"] == ["feature-completion-audit"]
 
 
 def test_sensitive_token_value_and_naive_timestamp_are_rejected(tmp_path: Path) -> None:

--- a/tools/agent_workflow/telemetry.py
+++ b/tools/agent_workflow/telemetry.py
@@ -1339,10 +1339,7 @@ def _validate_event_identity_against_manifest(
         return
 
     event_title = identity.get("task_canonical_title")
-    if (
-        event_title is not None
-        and event_title != manifest["task_canonical_title"]
-    ):
+    if event_title is not None and event_title != manifest["task_canonical_title"]:
         raise TelemetryError("event Task title conflicts with manifest")
 
     event_workflow_sha = identity.get("workflow_main_sha")

--- a/tools/agent_workflow/telemetry.py
+++ b/tools/agent_workflow/telemetry.py
@@ -1019,7 +1019,6 @@ def _aggregate_events(
     required_phases = {
         "task-delivery",
         "task-pr-review",
-        "manual-merge",
         "task-closeout",
     }
     if manifest.get("workflow_shape") == "task-plus-feature-audit":
@@ -1331,7 +1330,43 @@ def _validate_event(event: Any) -> dict[str, Any]:
     return dict(event)
 
 
-def _validate_run(paths: RunPaths) -> dict[str, Any]:
+def _validate_event_identity_against_manifest(
+    event: Mapping[str, Any],
+    manifest: Mapping[str, Any],
+) -> None:
+    identity = event.get("identity")
+    if not isinstance(identity, dict):
+        return
+
+    event_title = identity.get("task_canonical_title")
+    if (
+        event_title is not None
+        and event_title != manifest["task_canonical_title"]
+    ):
+        raise TelemetryError("event Task title conflicts with manifest")
+
+    event_workflow_sha = identity.get("workflow_main_sha")
+    if (
+        event_workflow_sha is not None
+        and event_workflow_sha != manifest["workflow_main_sha"]
+    ):
+        raise TelemetryError("event workflow_main_sha conflicts with manifest")
+
+    event_feature = identity.get("feature_number")
+    manifest_feature = manifest.get("feature_number")
+    if (
+        isinstance(event_feature, int)
+        and manifest_feature is not None
+        and event_feature != manifest_feature
+    ):
+        raise TelemetryError("event Feature number conflicts with manifest")
+
+
+def _validate_run(
+    paths: RunPaths,
+    *,
+    check_stored_summary: bool = True,
+) -> dict[str, Any]:
     manifest = _validate_manifest(_read_json(paths.manifest_file))
     events = _read_events(paths.events_file)
     seen_ids: set[str] = set()
@@ -1348,20 +1383,9 @@ def _validate_run(paths: RunPaths) -> dict[str, Any]:
     feature_numbers: set[int] = set()
     for event in events:
         validated = _validate_event(event)
+        _validate_event_identity_against_manifest(validated, manifest)
         identity = validated.get("identity")
         if isinstance(identity, dict):
-            event_title = identity.get("task_canonical_title")
-            if (
-                event_title is not None
-                and event_title != manifest["task_canonical_title"]
-            ):
-                raise TelemetryError("event Task title conflicts with manifest")
-            event_workflow_sha = identity.get("workflow_main_sha")
-            if (
-                event_workflow_sha is not None
-                and event_workflow_sha != manifest["workflow_main_sha"]
-            ):
-                raise TelemetryError("event workflow_main_sha conflicts with manifest")
             event_pr = identity.get("pr_number")
             if isinstance(event_pr, int):
                 pr_numbers.add(event_pr)
@@ -1400,7 +1424,7 @@ def _validate_run(paths: RunPaths) -> dict[str, Any]:
         ):
             raise TelemetryError("usage patch targets an unknown event")
     computed = _aggregate_events(manifest, events)
-    if paths.summary_file.exists():
+    if check_stored_summary and paths.summary_file.exists():
         stored = _read_json(paths.summary_file)
         if stored != computed:
             raise TelemetryError(
@@ -1829,7 +1853,7 @@ def _command_record(args: argparse.Namespace) -> int:
     if phase not in PHASES:
         raise TelemetryError("unsupported phase")
     _validate_run(paths)
-    _require_active_manifest(paths)
+    manifest = _require_active_manifest(paths)
     events = _read_events(paths.events_file)
     if data["event_type"] == "phase-summary" and any(
         event.get("event_type") == "phase-summary" and event.get("phase") == phase
@@ -1844,6 +1868,7 @@ def _command_record(args: argparse.Namespace) -> int:
         "recorded_at": data.get("recorded_at") or _utc_now(),
     }
     _validate_event(event)
+    _validate_event_identity_against_manifest(event, manifest)
     _ensure_append_timestamp(events, event["recorded_at"])
     _append_jsonl(paths.events_file, event)
     active = _read_json(paths.active_file)
@@ -1980,10 +2005,12 @@ def _command_summarize(args: argparse.Namespace) -> int:
         feature=args.feature,
         run_id=args.run_id,
     )
-    _validate_run(paths)
+    _validate_run(paths, check_stored_summary=False)
     manifest = _validate_manifest(_read_json(paths.manifest_file))
     events = _read_events(paths.events_file)
     summary = _aggregate_events(manifest, events)
+    if manifest["status"] != "active":
+        _atomic_write_json(paths.summary_file, summary)
     comparison = (
         _spot_check(config, summary) if manifest["mode"] == "spot-check" else None
     )


### PR DESCRIPTION
# Pull Request

## 关联 Issue

Closes #69
Fixes #68

## 实现摘要

- 在 telemetry record 追加事件前校验 event identity 与 manifest 的 Task title、Feature number、workflow_main_sha 一致性
- 将标准 task-only / task-with-re-review 完整性判定调整为只要求 Agent 执行阶段，保留 manual-merge 为兼容的可选事件
- 更新 task-closeout skill、telemetry policy 与工作流文档，明确 workflow baseline SHA 与 PR/merge SHA 的区别

## 修改范围

- Telemetry CLI identity 校验、phase completeness 和 summary 逻辑
- Telemetry 自动化测试与 Task #63 本地回归验证
- 相关 policy、skill 和 docs 文档

## 关键设计决定

- workflow_main_sha 继续表示 run 启动时锁定的 workflow baseline SHA，不从 PR base/head、merge commit 或 post-merge main 推导
- manual-merge 仍是业务人工门禁，但不是必需 Telemetry phase/event
- 历史 manual-merge event 保持合法兼容，不参与模型 token 统计要求

## 验证结果

| 命令 | 结果 | 说明 |
| --- | --- | --- |
| `uv lock --check` | 通过 | Resolved 14 packages |
| `uv run --frozen pytest` | 通过 | 73 passed |
| `uv run --frozen ruff check .` | 通过 | All checks passed |
| `uv run --frozen ruff format --check .` | 通过 | 9 files already formatted |
| `uv run --frozen mypy src tests` | 通过 | Success: no issues found in 8 source files |
| `git diff --check` | 通过 | 无 whitespace error |
| `python tools/agent_workflow/telemetry.py validate --task 63 --run-id tw-63-20260726T060745-18ab2950` | 通过 | valid=true, missing_phases=[] |
| `python tools/agent_workflow/telemetry.py summarize --task 63 --run-id tw-63-20260726T060745-18ab2950 --format json` | 通过 | telemetry_complete=true, manifest.status=completed |
| `git status --short --branch --untracked-files=all` | 通过 | 工作区干净 |

## 从 Issue 复制的验收标准

- [x] `record` 在 event 追加前校验 `identity.workflow_main_sha` 与 manifest。
- [x] 当 `workflow_main_sha` 冲突时，命令失败且 `events.jsonl` 的行数和内容保持不变。
- [x] 冲突失败不会修改 manifest、summary、active pointer 或其他 Run 状态。
- [x] 使用与 manifest 一致的 `workflow_main_sha` 重试后，可以正常记录 event。
- [x] `task-closeout` event 从活动 Run manifest 获取固定的 `workflow_main_sha`。
- [x] 增加测试证明合并后当前 `main` SHA 与 workflow baseline SHA 不同时，closeout event 仍写入 workflow baseline SHA。
- [x] 增加测试区分 workflow baseline SHA、PR base SHA、PR head SHA 和 merge commit/post-merge main SHA。
- [x] `manual-merge` 已从 `task-only` workflow 的必需阶段集合中移除。
- [x] `task-delivery + task-pr-review + task-closeout` 的有效已完成 Run 得到 `missing_phases=[]`。
- [x] 上述 Run 得到 `telemetry_complete=true`。
- [x] 缺少任一真正必需 Agent phase 的 Run 仍得到 `telemetry_complete=false`，并准确列出缺失阶段。
- [x] `task-plus-feature-audit` 或等价 Feature workflow 仍额外要求 `feature-completion-audit`。
- [x] 已包含 `manual-merge` event 的历史兼容 Run 仍能通过 validate 和 summarize。
- [x] 可选 `manual-merge` event 不会被错误统计为模型 Token 或造成重复 phase 错误。
- [x] Telemetry policy 明确人工 Merge 是业务门禁，但不是必需 Telemetry phase。
- [x] 开发指南删除“每次人工 Merge 后必须手工 record 才能完成 Run”的要求。
- [x] `task-closeout` Skill 或相关文档明确 `workflow_main_sha` 必须来自 manifest，而非合并后的 `main`。
- [x] 文档明确不同 SHA 字段的职责，避免再次混用。
- [x] 自动化测试不依赖维护者本地 `.agents/telemetry.local` 数据。
- [x] 在本地 Task #63 Run 存在时，不新增 event、不修改已有 event，重新 summarize 后得到 `missing_phases=[]` 和 `telemetry_complete=true`。
- [x] Task #63 Run 的 manifest 仍为 `status=completed`，且 active pointer 仍不存在。
- [x] `.agents/telemetry.local`、备份目录和 summary 产物未进入 Git 跟踪变更。
- [x] 修复不改变 Task/PR 生命周期权限、人工 Merge 要求、独立 review 门禁或 closeout 业务结论。
- [x] 所有新增和修改代码均有对应测试，仓库完整验证和 CI 通过。
- [x] PR 正文包含 `Closes #<本 Task 编号>` 和 `Fixes #68`。

## 风险检查

- [x] 未引入未授权实盘交易行为
- [x] 未提交或记录 API 密钥
- [x] 未引入无时区 datetime
- [x] 未引入未来数据泄漏
- [x] 未将缺失数据静默填零
- [x] 未绕过风险模块
- [x] 未进行范围外重构
- [x] 已测试失败路径

## 范围外内容

- 未新增历史事件修复 CLI 或 schema major version
- 未伪造或补录 Task #63 manual-merge event
- 未改变人工 Merge、独立 review、closeout 业务门禁

## 已知限制

- Required Checks 配置需以 GitHub 当前分支保护/规则集事实为准；本 PR 创建后将继续读取实际 checks 状态