### PR TITLE
[Task] 实现结构化日志与敏感信息保护

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Supported environment variables:
 
 - `QUANT_SYSTEM_ENV`: required; one of `development`, `test`, or `production`.
 - `QUANT_SYSTEM_LOG_LEVEL`: optional; one of `DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL`; defaults to `INFO`.
-- `QUANT_SYSTEM_LOG_FORMAT`: optional; one of `text` or `json`; defaults to `text`.
+- `QUANT_SYSTEM_LOG_FORMAT`: optional; one of `text` or `json`; defaults to `json`. Logging currently supports `json`.
 - `QUANT_SYSTEM_LOG_DIR`: optional; empty or unset disables file logging.
 
 Loading priority is:
@@ -124,3 +124,20 @@ It is a display-safety boundary only, not encryption, a secrets manager, or a sy
 keyring. Current configuration scope does not include exchange credentials, account
 settings, databases, trading modes, structured logging setup, or automatic log
 directory creation.
+
+## Structured logging
+
+Applications configure logging explicitly with `quant_system.logging.configure_logging(settings)`.
+Importing the logging module does not configure handlers, create directories, or open
+files. Modules should continue to use `logging.getLogger(__name__)`.
+
+JSON log records are single-line UTF-8 objects with stable `timestamp`, `level`,
+`logger`, and `message` fields. Timestamps are timezone-aware UTC ISO 8601 strings.
+When `settings.log_dir` is set, the exact directory is created and logs are appended
+to `quant-system.jsonl`; when it is empty or unset, only console logging is enabled.
+
+Known sensitive keys are redacted case-insensitively in structured fields and
+exception output: `password`, `secret`, `token`, `api_key`, `apikey`,
+`authorization`, and `cookie`. This boundary does not guarantee detection of secrets
+that callers manually concatenate into free-text messages, so callers must not place
+raw credentials in log messages.

--- a/src/quant_system/config.py
+++ b/src/quant_system/config.py
@@ -92,7 +92,7 @@ class Settings:
 
     environment: Environment
     log_level: LogLevel = LogLevel.INFO
-    log_format: LogFormat = LogFormat.TEXT
+    log_format: LogFormat = LogFormat.JSON
     log_dir: Path | None = None
 
 
@@ -117,7 +117,7 @@ def load_settings(
         ),
         log_format=_parse_log_format(
             _select_value(
-                log_format, source, EnvVarName.LOG_FORMAT, default=LogFormat.TEXT
+                log_format, source, EnvVarName.LOG_FORMAT, default=LogFormat.JSON
             )
         ),
         log_dir=_parse_log_dir(

--- a/src/quant_system/logging.py
+++ b/src/quant_system/logging.py
@@ -1,0 +1,188 @@
+"""Structured application logging with secret-safe JSON output."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, is_dataclass
+from datetime import date, datetime
+from pathlib import Path
+from types import TracebackType
+from typing import Any, Final, TextIO, cast
+
+from quant_system.config import LogFormat, SecretValue, Settings
+from quant_system.core.time import UTC, format_utc
+
+__all__ = [
+    "FIELD_LEVEL",
+    "FIELD_LOGGER",
+    "FIELD_MESSAGE",
+    "FIELD_TIMESTAMP",
+    "LOG_FILE_NAME",
+    "LoggingConfigError",
+    "REDACTED_VALUE",
+    "configure_logging",
+    "redact_sensitive",
+]
+
+FIELD_TIMESTAMP: Final = "timestamp"
+FIELD_LEVEL: Final = "level"
+FIELD_LOGGER: Final = "logger"
+FIELD_MESSAGE: Final = "message"
+FIELD_EXCEPTION: Final = "exception"
+FIELD_EXTRA: Final = "extra"
+LOG_FILE_NAME: Final = "quant-system.jsonl"
+REDACTED_VALUE: Final = "<redacted>"
+
+_HANDLER_MARKER: Final = "_quant_system_logging_handler"
+_SENSITIVE_KEYS: Final[frozenset[str]] = frozenset(
+    {"password", "secret", "token", "api_key", "apikey", "authorization", "cookie"}
+)
+_STANDARD_LOG_RECORD_KEYS: Final[frozenset[str]] = frozenset(
+    {*logging.makeLogRecord({}).__dict__, "message"}
+)
+
+
+class LoggingConfigError(ValueError):
+    """Raised when logging cannot be configured safely."""
+
+
+class _JsonFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        payload: dict[str, Any] = {
+            FIELD_TIMESTAMP: format_utc(datetime.fromtimestamp(record.created, UTC)),
+            FIELD_LEVEL: record.levelname,
+            FIELD_LOGGER: record.name,
+            FIELD_MESSAGE: _safe_message(record),
+        }
+        extra = _safe_extra(record)
+        if extra:
+            payload[FIELD_EXTRA] = extra
+        if record.exc_info is not None and record.exc_info[0] is not None:
+            payload[FIELD_EXCEPTION] = _safe_exception(record.exc_info)
+        return json.dumps(payload, ensure_ascii=False, sort_keys=True)
+
+
+def configure_logging(
+    settings: Settings,
+    *,
+    stream: TextIO | None = None,
+    logger: logging.Logger | None = None,
+) -> None:
+    """Configure project-owned JSON handlers from explicit settings."""
+    if settings.log_format is not LogFormat.JSON:
+        raise LoggingConfigError("only json log format is supported")
+
+    target_logger = logging.getLogger() if logger is None else logger
+    target_logger.setLevel(settings.log_level.value)
+    _remove_project_handlers(target_logger)
+
+    formatter = _JsonFormatter()
+    console_handler = logging.StreamHandler(sys.stderr if stream is None else stream)
+    _mark_project_handler(console_handler)
+    console_handler.setFormatter(formatter)
+    target_logger.addHandler(console_handler)
+
+    if settings.log_dir is not None:
+        log_dir = _prepare_log_dir(settings.log_dir)
+        file_handler = logging.FileHandler(
+            log_dir / LOG_FILE_NAME, mode="a", encoding="utf-8"
+        )
+        _mark_project_handler(file_handler)
+        file_handler.setFormatter(formatter)
+        target_logger.addHandler(file_handler)
+
+
+def redact_sensitive(value: object) -> object:
+    """Return a JSON-safe value with known sensitive keys recursively redacted."""
+    return _redact(value, sensitive_context=False)
+
+
+def _remove_project_handlers(logger: logging.Logger) -> None:
+    for handler in list(logger.handlers):
+        if getattr(handler, _HANDLER_MARKER, False):
+            logger.removeHandler(handler)
+            handler.close()
+
+
+def _mark_project_handler(handler: logging.Handler) -> None:
+    setattr(handler, _HANDLER_MARKER, True)
+
+
+def _prepare_log_dir(log_dir: Path) -> Path:
+    if log_dir.exists() and not log_dir.is_dir():
+        raise LoggingConfigError(f"log path is not a directory: {log_dir}")
+    log_dir.mkdir(parents=True, exist_ok=True)
+    if not os.access(log_dir, os.W_OK):
+        raise LoggingConfigError(f"log directory is not writable: {log_dir}")
+    return log_dir
+
+
+def _safe_message(record: logging.LogRecord) -> str:
+    original_args = record.args
+    try:
+        if isinstance(original_args, Mapping):
+            record.args = cast(Mapping[str, object], redact_sensitive(original_args))
+        elif isinstance(original_args, tuple):
+            record.args = tuple(
+                _redact(item, sensitive_context=False) for item in original_args
+            )
+        return record.getMessage()
+    finally:
+        record.args = original_args
+
+
+def _safe_extra(record: logging.LogRecord) -> dict[str, object]:
+    extra: dict[str, object] = {}
+    for key, value in record.__dict__.items():
+        if key in _STANDARD_LOG_RECORD_KEYS or key.startswith("_"):
+            continue
+        redacted = cast(Mapping[str, object], redact_sensitive({key: value}))
+        extra[key] = redacted[key]
+    return extra
+
+
+def _safe_exception(
+    exc_info: tuple[type[BaseException], BaseException, TracebackType | None],
+) -> dict[str, object]:
+    exc_type, exc, _exc_traceback = exc_info
+    redacted_args = redact_sensitive(exc.args)
+    return {
+        "type": exc_type.__name__,
+        "message": str(redacted_args[0] if len(exc.args) == 1 else redacted_args),  # type: ignore[index]
+    }
+
+
+def _redact(value: object, *, sensitive_context: bool) -> object:
+    if sensitive_context:
+        return REDACTED_VALUE
+    if isinstance(value, SecretValue):
+        return REDACTED_VALUE
+    if isinstance(value, Mapping):
+        return {
+            str(key): _redact(
+                item,
+                sensitive_context=str(key).lower() in _SENSITIVE_KEYS,
+            )
+            for key, item in value.items()
+        }
+    if isinstance(value, tuple):
+        return [_redact(item, sensitive_context=False) for item in value]
+    if isinstance(value, list):
+        return [_redact(item, sensitive_context=False) for item in value]
+    if isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
+        return [_redact(item, sensitive_context=False) for item in value]
+    if isinstance(value, Path):
+        return value.as_posix()
+    if isinstance(value, datetime | date):
+        return value.isoformat()
+    if is_dataclass(value) and not isinstance(value, type):
+        return _redact(asdict(value), sensitive_context=False)
+    try:
+        json.dumps(value)
+    except (TypeError, ValueError):
+        return repr(value)
+    return value

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -22,7 +22,7 @@ def test_load_settings_uses_environment_and_defaults() -> None:
     assert settings == Settings(
         environment=Environment.DEVELOPMENT,
         log_level=LogLevel.INFO,
-        log_format=LogFormat.TEXT,
+        log_format=LogFormat.JSON,
         log_dir=None,
     )
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import importlib
+import json
+import logging
+from collections.abc import Generator
+from datetime import datetime
+from io import StringIO
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from quant_system.config import Environment, LogFormat, LogLevel, SecretValue, Settings
+from quant_system.core.time import parse_utc
+from quant_system.logging import (
+    LOG_FILE_NAME,
+    REDACTED_VALUE,
+    LoggingConfigError,
+    configure_logging,
+    redact_sensitive,
+)
+
+CANARY_SECRET = "canary-secret-task-64-never-log"
+
+
+@pytest.fixture
+def logger() -> Generator[logging.Logger]:
+    test_logger = logging.getLogger(f"quant_system.tests.logging.{uuid4().hex}")
+    test_logger.handlers.clear()
+    test_logger.propagate = False
+    yield test_logger
+    for handler in list(test_logger.handlers):
+        test_logger.removeHandler(handler)
+        handler.close()
+    test_logger.setLevel(logging.NOTSET)
+    test_logger.propagate = True
+
+
+def test_import_logging_module_has_no_side_effects(
+    tmp_path: Path, logger: logging.Logger
+) -> None:
+    logger.addHandler(logging.NullHandler())
+    before_handlers = list(logger.handlers)
+
+    module = importlib.import_module("quant_system.logging")
+
+    assert module.FIELD_TIMESTAMP == "timestamp"
+    assert logger.handlers == before_handlers
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_configure_logging_writes_single_line_json_to_console(
+    logger: logging.Logger,
+) -> None:
+    stream = StringIO()
+    settings = Settings(environment=Environment.TEST, log_level=LogLevel.INFO)
+    configure_logging(settings, stream=stream, logger=logger)
+
+    logger.info("hello %s", "world", extra={"module_field": "research"})
+
+    payload = json.loads(stream.getvalue())
+    assert set(payload) >= {"timestamp", "level", "logger", "message"}
+    assert payload["level"] == "INFO"
+    assert payload["logger"] == logger.name
+    assert payload["message"] == "hello world"
+    assert payload["extra"] == {"module_field": "research"}
+    assert parse_utc(payload["timestamp"]).tzinfo is not None
+    assert "\n" not in stream.getvalue().strip()
+
+
+def test_log_level_comes_from_settings(logger: logging.Logger) -> None:
+    stream = StringIO()
+    configure_logging(
+        Settings(environment=Environment.TEST, log_level=LogLevel.ERROR),
+        stream=stream,
+        logger=logger,
+    )
+
+    logger.warning("hidden")
+    logger.error("shown")
+
+    assert json.loads(stream.getvalue())["message"] == "shown"
+
+
+def test_empty_log_dir_does_not_create_file_handler(logger: logging.Logger) -> None:
+    configure_logging(
+        Settings(environment=Environment.TEST), stream=StringIO(), logger=logger
+    )
+
+    project_handlers = [
+        handler
+        for handler in logger.handlers
+        if handler.formatter is not None
+        and handler.formatter.__class__.__module__ == "quant_system.logging"
+    ]
+    assert len(project_handlers) == 1
+    assert not any(
+        isinstance(handler, logging.FileHandler) for handler in project_handlers
+    )
+
+
+def test_file_logging_creates_exact_log_directory_and_file(
+    tmp_path: Path, logger: logging.Logger
+) -> None:
+    stream = StringIO()
+    log_dir = tmp_path / "logs" / "app"
+    configure_logging(
+        Settings(environment=Environment.TEST, log_dir=log_dir),
+        stream=stream,
+        logger=logger,
+    )
+
+    logger.info("file output")
+    for handler in logger.handlers:
+        handler.flush()
+
+    assert log_dir.is_dir()
+    log_files = list(log_dir.iterdir())
+    assert log_files == [log_dir / LOG_FILE_NAME]
+    assert (
+        json.loads((log_dir / LOG_FILE_NAME).read_text(encoding="utf-8"))["message"]
+        == "file output"
+    )
+
+
+def test_log_dir_that_is_file_fails(tmp_path: Path, logger: logging.Logger) -> None:
+    log_path = tmp_path / "not-a-directory"
+    log_path.write_text("", encoding="utf-8")
+
+    with pytest.raises(LoggingConfigError, match="not a directory"):
+        configure_logging(
+            Settings(environment=Environment.TEST, log_dir=log_path),
+            stream=StringIO(),
+            logger=logger,
+        )
+
+
+def test_repeated_initialization_replaces_only_project_handlers(
+    logger: logging.Logger,
+) -> None:
+    third_party_handler = logging.NullHandler()
+    logger.addHandler(third_party_handler)
+
+    configure_logging(
+        Settings(environment=Environment.TEST), stream=StringIO(), logger=logger
+    )
+    configure_logging(
+        Settings(environment=Environment.TEST), stream=StringIO(), logger=logger
+    )
+
+    assert third_party_handler in logger.handlers
+    project_handlers = [
+        handler
+        for handler in logger.handlers
+        if handler.formatter is not None
+        and handler.formatter.__class__.__module__ == "quant_system.logging"
+    ]
+    assert len(project_handlers) == 1
+
+
+def test_rejects_unsupported_text_format(logger: logging.Logger) -> None:
+    with pytest.raises(LoggingConfigError, match="only json"):
+        configure_logging(
+            Settings(environment=Environment.TEST, log_format=LogFormat.TEXT),
+            stream=StringIO(),
+            logger=logger,
+        )
+
+
+def test_redact_sensitive_recurses_case_insensitive_keys() -> None:
+    value = {
+        "Authorization": "Bearer secret",
+        "nested": {"api_key": CANARY_SECRET, "safe": "visible"},
+        "items": [{"Cookie": CANARY_SECRET}, ("token", {"password": CANARY_SECRET})],
+        "similar_tokenized": "visible",
+    }
+
+    redacted = redact_sensitive(value)
+
+    assert CANARY_SECRET not in json.dumps(redacted)
+    assert redacted["Authorization"] == REDACTED_VALUE  # type: ignore[index]
+    assert redacted["nested"]["safe"] == "visible"  # type: ignore[index]
+    assert redacted["similar_tokenized"] == "visible"  # type: ignore[index]
+
+
+def test_secret_canary_is_absent_from_console_file_and_exception(
+    tmp_path: Path, logger: logging.Logger
+) -> None:
+    stream = StringIO()
+    log_dir = tmp_path / "logs"
+    configure_logging(
+        Settings(environment=Environment.TEST, log_dir=log_dir),
+        stream=stream,
+        logger=logger,
+    )
+
+    try:
+        raise ValueError({"token": CANARY_SECRET})
+    except ValueError:
+        logger.exception(
+            "failed for %(token)s",
+            {"token": CANARY_SECRET},
+            extra={
+                "settings": {"secret": SecretValue(CANARY_SECRET)},
+                "when": datetime(2026, 7, 26, 9, 0),
+                "path": Path("logs/example.jsonl"),
+            },
+        )
+    for handler in logger.handlers:
+        handler.flush()
+
+    console_output = stream.getvalue()
+    file_output = (log_dir / LOG_FILE_NAME).read_text(encoding="utf-8")
+    assert CANARY_SECRET not in console_output
+    assert CANARY_SECRET not in file_output
+    payload = json.loads(console_output)
+    assert payload["message"] == f"failed for {REDACTED_VALUE}"
+    assert payload["extra"]["settings"]["secret"] == REDACTED_VALUE
+    assert REDACTED_VALUE in payload["exception"]["message"]
+
+
+def test_unicode_and_non_json_extra_values_are_serialized(
+    logger: logging.Logger,
+) -> None:
+    stream = StringIO()
+    configure_logging(
+        Settings(environment=Environment.TEST), stream=stream, logger=logger
+    )
+
+    logger.info(
+        "unicode \u6d88\u606f", extra={"path": Path("logs/app"), "raw": object()}
+    )
+
+    payload = json.loads(stream.getvalue())
+    assert payload["message"] == "unicode \u6d88\u606f"
+    assert payload["extra"]["path"] == "logs/app"
+    assert isinstance(payload["extra"]["raw"], str)


### PR DESCRIPTION
# Pull Request

## 关联 Issue

Closes #64

## 实现摘要

- Add explicit JSON structured logging configuration with UTC timestamps and project-owned handler replacement.
- Add recursive redaction for common sensitive keys across message args, extra fields, Settings-like objects, and structured exception messages.
- Document structured logging usage and switch the default configured log format to json.

## 修改范围

- `src/quant_system/logging.py`
- `src/quant_system/config.py`
- `tests/test_logging.py`
- `tests/test_config.py`
- `README.md`

## 关键设计决定

- Use only Python standard-library logging and JSON output.
- Mark and replace only quant-system-owned handlers so third-party handlers remain intact.
- Treat free-text secret scanning as out of scope and document that callers must not concatenate raw secrets into log messages.

## 验证结果

| 命令 | 结果 | 说明 |
| --- | --- | --- |
| `uv lock --check` | Pass | Lock file remains consistent. |
| `uv run --frozen pytest` | Pass | 84 tests passed. |
| `uv run --frozen ruff check .` | Pass | All checks passed. |
| `uv run --frozen ruff format --check .` | Pass | 11 files already formatted. |
| `uv run --frozen mypy src tests` | Pass | No issues found in 10 source files. |
| `git diff --check` | Pass | No whitespace errors. |
| `git check-ignore -v logs/example.jsonl` | Pass | Ignored by `logs/`. |
| `git check-ignore -v .agents/telemetry.local/example.jsonl` | Pass | Ignored by `.agents/telemetry.local/`. |

## 从 Issue 复制的验收标准

- [x] 存在单一、显式的日志初始化入口
- [x] 模块导入不会配置 logger、创建目录或文件
- [x] 日志至少包含 timestamp、level、logger、message
- [x] timestamp 为带时区 UTC 且格式稳定
- [x] 控制台输出为可解析的单行结构化数据
- [x] 日志级别和输出目录来自统一 Settings
- [x] `log_dir` 为空时不创建文件 handler
- [x] 目录不存在时只创建精确日志目录
- [x] 路径不是目录或不可写时明确失败
- [x] 重复初始化不会叠加本模块 handler
- [x] 不删除第三方 handler
- [x] 常见敏感键名被大小写不敏感脱敏
- [x] 嵌套 mapping 中的秘密值被保护
- [x] canary secret 不出现在控制台、文件或异常输出
- [x] 文档明确自由文本秘密不保证自动识别
- [x] 测试可以隔离和清理 logging 状态
- [x] Windows/Linux 字段和路径语义一致
- [x] 公共 API 具有完整类型
- [x] 未引入外部日志平台或网络写入
- [x] 本地日志文件被 Git ignored
- [x] 正常、UTC、目录、重复初始化、异常和秘密保护测试通过
- [x] 当前完整 CI 等价命令通过
- [x] `git diff --check` 通过
- [x] 原始 telemetry、日志和秘密未进入 PR

## 风险检查

- [x] 未引入未授权实盘交易行为
- [x] 未提交或记录 API 密钥
- [x] 未引入无时区 datetime
- [x] 未引入未来数据泄漏
- [x] 未将缺失数据静默填零
- [x] 未绕过风险模块
- [x] 未进行范围外重构
- [x] 已测试失败路径

## 范围外内容

- OpenTelemetry, tracing, metrics, log platforms, network handlers, log rotation, audit/order logs, global exception capture, and automatic scanning of arbitrary free-text secrets.

## 已知限制

- Free-text messages are not scanned for arbitrary secrets; callers must avoid placing raw credentials in message text.