### PR TITLE
[Task] 定义初始公共领域模型与共享测试 Fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,18 @@ Pull requests targeting `main` and pushes to `main` automatically run CI. The wo
 
 Internal datetimes must be timezone-aware and use UTC as the standard timezone. Naive datetimes are explicitly rejected. Time utilities are provided by `quant_system.core.time`.
 
+## Domain models
+
+Initial Research MVP domain models live in `quant_system.domain`:
+
+- `InstrumentId`: normalized uppercase ASCII letters and digits, serialized as a string.
+- `TimeRange`: immutable UTC half-open interval `[start, end)`, serialized with UTC ISO 8601 timestamps.
+- `OHLCVBar`: immutable OHLCV bar with finite float prices and volume, stable JSON-compatible `to_dict` / `from_dict`, and no exchange metadata, timeframe enum, or trading fields.
+
+`OHLCVBar` rejects NaN, infinity, negative volume, and invalid OHLC relationships. Prices may currently be zero or negative so research datasets can represent adjusted or synthetic values without prematurely enforcing market-specific positivity rules. These models are the initial internal public Research MVP boundary, not a long-term external schema compatibility contract.
+
+Shared tests place deterministic factory helpers in `tests/fixtures/domain.py`. Put only fixtures reused by multiple test modules in `tests/conftest.py`; keep single-test data local to the test file. Shared factories should use fixed UTC timestamps, avoid randomness, time-of-day reads, environment reads, network and filesystem access, and expose explicit field overrides instead of hiding business values.
+
 ## Configuration
 
 Application configuration is loaded explicitly with `quant_system.config.load_settings`.

--- a/src/quant_system/domain.py
+++ b/src/quant_system/domain.py
@@ -1,0 +1,231 @@
+"""Initial shared domain value objects for research market data."""
+
+from __future__ import annotations
+
+import math
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Final
+
+from quant_system.core.time import ensure_aware, format_utc, is_utc, to_utc
+
+__all__ = ["DomainValidationError", "InstrumentId", "OHLCVBar", "TimeRange"]
+
+
+class DomainValidationError(ValueError):
+    """Raised when a domain value object receives invalid data."""
+
+
+_INSTRUMENT_PATTERN: Final = re.compile(r"^[A-Z0-9]+$")
+_MAX_INSTRUMENT_LENGTH: Final = 32
+
+
+@dataclass(frozen=True, slots=True, order=True)
+class InstrumentId:
+    """Standardized instrument identifier for the current market-data context."""
+
+    value: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.value, str):
+            raise DomainValidationError("instrument must be a string")
+        normalized = self.value.strip().upper()
+        if normalized == "":
+            raise DomainValidationError("instrument must not be empty")
+        if len(normalized) > _MAX_INSTRUMENT_LENGTH:
+            raise DomainValidationError(
+                f"instrument must be at most {_MAX_INSTRUMENT_LENGTH} characters"
+            )
+        if _INSTRUMENT_PATTERN.fullmatch(normalized) is None:
+            raise DomainValidationError(
+                "instrument must contain only ASCII uppercase letters and digits"
+            )
+        object.__setattr__(self, "value", normalized)
+
+    def __str__(self) -> str:
+        return self.value
+
+    def to_dict(self) -> str:
+        """Return the stable JSON-compatible representation."""
+        return self.value
+
+    @classmethod
+    def from_dict(cls, value: object) -> InstrumentId:
+        """Create an instrument identifier from its serialized string form."""
+        if not isinstance(value, str):
+            raise DomainValidationError("instrument payload must be a string")
+        return cls(value)
+
+
+@dataclass(frozen=True, slots=True)
+class TimeRange:
+    """UTC half-open time range using [start, end) semantics."""
+
+    start: datetime
+    end: datetime
+
+    def __post_init__(self) -> None:
+        start = _require_utc_datetime(self.start, field_name="start")
+        end = _require_utc_datetime(self.end, field_name="end")
+        if start >= end:
+            raise DomainValidationError("start must be earlier than end")
+        object.__setattr__(self, "start", start)
+        object.__setattr__(self, "end", end)
+
+    @property
+    def duration(self) -> timedelta:
+        """Return the range duration."""
+        return self.end - self.start
+
+    def contains(self, value: datetime) -> bool:
+        """Return whether an aware UTC datetime lies in [start, end)."""
+        checked = _require_utc_datetime(value, field_name="value")
+        return self.start <= checked < self.end
+
+    def to_dict(self) -> dict[str, str]:
+        """Return the stable JSON-compatible representation."""
+        return {
+            "start": format_utc(self.start),
+            "end": format_utc(self.end),
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, object]) -> TimeRange:
+        """Create a time range from its serialized mapping form."""
+        payload = _require_mapping_keys(value, required=("start", "end"))
+        return cls(
+            start=_parse_utc_iso(payload["start"], field_name="start"),
+            end=_parse_utc_iso(payload["end"], field_name="end"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class OHLCVBar:
+    """Basic OHLCV bar for one instrument and one UTC half-open interval."""
+
+    instrument: InstrumentId
+    start: datetime
+    end: datetime
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.instrument, InstrumentId):
+            raise DomainValidationError("instrument must be an InstrumentId")
+        time_range = TimeRange(self.start, self.end)
+        open_price = _require_finite_float(self.open, field_name="open")
+        high_price = _require_finite_float(self.high, field_name="high")
+        low_price = _require_finite_float(self.low, field_name="low")
+        close_price = _require_finite_float(self.close, field_name="close")
+        volume = _require_finite_float(self.volume, field_name="volume")
+        if volume < 0.0:
+            raise DomainValidationError("volume must be non-negative")
+        if high_price < max(open_price, low_price, close_price):
+            raise DomainValidationError("high must be at least open, low, and close")
+        if low_price > min(open_price, high_price, close_price):
+            raise DomainValidationError("low must be at most open, high, and close")
+        object.__setattr__(self, "start", time_range.start)
+        object.__setattr__(self, "end", time_range.end)
+
+    @property
+    def time_range(self) -> TimeRange:
+        """Return the bar interval as a TimeRange."""
+        return TimeRange(self.start, self.end)
+
+    def to_dict(self) -> dict[str, object]:
+        """Return the stable JSON-compatible representation."""
+        _validate_serializable_float_fields(self)
+        return {
+            "instrument": self.instrument.to_dict(),
+            "start": format_utc(self.start),
+            "end": format_utc(self.end),
+            "open": self.open,
+            "high": self.high,
+            "low": self.low,
+            "close": self.close,
+            "volume": self.volume,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, object]) -> OHLCVBar:
+        """Create a bar from its serialized mapping form."""
+        payload = _require_mapping_keys(
+            value,
+            required=(
+                "instrument",
+                "start",
+                "end",
+                "open",
+                "high",
+                "low",
+                "close",
+                "volume",
+            ),
+        )
+        return cls(
+            instrument=InstrumentId.from_dict(payload["instrument"]),
+            start=_parse_utc_iso(payload["start"], field_name="start"),
+            end=_parse_utc_iso(payload["end"], field_name="end"),
+            open=_require_finite_float(payload["open"], field_name="open"),
+            high=_require_finite_float(payload["high"], field_name="high"),
+            low=_require_finite_float(payload["low"], field_name="low"),
+            close=_require_finite_float(payload["close"], field_name="close"),
+            volume=_require_finite_float(payload["volume"], field_name="volume"),
+        )
+
+
+def _require_mapping_keys(
+    value: Mapping[str, object], *, required: tuple[str, ...]
+) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise DomainValidationError("payload must be a mapping")
+    actual_keys = set(value)
+    required_keys = set(required)
+    missing = sorted(required_keys - actual_keys)
+    extra = sorted(actual_keys - required_keys)
+    if missing:
+        raise DomainValidationError(f"payload missing fields: {', '.join(missing)}")
+    if extra:
+        raise DomainValidationError(f"payload has extra fields: {', '.join(extra)}")
+    return value
+
+
+def _require_utc_datetime(value: datetime, *, field_name: str) -> datetime:
+    try:
+        aware = ensure_aware(value)
+    except ValueError as exc:
+        raise DomainValidationError(f"{field_name} must be timezone-aware") from exc
+    if not is_utc(aware):
+        raise DomainValidationError(f"{field_name} must be UTC")
+    return to_utc(aware)
+
+
+def _parse_utc_iso(value: object, *, field_name: str) -> datetime:
+    if not isinstance(value, str):
+        raise DomainValidationError(f"{field_name} must be an ISO 8601 string")
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise DomainValidationError(f"{field_name} must be valid ISO 8601") from exc
+    return _require_utc_datetime(parsed, field_name=field_name)
+
+
+def _require_finite_float(value: object, *, field_name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, float):
+        raise DomainValidationError(f"{field_name} must be a float")
+    if not math.isfinite(value):
+        raise DomainValidationError(f"{field_name} must be finite")
+    return value
+
+
+def _validate_serializable_float_fields(value: OHLCVBar) -> None:
+    _require_finite_float(value.open, field_name="open")
+    _require_finite_float(value.high, field_name="high")
+    _require_finite_float(value.low, field_name="low")
+    _require_finite_float(value.close, field_name="close")
+    _require_finite_float(value.volume, field_name="volume")

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package for shared fixtures and helpers."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+from collections.abc import Callable
+
+import pytest
+
+from quant_system.domain import OHLCVBar
+from tests.fixtures.domain import make_ohlcv_bar
+
+
+@pytest.fixture
+def ohlcv_bar_factory() -> Callable[[], OHLCVBar]:
+    return make_ohlcv_bar

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,10 +2,10 @@ from collections.abc import Callable
 
 import pytest
 
-from quant_system.domain import OHLCVBar
-from tests.fixtures.domain import make_ohlcv_bar
+from quant_system.domain import InstrumentId
+from tests.fixtures.domain import make_instrument
 
 
 @pytest.fixture
-def ohlcv_bar_factory() -> Callable[[], OHLCVBar]:
-    return make_ohlcv_bar
+def instrument_factory() -> Callable[[str], InstrumentId]:
+    return make_instrument

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,0 +1,1 @@
+"""Shared deterministic test factories."""

--- a/tests/fixtures/domain.py
+++ b/tests/fixtures/domain.py
@@ -1,0 +1,66 @@
+"""Deterministic domain model factories for tests that need explicit overrides."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from quant_system.core.time import UTC
+from quant_system.domain import InstrumentId, OHLCVBar, TimeRange
+
+VALID_INSTRUMENT_VALUE = "BTCUSDT"
+VALID_RANGE_START = datetime(2026, 2, 28, 23, 45, tzinfo=UTC)
+VALID_RANGE_END = datetime(2026, 3, 1, 0, 0, tzinfo=UTC)
+VALID_OPEN = 100.0
+VALID_HIGH = 105.0
+VALID_LOW = 95.0
+VALID_CLOSE = 101.5
+VALID_VOLUME = 12.25
+
+INVALID_INSTRUMENT_VALUES = (
+    "",
+    "   ",
+    "BTC-USDT",
+    "BTC_USDT",
+    "BTC/USDT",
+    "BTCUSDT!",
+    "\u6bd4\u7279\u5e01",
+    "A" * 33,
+)
+
+
+def make_instrument(value: str = VALID_INSTRUMENT_VALUE) -> InstrumentId:
+    """Return a fresh valid instrument id."""
+    return InstrumentId(value)
+
+
+def make_time_range(
+    *,
+    start: datetime = VALID_RANGE_START,
+    end: datetime = VALID_RANGE_END,
+) -> TimeRange:
+    """Return a fresh valid UTC half-open time range."""
+    return TimeRange(start=start, end=end)
+
+
+def make_ohlcv_bar(
+    *,
+    instrument: InstrumentId | None = None,
+    start: datetime = VALID_RANGE_START,
+    end: datetime = VALID_RANGE_END,
+    open: float = VALID_OPEN,
+    high: float = VALID_HIGH,
+    low: float = VALID_LOW,
+    close: float = VALID_CLOSE,
+    volume: float = VALID_VOLUME,
+) -> OHLCVBar:
+    """Return a fresh valid OHLCV bar with explicit override hooks."""
+    return OHLCVBar(
+        instrument=make_instrument() if instrument is None else instrument,
+        start=start,
+        end=end,
+        open=open,
+        high=high,
+        low=low,
+        close=close,
+        volume=volume,
+    )

--- a/tests/test_domain_instrument.py
+++ b/tests/test_domain_instrument.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from dataclasses import FrozenInstanceError
 
 import pytest
@@ -6,8 +7,10 @@ from quant_system.domain import DomainValidationError, InstrumentId
 from tests.fixtures.domain import INVALID_INSTRUMENT_VALUES, make_instrument
 
 
-def test_instrument_id_normalizes_whitespace_and_case() -> None:
-    instrument = InstrumentId(" btcusdt ")
+def test_instrument_id_normalizes_whitespace_and_case(
+    instrument_factory: Callable[[str], InstrumentId],
+) -> None:
+    instrument = instrument_factory(" btcusdt ")
 
     assert instrument.value == "BTCUSDT"
     assert str(instrument) == "BTCUSDT"

--- a/tests/test_domain_instrument.py
+++ b/tests/test_domain_instrument.py
@@ -1,0 +1,50 @@
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from quant_system.domain import DomainValidationError, InstrumentId
+from tests.fixtures.domain import INVALID_INSTRUMENT_VALUES, make_instrument
+
+
+def test_instrument_id_normalizes_whitespace_and_case() -> None:
+    instrument = InstrumentId(" btcusdt ")
+
+    assert instrument.value == "BTCUSDT"
+    assert str(instrument) == "BTCUSDT"
+
+
+def test_instrument_id_is_immutable_comparable_and_hashable() -> None:
+    instrument = make_instrument()
+
+    with pytest.raises(FrozenInstanceError):
+        instrument.value = "ETHUSDT"  # type: ignore[misc]
+
+    assert instrument == InstrumentId("btcusdt")
+    assert {instrument, InstrumentId("BTCUSDT")} == {InstrumentId("BTCUSDT")}
+    assert sorted([InstrumentId("ETHUSDT"), InstrumentId("BTCUSDT")]) == [
+        InstrumentId("BTCUSDT"),
+        InstrumentId("ETHUSDT"),
+    ]
+
+
+@pytest.mark.parametrize("value", INVALID_INSTRUMENT_VALUES)
+def test_instrument_id_rejects_invalid_values(value: str) -> None:
+    with pytest.raises(DomainValidationError):
+        InstrumentId(value)
+
+
+def test_instrument_id_rejects_non_string_input() -> None:
+    with pytest.raises(DomainValidationError, match="instrument must be a string"):
+        InstrumentId(123)  # type: ignore[arg-type]
+
+
+def test_instrument_id_serializes_as_string() -> None:
+    instrument = make_instrument("ethusdc")
+
+    assert instrument.to_dict() == "ETHUSDC"
+    assert InstrumentId.from_dict("ethusdc") == instrument
+
+
+def test_instrument_id_from_dict_rejects_non_string_payload() -> None:
+    with pytest.raises(DomainValidationError, match="payload must be a string"):
+        InstrumentId.from_dict({"value": "BTCUSDT"})

--- a/tests/test_domain_ohlcv.py
+++ b/tests/test_domain_ohlcv.py
@@ -1,6 +1,7 @@
 import json
 import math
 import os
+from collections.abc import Callable
 from dataclasses import FrozenInstanceError
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -17,10 +18,9 @@ from tests.fixtures.domain import (
 
 
 def test_ohlcv_bar_uses_instrument_and_utc_interval(
-    ohlcv_bar_factory: object,
+    instrument_factory: Callable[[str], InstrumentId],
 ) -> None:
-    assert callable(ohlcv_bar_factory)
-    bar = make_ohlcv_bar()
+    bar = make_ohlcv_bar(instrument=instrument_factory("BTCUSDT"))
 
     assert bar.instrument == InstrumentId("BTCUSDT")
     assert bar.start == VALID_RANGE_START

--- a/tests/test_domain_ohlcv.py
+++ b/tests/test_domain_ohlcv.py
@@ -1,0 +1,231 @@
+import json
+import math
+import os
+from dataclasses import FrozenInstanceError
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from quant_system.domain import DomainValidationError, InstrumentId, OHLCVBar
+from tests.fixtures.domain import (
+    VALID_RANGE_END,
+    VALID_RANGE_START,
+    make_instrument,
+    make_ohlcv_bar,
+)
+
+
+def test_ohlcv_bar_uses_instrument_and_utc_interval(
+    ohlcv_bar_factory: object,
+) -> None:
+    assert callable(ohlcv_bar_factory)
+    bar = make_ohlcv_bar()
+
+    assert bar.instrument == InstrumentId("BTCUSDT")
+    assert bar.start == VALID_RANGE_START
+    assert bar.end == VALID_RANGE_END
+    assert bar.time_range.start == VALID_RANGE_START
+    assert bar.time_range.end == VALID_RANGE_END
+
+
+def test_ohlcv_bar_is_immutable_and_comparable() -> None:
+    bar = make_ohlcv_bar()
+
+    with pytest.raises(FrozenInstanceError):
+        bar.close = 102.0  # type: ignore[misc]
+
+    assert bar == make_ohlcv_bar()
+
+
+@pytest.mark.parametrize("field_name", ["open", "high", "low", "close", "volume"])
+@pytest.mark.parametrize("value", [math.nan, math.inf, -math.inf])
+def test_ohlcv_bar_rejects_non_finite_numbers(field_name: str, value: float) -> None:
+    with pytest.raises(DomainValidationError, match=f"{field_name} must be finite"):
+        if field_name == "open":
+            make_ohlcv_bar(open=value)
+        elif field_name == "high":
+            make_ohlcv_bar(high=value)
+        elif field_name == "low":
+            make_ohlcv_bar(low=value)
+        elif field_name == "close":
+            make_ohlcv_bar(close=value)
+        else:
+            make_ohlcv_bar(volume=value)
+
+
+def test_ohlcv_bar_rejects_negative_volume() -> None:
+    with pytest.raises(DomainValidationError, match="volume must be non-negative"):
+        make_ohlcv_bar(volume=-0.01)
+
+
+def test_ohlcv_bar_rejects_high_below_close() -> None:
+    with pytest.raises(DomainValidationError):
+        make_ohlcv_bar(high=100.0, close=101.0)
+
+
+def test_ohlcv_bar_rejects_low_above_close() -> None:
+    with pytest.raises(DomainValidationError):
+        make_ohlcv_bar(low=101.0, close=100.0)
+
+
+def test_ohlcv_bar_allows_zero_and_negative_prices_for_research_data() -> None:
+    bar = make_ohlcv_bar(open=0.0, high=1.0, low=-2.0, close=-1.0)
+
+    assert bar.open == 0.0
+    assert bar.low == -2.0
+    assert bar.close == -1.0
+
+
+def test_ohlcv_bar_rejects_non_instrument_id() -> None:
+    with pytest.raises(DomainValidationError):
+        OHLCVBar(
+            instrument="BTCUSDT",  # type: ignore[arg-type]
+            start=VALID_RANGE_START,
+            end=VALID_RANGE_END,
+            open=100.0,
+            high=105.0,
+            low=95.0,
+            close=101.5,
+            volume=12.25,
+        )
+
+
+def test_ohlcv_bar_rejects_naive_start() -> None:
+    with pytest.raises(DomainValidationError):
+        make_ohlcv_bar(start=datetime(2026, 2, 28, 23, 45))
+
+
+def test_ohlcv_bar_rejects_non_utc_end() -> None:
+    with pytest.raises(DomainValidationError):
+        make_ohlcv_bar(
+            end=datetime(2026, 3, 1, 8, 0, tzinfo=timezone(timedelta(hours=8)))
+        )
+
+
+def test_ohlcv_bar_rejects_integer_price() -> None:
+    with pytest.raises(DomainValidationError):
+        OHLCVBar(
+            instrument=make_instrument(),
+            start=VALID_RANGE_START,
+            end=VALID_RANGE_END,
+            open=100,
+            high=105.0,
+            low=95.0,
+            close=101.5,
+            volume=12.25,
+        )
+
+
+def test_ohlcv_bar_serializes_to_json_compatible_stable_dict() -> None:
+    bar = make_ohlcv_bar(instrument=make_instrument("ethusdt"))
+
+    payload = bar.to_dict()
+
+    assert payload == {
+        "instrument": "ETHUSDT",
+        "start": "2026-02-28T23:45:00Z",
+        "end": "2026-03-01T00:00:00Z",
+        "open": 100.0,
+        "high": 105.0,
+        "low": 95.0,
+        "close": 101.5,
+        "volume": 12.25,
+    }
+    assert json.loads(json.dumps(payload)) == payload
+    assert OHLCVBar.from_dict(payload) == bar
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {
+            "instrument": "BTCUSDT",
+            "start": "2026-02-28T23:45:00Z",
+            "end": "2026-03-01T00:00:00Z",
+            "open": 100.0,
+            "high": 105.0,
+            "low": 95.0,
+            "close": 101.5,
+        },
+        {
+            "instrument": "BTCUSDT",
+            "start": "2026-02-28T23:45:00Z",
+            "end": "2026-03-01T00:00:00Z",
+            "open": 100.0,
+            "high": 105.0,
+            "low": 95.0,
+            "close": 101.5,
+            "volume": 12.25,
+            "timeframe": "15m",
+        },
+        {
+            "instrument": "BTC-USDT",
+            "start": "2026-02-28T23:45:00Z",
+            "end": "2026-03-01T00:00:00Z",
+            "open": 100.0,
+            "high": 105.0,
+            "low": 95.0,
+            "close": 101.5,
+            "volume": 12.25,
+        },
+        {
+            "instrument": "BTCUSDT",
+            "start": "2026-02-28T23:45:00",
+            "end": "2026-03-01T00:00:00Z",
+            "open": 100.0,
+            "high": 105.0,
+            "low": 95.0,
+            "close": 101.5,
+            "volume": 12.25,
+        },
+        {
+            "instrument": "BTCUSDT",
+            "start": "2026-03-01T07:45:00+08:00",
+            "end": "2026-03-01T00:00:00Z",
+            "open": 100.0,
+            "high": 105.0,
+            "low": 95.0,
+            "close": 101.5,
+            "volume": 12.25,
+        },
+        {
+            "instrument": "BTCUSDT",
+            "start": "2026-02-28T23:45:00Z",
+            "end": "2026-03-01T00:00:00Z",
+            "open": 100,
+            "high": 105.0,
+            "low": 95.0,
+            "close": 101.5,
+            "volume": 12.25,
+        },
+    ],
+)
+def test_ohlcv_bar_from_dict_rejects_invalid_payload(
+    payload: dict[str, object],
+) -> None:
+    with pytest.raises(DomainValidationError):
+        OHLCVBar.from_dict(payload)
+
+
+def test_shared_factory_returns_isolated_objects() -> None:
+    first = make_ohlcv_bar()
+    second = make_ohlcv_bar()
+
+    assert first == second
+    assert first is not second
+    assert first.instrument is not second.instrument
+    assert first.to_dict() is not second.to_dict()
+
+
+def test_domain_module_import_has_no_io_or_configuration_side_effects(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("QUANT_SYSTEM_ENV", "production")
+    monkeypatch.chdir(tmp_path)
+
+    import quant_system.domain as module
+
+    assert str(module.InstrumentId("BTCUSDT")) == str(InstrumentId("BTCUSDT"))
+    assert "QUANT_SYSTEM_ENV" in os.environ
+    assert list(tmp_path.iterdir()) == []

--- a/tests/test_domain_time_range.py
+++ b/tests/test_domain_time_range.py
@@ -1,0 +1,100 @@
+from dataclasses import FrozenInstanceError
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from quant_system.core.time import UTC
+from quant_system.domain import DomainValidationError, TimeRange
+from tests.fixtures.domain import VALID_RANGE_END, VALID_RANGE_START, make_time_range
+
+
+def test_time_range_is_utc_half_open_and_has_duration() -> None:
+    time_range = make_time_range()
+
+    assert time_range.start == VALID_RANGE_START
+    assert time_range.end == VALID_RANGE_END
+    assert time_range.duration == timedelta(minutes=15)
+    assert time_range.contains(VALID_RANGE_START)
+    assert time_range.contains(VALID_RANGE_END - timedelta(microseconds=1))
+    assert not time_range.contains(VALID_RANGE_END)
+
+
+def test_time_range_is_immutable_and_comparable() -> None:
+    time_range = make_time_range()
+
+    with pytest.raises(FrozenInstanceError):
+        time_range.start = VALID_RANGE_END  # type: ignore[misc]
+
+    assert time_range == TimeRange(start=VALID_RANGE_START, end=VALID_RANGE_END)
+
+
+@pytest.mark.parametrize(
+    ("start", "end"),
+    [
+        (datetime(2026, 2, 28, 23, 45), VALID_RANGE_END),
+        (VALID_RANGE_START, datetime(2026, 3, 1, 0, 0)),
+        (
+            datetime(2026, 2, 28, 23, 45, tzinfo=timezone(timedelta(hours=8))),
+            VALID_RANGE_END,
+        ),
+        (
+            VALID_RANGE_START,
+            datetime(2026, 3, 1, 8, 0, tzinfo=timezone(timedelta(hours=8))),
+        ),
+        (VALID_RANGE_START, VALID_RANGE_START),
+        (VALID_RANGE_END, VALID_RANGE_START),
+    ],
+)
+def test_time_range_rejects_invalid_datetime_boundaries(
+    start: datetime, end: datetime
+) -> None:
+    with pytest.raises(DomainValidationError):
+        TimeRange(start=start, end=end)
+
+
+def test_time_range_supports_cross_day_month_and_leap_day_boundaries() -> None:
+    time_range = TimeRange(
+        start=datetime(2024, 2, 29, 23, 59, tzinfo=UTC),
+        end=datetime(2024, 3, 1, 0, 1, tzinfo=UTC),
+    )
+
+    assert time_range.duration == timedelta(minutes=2)
+
+
+def test_time_range_contains_rejects_naive_and_non_utc_datetime() -> None:
+    time_range = make_time_range()
+
+    with pytest.raises(DomainValidationError):
+        time_range.contains(datetime(2026, 2, 28, 23, 50))
+
+    with pytest.raises(DomainValidationError):
+        time_range.contains(
+            datetime(2026, 3, 1, 7, 50, tzinfo=timezone(timedelta(hours=8)))
+        )
+
+
+def test_time_range_serializes_to_stable_utc_iso_strings() -> None:
+    time_range = make_time_range()
+
+    assert time_range.to_dict() == {
+        "start": "2026-02-28T23:45:00Z",
+        "end": "2026-03-01T00:00:00Z",
+    }
+    assert TimeRange.from_dict(time_range.to_dict()) == time_range
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"start": "2026-02-28T23:45:00Z"},
+        {"start": "2026-02-28T23:45:00Z", "end": "2026-03-01T00:00:00Z", "x": "y"},
+        {"start": "2026-02-28T23:45:00", "end": "2026-03-01T00:00:00Z"},
+        {"start": "2026-03-01T07:45:00+08:00", "end": "2026-03-01T00:00:00Z"},
+        {"start": 1, "end": "2026-03-01T00:00:00Z"},
+    ],
+)
+def test_time_range_from_dict_rejects_invalid_payload(
+    payload: dict[str, object],
+) -> None:
+    with pytest.raises(DomainValidationError):
+        TimeRange.from_dict(payload)


### PR DESCRIPTION
## 关联 Issue

Closes #65

## 实现摘要

- Added `quant_system.domain` with immutable `InstrumentId`, `TimeRange`, `OHLCVBar`, and `DomainValidationError`.
- Added stable JSON-compatible `to_dict` / `from_dict` paths with explicit UTC, finite-float, OHLC, and payload-shape validation.
- Added deterministic shared domain factories and a function-scope pytest fixture reused across domain tests.
- Documented the initial Research MVP domain model boundary and fixture conventions in README.

## 修改范围

- `src/quant_system/domain.py`
- `tests/fixtures/domain.py`
- `tests/conftest.py`
- `tests/test_domain_instrument.py`
- `tests/test_domain_time_range.py`
- `tests/test_domain_ohlcv.py`
- `README.md`

## 关键设计决定

- Public import path is `quant_system.domain`; package root does not re-export these models.
- `InstrumentId` uses a conservative 1-32 character normalized ASCII uppercase letters/digits boundary.
- `TimeRange` accepts only aware UTC datetimes and reuses `quant_system.core.time` helpers for awareness, UTC checks, and formatting.
- `OHLCVBar` requires Python `float` values, rejects non-finite numbers and negative volume, and permits zero/negative prices for current research-data flexibility.
- No Pydantic, ORM, exchange metadata, timeframe enum, order/account/strategy abstractions, pickle, or fixture platform was added.

## 验证结果

| 命令 | 结果 | 说明 |
| --- | --- | --- |
| `uv lock --check` | Pass | lock file unchanged and valid |
| `uv run --frozen pytest` | Pass | 169 passed |
| `uv run --frozen ruff check .` | Pass | all checks passed |
| `uv run --frozen ruff format --check .` | Pass | 26 files already formatted |
| `uv run --frozen mypy src tests` | Pass | no issues in 22 source files |
| `git diff --check` | Pass | no whitespace errors |
| `workflow_validation.py --phase delivery` | Pass | 6/6 commands passed |
| Structural checks | Pass | import, invalid datetime, invalid floats/volume/OHLC, JSON serialization, fixture isolation, and no import I/O side effects covered |

## 从 Issue 复制的验收标准

- [x] 存在 `InstrumentId`、`TimeRange`、`OHLCVBar`
- [x] 三类模型具有明确、最小的公共导入路径
- [x] 模型不可变、可比较且类型完整
- [x] `InstrumentId` 规范化和非法输入测试完整
- [x] `TimeRange` 使用 #9 当前 UTC 公共工具
- [x] 没有复制第二套 timezone 校验
- [x] naive、非 UTC 和非法区间明确失败
- [x] `OHLCVBar` 拒绝 NaN、infinity 和负 volume
- [x] OHLC 关系得到校验
- [x] 价格为 0 或负值的当前语义已测试和记录
- [x] 序列化输出 JSON-compatible 且稳定
- [x] 反序列化非法数据明确失败
- [x] round-trip 测试通过
- [x] 不使用 pickle
- [x] 共享 fixture/factory 结构和命名规则明确
- [x] fixture 默认 function scope
- [x] fixture 不读取当前时间、随机数、环境、网络或文件
- [x] 多次 factory 调用不共享可变状态
- [x] 至少两个测试模块真实复用共享 fixture/factory
- [x] 没有 mega-fixture 或未来领域抽象
- [x] 没有新增大型 validation/ORM 依赖
- [x] 文档说明当前模型边界和已知限制
- [x] 当前完整 CI 等价命令通过
- [x] `git diff --check` 通过
- [x] 本地临时文件、运行日志和其他非交付物未进入 PR

## 风险检查

- [x] 未引入未授权实盘交易行为
- [x] 未提交或记录 API 密钥
- [x] 未引入无时区 datetime
- [x] 未引入未来数据泄漏
- [x] 未将缺失数据静默填零
- [x] 未绕过风险模块
- [x] 未进行范围外重构
- [x] 已测试失败路径

## 范围外内容

- Orders, fills, accounts, positions, strategies, factors, labels, backtest events, exchange adapters, storage schemas, timeframe enums, calendars, Decimal precision, and large fixture platforms remain out of scope.

## 已知限制

- These models are the initial internal Research MVP public boundary, not a long-term external schema compatibility contract.
- Instrument syntax is intentionally minimal and does not encode venue, market type, base/quote parsing, tick size, or lot size.