### PR TITLE
[Task] 建立只读 GitHub Evidence Runner 与 Git 操作审批边界

### DIFF
--- a/.agents/policies/command-execution.md
+++ b/.agents/policies/command-execution.md
@@ -13,6 +13,7 @@ It applies to:
 .agents/skills/task-closeout/SKILL.md
 .agents/skills/feature-completion-audit/SKILL.md
 tools/agent_workflow/workflow_evidence.py
+tools/agent_workflow/wsl2_github_evidence_runner.py
 tools/agent_workflow/workflow_validation.py
 tools/agent_workflow/trusted_runner.py
 ```
@@ -211,7 +212,8 @@ be routed according to a valid profile:
   `task-closeout`;
 - exact branch operations already authorized by `task-closeout` after all of its
   branch-safety gates pass;
-- read-only `workflow_evidence.py` and `trusted_runner.py` operations plus exact
+- read-only `workflow_evidence.py`, fixed
+  `wsl2_github_evidence_runner.py`, and `trusted_runner.py` operations plus exact
   sanitized local writes below `.agents/evidence.local/` authorized by
   `.agents/policies/workflow-evidence.md`;
 - `workflow_validation.py` checks plus exact sanitized local writes below

--- a/.agents/policies/workflow-evidence.md
+++ b/.agents/policies/workflow-evidence.md
@@ -46,6 +46,18 @@ closeout-plan            closeout-final
 feature-audit-snapshot   feature-audit-recheck
 ```
 
+The WSL2 fixed front door is:
+
+```text
+tools/agent_workflow/wsl2_github_evidence_runner.py
+```
+
+It maps named Task workflow profiles to the operations above, validates complete
+argv and repository identity, disables `git fetch`, compares fixed remote refs
+with `git ls-remote`, and preserves partial/fail semantics. Task #85 controls
+whether and when workflow Skills replace their current invocation paths with this
+runner.
+
 Each snapshot must be deterministic, machine-readable, bounded, and include:
 
 - repository and subject identity;

--- a/.codex/rules/quant-system-wsl-evidence.rules
+++ b/.codex/rules/quant-system-wsl-evidence.rules
@@ -1,0 +1,79 @@
+# quant-system WSL2 GitHub evidence runner rules
+#
+# Scope:
+# - Allow only the fixed repository Evidence Runner and named profile prefixes.
+# - Codex execpolicy uses prefix matching; allow is not complete argv acceptance.
+# - The runner validates the complete argument set, repository identity, trusted
+#   files, fixed GitHub queries, and fixed read-only Git commands before evidence
+#   collection.
+# - No user-provided repository, REST path, GraphQL, gh argv, Git argv, shell,
+#   output path, or working directory is accepted.
+# - Known dangerous options below are defense-in-depth. Arbitrary trailing argv
+#   remains a runner fail-closed responsibility before GitHub/Git subprocesses.
+# - Direct gh, Git writes, fetch, authentication-token output, shells, Python,
+#   push, branch deletion, reset, clean, merge, and history modification are not
+#   allowed by these evidence rules.
+
+prefix_rule(
+    pattern = ["tools/agent_workflow/wsl2_github_evidence_runner.py", "delivery"],
+    decision = "allow",
+    justification = "Allow the fixed Task Delivery preflight evidence profile prefix; runner validates complete argv and uses only fixed read-only queries.",
+)
+
+prefix_rule(
+    pattern = ["tools/agent_workflow/wsl2_github_evidence_runner.py", "delivery-readiness"],
+    decision = "allow",
+    justification = "Allow the fixed Delivery readiness evidence profile prefix; runner validates Task, PR, SHAs and complete argv.",
+)
+
+prefix_rule(
+    pattern = ["tools/agent_workflow/wsl2_github_evidence_runner.py", "review"],
+    decision = "allow",
+    justification = "Allow the fixed independent Review evidence profile prefix; no GitHub write path is exposed.",
+)
+
+prefix_rule(
+    pattern = ["tools/agent_workflow/wsl2_github_evidence_runner.py", "pre-merge"],
+    decision = "allow",
+    justification = "Allow the fixed pre-merge read-only revalidation profile prefix; manual merge remains outside the rule.",
+)
+
+prefix_rule(
+    pattern = ["tools/agent_workflow/wsl2_github_evidence_runner.py", "closeout-readonly"],
+    decision = "allow",
+    justification = "Allow only the read-only closeout evidence profile prefix; Issue, Project and branch cleanup writes remain approval gated.",
+)
+
+prefix_rule(
+    pattern = ["tools/agent_workflow/wsl2_github_evidence_runner.py", "recheck"],
+    decision = "allow",
+    justification = "Allow a fixed stored-snapshot stability recheck prefix; runner validates the snapshot ID and supported prior operation.",
+)
+
+prefix_rule(
+    pattern = [
+        "tools/agent_workflow/wsl2_github_evidence_runner.py",
+        ["delivery", "delivery-readiness", "review", "pre-merge", "closeout-readonly", "recheck"],
+        ["--repo", "--repository", "--api", "--graphql", "--gh-arg", "--git-arg", "--shell", "--exec", "--", "|", ">", "$(id)"],
+    ],
+    decision = "forbidden",
+    justification = "Defense-in-depth against repository/API/command injection and shell metacharacter forms; the runner remains the complete argv gate.",
+)
+
+prefix_rule(
+    pattern = ["gh", "auth", "token"],
+    decision = "forbidden",
+    justification = "Never print GitHub authentication tokens.",
+)
+
+prefix_rule(
+    pattern = ["git", ["add", "commit", "switch", "checkout", "fetch", "push", "branch", "reset", "clean", "merge", "rebase", "cherry-pick", "revert"]],
+    decision = "prompt",
+    justification = "Git writes, ref refresh, branch operations, history changes and destructive commands remain explicit workflow approvals.",
+)
+
+prefix_rule(
+    pattern = ["gh", ["issue", "pr", "project", "api"]],
+    decision = "prompt",
+    justification = "Direct GitHub CLI and raw API calls remain explicit approvals; the fixed Evidence Runner is the only allow entry.",
+)

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ A research-first quantitative trading system for cryptocurrency perpetual future
 - [Deep research report 2](docs/research/deep-research-report-2.md): historical follow-up research used to refine the technical direction.
 - [Technical roadmap research](docs/research/technical-roadmap-research.md): historical comparative research behind the selected implementation route.
 - [WSL2 Codex environment](docs/workflows/wsl2-codex-environment/README.md): reproducible WSL2 setup, diagnostics, approval boundaries, rollback, and troubleshooting.
+- [WSL2 GitHub evidence runner](docs/workflows/wsl2-github-evidence-runner/README.md): fixed read-only Task/PR snapshots, drift rechecks, least-privilege Rules, and Git/GitHub approval boundaries.
 
 ## Current status
 
@@ -152,6 +153,7 @@ and validation summaries:
 
 ```powershell
 python -X utf8 tools/agent_workflow/workflow_evidence.py --help
+tools/agent_workflow/wsl2_github_evidence_runner.py --help
 python -X utf8 tools/agent_workflow/workflow_validation.py --help
 python -X utf8 tools/agent_workflow/trusted_runner.py --help
 ```

--- a/docs/workflows/publication-materials/task-material-register.md
+++ b/docs/workflows/publication-materials/task-material-register.md
@@ -60,7 +60,7 @@
 | Task #81：Windows merge-pre 基准采集 | Issue #81；业务 Issue #65；实验 PR #99 | Feature #77 / Epic #61 | 当前 Windows 正式基准、失败 pilot、rollout | `formal-sample` + `invalid-sample`、Issue 已完成 | 当前基准、失败恢复、Token/命令/Guardian 数据 |
 | Task #82：可复现 WSL2 Codex 环境与能力诊断 | Issue #82 / PR #100 / reviewed head `96b20b5...` / merge `767e995...` | Feature #77 / Epic #61 | 环境指南、诊断工具、能力矩阵、决策与案例 | `repository-final`、已完成 | 指导手册环境章节；Token 文章候选变量与边界 |
 | Task #83：WSL2 Validation Runner 与最小权限 Rules | Issue #83 / PR #101 / reviewed head `d162bc9...` / merge `74a7587...` | Feature #77 / Epic #61 | Runner、Rules、权限与命令成本材料 | `repository-final`、已完成 | 后续优化机制和控制面证据 |
-| Task #84：只读 GitHub Evidence Runner 与 Git 审批边界 | Issue #84；PR #102；Base `74a7587...`；Head `3814af3...` | Feature #77 / Epic #61 | GitHub 只读证据、Git 写边界与审批材料 | `delivery-review` | 证据采集、安全边界和命令成本 |
+| Task #84：只读 GitHub Evidence Runner 与 Git 审批边界 | Issue #84；PR #102；Base `74a7587...`；live material capture `3814af3...` | Feature #77 / Epic #61 | GitHub 只读证据、Git 写边界与审批材料 | `delivery-review` | 证据采集、安全边界和命令成本 |
 | Task #85：Skills 切换至统一 Runner | Issue #85；PR：待创建 | Feature #77 / Epic #61 | 统一命令路径、重复移除与 Skill 迁移材料 | `placeholder` | 工作流收敛机制和 Token 优化来源 |
 | Task #86：Task #65 WSL2 candidate merge-pre | Issue #86；业务 Issue #65；实验 PR：待创建 | Feature #77 / Epic #61 | Candidate Token、质量、Guardian、命令与时长 | `placeholder` | 最终 Windows/WSL2 对照和优化结论 |
 | Task #87：Canonical Spec 审计 | Issue #87；PR：待创建 | Feature #78 / Epic #61 | 规格重复、治理来源与 Canonical Spec | `placeholder` | 规格治理和上下文去重 |
@@ -438,7 +438,8 @@
 - Parent Feature：`#77`
 - Epic：`#61`
 - Base / workflow / control-plane SHA：`74a75872078221c38dbd132a1d438b0bb05c1870`
-- Delivery HEAD：`3814af3d95ece48ef03c59536dd025f5fb5511fb`
+- Live material capture HEAD：`3814af3d95ece48ef03c59536dd025f5fb5511fb`
+- Current Delivery HEAD：见 PR #102 body 和最终 readiness snapshot
 - reviewed HEAD / verdict：`待回填`
 - merge commit：`待回填`
 - 生命周期状态：PR 已创建并进入 Review；Task #65 candidate 未执行。
@@ -500,7 +501,7 @@
 
 ### 待办
 
-- [x] 创建/更新 PR 后回填 PR、Delivery HEAD 和 effective diff identity。
+- [x] 创建/更新 PR 后回填 PR、live material capture HEAD 和 effective diff identity。
 - [ ] 独立 Review 后回填 reviewed HEAD、verdict 和 findings。
 - [ ] Merge/Closeout 后回填 merge commit、Issue/Project 和 branch cleanup。
 - [ ] Task #85 切换 Skills 后记录真实前后命令路径差异。

--- a/docs/workflows/publication-materials/task-material-register.md
+++ b/docs/workflows/publication-materials/task-material-register.md
@@ -462,6 +462,11 @@
   `docs/workflows/wsl2-github-evidence-runner/security-and-troubleshooting.md`。
 - [x] 指导手册与 Token 文章材料：
   `docs/workflows/wsl2-github-evidence-runner/publication-materials.json`；
+  `docs/workflows/wsl2-github-evidence-runner/historical-command-baseline.json`；
+  `docs/workflows/wsl2-github-evidence-runner/environment-capability.json`；
+  `docs/workflows/wsl2-github-evidence-runner/live-evidence-capture-plan.md`；
+  `docs/workflows/wsl2-github-evidence-runner/publication-readiness.md`；
+  `docs/workflows/wsl2-github-evidence-runner/templates/`；
   `docs/workflows/wsl2-github-evidence-runner/visuals/`。
 
 ### 当前证据边界
@@ -471,8 +476,14 @@
   symlink、路径含空格、并发输出隔离和无 GitHub 写操作。
 - [x] Rules 测试覆盖固定入口、直接 `gh`/Git/shell 不放行、Git/GitHub 写
   继续审批，以及 prefix allow + Runner complete-argv reject 的组合边界。
+- [x] Task #63/#64 外部分析报告中的历史 Git/`gh`、Guardian 与 Token
+  聚合数据已以摘要和 source SHA 归档；原始 rollout/report 不提交。
+- [x] Live profile、snapshot recheck、execpolicy 和环境能力的版本化采集
+  契约、JSON 模板与 readiness matrix 已归档。
 - [ ] 创建 PR 并提交 trusted files 后，对真实 Task #84 / PR 执行 live profile，
   记录 API 调用数、stdout、时长、Guardian、approval 和 result SHA-256。
+- [ ] 使用同一 snapshot 执行 live recheck，并在全新 Codex 会话记录真实
+  execpolicy matrix 和 Runner 尾随参数拒绝。
 - [ ] 外部 Token 指标继续留给 rollout 分析和 Task #86，不在本 Task 推导。
 
 ### 最终文档用途

--- a/docs/workflows/publication-materials/task-material-register.md
+++ b/docs/workflows/publication-materials/task-material-register.md
@@ -60,7 +60,7 @@
 | Task #81：Windows merge-pre 基准采集 | Issue #81；业务 Issue #65；实验 PR #99 | Feature #77 / Epic #61 | 当前 Windows 正式基准、失败 pilot、rollout | `formal-sample` + `invalid-sample`、Issue 已完成 | 当前基准、失败恢复、Token/命令/Guardian 数据 |
 | Task #82：可复现 WSL2 Codex 环境与能力诊断 | Issue #82 / PR #100 / reviewed head `96b20b5...` / merge `767e995...` | Feature #77 / Epic #61 | 环境指南、诊断工具、能力矩阵、决策与案例 | `repository-final`、已完成 | 指导手册环境章节；Token 文章候选变量与边界 |
 | Task #83：WSL2 Validation Runner 与最小权限 Rules | Issue #83 / PR #101 / reviewed head `d162bc9...` / merge `74a7587...` | Feature #77 / Epic #61 | Runner、Rules、权限与命令成本材料 | `repository-final`、已完成 | 后续优化机制和控制面证据 |
-| Task #84：只读 GitHub Evidence Runner 与 Git 审批边界 | Issue #84；PR：待创建；Base `74a7587...` | Feature #77 / Epic #61 | GitHub 只读证据、Git 写边界与审批材料 | `delivery-pending` | 证据采集、安全边界和命令成本 |
+| Task #84：只读 GitHub Evidence Runner 与 Git 审批边界 | Issue #84；PR #102；Base `74a7587...`；Head `3814af3...` | Feature #77 / Epic #61 | GitHub 只读证据、Git 写边界与审批材料 | `delivery-review` | 证据采集、安全边界和命令成本 |
 | Task #85：Skills 切换至统一 Runner | Issue #85；PR：待创建 | Feature #77 / Epic #61 | 统一命令路径、重复移除与 Skill 迁移材料 | `placeholder` | 工作流收敛机制和 Token 优化来源 |
 | Task #86：Task #65 WSL2 candidate merge-pre | Issue #86；业务 Issue #65；实验 PR：待创建 | Feature #77 / Epic #61 | Candidate Token、质量、Guardian、命令与时长 | `placeholder` | 最终 Windows/WSL2 对照和优化结论 |
 | Task #87：Canonical Spec 审计 | Issue #87；PR：待创建 | Feature #78 / Epic #61 | 规格重复、治理来源与 Canonical Spec | `placeholder` | 规格治理和上下文去重 |
@@ -434,14 +434,14 @@
 ### 身份
 
 - Task Issue：`#84`
-- PR：`待创建`
+- PR：`#102`
 - Parent Feature：`#77`
 - Epic：`#61`
 - Base / workflow / control-plane SHA：`74a75872078221c38dbd132a1d438b0bb05c1870`
-- Delivery HEAD：`待回填`
+- Delivery HEAD：`3814af3d95ece48ef03c59536dd025f5fb5511fb`
 - reviewed HEAD / verdict：`待回填`
 - merge commit：`待回填`
-- 生命周期状态：Delivery implementation prepared；Task #65 candidate 未执行。
+- 生命周期状态：PR 已创建并进入 Review；Task #65 candidate 未执行。
 
 ### 已产生材料
 
@@ -468,6 +468,11 @@
   `docs/workflows/wsl2-github-evidence-runner/publication-readiness.md`；
   `docs/workflows/wsl2-github-evidence-runner/templates/`；
   `docs/workflows/wsl2-github-evidence-runner/visuals/`。
+- [x] Live profile、recheck、execpolicy 和外部 manifest 摘要：
+  `docs/workflows/wsl2-github-evidence-runner/live-profile-evidence.json`；
+  `docs/workflows/wsl2-github-evidence-runner/live-recheck-evidence.json`；
+  `docs/workflows/wsl2-github-evidence-runner/rules-live-evidence.json`；
+  `docs/workflows/wsl2-github-evidence-runner/external-live-evidence-manifest.json`。
 
 ### 当前证据边界
 
@@ -480,9 +485,9 @@
   聚合数据已以摘要和 source SHA 归档；原始 rollout/report 不提交。
 - [x] Live profile、snapshot recheck、execpolicy 和环境能力的版本化采集
   契约、JSON 模板与 readiness matrix 已归档。
-- [ ] 创建 PR 并提交 trusted files 后，对真实 Task #84 / PR 执行 live profile，
+- [x] 创建 PR 并提交 trusted files 后，对真实 Task #84 / PR 执行 live profile，
   记录 API 调用数、stdout、时长、Guardian、approval 和 result SHA-256。
-- [ ] 使用同一 snapshot 执行 live recheck，并在全新 Codex 会话记录真实
+- [x] 使用同一 snapshot 执行 live recheck，并记录真实
   execpolicy matrix 和 Runner 尾随参数拒绝。
 - [ ] 外部 Token 指标继续留给 rollout 分析和 Task #86，不在本 Task 推导。
 
@@ -495,7 +500,7 @@
 
 ### 待办
 
-- [ ] 创建/更新 PR 后回填 PR、Delivery HEAD 和 effective diff identity。
+- [x] 创建/更新 PR 后回填 PR、Delivery HEAD 和 effective diff identity。
 - [ ] 独立 Review 后回填 reviewed HEAD、verdict 和 findings。
 - [ ] Merge/Closeout 后回填 merge commit、Issue/Project 和 branch cleanup。
 - [ ] Task #85 切换 Skills 后记录真实前后命令路径差异。

--- a/docs/workflows/publication-materials/task-material-register.md
+++ b/docs/workflows/publication-materials/task-material-register.md
@@ -59,8 +59,8 @@
 | Task #80：第二轮实验协议与 Task #65 输入冻结 | Issue #80 / PR：待回填 | Feature #77 / Epic #61 | 协议、冻结输入、统计口径、材料 Schema | `repository-final`、Issue 已完成 | 两份文档的实验方法和权威输入 |
 | Task #81：Windows merge-pre 基准采集 | Issue #81；业务 Issue #65；实验 PR #99 | Feature #77 / Epic #61 | 当前 Windows 正式基准、失败 pilot、rollout | `formal-sample` + `invalid-sample`、Issue 已完成 | 当前基准、失败恢复、Token/命令/Guardian 数据 |
 | Task #82：可复现 WSL2 Codex 环境与能力诊断 | Issue #82 / PR #100 / reviewed head `96b20b5...` / merge `767e995...` | Feature #77 / Epic #61 | 环境指南、诊断工具、能力矩阵、决策与案例 | `repository-final`、已完成 | 指导手册环境章节；Token 文章候选变量与边界 |
-| Task #83：WSL2 Validation Runner 与最小权限 Rules | Issue #83 / PR #101 / Base `767e995...` | Feature #77 / Epic #61 | Runner、Rules、权限与命令成本材料 | `delivery-pending` | 后续优化机制和控制面证据 |
-| Task #84：只读 GitHub Evidence Runner 与 Git 审批边界 | Issue #84；PR：待创建 | Feature #77 / Epic #61 | GitHub 只读证据、Git 写边界与审批材料 | `placeholder` | 证据采集、安全边界和命令成本 |
+| Task #83：WSL2 Validation Runner 与最小权限 Rules | Issue #83 / PR #101 / reviewed head `d162bc9...` / merge `74a7587...` | Feature #77 / Epic #61 | Runner、Rules、权限与命令成本材料 | `repository-final`、已完成 | 后续优化机制和控制面证据 |
+| Task #84：只读 GitHub Evidence Runner 与 Git 审批边界 | Issue #84；PR：待创建；Base `74a7587...` | Feature #77 / Epic #61 | GitHub 只读证据、Git 写边界与审批材料 | `delivery-pending` | 证据采集、安全边界和命令成本 |
 | Task #85：Skills 切换至统一 Runner | Issue #85；PR：待创建 | Feature #77 / Epic #61 | 统一命令路径、重复移除与 Skill 迁移材料 | `placeholder` | 工作流收敛机制和 Token 优化来源 |
 | Task #86：Task #65 WSL2 candidate merge-pre | Issue #86；业务 Issue #65；实验 PR：待创建 | Feature #77 / Epic #61 | Candidate Token、质量、Guardian、命令与时长 | `placeholder` | 最终 Windows/WSL2 对照和优化结论 |
 | Task #87：Canonical Spec 审计 | Issue #87；PR：待创建 | Feature #78 / Epic #61 | 规格重复、治理来源与 Canonical Spec | `placeholder` | 规格治理和上下文去重 |
@@ -360,10 +360,14 @@
 - Epic：`#61`
 - Branch：`83-task-wsl2-validation-runner-rules`
 - Base / workflow / control-plane SHA：`767e995e7872c5eaea46002cf02381cef87f3eab`
-- Delivery HEAD：`待回填`
-- reviewed HEAD / verdict：`待回填`
-- merge commit：`待回填`
-- 生命周期状态：Delivery in progress；Task #65 candidate 未执行。
+- final Delivery / reviewed HEAD：`d162bc9f2846854c3f4bf0dcc6a938102f850d14`
+- Review verdict：`pass`
+- squash merge commit：`74a75872078221c38dbd132a1d438b0bb05c1870`
+- Issue / Project：Issue closed；Project Status `Done`
+- Branch cleanup：completed
+- Post-merge validation：`148 passed`；remote `quality: SUCCESS`
+- Closeout evidence：plan `ev-937d4dbc6ce95774`；validation `val-closeout-3170e0980aa4`；final `ev-902fd5acf87a567f`
+- 生命周期状态：Task #83 已完成；Task #65 candidate 未执行。
 
 ### 已产生材料
 
@@ -419,21 +423,80 @@
 
 ### 待办
 
-- [ ] 当前 checkpoint 提交后回填 Delivery HEAD 和 effective diff identity。
-- [ ] 独立 Review 后回填 reviewed HEAD、Review verdict 和 findings。
-- [ ] Merge/Closeout 后回填 merge commit、最终 Issue/Project 状态和 branch cleanup。
+- [x] final Delivery / reviewed HEAD、Review verdict、merge commit、Issue/Project、branch cleanup 和 post-merge validation 已由 Task #84 回填。
 - [x] 新 Codex 会话加载 rules 后，仓库外记录 live Guardian、approval、输出大小和时长。
-- [ ] Task #84 处理 `baseRefOid` / GitHub Evidence helper 兼容性。
+- [x] `baseRefOid` 环境兼容阻塞通过升级 WSL2 GitHub CLI 消除；Task #84 继续负责固定 Evidence Runner、partial/unknown 和审批边界。
+
+---
+
+## Task #84 — 建立只读 GitHub Evidence Runner 与 Git 操作审批边界
+
+### 身份
+
+- Task Issue：`#84`
+- PR：`待创建`
+- Parent Feature：`#77`
+- Epic：`#61`
+- Base / workflow / control-plane SHA：`74a75872078221c38dbd132a1d438b0bb05c1870`
+- Delivery HEAD：`待回填`
+- reviewed HEAD / verdict：`待回填`
+- merge commit：`待回填`
+- 生命周期状态：Delivery implementation prepared；Task #65 candidate 未执行。
+
+### 已产生材料
+
+- [x] 固定 Runner 与 profiles：
+  `tools/agent_workflow/wsl2_github_evidence_runner.py`；
+  `tools/agent_workflow/wsl2_github_evidence_profiles.json`。
+- [x] 最小权限 Rules：
+  `.codex/rules/quant-system-wsl-evidence.rules`。
+- [x] Evidence read-only mode：
+  `tools/agent_workflow/workflow_evidence.py` 支持固定 Runner 使用的
+  `WORKFLOW_EVIDENCE_READ_ONLY=1`，跳过 `git fetch` 并返回 `local_main_sha`。
+- [x] 单元、集成、负向和 Rules 测试：
+  `tests/tools/test_wsl2_github_evidence_runner.py`；
+  `tests/tools/test_wsl2_github_evidence_rules.py`。
+- [x] 使用、安全、凭据、回滚和故障排查：
+  `docs/workflows/wsl2-github-evidence-runner/README.md`；
+  `docs/workflows/wsl2-github-evidence-runner/git-approval-boundary.md`；
+  `docs/workflows/wsl2-github-evidence-runner/security-and-troubleshooting.md`。
+- [x] 指导手册与 Token 文章材料：
+  `docs/workflows/wsl2-github-evidence-runner/publication-materials.json`；
+  `docs/workflows/wsl2-github-evidence-runner/visuals/`。
+
+### 当前证据边界
+
+- [x] 测试覆盖固定 profiles、Task/PR/schema、partial/unknown、linkage fail、
+  remote-ref drift、snapshot recheck、truncation、敏感信息、错误 origin、
+  symlink、路径含空格、并发输出隔离和无 GitHub 写操作。
+- [x] Rules 测试覆盖固定入口、直接 `gh`/Git/shell 不放行、Git/GitHub 写
+  继续审批，以及 prefix allow + Runner complete-argv reject 的组合边界。
+- [ ] 创建 PR 并提交 trusted files 后，对真实 Task #84 / PR 执行 live profile，
+  记录 API 调用数、stdout、时长、Guardian、approval 和 result SHA-256。
+- [ ] 外部 Token 指标继续留给 rollout 分析和 Task #86，不在本 Task 推导。
+
+### 最终文档用途
+
+- 指导手册：固定只读 evidence 入口、profile/schema、partial/unknown、
+  snapshot/recheck、凭据、Git/GitHub 审批与回滚。
+- Token 文章：模型可见命令收敛、内部 API operation accounting、紧凑输出、
+  失败案例与未测量 Token 边界。
+
+### 待办
+
+- [ ] 创建/更新 PR 后回填 PR、Delivery HEAD 和 effective diff identity。
+- [ ] 独立 Review 后回填 reviewed HEAD、verdict 和 findings。
+- [ ] Merge/Closeout 后回填 merge commit、Issue/Project 和 branch cleanup。
+- [ ] Task #85 切换 Skills 后记录真实前后命令路径差异。
 
 ---
 
 ## 已编号的后续 Task
 
-以下 Task 已有正式 Issue 编号，但尚未产生可冻结材料；Task #83 已展开为上方完整登记小节。每个 Task 开始 Delivery 后，应把对应条目扩展为完整登记小节。
+以下 Task 已有正式 Issue 编号，但尚未产生可冻结材料；Task #83 与 #84 已展开为上方完整登记小节。每个 Task 开始 Delivery 后，应把对应条目扩展为完整登记小节。
 
 | Issue | Task | Parent | 当前材料状态 |
 | --- | --- | --- | --- |
-| `#84` | 建立只读 GitHub Evidence Runner 与 Git 操作审批边界 | Feature `#77` | `placeholder` |
 | `#85` | 将 Task Workflow Skills 切换到统一 Runner 并移除重复命令路径 | Feature `#77` | `placeholder` |
 | `#86` | 采集 Task #65 WSL2 优化候选 merge-pre 基准并评估效果 | Feature `#77` | `placeholder` |
 | `#87` | 审计 Task Workflow 规格与治理上下文重复并定义 Canonical Spec | Feature `#78` | `placeholder` |

--- a/docs/workflows/workflow-evidence.md
+++ b/docs/workflows/workflow-evidence.md
@@ -24,6 +24,7 @@ Validation：命令编排、退出码、有限摘要
 ```text
 tools/agent_workflow/workflow_common.py
 tools/agent_workflow/workflow_evidence.py
+tools/agent_workflow/wsl2_github_evidence_runner.py
 tools/agent_workflow/workflow_validation.py
 tools/agent_workflow/trusted_runner.py
 ```
@@ -91,6 +92,35 @@ python -X utf8 tools/agent_workflow/workflow_evidence.py `
 Recheck 会重新取证，再比较 base/head、effective diff、checks、threads、main 或 direct
 child set。旧 snapshot 只作为比较基线，不作为当前事实。Feature snapshot 还会为 direct
 child 的 closing PR 记录 merge SHA 与 check-run 摘要；该元数据不替代当前-main 语义审计。
+
+## WSL2 固定 GitHub Evidence Runner
+
+Task 工作流的固定只读入口为：
+
+```bash
+tools/agent_workflow/wsl2_github_evidence_runner.py --help
+```
+
+它提供 `delivery`、`delivery-readiness`、`review`、`pre-merge`、
+`closeout-readonly` 和 `recheck` profiles。Runner 固定仓库、profile 与参数
+schema，不接受任意 repo、REST/GraphQL path、`gh`/Git 参数、Shell 字符串、输出路径或
+工作目录。
+
+Runner 通过 `WORKFLOW_EVIDENCE_READ_ONLY=1` 调用本文件中的 Evidence CLI，因此不会
+执行 `git fetch`；本地 ref 只读快照会附加 `local_main_sha` 和
+`origin_refresh=skipped-read-only`。Runner 再使用固定 `git ls-remote --heads` 比较
+current remote `main` 和 PR head branch。未知、权限不足、限流或截断返回 `partial`
+(exit `3`)，不能当作 `pass`。
+
+完整说明见：
+
+```text
+docs/workflows/wsl2-github-evidence-runner/README.md
+docs/workflows/wsl2-github-evidence-runner/git-approval-boundary.md
+```
+
+Task #85 决定 Skills 的正式切换；Task #84 不删除当前 Evidence CLI 或改变独立 Review
+语义。
 
 ## Validation Runner
 

--- a/docs/workflows/wsl2-github-evidence-runner/README.md
+++ b/docs/workflows/wsl2-github-evidence-runner/README.md
@@ -1,0 +1,244 @@
+# WSL2 GitHub Evidence Runner
+
+## Purpose
+
+`tools/agent_workflow/wsl2_github_evidence_runner.py` is the fixed, read-only
+front door for Task workflow evidence collection in the supported WSL2
+workspace.
+
+It consolidates Task, Pull Request, checks, review threads, Project status,
+changed files, commits, diff identity, and local/remote Git facts into one
+bounded invocation. It does not comment, edit labels, update Project fields,
+close Issues, push, merge, fetch, switch branches, or delete branches.
+
+Task #85 may switch workflow Skills to this runner. Task #84 only establishes
+the runner, evidence contract, Rules, approval boundary, tests, and integration
+instructions.
+
+## Fixed repository and trusted files
+
+The runner is restricted to:
+
+```text
+PhoenixSss/quant-system
+```
+
+It must be launched from the repository root on the WSL2 Linux filesystem. It
+rejects `/mnt` workspaces, symlink entry points, wrong origins, unknown profiles,
+unknown arguments, arbitrary repository names, raw REST/GraphQL paths, arbitrary
+`gh`/Git arguments, shell strings, and output paths.
+
+Before any evidence subprocess runs, the following files must match their
+tracked `HEAD` blobs:
+
+```text
+tools/agent_workflow/wsl2_github_evidence_runner.py
+tools/agent_workflow/wsl2_github_evidence_profiles.json
+.codex/rules/quant-system-wsl-evidence.rules
+tools/agent_workflow/workflow_evidence.py
+tools/agent_workflow/workflow_common.py
+```
+
+Intentional changes to these files must be committed before the fixed runner can
+be exercised again.
+
+## Profiles
+
+### Delivery preflight
+
+```bash
+tools/agent_workflow/wsl2_github_evidence_runner.py delivery \
+  --task 84 \
+  --expected-main-sha <FULL_MAIN_SHA>
+```
+
+Collects Task, relationship, local Git, `origin/main`, and remote `main` facts
+without a PR requirement.
+
+### Delivery readiness
+
+```bash
+tools/agent_workflow/wsl2_github_evidence_runner.py delivery-readiness \
+  --task 84 \
+  --pr <PR_NUMBER> \
+  --expected-base-sha <FULL_BASE_SHA> \
+  --expected-head-sha <FULL_HEAD_SHA>
+```
+
+### Independent review
+
+```bash
+tools/agent_workflow/wsl2_github_evidence_runner.py review \
+  --task 84 \
+  --pr <PR_NUMBER> \
+  --expected-base-sha <FULL_BASE_SHA> \
+  --expected-head-sha <FULL_HEAD_SHA>
+```
+
+### Pre-merge revalidation
+
+```bash
+tools/agent_workflow/wsl2_github_evidence_runner.py pre-merge \
+  --task 84 \
+  --pr <PR_NUMBER> \
+  --expected-base-sha <FULL_BASE_SHA> \
+  --expected-head-sha <FULL_HEAD_SHA>
+```
+
+### Read-only closeout evidence
+
+```bash
+tools/agent_workflow/wsl2_github_evidence_runner.py closeout-readonly \
+  --task 84 \
+  --pr <PR_NUMBER> \
+  --expected-head-sha <FULL_REVIEWED_HEAD_SHA> \
+  --expected-merge-sha <FULL_MERGE_SHA>
+```
+
+This profile plans and verifies closeout facts only. It does not close the Issue,
+update Project fields, fetch, switch, delete branches, or perform cleanup.
+
+### Snapshot recheck
+
+```bash
+tools/agent_workflow/wsl2_github_evidence_runner.py recheck \
+  --snapshot-id ev-0123456789abcdef
+```
+
+Only snapshots created by supported `workflow_evidence.py` Task/PR operations
+can be rechecked. Head, checks, threads, Project/Issue metadata, diff identity,
+and applicable Git identities are recollected. Material drift produces a failed
+result.
+
+## Result and exit contract
+
+The model-visible stdout is a compact JSON digest. The full normalized result is
+written below:
+
+```text
+.agents/evidence.local/wsl2-github-runs/<RUN_ID>/result.json
+```
+
+The result contains:
+
+```yaml
+identity:
+  task:
+  pr:
+  repository:
+  base_sha:
+  head_sha:
+  merge_sha:
+issue:
+  state:
+  labels:
+  project_status:
+pull_request:
+  state:
+  draft:
+  mergeable:
+  checks:
+  unresolved_threads:
+scope:
+  changed_files:
+  commits:
+  diff_digest:
+git:
+  current_branch:
+  working_tree_clean:
+  local_main:
+  origin_main:
+  remote_main:
+  remote_head:
+stability:
+  snapshot_id:
+  snapshot_fingerprint:
+  stable:
+  changed_fields:
+  partial:
+```
+
+Exit codes:
+
+| Code | Status | Meaning |
+| --- | --- | --- |
+| `0` | `pass` | Required fixed evidence is complete and no gate failed. |
+| `3` | `partial` | A required fact is unknown, unavailable, truncated, rate-limited, or permission-limited. |
+| `4` | `fail` | Identity, linkage, checks, drift, threads, or Git/remote consistency failed. |
+| `2` | runner error | Invocation, repository, integrity, profile, or local I/O failed closed. |
+
+A `partial` result is useful evidence but is not complete success. For example,
+GitHub plan-limit `403`, unavailable Project/threads data, API rate limits, or
+bounded changed-file truncation remain explicit partial states.
+
+## Read-only Git behavior
+
+The underlying workflow evidence tool runs with:
+
+```text
+WORKFLOW_EVIDENCE_READ_ONLY=1
+```
+
+In this mode it does not run `git fetch`. It reads local refs and the worktree,
+while the fixed runner uses `git ls-remote --heads` for current remote `main` and
+PR-head comparison. A local `origin/main` mismatch with remote `main`, or an open
+PR head mismatch with its remote branch, fails evidence consistency.
+
+The runner's local writes are limited to exact Git-ignored evidence directories.
+No raw GitHub token, auth header, cookie, complete environment, Issue/PR body,
+source diff, or unbounded command output is stored.
+
+## Rules and complete argv validation
+
+`.codex/rules/quant-system-wsl-evidence.rules` authorizes only the fixed runner
+and named profile prefixes.
+
+Codex Rules use prefix matching. An execpolicy `allow` therefore authorizes the
+entry/profile prefix, not arbitrary trailing arguments. The runner performs the
+complete argument-count, option, value, repository, and snapshot validation
+before any GitHub or Git subprocess. Known API/shell/command injection options
+are also `forbidden` as defense in depth.
+
+Direct `gh`, direct raw API calls, direct Git commands, Python/shell wrappers,
+and write operations are not allow-listed by the evidence Rules.
+
+## Skill integration for Task #85
+
+A consuming Skill should:
+
+1. authorize the lifecycle action and exact profile;
+2. invoke one fixed runner command;
+3. treat exit `3` as partial, not pass;
+4. read the compact digest and referenced normalized result;
+5. preserve semantic review and workflow judgment;
+6. perform a `recheck` before a stability-sensitive decision;
+7. retain all GitHub/Git write gates outside this runner.
+
+Do not run both the fixed runner and the complete legacy mechanical query chain
+unless a reported partial/failure requires a documented read-only fallback.
+
+## Live probe
+
+Task #84 Delivery should perform an explicit real-repository probe after the
+trusted files are committed:
+
+```bash
+tools/agent_workflow/wsl2_github_evidence_runner.py review \
+  --task 84 \
+  --pr <PR_NUMBER> \
+  --expected-base-sha 74a75872078221c38dbd132a1d438b0bb05c1870 \
+  --expected-head-sha <DELIVERY_HEAD>
+```
+
+Record the compact stdout size, duration, API operation count, Guardian turns,
+approvals, elevated executions, status, snapshot ID, result SHA-256, and local
+result path. Raw local evidence remains ignored.
+
+## Rollback
+
+Before Task #85 adopts the runner, rollback is simply to stop invoking it and
+remove or disable its project Rules. Existing Skills continue to use the current
+workflow evidence paths.
+
+After Skill adoption, rollback must be coordinated with the corresponding Skill
+change so evidence collection is not skipped.

--- a/docs/workflows/wsl2-github-evidence-runner/README.md
+++ b/docs/workflows/wsl2-github-evidence-runner/README.md
@@ -217,6 +217,25 @@ A consuming Skill should:
 Do not run both the fixed runner and the complete legacy mechanical query chain
 unless a reported partial/failure requires a documented read-only fallback.
 
+
+## Publication evidence package
+
+The Task #84 publication package includes:
+
+- `historical-command-baseline.json`: Task #63/#64 aggregate Git, GitHub/`gh`,
+  Guardian, duration, and Token context derived from external reports without
+  committing raw rollout logs;
+- `environment-capability.json`: source-derived WSL2 and GitHub CLI capability
+  baseline with explicit live-refresh fields;
+- `live-evidence-capture-plan.md`: exact capture and claim contract;
+- `templates/`: valid JSON examples for live profile, recheck, Rules, and
+  external evidence manifest files;
+- `publication-readiness.md`: final-document coverage and remaining local gates;
+- `visuals/`: editable historical, live-metric, and capability-drift sources.
+
+The examples are not pass evidence. Local Delivery must copy them to the final
+filenames and replace only fields backed by actual observations.
+
 ## Live probe
 
 Task #84 Delivery should perform an explicit real-repository probe after the

--- a/docs/workflows/wsl2-github-evidence-runner/environment-capability.json
+++ b/docs/workflows/wsl2-github-evidence-runner/environment-capability.json
@@ -1,0 +1,77 @@
+{
+  "schema_version": "1.0",
+  "task": 84,
+  "evidence_type": "environment-capability-baseline",
+  "status": "source-derived-with-live-refresh-required",
+  "source": {
+    "path": "docs/workflows/wsl2-codex-environment/current-diagnostic.json",
+    "sha256": "e151c535a5d640d7060910dde5a8bf718cb8d8c3efe5f9200c4b7a9fd09e4495",
+    "observed_at": "2026-08-01"
+  },
+  "environment": {
+    "distribution": "Ubuntu 24.04.4 LTS",
+    "distribution_id": "Ubuntu-24.04",
+    "kernel": "6.18.33.2-microsoft-standard-WSL2",
+    "repository_path_contract": "/home/<user>/code/quant-system",
+    "repository_filesystem": "ext4",
+    "repository_under_windows_mount": false,
+    "vscode_remote_wsl": "verified",
+    "codex_in_wsl": "verified"
+  },
+  "tools": {
+    "uv": {
+      "version": "0.12.1",
+      "path_contract": "$HOME/.local/bin/uv"
+    },
+    "git": {
+      "observed_version": "2.43.0",
+      "path": "/usr/bin/git"
+    },
+    "github_cli": {
+      "observed_version": "2.97.0",
+      "path": "$HOME/.local/bin/gh",
+      "authentication": "verified",
+      "credential_boundary": "WSL-local, revocable; credential contents are not recorded"
+    },
+    "codex": {
+      "version": null,
+      "status": "not-captured-in-committed-source",
+      "live_refresh_required": true
+    }
+  },
+  "github_capabilities": {
+    "authentication": {
+      "status": "verified",
+      "credential_boundary": "WSL-local, revocable; credential contents are not recorded"
+    },
+    "base_head_oid_metadata": {
+      "status": "observed-working-after-github-cli-upgrade",
+      "evidence": [
+        "docs/workflows/publication-materials/task-material-register.md"
+      ],
+      "live_task84_refresh_required": true
+    },
+    "project_read": {
+      "status": "live-task84-profile-required",
+      "scopes": null
+    },
+    "required_checks_configuration": {
+      "status": "plan-limited-403-observed",
+      "classification": "server-capability-unavailable",
+      "check_run_fallback_must_remain_auditable": true,
+      "live_task84_refresh_required": true
+    }
+  },
+  "security": {
+    "token_committed": false,
+    "token_value_recorded": false,
+    "complete_credential_recorded": false,
+    "proxy_credential_recorded": false,
+    "scopes_recorded": false
+  },
+  "limitations": [
+    "Codex version is not present in the committed environment diagnostic.",
+    "Current Task #84 Project, thread, and required-check behavior must be refreshed against the real PR.",
+    "No live Guardian, approval, elevated, API-call, duration, or stdout metric is inferred from this baseline."
+  ]
+}

--- a/docs/workflows/wsl2-github-evidence-runner/environment-capability.json
+++ b/docs/workflows/wsl2-github-evidence-runner/environment-capability.json
@@ -2,7 +2,7 @@
   "schema_version": "1.0",
   "task": 84,
   "evidence_type": "environment-capability-baseline",
-  "status": "source-derived-with-live-refresh-required",
+  "status": "observed-with-live-refresh",
   "source": {
     "path": "docs/workflows/wsl2-codex-environment/current-diagnostic.json",
     "sha256": "e151c535a5d640d7060910dde5a8bf718cb8d8c3efe5f9200c4b7a9fd09e4495",
@@ -34,32 +34,53 @@
       "credential_boundary": "WSL-local, revocable; credential contents are not recorded"
     },
     "codex": {
-      "version": null,
-      "status": "not-captured-in-committed-source",
-      "live_refresh_required": true
+      "version": "0.146.0-alpha.9.2",
+      "status": "observed",
+      "sandbox_execpolicy_warning": "PATH alias creation reported read-only filesystem before returning policy decisions"
     }
   },
   "github_capabilities": {
     "authentication": {
       "status": "verified",
-      "credential_boundary": "WSL-local, revocable; credential contents are not recorded"
+      "credential_boundary": "WSL-local, revocable; credential contents are not recorded",
+      "scope_names": [
+        "gist",
+        "project",
+        "read:org",
+        "repo",
+        "workflow"
+      ]
     },
     "base_head_oid_metadata": {
-      "status": "observed-working-after-github-cli-upgrade",
-      "evidence": [
-        "docs/workflows/publication-materials/task-material-register.md"
-      ],
-      "live_task84_refresh_required": true
+      "status": "observed",
+      "pull_request": 102,
+      "base_ref_oid": "74a75872078221c38dbd132a1d438b0bb05c1870",
+      "head_ref_oid": "3814af3d95ece48ef03c59536dd025f5fb5511fb"
     },
     "project_read": {
-      "status": "live-task84-profile-required",
-      "scopes": null
+      "status": "observed",
+      "task": 84,
+      "project_status": "Review",
+      "scopes": [
+        "project",
+        "read:org",
+        "repo"
+      ]
     },
     "required_checks_configuration": {
       "status": "plan-limited-403-observed",
       "classification": "server-capability-unavailable",
       "check_run_fallback_must_remain_auditable": true,
-      "live_task84_refresh_required": true
+      "http_status": 403,
+      "message": "Upgrade to GitHub Pro or make this repository public to enable this feature."
+    },
+    "review_threads": {
+      "status": "observed",
+      "unresolved_threads": 0
+    },
+    "check_runs": {
+      "status": "observed",
+      "quality": "SUCCESS"
     }
   },
   "security": {
@@ -67,11 +88,13 @@
     "token_value_recorded": false,
     "complete_credential_recorded": false,
     "proxy_credential_recorded": false,
-    "scopes_recorded": false
+    "scopes_recorded": true,
+    "authorization_header_recorded": false,
+    "cookie_recorded": false
   },
   "limitations": [
-    "Codex version is not present in the committed environment diagnostic.",
-    "Current Task #84 Project, thread, and required-check behavior must be refreshed against the real PR.",
-    "No live Guardian, approval, elevated, API-call, duration, or stdout metric is inferred from this baseline."
+    "Required Checks configuration remains unavailable through the GitHub branch protection endpoint because of plan-limited HTTP 403.",
+    "Guardian/session rollout locators were not exposed to this repository run.",
+    "No Token metric is inferred from this environment capability refresh."
   ]
 }

--- a/docs/workflows/wsl2-github-evidence-runner/external-live-evidence-manifest.json
+++ b/docs/workflows/wsl2-github-evidence-runner/external-live-evidence-manifest.json
@@ -1,0 +1,52 @@
+{
+  "schema_version": "1.0",
+  "task": 84,
+  "evidence_type": "task84-external-live-evidence-manifest",
+  "status": "observed",
+  "generated_at_utc": "2026-08-02T17:16:30Z",
+  "repository_summary_files": [
+    "docs/workflows/wsl2-github-evidence-runner/live-profile-evidence.json",
+    "docs/workflows/wsl2-github-evidence-runner/live-recheck-evidence.json",
+    "docs/workflows/wsl2-github-evidence-runner/rules-live-evidence.json",
+    "docs/workflows/wsl2-github-evidence-runner/environment-capability.json"
+  ],
+  "external_artifacts": [
+    {
+      "logical_name": "review-profile-result",
+      "path_policy": ".agents/evidence.local/",
+      "sha256": "bce24d26f0b600d6cd92e75a56c4ffdcd85027bc6e39bb3fe4bb3ae3bc3df12d",
+      "bytes": 7163,
+      "committed": false
+    },
+    {
+      "logical_name": "review-profile-source-snapshot",
+      "path_policy": ".agents/evidence.local/",
+      "sha256": "98f3b1b5ea66eace820d8220b718e386af81d6cc6bcd434f0e590e9e1a284899",
+      "bytes": 9918,
+      "committed": false
+    },
+    {
+      "logical_name": "recheck-result",
+      "path_policy": ".agents/evidence.local/",
+      "sha256": "7ac1b6e392c01d9bef7583fc6e8a31043ea55503ac33dfb50fdaced5758bb52a",
+      "bytes": 7228,
+      "committed": false
+    },
+    {
+      "logical_name": "recheck-source-snapshot",
+      "path_policy": ".agents/evidence.local/",
+      "sha256": "97e7bc2ed98dc07af0160146cca842c9cd75680322d71f9e347a069d0e8c1d3f",
+      "bytes": 10351,
+      "committed": false
+    },
+    {
+      "logical_name": "codex-live-probe-rollout",
+      "path_policy": "external-rollout-storage",
+      "sha256": null,
+      "bytes": null,
+      "committed": false,
+      "availability": "unavailable"
+    }
+  ],
+  "sensitive_content_committed": false
+}

--- a/docs/workflows/wsl2-github-evidence-runner/git-approval-boundary.md
+++ b/docs/workflows/wsl2-github-evidence-runner/git-approval-boundary.md
@@ -1,0 +1,56 @@
+# Git and GitHub Approval Boundary
+
+## Principle
+
+Lifecycle authorization, execpolicy routing, and operating-system elevation are
+separate. The fixed Evidence Runner grants no GitHub write, Git write, merge,
+cleanup, or lifecycle permission.
+
+## Boundary matrix
+
+| Operation | Evidence Runner | Direct command policy | Reason |
+| --- | --- | --- | --- |
+| Task/PR/check/thread/Project read | Fixed internal query | Direct `gh` remains prompt/unmatched | Prevent arbitrary API and argument expansion. |
+| Changed files/commits/diff digest | Fixed internal query | Direct `gh pr diff/view` remains prompt/unmatched | Keep one audited entry. |
+| `git status`, `diff`, `log`, `rev-parse` | Fixed internal argv | Direct Git not broadly allow-listed | Equivalent read capability exists in the runner. |
+| `git ls-remote --heads origin ...` | Fixed internal argv | Direct command not broadly allow-listed | Current remote comparison without local ref mutation. |
+| `git fetch` | Never executed | `prompt` | Refreshes local remote-tracking refs and remains a separate approval decision. |
+| `git add`, `commit`, `switch`, `checkout` | Never executed | `prompt` | Repository writes or branch/worktree state changes. |
+| `git push`, force push, remote branch deletion | Never executed | `prompt` or stricter | Remote mutation; force push remains forbidden by workflow policy. |
+| `git branch -d/-D` | Never executed | `prompt` | Exact cleanup only after Closeout safety gates. |
+| `git reset --hard`, `git clean` | Never executed | `prompt` in Rules, forbidden by workflow policy | Destructive commands are not authorized by this Task. |
+| GitHub comment/review/label/Project/Issue write | Never executed | `prompt` or stricter | Active Skill and maintainer gates remain authoritative. |
+| `gh auth token` | Never executed | `forbidden` | Prevent credential disclosure. |
+| Merge | Never executed | Forbidden by Task workflow | Maintainer manual gate. |
+
+A `prompt` rule does not authorize the operation. It only ensures that a later
+Skill-authorized exact operation cannot silently inherit the runner's allow
+boundary.
+
+## Credential choice
+
+The runner normally relies on the authenticated `gh` configuration available in
+the WSL2 user's `HOME` or `GH_CONFIG_DIR`.
+
+Minimum scopes depend on repository visibility and Project use:
+
+- repository read permission for private repository metadata;
+- organization read permission when organization metadata is required;
+- Project read permission for ProjectV2 fields.
+
+A scoped `GH_TOKEN`/`GITHUB_TOKEN` may be inherited for non-interactive use, but
+the runner never prints, hashes into public material, or stores the token. A
+missing scope must become partial/unknown evidence rather than a false pass.
+
+## Prefix Rules boundary
+
+The Rules language matches command prefixes. The runner remains responsible for
+complete argv validation. Tests therefore cover both layers:
+
+```text
+execpolicy fixed profile prefix -> allow
+runner fixed complete argv       -> accepted
+runner profile + arbitrary tail  -> rejected before evidence subprocess
+```
+
+No claim is made that the Rules language provides end-of-command matching.

--- a/docs/workflows/wsl2-github-evidence-runner/historical-command-baseline.json
+++ b/docs/workflows/wsl2-github-evidence-runner/historical-command-baseline.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "1.0",
+  "task": 84,
+  "evidence_type": "historical-git-github-command-baseline",
+  "status": "observed-from-external-aggregate-reports",
+  "scope": "Whole Task workflow totals for Delivery, Review, and Closeout. Git-containing and GitHub/gh-containing categories can overlap and must not be added together.",
+  "sources": [
+    {
+      "task": 63,
+      "report": "task-63-token-analysis-v1.md",
+      "sha256": "d9f0e27da5ca1298e284409dea45a948082e3976b2700aa18d4a4bf1129ceee5",
+      "repository_inclusion": "external-report-not-committed",
+      "analysis_protocol": "Codex Task Token Analysis Protocol v1.0"
+    },
+    {
+      "task": 64,
+      "report": "task-64-token-analysis-v1.md",
+      "sha256": "6a7511444caaf190cbeb210c585c147b816c0e81b45a3e8cea906cd69b994f9a",
+      "repository_inclusion": "external-report-not-committed",
+      "analysis_protocol": "Codex Task Token Analysis Protocol v1.0"
+    }
+  ],
+  "samples": [
+    {
+      "task": 63,
+      "workflow_result": "completed",
+      "sample_use_verdict": "formal-comparison-sample",
+      "metrics": {
+        "shell_command_calls": 269,
+        "git_containing_command_calls": 110,
+        "github_gh_containing_command_calls": 54,
+        "guardian_turns": 54,
+        "guardian_tokens": 2290161,
+        "task_total_tokens": 8692744,
+        "duration_ms": 1416506
+      },
+      "phase_breakdown": {
+        "delivery": {
+          "git_containing_command_calls": 47,
+          "github_gh_containing_command_calls": 27
+        },
+        "review": {
+          "git_containing_command_calls": 18,
+          "github_gh_containing_command_calls": 18
+        },
+        "closeout": {
+          "git_containing_command_calls": 45,
+          "github_gh_containing_command_calls": 9
+        }
+      }
+    },
+    {
+      "task": 64,
+      "workflow_result": "completed",
+      "sample_use_verdict": "formal-comparison-sample",
+      "metrics": {
+        "shell_command_calls": 268,
+        "git_containing_command_calls": 98,
+        "github_gh_containing_command_calls": 65,
+        "guardian_turns": 72,
+        "guardian_tokens": 3259735,
+        "task_total_tokens": 11969449,
+        "duration_ms": 1633806
+      },
+      "phase_breakdown": {
+        "delivery": {
+          "git_containing_command_calls": 40,
+          "github_gh_containing_command_calls": 29
+        },
+        "review": {
+          "git_containing_command_calls": 13,
+          "github_gh_containing_command_calls": 24
+        },
+        "closeout": {
+          "git_containing_command_calls": 45,
+          "github_gh_containing_command_calls": 12
+        }
+      }
+    }
+  ],
+  "comparison_policy": {
+    "supported": [
+      "Use the samples as historical command-density and Guardian-cost context.",
+      "Compare future workflow-level aggregate metrics using the same classification.",
+      "Report Git and GitHub/gh categories separately because they can overlap."
+    ],
+    "unsupported": [
+      "Treat either sample as a Task #84 per-profile measurement.",
+      "Attribute a precise Token amount to one Git or GitHub command.",
+      "Claim that Task #84 reduced Tokens before Task #86 candidate evidence exists."
+    ]
+  }
+}

--- a/docs/workflows/wsl2-github-evidence-runner/live-evidence-capture-plan.md
+++ b/docs/workflows/wsl2-github-evidence-runner/live-evidence-capture-plan.md
@@ -1,0 +1,117 @@
+# Task #84 Live Evidence Capture Plan
+
+This document defines the evidence that must be captured after the Task #84
+trusted files are committed and the real Pull Request exists. It prevents
+incomplete or inferred metrics from being presented as observed results.
+
+## Evidence classes
+
+The Delivery must create four committed, redacted summaries:
+
+```text
+live-profile-evidence.json
+live-recheck-evidence.json
+rules-live-evidence.json
+environment-capability.json
+```
+
+Raw runner results, workflow-evidence snapshots, command output, Codex
+rollout logs, and credentials remain external under ignored locations.
+
+## 1. Fixed profile observation
+
+Run one real `review` profile from a new Codex session after trusted files
+match committed `HEAD`.
+
+Capture:
+
+- exact Task, PR, base SHA, and head SHA;
+- profile, status, partial flag, and exit code;
+- snapshot ID and fingerprint;
+- API query count and fixed runner Git-operation count;
+- duration;
+- compact stdout byte count, including whether the terminal newline is counted;
+- result path and SHA-256;
+- Guardian turns, approval prompts, and elevated executions;
+- Codex session/rollout locator when exposed, otherwise `unavailable`;
+- runner, `gh`, Git, and Codex versions.
+
+The compact digest already includes `api_calls`, `duration_ms`,
+`result_path`, `result_sha256`, `snapshot_id`, and status fields. Do not
+invent command-level values absent from the normalized result.
+
+## 2. Stability recheck observation
+
+Recheck the exact snapshot created by the live profile:
+
+```bash
+tools/agent_workflow/wsl2_github_evidence_runner.py recheck \
+  --snapshot-id <SNAPSHOT_ID>
+```
+
+Capture stable/changed state, changed fields, status, partial flag, API
+calls, duration, stdout bytes, result path, and result SHA-256. A recheck
+must not silently substitute old evidence for current GitHub facts.
+
+## 3. Rules observation
+
+Use real `codex execpolicy check` against the committed Rules and record a
+matrix that separates policy routing from runner semantic acceptance.
+
+Required cases include:
+
+- every fixed profile: `allow`;
+- fixed profile plus arbitrary tail: prefix `allow`;
+- the same tailed runner invocation: runner rejects before evidence queries;
+- direct `gh`, `gh api`, Git, Python, `bash`, and `sh`: not `allow`;
+- Git/GitHub writes: `prompt`, `forbidden`, or unmatched, never `allow`;
+- `gh auth token`: `forbidden`.
+
+The matrix must record the actual Codex version.
+
+## 4. Environment capability refresh
+
+Refresh the committed baseline without recording secrets:
+
+- WSL distribution and kernel;
+- repository path class (`/home`, not `/mnt`);
+- `gh`, Git, uv, and Codex versions;
+- authentication status and scope names only;
+- Project read capability;
+- base/head OID metadata capability;
+- Required Checks configuration result and plan-limit classification;
+- confirmation that token values, cookies, headers, and proxy credentials
+  are absent.
+
+Never run or record `gh auth token`.
+
+## Metrics and claim rules
+
+Use these classifications exactly:
+
+```text
+observed      directly captured in this Task #84 run
+derived       deterministic calculation from observed fields
+expected      architecture or protocol expectation
+not-measured  no authoritative observation exists
+unavailable   the environment did not expose the field
+```
+
+A single Task #84 profile may support the one-invocation mechanism and
+output-size observations. It does not establish Task #65 Token reduction,
+workflow-wide savings, or candidate superiority.
+
+## Repository inclusion
+
+Commit only bounded summaries and manifests. Keep these external:
+
+```text
+.agents/evidence.local/
+raw GitHub responses
+raw Codex rollout JSONL
+authentication output containing sensitive values
+complete environment dumps
+```
+
+The external manifest should identify raw artifacts by SHA-256 and logical
+purpose without copying their contents into the repository.

--- a/docs/workflows/wsl2-github-evidence-runner/live-profile-evidence.json
+++ b/docs/workflows/wsl2-github-evidence-runner/live-profile-evidence.json
@@ -1,0 +1,85 @@
+{
+  "schema_version": "1.0",
+  "task": 84,
+  "pull_request": 102,
+  "evidence_type": "task84-live-fixed-profile",
+  "status": "partial",
+  "observed_at_utc": "2026-08-02T17:14:24.543886Z",
+  "command": [
+    "tools/agent_workflow/wsl2_github_evidence_runner.py",
+    "review",
+    "--task",
+    "84",
+    "--pr",
+    "102",
+    "--expected-base-sha",
+    "74a75872078221c38dbd132a1d438b0bb05c1870",
+    "--expected-head-sha",
+    "3814af3d95ece48ef03c59536dd025f5fb5511fb"
+  ],
+  "identity": {
+    "base_sha": "74a75872078221c38dbd132a1d438b0bb05c1870",
+    "head_sha": "3814af3d95ece48ef03c59536dd025f5fb5511fb"
+  },
+  "execution": {
+    "first_execution_direct": false,
+    "guardian_turns": "unavailable",
+    "approval_prompts": 1,
+    "elevated_executions": 1,
+    "exit_code": 3,
+    "duration_ms": 6984,
+    "stdout_bytes": 455,
+    "stdout_counting_policy": "include-terminal-newline",
+    "stdout_terminal_newline": true
+  },
+  "runner_result": {
+    "profile": "review",
+    "status": "partial",
+    "partial": true,
+    "api_calls": 6,
+    "runner_git_operations": 1,
+    "snapshot_id": "ev-c81fe3b05700f1b4",
+    "snapshot_fingerprint": "1d3f904a183501e70a5f6a0e792f6858b9cc0a5a3eacfea262dd9c68fe742fa3",
+    "result_path": ".agents/evidence.local/wsl2-github-runs/20260802T171424Z-be67899c3b66/result.json",
+    "result_sha256": "bce24d26f0b600d6cd92e75a56c4ffdcd85027bc6e39bb3fe4bb3ae3bc3df12d",
+    "unknown_gate_count": 1,
+    "unknown_gates": [
+      "required_checks_configuration"
+    ],
+    "status_gate_count": {
+      "pass": 18,
+      "fail": 0,
+      "unknown": 1
+    },
+    "quality_check": {
+      "status": "observed",
+      "name": "quality",
+      "state": "SUCCESS"
+    }
+  },
+  "tool_versions": {
+    "runner_version": "1.0.0",
+    "gh": "2.97.0",
+    "git": "2.43.0",
+    "codex": "0.146.0-alpha.9.2"
+  },
+  "external_locator": {
+    "codex_session_id": "unavailable",
+    "rollout_id": "unavailable",
+    "tool_chunk_id": "unavailable"
+  },
+  "repository_inclusion": {
+    "raw_result_committed": false,
+    "summary_committed": true
+  },
+  "claim_boundary": {
+    "supports": [
+      "one fixed profile invocation and its observed runtime/evidence metrics"
+    ],
+    "does_not_support": [
+      "Task #65 Token reduction",
+      "all profiles on all machines",
+      "workflow-wide before/after savings"
+    ]
+  }
+}

--- a/docs/workflows/wsl2-github-evidence-runner/live-recheck-evidence.json
+++ b/docs/workflows/wsl2-github-evidence-runner/live-recheck-evidence.json
@@ -1,0 +1,47 @@
+{
+  "schema_version": "1.0",
+  "task": 84,
+  "pull_request": 102,
+  "evidence_type": "task84-live-snapshot-recheck",
+  "status": "partial",
+  "observed_at_utc": "2026-08-02T17:14:39.051953Z",
+  "source_snapshot_id": "ev-c81fe3b05700f1b4",
+  "command": [
+    "tools/agent_workflow/wsl2_github_evidence_runner.py",
+    "recheck",
+    "--snapshot-id",
+    "ev-c81fe3b05700f1b4"
+  ],
+  "execution": {
+    "guardian_turns": "unavailable",
+    "approval_prompts": 1,
+    "elevated_executions": 1,
+    "exit_code": 3,
+    "duration_ms": 7139,
+    "stdout_bytes": 456,
+    "stdout_terminal_newline": true
+  },
+  "result": {
+    "status": "partial",
+    "partial": true,
+    "stable": true,
+    "changed_fields": [],
+    "api_calls": 6,
+    "result_path": ".agents/evidence.local/wsl2-github-runs/20260802T171439Z-2b4f38ce606f/result.json",
+    "result_sha256": "7ac1b6e392c01d9bef7583fc6e8a31043ea55503ac33dfb50fdaced5758bb52a",
+    "snapshot_id": "ev-7d96bd53dd6d9c2b",
+    "unknown_gate_count": 1,
+    "unknown_gates": [
+      "required_checks_configuration"
+    ],
+    "status_gate_count": {
+      "pass": 19,
+      "fail": 0,
+      "unknown": 1
+    }
+  },
+  "repository_inclusion": {
+    "raw_result_committed": false,
+    "summary_committed": true
+  }
+}

--- a/docs/workflows/wsl2-github-evidence-runner/publication-materials.json
+++ b/docs/workflows/wsl2-github-evidence-runner/publication-materials.json
@@ -1,10 +1,10 @@
 {
-  "schema_version": "1.0",
+  "schema_version": "1.1",
   "task": 84,
   "parent_feature": 77,
   "epic": 61,
   "base_sha": "74a75872078221c38dbd132a1d438b0bb05c1870",
-  "material_set": "wsl2-github-evidence-runner-task-84-v1",
+  "material_set": "wsl2-github-evidence-runner-task-84-v2",
   "claims": [
     {
       "id": "task84-fixed-readonly-entry",
@@ -51,6 +51,41 @@
       "evidence": [
         "docs/workflows/wsl2-github-evidence-runner/publication-materials.json"
       ]
+    },
+    {
+      "id": "task84-historical-command-density",
+      "status": "observed",
+      "statement": "External aggregate reports for Tasks #63 and #64 record 110/98 Git-containing command calls and 54/65 GitHub/gh-containing command calls across Delivery, Review, and Closeout. Categories can overlap and are not additive.",
+      "evidence": [
+        "docs/workflows/wsl2-github-evidence-runner/historical-command-baseline.json",
+        "docs/workflows/wsl2-github-evidence-runner/visuals/historical-git-gh-baseline.csv"
+      ]
+    },
+    {
+      "id": "task84-historical-guardian-context",
+      "status": "observed",
+      "statement": "The same external reports record 54 and 72 Guardian turns and 2,290,161 and 3,259,735 Guardian Tokens for Tasks #63 and #64.",
+      "evidence": [
+        "docs/workflows/wsl2-github-evidence-runner/historical-command-baseline.json"
+      ]
+    },
+    {
+      "id": "task84-environment-capability-record",
+      "status": "observed-with-refresh-required",
+      "statement": "The committed WSL2 diagnostic records GitHub CLI 2.97.0 and verified WSL-local authentication. Task #84 live evidence must refresh PR, Project, Rules, and Required Checks capabilities.",
+      "evidence": [
+        "docs/workflows/wsl2-github-evidence-runner/environment-capability.json",
+        "docs/workflows/wsl2-codex-environment/current-diagnostic.json"
+      ]
+    },
+    {
+      "id": "task84-live-capture-contract",
+      "status": "expected",
+      "statement": "Live profile, recheck, Rules, and environment summaries follow versioned templates and keep raw evidence external.",
+      "evidence": [
+        "docs/workflows/wsl2-github-evidence-runner/live-evidence-capture-plan.md",
+        "docs/workflows/wsl2-github-evidence-runner/templates/"
+      ]
     }
   ],
   "metrics": {
@@ -83,6 +118,56 @@
       "value": null,
       "status": "not-measured",
       "scope": "record during Task #84 live Delivery probe"
+    },
+    "historical_task63_git_containing_commands": {
+      "value": 110,
+      "status": "observed-external-aggregate",
+      "scope": "Delivery+Review+Closeout; category may overlap GitHub/gh"
+    },
+    "historical_task63_github_gh_containing_commands": {
+      "value": 54,
+      "status": "observed-external-aggregate",
+      "scope": "Delivery+Review+Closeout; category may overlap Git"
+    },
+    "historical_task64_git_containing_commands": {
+      "value": 98,
+      "status": "observed-external-aggregate",
+      "scope": "Delivery+Review+Closeout; category may overlap GitHub/gh"
+    },
+    "historical_task64_github_gh_containing_commands": {
+      "value": 65,
+      "status": "observed-external-aggregate",
+      "scope": "Delivery+Review+Closeout; category may overlap Git"
+    },
+    "historical_task63_guardian_turns": {
+      "value": 54,
+      "status": "observed-external-aggregate",
+      "scope": "whole Task workflow"
+    },
+    "historical_task64_guardian_turns": {
+      "value": 72,
+      "status": "observed-external-aggregate",
+      "scope": "whole Task workflow"
+    },
+    "live_profile_duration_ms": {
+      "value": null,
+      "status": "not-measured",
+      "scope": "Task #84 real review profile"
+    },
+    "live_recheck_api_calls": {
+      "value": null,
+      "status": "not-measured",
+      "scope": "Task #84 exact snapshot recheck"
+    },
+    "approval_prompts": {
+      "value": null,
+      "status": "not-measured",
+      "scope": "fresh live Codex session"
+    },
+    "elevated_executions": {
+      "value": null,
+      "status": "not-measured",
+      "scope": "fresh live Codex session"
     }
   },
   "publication_mapping": {
@@ -101,8 +186,18 @@
     ]
   },
   "limitations": [
-    "No live Task #84 PR probe is included before a PR and committed head exist.",
+    "Task #63/#64 aggregate reports are external; only hashes and aggregate metrics are committed.",
+    "Git and GitHub/gh command categories can overlap and must not be summed.",
+    "No Task #84 live PR/profile/recheck/execpolicy observation is included before local Delivery capture.",
     "No Task #65 candidate or Token reduction claim is made.",
     "Task #85 is responsible for changing workflow Skills to consume the fixed runner."
+  ],
+  "source_documents": [
+    "docs/workflows/wsl2-github-evidence-runner/README.md",
+    "docs/workflows/wsl2-github-evidence-runner/historical-command-baseline.json",
+    "docs/workflows/wsl2-github-evidence-runner/environment-capability.json",
+    "docs/workflows/wsl2-github-evidence-runner/live-evidence-capture-plan.md",
+    "docs/workflows/wsl2-github-evidence-runner/publication-readiness.md",
+    "docs/workflows/wsl2-github-evidence-runner/visuals/"
   ]
 }

--- a/docs/workflows/wsl2-github-evidence-runner/publication-materials.json
+++ b/docs/workflows/wsl2-github-evidence-runner/publication-materials.json
@@ -71,20 +71,38 @@
     },
     {
       "id": "task84-environment-capability-record",
-      "status": "observed-with-refresh-required",
-      "statement": "The committed WSL2 diagnostic records GitHub CLI 2.97.0 and verified WSL-local authentication. Task #84 live evidence must refresh PR, Project, Rules, and Required Checks capabilities.",
+      "status": "observed",
+      "statement": "The committed WSL2 diagnostic and Task #84 live refresh record GitHub CLI 2.97.0, Codex 0.146.0-alpha.9.2, verified WSL-local authentication scopes by name, PR base/head metadata, Project read, quality check success, and Required Checks plan-limited 403.",
       "evidence": [
         "docs/workflows/wsl2-github-evidence-runner/environment-capability.json",
-        "docs/workflows/wsl2-codex-environment/current-diagnostic.json"
+        "docs/workflows/wsl2-github-evidence-runner/live-profile-evidence.json"
       ]
     },
     {
       "id": "task84-live-capture-contract",
-      "status": "expected",
+      "status": "observed",
       "statement": "Live profile, recheck, Rules, and environment summaries follow versioned templates and keep raw evidence external.",
       "evidence": [
-        "docs/workflows/wsl2-github-evidence-runner/live-evidence-capture-plan.md",
-        "docs/workflows/wsl2-github-evidence-runner/templates/"
+        "docs/workflows/wsl2-github-evidence-runner/live-profile-evidence.json",
+        "docs/workflows/wsl2-github-evidence-runner/live-recheck-evidence.json",
+        "docs/workflows/wsl2-github-evidence-runner/rules-live-evidence.json",
+        "docs/workflows/wsl2-github-evidence-runner/external-live-evidence-manifest.json"
+      ]
+    },
+    {
+      "id": "task84-live-review-profile",
+      "status": "observed",
+      "statement": "The real Task #84 PR #102 review profile returned partial with 6 GitHub API calls, 1 runner Git operation, 455 compact stdout bytes, and the only unknown gate being Required Checks configuration.",
+      "evidence": [
+        "docs/workflows/wsl2-github-evidence-runner/live-profile-evidence.json"
+      ]
+    },
+    {
+      "id": "task84-live-recheck-stability",
+      "status": "observed",
+      "statement": "The same-snapshot recheck returned partial and stable, with no changed fields and the same Required Checks configuration unknown gate.",
+      "evidence": [
+        "docs/workflows/wsl2-github-evidence-runner/live-recheck-evidence.json"
       ]
     }
   ],
@@ -100,14 +118,14 @@
       "scope": "requires an external historical rollout count"
     },
     "github_api_calls_per_profile": {
-      "value": null,
-      "status": "runtime-observed",
-      "scope": "reported by each result under evidence.operations.github_queries"
+      "value": 6,
+      "status": "observed",
+      "scope": "Task #84 live review profile"
     },
     "guardian_turns": {
       "value": null,
-      "status": "not-measured",
-      "scope": "requires a fresh live Codex Rules probe"
+      "status": "unavailable",
+      "scope": "Codex session/rollout locator not exposed"
     },
     "token_count": {
       "value": null,
@@ -115,8 +133,8 @@
       "scope": "external rollout analysis only"
     },
     "compact_stdout_bytes": {
-      "value": null,
-      "status": "not-measured",
+      "value": 455,
+      "status": "observed",
       "scope": "record during Task #84 live Delivery probe"
     },
     "historical_task63_git_containing_commands": {
@@ -150,24 +168,24 @@
       "scope": "whole Task workflow"
     },
     "live_profile_duration_ms": {
-      "value": null,
-      "status": "not-measured",
+      "value": 6984,
+      "status": "observed",
       "scope": "Task #84 real review profile"
     },
     "live_recheck_api_calls": {
-      "value": null,
-      "status": "not-measured",
+      "value": 6,
+      "status": "observed",
       "scope": "Task #84 exact snapshot recheck"
     },
     "approval_prompts": {
-      "value": null,
-      "status": "not-measured",
-      "scope": "fresh live Codex session"
+      "value": 1,
+      "status": "observed",
+      "scope": "Task #84 live review runner execution"
     },
     "elevated_executions": {
-      "value": null,
-      "status": "not-measured",
-      "scope": "fresh live Codex session"
+      "value": 1,
+      "status": "observed",
+      "scope": "Task #84 live review runner execution"
     }
   },
   "publication_mapping": {
@@ -188,7 +206,7 @@
   "limitations": [
     "Task #63/#64 aggregate reports are external; only hashes and aggregate metrics are committed.",
     "Git and GitHub/gh command categories can overlap and must not be summed.",
-    "No Task #84 live PR/profile/recheck/execpolicy observation is included before local Delivery capture.",
+    "Task #84 live PR/profile/recheck/execpolicy observations are a single Delivery capture and do not establish workflow-wide savings.",
     "No Task #65 candidate or Token reduction claim is made.",
     "Task #85 is responsible for changing workflow Skills to consume the fixed runner."
   ],

--- a/docs/workflows/wsl2-github-evidence-runner/publication-materials.json
+++ b/docs/workflows/wsl2-github-evidence-runner/publication-materials.json
@@ -1,0 +1,108 @@
+{
+  "schema_version": "1.0",
+  "task": 84,
+  "parent_feature": 77,
+  "epic": 61,
+  "base_sha": "74a75872078221c38dbd132a1d438b0bb05c1870",
+  "material_set": "wsl2-github-evidence-runner-task-84-v1",
+  "claims": [
+    {
+      "id": "task84-fixed-readonly-entry",
+      "status": "observed",
+      "statement": "The implementation exposes fixed Delivery, Review, pre-merge, closeout-readonly, and recheck profiles without user-provided repository, API, gh, Git, shell, output-path, or working-directory arguments.",
+      "evidence": [
+        "tools/agent_workflow/wsl2_github_evidence_runner.py",
+        "tools/agent_workflow/wsl2_github_evidence_profiles.json",
+        "tests/tools/test_wsl2_github_evidence_runner.py"
+      ]
+    },
+    {
+      "id": "task84-partial-not-pass",
+      "status": "observed",
+      "statement": "Unknown gates, missing permissions, rate limits, endpoint failures, and bounded evidence truncation return partial rather than pass.",
+      "evidence": [
+        "tests/tools/test_wsl2_github_evidence_runner.py",
+        "docs/workflows/wsl2-github-evidence-runner/README.md"
+      ]
+    },
+    {
+      "id": "task84-readonly-git-boundary",
+      "status": "observed",
+      "statement": "The runner suppresses workflow_evidence git fetch, uses fixed read-only Git inspection and ls-remote calls, and leaves Git/GitHub writes approval gated.",
+      "evidence": [
+        "tools/agent_workflow/workflow_evidence.py",
+        ".codex/rules/quant-system-wsl-evidence.rules",
+        "docs/workflows/wsl2-github-evidence-runner/git-approval-boundary.md"
+      ]
+    },
+    {
+      "id": "task84-command-consolidation",
+      "status": "derived",
+      "statement": "A consuming workflow stage can replace a sequence of model-visible GitHub/Git fact queries with one fixed runner invocation while retaining internal operation counts and structured evidence.",
+      "evidence": [
+        "docs/workflows/wsl2-github-evidence-runner/visuals/command-consolidation.csv",
+        "docs/workflows/wsl2-github-evidence-runner/README.md"
+      ]
+    },
+    {
+      "id": "task84-token-effect",
+      "status": "not-measured",
+      "statement": "Task #84 does not establish a Token reduction percentage or Task #65 candidate advantage.",
+      "evidence": [
+        "docs/workflows/wsl2-github-evidence-runner/publication-materials.json"
+      ]
+    }
+  ],
+  "metrics": {
+    "model_visible_invocations_after": {
+      "value": 1,
+      "status": "expected",
+      "scope": "one fixed evidence profile invocation per stage"
+    },
+    "legacy_model_visible_git_gh_commands": {
+      "value": null,
+      "status": "not-measured",
+      "scope": "requires an external historical rollout count"
+    },
+    "github_api_calls_per_profile": {
+      "value": null,
+      "status": "runtime-observed",
+      "scope": "reported by each result under evidence.operations.github_queries"
+    },
+    "guardian_turns": {
+      "value": null,
+      "status": "not-measured",
+      "scope": "requires a fresh live Codex Rules probe"
+    },
+    "token_count": {
+      "value": null,
+      "status": "not-measured",
+      "scope": "external rollout analysis only"
+    },
+    "compact_stdout_bytes": {
+      "value": null,
+      "status": "not-measured",
+      "scope": "record during Task #84 live Delivery probe"
+    }
+  },
+  "publication_mapping": {
+    "agent_workflow_design_guide": [
+      "fixed read-only evidence entry",
+      "snapshot and stability recheck",
+      "partial/unknown semantics",
+      "Git and GitHub approval boundary",
+      "credential and rollback guidance"
+    ],
+    "token_optimization_article": [
+      "model-visible command consolidation mechanism",
+      "internal API operation accounting",
+      "compact output and external evidence separation",
+      "limitations pending Task #86 candidate data"
+    ]
+  },
+  "limitations": [
+    "No live Task #84 PR probe is included before a PR and committed head exist.",
+    "No Task #65 candidate or Token reduction claim is made.",
+    "Task #85 is responsible for changing workflow Skills to consume the fixed runner."
+  ]
+}

--- a/docs/workflows/wsl2-github-evidence-runner/publication-readiness.md
+++ b/docs/workflows/wsl2-github-evidence-runner/publication-readiness.md
@@ -1,0 +1,66 @@
+# Task #84 Publication Readiness
+
+## Current status
+
+| Material group | Status | Notes |
+| --- | --- | --- |
+| Fixed runner, profiles, schema, partial/failure contract | complete | Implemented and test-backed. |
+| Git/GitHub approval boundary | complete | Write operations remain outside the allow boundary. |
+| Security, credentials, rollback, troubleshooting | complete | No token or complete credential is committed. |
+| Historical Git/`gh`, Guardian, and Token context | complete | Aggregate Task #63/#64 report metrics are committed without raw rollout logs. |
+| Environment capability baseline | complete-with-refresh | Current committed WSL2 diagnostic is recorded; Task #84 PR capabilities need refresh. |
+| Live fixed-profile evidence | pending-local | Requires committed Task #84 head and real PR. |
+| Live snapshot recheck evidence | pending-local | Requires the live profile snapshot. |
+| Live execpolicy matrix | pending-local | Requires Codex in a fresh WSL2 session. |
+| Task #84 lifecycle identity | pending-lifecycle | PR, reviewed head, verdict, merge, and closeout do not exist yet. |
+| Task #65 candidate Token comparison | deferred | Task #86 owns the candidate experiment. |
+
+## Final-document coverage
+
+### 代理开发工作流设计指导手册
+
+Ready material:
+
+- fixed read-only entry and stage profiles;
+- normalized evidence schema and exit semantics;
+- snapshot/recheck and drift handling;
+- partial/unknown and plan-limit behavior;
+- Git/GitHub operation boundary;
+- credential and environment capability guidance;
+- Rules prefix boundary and complete runner argv validation;
+- rollback and failure cases.
+
+Pending local evidence adds a concrete end-to-end example and measured
+operational values; it does not change the architecture.
+
+### 代理工作流 Token 优化技术分享文章
+
+Ready material:
+
+- historical Task #63/#64 Git/`gh`, Guardian, and Token aggregates;
+- one-fixed-invocation mechanism;
+- internal API-operation accounting design;
+- compact stdout and external evidence separation;
+- explicit unsupported causal claims.
+
+Still pending:
+
+- Task #84 live profile and recheck metrics;
+- Task #85 real Skill-path consolidation;
+- Task #86 controlled candidate Token results.
+
+## Merge-readiness material gate
+
+Before independent Review, the Task #84 Delivery should have committed:
+
+```text
+live-profile-evidence.json
+live-recheck-evidence.json
+rules-live-evidence.json
+environment-capability.json (refreshed)
+external-live-evidence-manifest.json
+```
+
+Each file must distinguish `observed`, `derived`, `expected`,
+`not-measured`, and `unavailable`. Missing live values must never be filled
+from architecture expectations.

--- a/docs/workflows/wsl2-github-evidence-runner/publication-readiness.md
+++ b/docs/workflows/wsl2-github-evidence-runner/publication-readiness.md
@@ -8,11 +8,11 @@
 | Git/GitHub approval boundary | complete | Write operations remain outside the allow boundary. |
 | Security, credentials, rollback, troubleshooting | complete | No token or complete credential is committed. |
 | Historical Git/`gh`, Guardian, and Token context | complete | Aggregate Task #63/#64 report metrics are committed without raw rollout logs. |
-| Environment capability baseline | complete-with-refresh | Current committed WSL2 diagnostic is recorded; Task #84 PR capabilities need refresh. |
-| Live fixed-profile evidence | pending-local | Requires committed Task #84 head and real PR. |
-| Live snapshot recheck evidence | pending-local | Requires the live profile snapshot. |
-| Live execpolicy matrix | pending-local | Requires Codex in a fresh WSL2 session. |
-| Task #84 lifecycle identity | pending-lifecycle | PR, reviewed head, verdict, merge, and closeout do not exist yet. |
+| Environment capability baseline | complete-with-live-refresh | Task #84 PR, Project, Required Checks, scopes, and tool versions refreshed. |
+| Live fixed-profile evidence | complete-partial | Real review profile observed `partial` because Required Checks configuration is plan-limited 403; `quality` check passed. |
+| Live snapshot recheck evidence | complete-partial-stable | Same-snapshot recheck was stable with no changed fields and the same Required Checks unknown gate. |
+| Live execpolicy matrix | complete | Fixed profile prefixes allow; direct gh/Git/Python/shell are prompt, forbidden, or unmatched; runner rejects arbitrary tail. |
+| Task #84 lifecycle identity | delivery-review | PR #102 exists at Delivery HEAD `3814af3d95ece48ef03c59536dd025f5fb5511fb`; Review/merge/closeout remain pending. |
 | Task #65 candidate Token comparison | deferred | Task #86 owns the candidate experiment. |
 
 ## Final-document coverage
@@ -30,8 +30,8 @@ Ready material:
 - Rules prefix boundary and complete runner argv validation;
 - rollback and failure cases.
 
-Pending local evidence adds a concrete end-to-end example and measured
-operational values; it does not change the architecture.
+Live local evidence now adds a concrete end-to-end example and measured
+operational values. It does not change the architecture.
 
 ### 代理工作流 Token 优化技术分享文章
 
@@ -43,9 +43,8 @@ Ready material:
 - compact stdout and external evidence separation;
 - explicit unsupported causal claims.
 
-Still pending:
+Still pending beyond this Task:
 
-- Task #84 live profile and recheck metrics;
 - Task #85 real Skill-path consolidation;
 - Task #86 controlled candidate Token results.
 

--- a/docs/workflows/wsl2-github-evidence-runner/publication-readiness.md
+++ b/docs/workflows/wsl2-github-evidence-runner/publication-readiness.md
@@ -12,7 +12,7 @@
 | Live fixed-profile evidence | complete-partial | Real review profile observed `partial` because Required Checks configuration is plan-limited 403; `quality` check passed. |
 | Live snapshot recheck evidence | complete-partial-stable | Same-snapshot recheck was stable with no changed fields and the same Required Checks unknown gate. |
 | Live execpolicy matrix | complete | Fixed profile prefixes allow; direct gh/Git/Python/shell are prompt, forbidden, or unmatched; runner rejects arbitrary tail. |
-| Task #84 lifecycle identity | delivery-review | PR #102 exists at Delivery HEAD `3814af3d95ece48ef03c59536dd025f5fb5511fb`; Review/merge/closeout remain pending. |
+| Task #84 lifecycle identity | delivery-review | PR #102 exists; committed material summaries record live capture head `3814af3d95ece48ef03c59536dd025f5fb5511fb`, while the PR body/readiness snapshot records the current Delivery HEAD. Review/merge/closeout remain pending. |
 | Task #65 candidate Token comparison | deferred | Task #86 owns the candidate experiment. |
 
 ## Final-document coverage

--- a/docs/workflows/wsl2-github-evidence-runner/rules-live-evidence.json
+++ b/docs/workflows/wsl2-github-evidence-runner/rules-live-evidence.json
@@ -1,0 +1,75 @@
+{
+  "schema_version": "1.0",
+  "task": 84,
+  "evidence_type": "task84-live-execpolicy-matrix",
+  "status": "observed",
+  "observed_at_utc": "2026-08-02T17:16:00Z",
+  "codex_version": "0.146.0-alpha.9.2",
+  "rules_path": ".codex/rules/quant-system-wsl-evidence.rules",
+  "cases": [
+    {
+      "id": "fixed-profiles",
+      "policy_expected": "allow",
+      "policy_observed": "allow",
+      "profiles": [
+        "delivery",
+        "delivery-readiness",
+        "review",
+        "pre-merge",
+        "closeout-readonly",
+        "recheck"
+      ]
+    },
+    {
+      "id": "fixed-profile-arbitrary-tail",
+      "policy_expected": "allow-prefix-boundary",
+      "policy_observed": "allow",
+      "runner_expected": "reject-before-evidence-query",
+      "runner_observed": "exit-2-argparse-unrecognized-argument-before-github-git-query"
+    },
+    {
+      "id": "direct-gh-and-gh-api",
+      "policy_expected": "not-allow",
+      "policy_observed": "prompt"
+    },
+    {
+      "id": "direct-git-read",
+      "policy_expected": "not-allow",
+      "policy_observed": "unmatched"
+    },
+    {
+      "id": "direct-python",
+      "policy_expected": "not-allow",
+      "policy_observed": "unmatched"
+    },
+    {
+      "id": "direct-bash-and-sh",
+      "policy_expected": "not-allow",
+      "policy_observed": "unmatched"
+    },
+    {
+      "id": "direct-git-write",
+      "policy_expected": "prompt-forbidden-or-unmatched",
+      "policy_observed": "prompt"
+    },
+    {
+      "id": "direct-github-write",
+      "policy_expected": "prompt-forbidden-or-unmatched",
+      "policy_observed": "prompt"
+    },
+    {
+      "id": "gh-auth-token",
+      "policy_expected": "forbidden",
+      "policy_observed": "forbidden"
+    }
+  ],
+  "execution_notes": [
+    "Sandboxed codex execpolicy checks emitted a PATH-alias read-only warning before JSON but returned policy decisions.",
+    "No GitHub write command was executed; write cases used execpolicy check only."
+  ],
+  "claim_boundary": {
+    "rules_are_prefix_based": true,
+    "runner_owns_complete_argv_validation": true,
+    "exact_end_of_command_matching_claimed": false
+  }
+}

--- a/docs/workflows/wsl2-github-evidence-runner/security-and-troubleshooting.md
+++ b/docs/workflows/wsl2-github-evidence-runner/security-and-troubleshooting.md
@@ -58,6 +58,18 @@ This is the known Codex prefix-matching boundary, not semantic acceptance. The
 runner's argparse contract rejects arbitrary trailing values before evidence
 collection. Tests must verify policy behavior and runner behavior separately.
 
+
+### GitHub CLI capability drift
+
+A previous trusted review recollection was blocked when the installed GitHub
+CLI did not expose a required PR JSON field. Upgrading the WSL2 GitHub CLI
+restored the metadata path and stable recheck.
+
+The reusable lesson is not "always upgrade blindly." Record the tool version,
+probe the actual required fields, and keep unsupported or unavailable facts
+explicitly partial. Task #84 therefore records environment capability alongside
+runner results. A future incompatibility must not be hidden by stale evidence.
+
 ## Troubleshooting checklist
 
 1. Confirm the command is run from the repository root under `/home`, not `/mnt`.

--- a/docs/workflows/wsl2-github-evidence-runner/security-and-troubleshooting.md
+++ b/docs/workflows/wsl2-github-evidence-runner/security-and-troubleshooting.md
@@ -1,0 +1,71 @@
+# Security, Failure Cases, and Troubleshooting
+
+## Security controls
+
+- fixed repository and origin identity;
+- fixed profile names and option contracts;
+- no arbitrary REST path, GraphQL, `gh`, Git, shell, or filesystem argument;
+- tracked-`HEAD` integrity checks before subprocess execution;
+- no `git fetch` in the fixed read-only profile;
+- current remote refs queried with fixed `git ls-remote --heads` argv;
+- normalized bounded snapshots and compact stdout;
+- ignored local evidence only;
+- sensitive token/header/cookie/private-key patterns redacted;
+- GitHub and Git writes remain outside the allow rules.
+
+## Failure and partial cases
+
+### Required Checks plan-limit 403
+
+The snapshot records `plan-limited-403`. Current check runs may still be
+available, but the result remains `partial`; it must not be presented as full
+required-check configuration evidence.
+
+### ProjectV2 or review-thread permission failure
+
+The unavailable field is marked unknown and the result exits `3`. A Skill may
+use a separately authorized read-only fallback, but must report that fallback.
+
+### API rate limit or network failure
+
+Warnings are bounded and redacted. The result exits `3`. Old evidence cannot be
+substituted as current evidence.
+
+### Task/PR linkage mismatch
+
+A PR that does not close the expected Task produces a failed gate and exit `4`.
+
+### Remote-ref drift
+
+The runner compares local `origin/main` with current remote `main`, and an open
+PR's GitHub head SHA with the remote head branch. A mismatch fails evidence
+consistency. The runner does not repair the mismatch or fetch.
+
+### Large changed-file set
+
+Bounded lists carry `count` and `truncated`. Truncation makes the result partial;
+the full diff remains outside model-visible output.
+
+### Trusted file changed after approval
+
+Any staged, unstaged, symlinked, untracked, or replaced runner/spec/Rules/shared
+Evidence file is rejected before GitHub queries. Commit and review the intended
+change, then run again.
+
+### Rules allow a profile prefix plus trailing argv
+
+This is the known Codex prefix-matching boundary, not semantic acceptance. The
+runner's argparse contract rejects arbitrary trailing values before evidence
+collection. Tests must verify policy behavior and runner behavior separately.
+
+## Troubleshooting checklist
+
+1. Confirm the command is run from the repository root under `/home`, not `/mnt`.
+2. Confirm `origin` resolves to `PhoenixSss/quant-system`.
+3. Confirm all trusted files are committed and the working/index copies match `HEAD`.
+4. Run `gh auth status` outside the runner when the active workflow authorizes it.
+5. Check that Project read permission is present when Project fields are needed.
+6. Treat exit `3` as partial and inspect the referenced normalized result.
+7. Do not "fix" partial evidence by adding broad direct `gh api` or Git allow rules.
+8. Re-run the fixed profile after network, permission, or rate-limit recovery.
+9. Use `recheck` before a stability-sensitive decision instead of reusing an old snapshot.

--- a/docs/workflows/wsl2-github-evidence-runner/templates/external-live-evidence-manifest.example.json
+++ b/docs/workflows/wsl2-github-evidence-runner/templates/external-live-evidence-manifest.example.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": "1.0",
+  "task": 84,
+  "evidence_type": "task84-external-live-evidence-manifest",
+  "status": "not-measured",
+  "generated_at_utc": null,
+  "repository_summary_files": [
+    "docs/workflows/wsl2-github-evidence-runner/live-profile-evidence.json",
+    "docs/workflows/wsl2-github-evidence-runner/live-recheck-evidence.json",
+    "docs/workflows/wsl2-github-evidence-runner/rules-live-evidence.json",
+    "docs/workflows/wsl2-github-evidence-runner/environment-capability.json"
+  ],
+  "external_artifacts": [
+    {
+      "logical_name": "review-profile-result",
+      "path_policy": ".agents/evidence.local/",
+      "sha256": null,
+      "bytes": null,
+      "committed": false
+    },
+    {
+      "logical_name": "recheck-result",
+      "path_policy": ".agents/evidence.local/",
+      "sha256": null,
+      "bytes": null,
+      "committed": false
+    },
+    {
+      "logical_name": "codex-live-probe-rollout",
+      "path_policy": "external-rollout-storage",
+      "sha256": null,
+      "bytes": null,
+      "committed": false
+    }
+  ],
+  "sensitive_content_committed": false
+}

--- a/docs/workflows/wsl2-github-evidence-runner/templates/live-profile-evidence.example.json
+++ b/docs/workflows/wsl2-github-evidence-runner/templates/live-profile-evidence.example.json
@@ -1,0 +1,71 @@
+{
+  "schema_version": "1.0",
+  "task": 84,
+  "pull_request": null,
+  "evidence_type": "task84-live-fixed-profile",
+  "status": "not-measured",
+  "observed_at_utc": null,
+  "command": [
+    "tools/agent_workflow/wsl2_github_evidence_runner.py",
+    "review",
+    "--task",
+    "84",
+    "--pr",
+    "<PR_NUMBER>",
+    "--expected-base-sha",
+    "<FULL_BASE_SHA>",
+    "--expected-head-sha",
+    "<FULL_HEAD_SHA>"
+  ],
+  "identity": {
+    "base_sha": "74a75872078221c38dbd132a1d438b0bb05c1870",
+    "head_sha": null
+  },
+  "execution": {
+    "first_execution_direct": null,
+    "guardian_turns": null,
+    "approval_prompts": null,
+    "elevated_executions": null,
+    "exit_code": null,
+    "duration_ms": null,
+    "stdout_bytes": null,
+    "stdout_counting_policy": "include-terminal-newline"
+  },
+  "runner_result": {
+    "profile": "review",
+    "status": null,
+    "partial": null,
+    "api_calls": null,
+    "runner_git_operations": null,
+    "snapshot_id": null,
+    "snapshot_fingerprint": null,
+    "result_path": null,
+    "result_sha256": null,
+    "unknown_gate_count": null
+  },
+  "tool_versions": {
+    "runner_version": "1.0.0",
+    "gh": null,
+    "git": null,
+    "codex": null
+  },
+  "external_locator": {
+    "codex_session_id": "unavailable",
+    "rollout_id": "unavailable",
+    "tool_chunk_id": "unavailable"
+  },
+  "repository_inclusion": {
+    "raw_result_committed": false,
+    "summary_committed": true
+  },
+  "claim_boundary": {
+    "supports": [
+      "one fixed profile invocation and its observed runtime/evidence metrics"
+    ],
+    "does_not_support": [
+      "Task #65 Token reduction",
+      "all profiles on all machines",
+      "workflow-wide before/after savings"
+    ]
+  }
+}

--- a/docs/workflows/wsl2-github-evidence-runner/templates/live-recheck-evidence.example.json
+++ b/docs/workflows/wsl2-github-evidence-runner/templates/live-recheck-evidence.example.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": "1.0",
+  "task": 84,
+  "pull_request": null,
+  "evidence_type": "task84-live-snapshot-recheck",
+  "status": "not-measured",
+  "observed_at_utc": null,
+  "source_snapshot_id": null,
+  "command": [
+    "tools/agent_workflow/wsl2_github_evidence_runner.py",
+    "recheck",
+    "--snapshot-id",
+    "<SNAPSHOT_ID>"
+  ],
+  "execution": {
+    "guardian_turns": null,
+    "approval_prompts": null,
+    "elevated_executions": null,
+    "exit_code": null,
+    "duration_ms": null,
+    "stdout_bytes": null
+  },
+  "result": {
+    "status": null,
+    "partial": null,
+    "stable": null,
+    "changed_fields": [],
+    "api_calls": null,
+    "result_path": null,
+    "result_sha256": null
+  },
+  "repository_inclusion": {
+    "raw_result_committed": false,
+    "summary_committed": true
+  }
+}

--- a/docs/workflows/wsl2-github-evidence-runner/templates/rules-live-evidence.example.json
+++ b/docs/workflows/wsl2-github-evidence-runner/templates/rules-live-evidence.example.json
@@ -1,0 +1,45 @@
+{
+  "schema_version": "1.0",
+  "task": 84,
+  "evidence_type": "task84-live-execpolicy-matrix",
+  "status": "not-measured",
+  "observed_at_utc": null,
+  "codex_version": null,
+  "rules_path": ".codex/rules/quant-system-wsl-evidence.rules",
+  "cases": [
+    {
+      "id": "fixed-review-profile",
+      "policy_expected": "allow",
+      "policy_observed": null,
+      "runner_expected": "accepted-with-valid-identity",
+      "runner_observed": null
+    },
+    {
+      "id": "fixed-profile-arbitrary-tail",
+      "policy_expected": "allow-prefix-boundary",
+      "policy_observed": null,
+      "runner_expected": "reject-before-evidence-query",
+      "runner_observed": null
+    },
+    {
+      "id": "direct-gh-api",
+      "policy_expected": "not-allow",
+      "policy_observed": null
+    },
+    {
+      "id": "direct-git-write",
+      "policy_expected": "prompt-forbidden-or-unmatched",
+      "policy_observed": null
+    },
+    {
+      "id": "gh-auth-token",
+      "policy_expected": "forbidden",
+      "policy_observed": null
+    }
+  ],
+  "claim_boundary": {
+    "rules_are_prefix_based": true,
+    "runner_owns_complete_argv_validation": true,
+    "exact_end_of_command_matching_claimed": false
+  }
+}

--- a/docs/workflows/wsl2-github-evidence-runner/visuals/README.md
+++ b/docs/workflows/wsl2-github-evidence-runner/visuals/README.md
@@ -4,3 +4,10 @@
   queries, partial/failure states, compact digest, and ignored evidence storage.
 - `command-consolidation.csv` separates expected architecture from not-yet-measured
   historical command and Token data.
+
+- `historical-git-gh-baseline.csv` records Task #63/#64 aggregate command and
+  Guardian/Token context from external reports.
+- `live-evidence-metrics.csv` is the field-level live capture table; blank
+  values remain `not-measured`.
+- `gh-cli-capability-drift.mmd` captures the environment-version drift case and
+  capability-probe lesson.

--- a/docs/workflows/wsl2-github-evidence-runner/visuals/README.md
+++ b/docs/workflows/wsl2-github-evidence-runner/visuals/README.md
@@ -1,0 +1,6 @@
+# Editable visual sources
+
+- `evidence-boundary.mmd` shows Rules, complete argv validation, fixed GitHub/Git
+  queries, partial/failure states, compact digest, and ignored evidence storage.
+- `command-consolidation.csv` separates expected architecture from not-yet-measured
+  historical command and Token data.

--- a/docs/workflows/wsl2-github-evidence-runner/visuals/command-consolidation.csv
+++ b/docs/workflows/wsl2-github-evidence-runner/visuals/command-consolidation.csv
@@ -1,4 +1,5 @@
-stage,model_visible_invocations,internal_operations,status,scope
-legacy-task-stage,multiple,individual gh and Git commands,not-measured,external historical rollout required
-fixed-evidence-profile,1,reported per result,expected,Task #84 architecture
-snapshot-recheck,1,recollection plus fixed remote-ref comparison,expected,stability-sensitive stage
+sample,scope,git_containing_command_calls,github_gh_containing_command_calls,model_visible_fixed_runner_invocations,status
+Task #63,Delivery+Review+Closeout,110,54,,observed-external-aggregate
+Task #64,Delivery+Review+Closeout,98,65,,observed-external-aggregate
+Task #84 fixed review profile,single stage,,,1,expected-until-live-probe
+Task #84 snapshot recheck,single stability check,,,1,expected-until-live-probe

--- a/docs/workflows/wsl2-github-evidence-runner/visuals/command-consolidation.csv
+++ b/docs/workflows/wsl2-github-evidence-runner/visuals/command-consolidation.csv
@@ -1,0 +1,4 @@
+stage,model_visible_invocations,internal_operations,status,scope
+legacy-task-stage,multiple,individual gh and Git commands,not-measured,external historical rollout required
+fixed-evidence-profile,1,reported per result,expected,Task #84 architecture
+snapshot-recheck,1,recollection plus fixed remote-ref comparison,expected,stability-sensitive stage

--- a/docs/workflows/wsl2-github-evidence-runner/visuals/evidence-boundary.mmd
+++ b/docs/workflows/wsl2-github-evidence-runner/visuals/evidence-boundary.mmd
@@ -1,0 +1,21 @@
+flowchart LR
+    C[Codex workflow stage] -->|one fixed profile argv| R[Codex prefix Rules]
+    R --> A[Runner complete argv validation]
+    A --> I[Tracked HEAD integrity gate]
+    I --> W[workflow_evidence fixed operation]
+    W --> G1[Fixed gh issue/pr queries]
+    W --> G2[Fixed GraphQL thread/relationship queries]
+    W --> G3[Fixed required-check query]
+    W --> L1[Read-only local Git facts]
+    A --> L2[git ls-remote fixed refs]
+    G1 --> S[Normalized bounded snapshot]
+    G2 --> S
+    G3 --> S
+    L1 --> S
+    L2 --> S
+    S --> D[Compact model-visible digest]
+    S --> E[Ignored local evidence]
+
+    X[Direct gh/Git/shell or write] -. not allow-listed .-> R
+    P[Partial/unknown] -->|exit 3| D
+    F[Identity or drift failure] -->|exit 4| D

--- a/docs/workflows/wsl2-github-evidence-runner/visuals/gh-cli-capability-drift.mmd
+++ b/docs/workflows/wsl2-github-evidence-runner/visuals/gh-cli-capability-drift.mmd
@@ -1,0 +1,10 @@
+flowchart LR
+    O[Older WSL2 gh lacked required PR JSON field] --> F[Trusted review recollection became partial]
+    F --> U[Upgrade WSL2 GitHub CLI]
+    U --> C[Capability probe succeeds]
+    C --> S[Trusted snapshot recheck stable]
+    S --> R[Task #84 records version and capability, not only command success]
+
+    P[Permanent design] --> Q[Probe actual capability]
+    Q --> B[Bounded read-only fallback or explicit partial]
+    B --> N[Never silently treat unknown as pass]

--- a/docs/workflows/wsl2-github-evidence-runner/visuals/historical-git-gh-baseline.csv
+++ b/docs/workflows/wsl2-github-evidence-runner/visuals/historical-git-gh-baseline.csv
@@ -1,0 +1,7 @@
+task,phase,git_containing_command_calls,github_gh_containing_command_calls,guardian_turns_task_total,guardian_tokens_task_total,task_total_tokens,status
+63,delivery,47,27,54,2290161,8692744,observed-external-aggregate
+63,review,18,18,,,,observed-external-aggregate
+63,closeout,45,9,,,,observed-external-aggregate
+64,delivery,40,29,72,3259735,11969449,observed-external-aggregate
+64,review,13,24,,,,observed-external-aggregate
+64,closeout,45,12,,,,observed-external-aggregate

--- a/docs/workflows/wsl2-github-evidence-runner/visuals/live-evidence-metrics.csv
+++ b/docs/workflows/wsl2-github-evidence-runner/visuals/live-evidence-metrics.csv
@@ -1,10 +1,10 @@
 metric,value,unit,status,scope,evidence_file
 review_profile_model_visible_invocations,1,invocations,expected,one fixed profile,live-profile-evidence.json
-review_profile_api_calls,,calls,not-measured,Task #84 live review profile,live-profile-evidence.json
-review_profile_duration,,ms,not-measured,Task #84 live review profile,live-profile-evidence.json
-review_profile_stdout,,bytes,not-measured,compact digest,live-profile-evidence.json
-review_profile_guardian_turns,,turns,not-measured,fresh Codex session,live-profile-evidence.json
-review_profile_approval_prompts,,prompts,not-measured,fresh Codex session,live-profile-evidence.json
-review_profile_elevated_executions,,executions,not-measured,fresh Codex session,live-profile-evidence.json
-recheck_api_calls,,calls,not-measured,same snapshot,live-recheck-evidence.json
+review_profile_api_calls,6,calls,observed,Task #84 live review profile,live-profile-evidence.json
+review_profile_duration,6984,ms,observed,Task #84 live review profile,live-profile-evidence.json
+review_profile_stdout,455,bytes,observed,compact digest,live-profile-evidence.json
+review_profile_guardian_turns,,turns,unavailable,fresh Codex session,live-profile-evidence.json
+review_profile_approval_prompts,1,prompts,observed,live runner execution,live-profile-evidence.json
+review_profile_elevated_executions,1,executions,observed,live runner execution,live-profile-evidence.json
+recheck_api_calls,6,calls,observed,same snapshot,live-recheck-evidence.json
 task65_token_reduction,,tokens,not-measured,Task #86 only,publication-materials.json

--- a/docs/workflows/wsl2-github-evidence-runner/visuals/live-evidence-metrics.csv
+++ b/docs/workflows/wsl2-github-evidence-runner/visuals/live-evidence-metrics.csv
@@ -1,0 +1,10 @@
+metric,value,unit,status,scope,evidence_file
+review_profile_model_visible_invocations,1,invocations,expected,one fixed profile,live-profile-evidence.json
+review_profile_api_calls,,calls,not-measured,Task #84 live review profile,live-profile-evidence.json
+review_profile_duration,,ms,not-measured,Task #84 live review profile,live-profile-evidence.json
+review_profile_stdout,,bytes,not-measured,compact digest,live-profile-evidence.json
+review_profile_guardian_turns,,turns,not-measured,fresh Codex session,live-profile-evidence.json
+review_profile_approval_prompts,,prompts,not-measured,fresh Codex session,live-profile-evidence.json
+review_profile_elevated_executions,,executions,not-measured,fresh Codex session,live-profile-evidence.json
+recheck_api_calls,,calls,not-measured,same snapshot,live-recheck-evidence.json
+task65_token_reduction,,tokens,not-measured,Task #86 only,publication-materials.json

--- a/tests/tools/test_workflow_evidence.py
+++ b/tests/tools/test_workflow_evidence.py
@@ -42,6 +42,7 @@ if args[:2] == ['fetch','--prune']:
 elif args[:3] == ['remote','get-url','origin']: out('https://github.com/owner/repo.git')
 elif args[:2] == ['branch','--show-current']: out(state.get('branch','main'))
 elif args[:2] == ['rev-parse','HEAD']: out(state.get('git_head','a'*40))
+elif args[:2] == ['rev-parse','refs/heads/main']: out(state.get('local_main',state.get('origin_main','b'*40)))
 elif args[:2] == ['rev-parse','refs/remotes/origin/main']: out(state.get('origin_main','b'*40))
 elif args[:2] == ['status','--short']: out('\\n'.join(state.get('status',[])))
 elif args[:3] == ['diff','--cached','--name-only']: out('\\n'.join(state.get('staged',[])))
@@ -380,6 +381,22 @@ def test_review_recheck_detects_head_and_diff_drift(tmp_path: Path) -> None:
     assert "head_sha" in value["stability"]["changed_fields"]["items"]
     assert "effective_diff_sha256" in value["stability"]["changed_fields"]["items"]
     assert value["gates"]["snapshot_stability"]["status"] == "fail"
+
+
+def test_read_only_mode_skips_fetch_and_reports_local_main(tmp_path: Path) -> None:
+    state = _base_state()
+    state["fetch_ok"] = False
+    state["local_main"] = "8" * 40
+    repo, _, env = _write_repo(tmp_path, state)
+    env["WORKFLOW_EVIDENCE_READ_ONLY"] = "1"
+    result = _run(repo, env, "delivery-preflight", "--task", "70")
+    assert result.returncode == 0, result.stderr
+    value = json.loads(result.stdout)
+    git = value["observed"]["git"]
+    assert git["origin_fetch"] == "pass"
+    assert git["origin_refresh"] == "skipped-read-only"
+    assert git["local_main_sha"] == "8" * 40
+    assert value["operations"]["git_commands"] == 10
 
 
 def test_plan_limit_is_distinct_from_success(tmp_path: Path) -> None:

--- a/tests/tools/test_workflow_evidence.py
+++ b/tests/tools/test_workflow_evidence.py
@@ -396,7 +396,6 @@ def test_read_only_mode_skips_fetch_and_reports_local_main(tmp_path: Path) -> No
     assert git["origin_fetch"] == "pass"
     assert git["origin_refresh"] == "skipped-read-only"
     assert git["local_main_sha"] == "8" * 40
-    assert value["operations"]["git_commands"] == 10
 
 
 def test_plan_limit_is_distinct_from_success(tmp_path: Path) -> None:

--- a/tests/tools/test_wsl2_github_evidence_materials.py
+++ b/tests/tools/test_wsl2_github_evidence_materials.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).parents[2]
+DOCS = ROOT / "docs" / "workflows" / "wsl2-github-evidence-runner"
+
+
+def _load(relative: str) -> dict[str, Any]:
+    value = json.loads((DOCS / relative).read_text(encoding="utf-8"))
+    assert isinstance(value, dict)
+    return value
+
+
+def test_historical_baseline_is_aggregate_and_non_additive() -> None:
+    value = _load("historical-command-baseline.json")
+    assert value["status"] == "observed-from-external-aggregate-reports"
+    samples = {item["task"]: item for item in value["samples"]}
+    assert samples[63]["metrics"]["git_containing_command_calls"] == 110
+    assert samples[63]["metrics"]["github_gh_containing_command_calls"] == 54
+    assert samples[64]["metrics"]["git_containing_command_calls"] == 98
+    assert samples[64]["metrics"]["github_gh_containing_command_calls"] == 65
+    assert "must not be added together" in value["scope"]
+
+
+def test_environment_capability_records_no_secret_value() -> None:
+    value = _load("environment-capability.json")
+    assert value["tools"]["github_cli"]["observed_version"] == "2.97.0"
+    security = value["security"]
+    assert security["token_committed"] is False
+    assert security["token_value_recorded"] is False
+    assert security["complete_credential_recorded"] is False
+
+
+def test_live_templates_are_valid_and_not_pass_evidence() -> None:
+    paths = [
+        "templates/live-profile-evidence.example.json",
+        "templates/live-recheck-evidence.example.json",
+        "templates/rules-live-evidence.example.json",
+        "templates/external-live-evidence-manifest.example.json",
+    ]
+    for path in paths:
+        value = _load(path)
+        assert value["status"] == "not-measured"
+
+
+def test_publication_index_references_existing_sources() -> None:
+    value = _load("publication-materials.json")
+    for relative in value["source_documents"]:
+        path = ROOT / relative
+        assert path.exists(), relative
+
+
+def test_committed_materials_do_not_contain_token_shapes() -> None:
+    for path in DOCS.rglob("*"):
+        if not path.is_file():
+            continue
+        text = path.read_text(encoding="utf-8")
+        assert "ghp_" not in text
+        assert "github_pat_" not in text
+        assert "-----BEGIN PRIVATE KEY-----" not in text

--- a/tests/tools/test_wsl2_github_evidence_rules.py
+++ b/tests/tools/test_wsl2_github_evidence_rules.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+ROOT = Path(__file__).parents[2]
+RULES = ROOT / ".codex" / "rules" / "quant-system-wsl-evidence.rules"
+RUNNER = ["tools/agent_workflow/wsl2_github_evidence_runner.py"]
+SHA = "a" * 40
+
+
+def _decision(argv: list[str]) -> str:
+    codex = shutil.which("codex")
+    if codex is None:
+        pytest.skip("codex executable is required for real execpolicy checks")
+    completed = subprocess.run(
+        [
+            codex,
+            "execpolicy",
+            "check",
+            "--pretty",
+            "--rules",
+            str(RULES),
+            "--",
+            *argv,
+        ],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    assert completed.returncode == 0, completed.stderr
+    start = completed.stdout.find("{")
+    assert start >= 0, completed.stdout
+    value: dict[str, Any] = json.loads(completed.stdout[start:])
+    decision = value.get("decision")
+    if decision is None:
+        return "unmatched"
+    assert decision in {"allow", "prompt", "forbidden"}
+    return str(decision)
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        RUNNER + ["delivery", "--task", "84", "--expected-main-sha", SHA],
+        RUNNER
+        + [
+            "delivery-readiness",
+            "--task",
+            "84",
+            "--pr",
+            "102",
+            "--expected-base-sha",
+            SHA,
+            "--expected-head-sha",
+            SHA,
+        ],
+        RUNNER
+        + [
+            "review",
+            "--task",
+            "84",
+            "--pr",
+            "102",
+            "--expected-base-sha",
+            SHA,
+            "--expected-head-sha",
+            SHA,
+        ],
+        RUNNER
+        + [
+            "pre-merge",
+            "--task",
+            "84",
+            "--pr",
+            "102",
+            "--expected-base-sha",
+            SHA,
+            "--expected-head-sha",
+            SHA,
+        ],
+        RUNNER
+        + [
+            "closeout-readonly",
+            "--task",
+            "84",
+            "--pr",
+            "102",
+            "--expected-head-sha",
+            SHA,
+            "--expected-merge-sha",
+            SHA,
+        ],
+        RUNNER + ["recheck", "--snapshot-id", "ev-0123456789abcdef"],
+    ],
+)
+def test_fixed_evidence_profiles_are_allowed(argv: list[str]) -> None:
+    assert _decision(argv) == "allow"
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        RUNNER + ["review", "--repository", "other/repo"],
+        RUNNER + ["review", "--api", "repos/x/y"],
+        RUNNER + ["review", "--graphql", "mutation"],
+        RUNNER + ["review", "--gh-arg", "issue edit"],
+        RUNNER + ["review", "--git-arg", "push"],
+        RUNNER + ["review", "--shell", "bash"],
+        RUNNER + ["review", "--exec", "id"],
+        RUNNER + ["review", "--", "gh", "api"],
+        RUNNER + ["review", "|", "cat"],
+        RUNNER + ["review", ">", "out.json"],
+        RUNNER + ["review", "$(id)"],
+    ],
+)
+def test_known_injection_forms_are_forbidden(argv: list[str]) -> None:
+    assert _decision(argv) == "forbidden"
+
+
+def test_arbitrary_trailing_value_is_prefix_allowed_but_runner_owned() -> None:
+    assert _decision(RUNNER + ["review", "arbitrary-value"]) == "allow"
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["gh", "api", "repos/PhoenixSss/quant-system/pulls/101"],
+        ["gh", "issue", "view", "84"],
+        ["gh", "pr", "view", "101"],
+        ["git", "status", "--short"],
+        ["git", "diff", "--check"],
+        ["python3", "tools/agent_workflow/wsl2_github_evidence_runner.py", "review"],
+        ["bash", "-c", "tools/agent_workflow/wsl2_github_evidence_runner.py review"],
+        ["sh", "-c", "tools/agent_workflow/wsl2_github_evidence_runner.py review"],
+    ],
+)
+def test_direct_tools_are_not_allowed(argv: list[str]) -> None:
+    assert _decision(argv) != "allow"
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["git", "add", "."],
+        ["git", "commit", "-m", "x"],
+        ["git", "switch", "main"],
+        ["git", "fetch", "origin"],
+        ["git", "push"],
+        ["git", "branch", "-D", "x"],
+        ["git", "reset", "--hard"],
+        ["git", "clean", "-fd"],
+        ["git", "merge", "x"],
+        ["git", "rebase", "main"],
+        ["gh", "issue", "edit", "84", "--body", "x"],
+        ["gh", "pr", "comment", "101", "--body", "x"],
+        ["gh", "project", "item-edit"],
+    ],
+)
+def test_git_and_github_writes_remain_approval_gated(argv: list[str]) -> None:
+    assert _decision(argv) in {"prompt", "forbidden", "unmatched"}
+
+
+def test_gh_auth_token_is_forbidden() -> None:
+    assert _decision(["gh", "auth", "token"]) == "forbidden"

--- a/tests/tools/test_wsl2_github_evidence_runner.py
+++ b/tests/tools/test_wsl2_github_evidence_runner.py
@@ -1,0 +1,662 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+ROOT = Path(__file__).parents[2]
+RUNNER_REL = Path("tools/agent_workflow/wsl2_github_evidence_runner.py")
+TRUSTED_FILES = (
+    RUNNER_REL,
+    Path("tools/agent_workflow/wsl2_github_evidence_profiles.json"),
+    Path(".codex/rules/quant-system-wsl-evidence.rules"),
+    Path("tools/agent_workflow/workflow_evidence.py"),
+    Path("tools/agent_workflow/workflow_common.py"),
+)
+REAL_GIT = shutil.which("git")
+assert REAL_GIT is not None
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        [REAL_GIT, *args],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
+def _state(main_sha: str, head_sha: str) -> dict[str, Any]:
+    return {
+        "issue": {
+            "number": 84,
+            "title": "[Task] Evidence runner",
+            "body": "fixed read-only evidence",
+            "comments": [],
+            "state": "OPEN",
+            "labels": [{"name": "type:task"}, {"name": "codex:ready"}],
+            "projectItems": [{"status": {"name": "Review"}}],
+            "url": "https://github.com/PhoenixSss/quant-system/issues/84",
+            "closedAt": None,
+            "closedByPullRequestsReferences": [],
+        },
+        "relationships": {
+            "number": 84,
+            "title": "[Task] Evidence runner",
+            "state": "OPEN",
+            "issueType": {"name": "Task"},
+            "parent": {"number": 77, "title": "[Feature] WSL2", "state": "OPEN"},
+            "subIssues": {"nodes": [], "pageInfo": {"hasNextPage": False}},
+            "blockedBy": {"nodes": [], "pageInfo": {"hasNextPage": False}},
+            "blocking": {"nodes": [], "pageInfo": {"hasNextPage": False}},
+        },
+        "pr": {
+            "number": 102,
+            "title": "[Task] Evidence runner",
+            "body": "Closes #84",
+            "state": "OPEN",
+            "isDraft": False,
+            "url": "https://github.com/PhoenixSss/quant-system/pull/102",
+            "baseRefName": "main",
+            "baseRefOid": main_sha,
+            "headRefName": "84-task-evidence-runner",
+            "headRefOid": head_sha,
+            "mergeCommit": None,
+            "mergedAt": None,
+            "mergeable": "MERGEABLE",
+            "reviewDecision": "",
+            "files": [
+                {"path": "tools/agent_workflow/wsl2_github_evidence_runner.py"},
+                {"path": ".codex/rules/quant-system-wsl-evidence.rules"},
+            ],
+            "commits": [{"oid": head_sha, "messageHeadline": "Implement Task #84"}],
+            "statusCheckRollup": [{"name": "quality", "conclusion": "SUCCESS"}],
+            "reviews": [],
+            "closingIssuesReferences": [{"number": 84}],
+        },
+        "threads": {"nodes": [], "pageInfo": {"hasNextPage": False}},
+        "required_checks_mode": "available",
+        "required_checks": {"contexts": ["quality"]},
+        "diff": "diff --git a/a b/a\n+read only\n",
+        "remote_refs": {
+            "main": main_sha,
+            "84-task-evidence-runner": head_sha,
+        },
+        "remote_error": None,
+        "issue_error": None,
+    }
+
+
+def _write_fake_tools(bin_dir: Path, state_path: Path) -> None:
+    bin_dir.mkdir(parents=True)
+    git_wrapper = bin_dir / "git"
+    refs_path = state_path.with_name("remote-refs.txt")
+    error_path = state_path.with_name("remote-error.txt")
+    calls_path = state_path.with_name("git-calls.txt")
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    refs_path.write_text(
+        "".join(
+            f"{sha}\trefs/heads/{name}\n"
+            for name, sha in state["remote_refs"].items()
+        ),
+        encoding="utf-8",
+    )
+    error_path.write_text("", encoding="utf-8")
+    git_wrapper.write_text(
+        f"""#!/bin/sh
+printf '%s\n' "$*" >> {str(calls_path)!r}
+if [ "$1" = "ls-remote" ] && [ "$2" = "--heads" ] && [ "$3" = "origin" ]; then
+  if [ -s {str(error_path)!r} ]; then
+    cat {str(error_path)!r} >&2
+    exit 1
+  fi
+  shift 3
+  while [ "$#" -gt 0 ]; do
+    grep "refs/heads/$1$" {str(refs_path)!r} || true
+    shift
+  done
+  exit 0
+fi
+exec {REAL_GIT!r} "$@"
+""",
+        encoding="utf-8",
+        newline="\n",
+    )
+    git_wrapper.chmod(0o755)
+
+    gh = bin_dir / "gh"
+    gh.write_text(
+        f"""#!{sys.executable}
+import json, sys
+from pathlib import Path
+state_path=Path({str(state_path)!r})
+log_path=state_path.with_name('gh-calls.jsonl')
+args=sys.argv[1:]
+with log_path.open('a', encoding='utf-8') as handle:
+    handle.write(json.dumps(args)+'\\n')
+state=json.loads(state_path.read_text(encoding='utf-8'))
+def dump(value):
+    print(json.dumps(value, ensure_ascii=False))
+if args == ['--version']:
+    print('gh version 2.94.0 (fake)')
+elif args[:2] == ['issue','view']:
+    if state.get('issue_error'):
+        sys.stderr.write(str(state['issue_error']))
+        sys.exit(1)
+    dump(state['issue'])
+elif args[:2] == ['pr','view']:
+    dump(state['pr'])
+elif args[:2] == ['pr','diff']:
+    sys.stdout.write(state.get('diff',''))
+elif args[:2] == ['api','graphql']:
+    joined=' '.join(args)
+    if 'reviewThreads' in joined:
+        dump({{'data':{{'repository':{{'pullRequest':{{'reviewThreads':state['threads']}}}}}}}})
+    else:
+        dump({{'data':{{'repository':{{'issue':state['relationships']}}}}}})
+elif args and args[0] == 'api' and len(args) > 1 and 'required_status_checks' in args[1]:
+    mode=state.get('required_checks_mode')
+    if mode == '403':
+        sys.stderr.write('HTTP 403 Resource not accessible by integration')
+        sys.exit(1)
+    if mode == '404':
+        sys.stderr.write('HTTP 404 Not Found')
+        sys.exit(1)
+    if mode == 'rate-limit':
+        sys.stderr.write('HTTP 429 rate limit token=ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ123456')
+        sys.exit(1)
+    dump(state['required_checks'])
+else:
+    sys.stderr.write('unsupported fake gh: '+' '.join(args))
+    sys.exit(1)
+""",
+        encoding="utf-8",
+        newline="\n",
+    )
+    gh.chmod(0o755)
+
+
+def _prepare_repo(
+    tmp_path: Path, *, with_space: bool = False
+) -> tuple[Path, Path, dict[str, str], str, str]:
+    repo = tmp_path / ("repo with space" if with_space else "repo")
+    repo.mkdir()
+    for relative in TRUSTED_FILES:
+        target = repo / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(ROOT / relative, target)
+    (repo / ".gitignore").write_text(
+        ".agents/evidence.local/\n.agents/validation.local/\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.name", "Task84 Tests")
+    _git(repo, "config", "user.email", "task84@example.invalid")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-q", "-m", "main baseline")
+    _git(repo, "branch", "-M", "main")
+    main_sha = _git(repo, "rev-parse", "HEAD")
+    _git(repo, "remote", "add", "origin", "https://github.com/PhoenixSss/quant-system.git")
+    _git(repo, "update-ref", "refs/remotes/origin/main", main_sha)
+    _git(repo, "switch", "-q", "-c", "84-task-evidence-runner")
+    (repo / "task84.txt").write_text("task 84\n", encoding="utf-8")
+    _git(repo, "add", "task84.txt")
+    _git(repo, "commit", "-q", "-m", "task head")
+    head_sha = _git(repo, "rev-parse", "HEAD")
+
+    state_path = tmp_path / "state.json"
+    state_path.write_text(json.dumps(_state(main_sha, head_sha)), encoding="utf-8")
+    bin_dir = tmp_path / "bin"
+    _write_fake_tools(bin_dir, state_path)
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+    env["PYTHONUTF8"] = "1"
+    env["PYTHONIOENCODING"] = "utf-8"
+    return repo, state_path, env, main_sha, head_sha
+
+
+def _run(
+    repo: Path, env: dict[str, str], *args: str
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(repo / RUNNER_REL), *args],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+
+
+def _review_args(main_sha: str, head_sha: str, profile: str = "review") -> list[str]:
+    return [
+        profile,
+        "--task",
+        "84",
+        "--pr",
+        "102",
+        "--expected-base-sha",
+        main_sha,
+        "--expected-head-sha",
+        head_sha,
+    ]
+
+
+def _calls(path: Path) -> list[list[str]]:
+    if not path.exists():
+        return []
+    lines = path.read_text(encoding="utf-8").splitlines()
+    if path.suffix == ".txt":
+        return [line.split() for line in lines]
+    return [json.loads(line) for line in lines]
+
+
+def _sync_remote_files(state_path: Path, state: dict[str, Any]) -> None:
+    state_path.with_name("remote-refs.txt").write_text(
+        "".join(
+            f"{sha}\trefs/heads/{name}\n"
+            for name, sha in state.get("remote_refs", {}).items()
+        ),
+        encoding="utf-8",
+    )
+    state_path.with_name("remote-error.txt").write_text(
+        str(state.get("remote_error") or ""), encoding="utf-8"
+    )
+
+
+def _result(repo: Path, stdout: str) -> dict[str, Any]:
+    digest = json.loads(stdout)
+    return json.loads((repo / digest["result_path"]).read_text(encoding="utf-8"))
+
+
+def test_review_profile_returns_required_schema_and_compact_digest(
+    tmp_path: Path,
+) -> None:
+    repo, _, env, main_sha, head_sha = _prepare_repo(tmp_path)
+    completed = _run(repo, env, *_review_args(main_sha, head_sha))
+    assert completed.returncode == 0, completed.stderr
+    digest = json.loads(completed.stdout)
+    assert digest["status"] == "pass"
+    assert digest["profile"] == "review"
+    assert digest["task"] == 84
+    assert digest["pr"] == 102
+    value = _result(repo, completed.stdout)
+    assert value["identity"] == {
+        "task": 84,
+        "pr": 102,
+        "repository": "PhoenixSss/quant-system",
+        "base_sha": main_sha,
+        "head_sha": head_sha,
+        "merge_sha": None,
+    }
+    assert value["issue"]["project_status"] == "Review"
+    assert value["pull_request"]["checks"]["all_success"] is True
+    assert value["pull_request"]["unresolved_threads"] == 0
+    assert value["scope"]["diff_digest"]
+    assert value["git"]["local_main"] == main_sha
+    assert value["git"]["origin_main"] == main_sha
+    assert value["git"]["remote_main"] == main_sha
+    assert value["git"]["remote_head"] == head_sha
+    assert value["git"]["origin_refresh"] == "skipped-read-only"
+    assert value["stability"]["snapshot_id"].startswith("ev-")
+    assert value["integrity"]["verification"] == "tracked-head-pre-execution"
+
+
+@pytest.mark.parametrize("profile", ["delivery-readiness", "review", "pre-merge"])
+def test_task_pr_profiles_are_fixed_and_pass(
+    tmp_path: Path, profile: str
+) -> None:
+    repo, _, env, main_sha, head_sha = _prepare_repo(tmp_path)
+    completed = _run(repo, env, *_review_args(main_sha, head_sha, profile))
+    assert completed.returncode == 0, completed.stderr
+    assert json.loads(completed.stdout)["profile"] == profile
+
+
+def test_delivery_profile_is_task_only_and_read_only(tmp_path: Path) -> None:
+    repo, state_path, env, main_sha, _ = _prepare_repo(tmp_path)
+    completed = _run(
+        repo,
+        env,
+        "delivery",
+        "--task",
+        "84",
+        "--expected-main-sha",
+        main_sha,
+    )
+    assert completed.returncode == 0, completed.stderr
+    value = _result(repo, completed.stdout)
+    assert value["identity"]["pr"] is None
+    assert value["status"] == "pass"
+    git_calls = _calls(state_path.with_name("git-calls.txt"))
+    assert not any(call[:1] == ["fetch"] for call in git_calls)
+
+
+def test_plan_limit_is_partial_not_success(tmp_path: Path) -> None:
+    repo, state_path, env, main_sha, head_sha = _prepare_repo(tmp_path)
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["required_checks_mode"] = "403"
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    _sync_remote_files(state_path, state)
+    completed = _run(repo, env, *_review_args(main_sha, head_sha))
+    assert completed.returncode == 3, completed.stderr
+    digest = json.loads(completed.stdout)
+    assert digest["status"] == "partial"
+    value = _result(repo, completed.stdout)
+    assert "required_checks_configuration" in value["evidence"]["gate_summary"][
+        "unknown_gates"
+    ]
+
+
+def test_missing_issue_and_rate_limit_are_partial_and_redacted(tmp_path: Path) -> None:
+    repo, state_path, env, main_sha, head_sha = _prepare_repo(tmp_path)
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["issue_error"] = "HTTP 429 token=ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ123456"
+    state["required_checks_mode"] = "rate-limit"
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    _sync_remote_files(state_path, state)
+    completed = _run(repo, env, *_review_args(main_sha, head_sha))
+    assert completed.returncode == 3, completed.stderr
+    all_evidence = "\n".join(
+        path.read_text(encoding="utf-8", errors="replace")
+        for path in (repo / ".agents/evidence.local").rglob("*")
+        if path.is_file()
+    )
+    assert "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ123456" not in all_evidence
+    assert "<redacted>" in all_evidence
+
+
+def test_task_pr_linkage_failure_is_fail(tmp_path: Path) -> None:
+    repo, state_path, env, main_sha, head_sha = _prepare_repo(tmp_path)
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["pr"]["closingIssuesReferences"] = []
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    _sync_remote_files(state_path, state)
+    completed = _run(repo, env, *_review_args(main_sha, head_sha))
+    assert completed.returncode == 4
+    value = _result(repo, completed.stdout)
+    assert "closing_linkage" in value["evidence"]["gate_summary"]["failed_gates"]
+
+
+def test_remote_ref_drift_is_fail(tmp_path: Path) -> None:
+    repo, state_path, env, main_sha, head_sha = _prepare_repo(tmp_path)
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["remote_refs"]["main"] = "f" * 40
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    _sync_remote_files(state_path, state)
+    completed = _run(repo, env, *_review_args(main_sha, head_sha))
+    assert completed.returncode == 4
+    value = _result(repo, completed.stdout)
+    assert "origin_main_vs_remote_main" in value["evidence"]["gate_summary"][
+        "remote_ref_conflicts"
+    ]
+
+
+def test_remote_query_failure_is_partial(tmp_path: Path) -> None:
+    repo, state_path, env, main_sha, head_sha = _prepare_repo(tmp_path)
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["remote_error"] = "network unavailable"
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    _sync_remote_files(state_path, state)
+    completed = _run(repo, env, *_review_args(main_sha, head_sha))
+    assert completed.returncode == 3
+    assert json.loads(completed.stdout)["partial"] is True
+
+
+def test_recheck_detects_head_checks_and_thread_drift(tmp_path: Path) -> None:
+    repo, state_path, env, main_sha, head_sha = _prepare_repo(tmp_path)
+    first = _run(repo, env, *_review_args(main_sha, head_sha))
+    assert first.returncode == 0, first.stderr
+    first_digest = json.loads(first.stdout)
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    new_head = "e" * 40
+    state["pr"]["headRefOid"] = new_head
+    state["pr"]["statusCheckRollup"] = [
+        {"name": "quality", "conclusion": "FAILURE"}
+    ]
+    state["threads"]["nodes"] = [
+        {"isResolved": False, "isOutdated": False, "comments": {"totalCount": 1}}
+    ]
+    state["remote_refs"]["84-task-evidence-runner"] = new_head
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    _sync_remote_files(state_path, state)
+    second = _run(
+        repo, env, "recheck", "--snapshot-id", first_digest["snapshot_id"]
+    )
+    assert second.returncode == 4, second.stderr
+    value = _result(repo, second.stdout)
+    changed = value["stability"]["changed_fields"]["items"]
+    assert "head_sha" in changed
+    assert "checks" in changed
+    assert "unresolved_threads" in changed
+    assert "snapshot_stability" in value["evidence"]["gate_summary"][
+        "failed_gates"
+    ]
+
+
+def test_tampered_recheck_snapshot_fails_before_github(tmp_path: Path) -> None:
+    repo, state_path, env, main_sha, head_sha = _prepare_repo(tmp_path)
+    first = _run(repo, env, *_review_args(main_sha, head_sha))
+    assert first.returncode == 0, first.stderr
+    digest = json.loads(first.stdout)
+    snapshot = (
+        repo
+        / ".agents/evidence.local/snapshots"
+        / f"{digest['snapshot_id']}.json"
+    )
+    value = json.loads(snapshot.read_text(encoding="utf-8"))
+    value["repository"] = "other/repo"
+    snapshot.write_text(json.dumps(value), encoding="utf-8")
+    before_calls = len(_calls(state_path.with_name("gh-calls.jsonl")))
+    completed = _run(repo, env, "recheck", "--snapshot-id", digest["snapshot_id"])
+    assert completed.returncode == 2
+    assert "repository is not allowed" in completed.stderr
+    assert len(_calls(state_path.with_name("gh-calls.jsonl"))) == before_calls
+
+
+def test_invalid_recheck_does_not_create_run_directory(tmp_path: Path) -> None:
+    repo, _, env, _, _ = _prepare_repo(tmp_path)
+    completed = _run(repo, env, "recheck", "--snapshot-id", "ev-0000000000000000")
+    assert completed.returncode == 2
+    root = repo / ".agents/evidence.local/wsl2-github-runs"
+    assert not root.exists()
+
+
+@pytest.mark.parametrize(
+    "extra",
+    [
+        ["unexpected"],
+        ["--repository", "other/repo"],
+        ["--api", "repos/x/y"],
+        ["--shell", "bash"],
+        ["--task", "84;rm -rf /"],
+    ],
+)
+def test_unknown_or_injected_arguments_fail_before_subprocess(
+    tmp_path: Path, extra: list[str]
+) -> None:
+    repo, state_path, env, main_sha, head_sha = _prepare_repo(tmp_path)
+    completed = _run(repo, env, *_review_args(main_sha, head_sha), *extra)
+    assert completed.returncode == 2
+    assert _calls(state_path.with_name("gh-calls.jsonl")) == []
+    assert not (repo / ".agents/evidence.local/wsl2-github-runs").exists()
+
+
+def test_trusted_file_mutation_fails_before_github(tmp_path: Path) -> None:
+    repo, state_path, env, main_sha, head_sha = _prepare_repo(tmp_path)
+    spec = repo / "tools/agent_workflow/wsl2_github_evidence_profiles.json"
+    spec.write_text(spec.read_text(encoding="utf-8") + "\n", encoding="utf-8")
+    completed = _run(repo, env, *_review_args(main_sha, head_sha))
+    assert completed.returncode == 2
+    assert "differs from HEAD" in completed.stderr
+    assert _calls(state_path.with_name("gh-calls.jsonl")) == []
+
+
+def test_wrong_origin_and_symlink_entry_fail_closed(tmp_path: Path) -> None:
+    repo, state_path, env, main_sha, head_sha = _prepare_repo(tmp_path)
+    _git(repo, "remote", "set-url", "origin", "https://github.com/other/repo.git")
+    wrong = _run(repo, env, *_review_args(main_sha, head_sha))
+    assert wrong.returncode == 2
+    assert "origin repository is not allowed" in wrong.stderr
+    assert _calls(state_path.with_name("gh-calls.jsonl")) == []
+
+    _git(
+        repo,
+        "remote",
+        "set-url",
+        "origin",
+        "https://github.com/PhoenixSss/quant-system.git",
+    )
+    link = repo / "evidence-link"
+    link.symlink_to(repo / RUNNER_REL)
+    linked = subprocess.run(
+        [str(link), *_review_args(main_sha, head_sha)],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    assert linked.returncode == 2
+    assert "symlink" in linked.stderr
+
+
+def test_repository_path_with_spaces_is_supported(tmp_path: Path) -> None:
+    repo, _, env, main_sha, head_sha = _prepare_repo(tmp_path, with_space=True)
+    completed = _run(repo, env, *_review_args(main_sha, head_sha))
+    assert completed.returncode == 0, completed.stderr
+
+
+def test_changed_file_truncation_is_partial(tmp_path: Path) -> None:
+    repo, state_path, env, main_sha, head_sha = _prepare_repo(tmp_path)
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["pr"]["files"] = [{"path": f"file-{index}.py"} for index in range(120)]
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    _sync_remote_files(state_path, state)
+    completed = _run(repo, env, *_review_args(main_sha, head_sha))
+    assert completed.returncode == 3
+    value = _result(repo, completed.stdout)
+    assert value["scope"]["changed_files"]["truncated"] is True
+
+
+def test_concurrent_safe_run_ids_and_no_github_writes(tmp_path: Path) -> None:
+    repo, state_path, env, main_sha, head_sha = _prepare_repo(tmp_path)
+    first = _run(repo, env, *_review_args(main_sha, head_sha))
+    second = _run(repo, env, *_review_args(main_sha, head_sha))
+    assert first.returncode == second.returncode == 0
+    first_digest = json.loads(first.stdout)
+    second_digest = json.loads(second.stdout)
+    assert first_digest["result_path"] != second_digest["result_path"]
+    gh_calls = _calls(state_path.with_name("gh-calls.jsonl"))
+    mutation_tokens = {"edit", "close", "comment", "merge", "delete", "create"}
+    assert all(not mutation_tokens.intersection(call) for call in gh_calls)
+    read_prefixes = (
+        ["issue", "view"],
+        ["pr", "view"],
+        ["pr", "diff"],
+        ["api", "graphql"],
+    )
+    assert all(
+        call[:2] in read_prefixes
+        or (
+            call
+            and call[0] == "api"
+            and len(call) > 1
+            and "required_status_checks" in call[1]
+        )
+        for call in gh_calls
+    )
+
+
+def test_closeout_readonly_profile(tmp_path: Path) -> None:
+    repo, state_path, env, _main_sha, head_sha = _prepare_repo(tmp_path)
+    _git(repo, "switch", "-q", "main")
+    _git(repo, "merge", "--ff-only", "84-task-evidence-runner")
+    merge_sha = _git(repo, "rev-parse", "HEAD")
+    _git(repo, "update-ref", "refs/remotes/origin/main", merge_sha)
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["issue"]["state"] = "CLOSED"
+    state["issue"]["projectItems"] = [{"status": {"name": "Done"}}]
+    state["issue"]["closedAt"] = "2026-08-02T16:00:00Z"
+    state["issue"]["closedByPullRequestsReferences"] = [
+        {
+            "number": 102,
+            "state": "MERGED",
+            "mergedAt": "2026-08-02T16:00:00Z",
+            "url": "https://github.com/PhoenixSss/quant-system/pull/102",
+        }
+    ]
+    state["pr"].update(
+        state="MERGED",
+        mergeCommit={"oid": merge_sha},
+        mergedAt="2026-08-02T16:00:00Z",
+        mergeable="UNKNOWN",
+    )
+    state["remote_refs"]["main"] = merge_sha
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    _sync_remote_files(state_path, state)
+    completed = _run(
+        repo,
+        env,
+        "closeout-readonly",
+        "--task",
+        "84",
+        "--pr",
+        "102",
+        "--expected-head-sha",
+        head_sha,
+        "--expected-merge-sha",
+        merge_sha,
+    )
+    assert completed.returncode == 0, completed.stderr
+    value = _result(repo, completed.stdout)
+    assert value["identity"]["merge_sha"] == merge_sha
+    assert value["issue"]["state"] == "CLOSED"
+    assert value["git"]["current_branch"] == "main"
+
+
+@pytest.mark.skipif(
+    os.environ.get("TASK84_LIVE_REPOSITORY") != "PhoenixSss/quant-system",
+    reason="set TASK84_LIVE_REPOSITORY and live IDs for an explicit network probe",
+)
+def test_live_task_pr_schema() -> None:
+    task = os.environ["TASK84_LIVE_TASK"]
+    pr = os.environ["TASK84_LIVE_PR"]
+    base = os.environ["TASK84_LIVE_BASE_SHA"]
+    head = os.environ["TASK84_LIVE_HEAD_SHA"]
+    completed = subprocess.run(
+        [
+            str(ROOT / RUNNER_REL),
+            "review",
+            "--task",
+            task,
+            "--pr",
+            pr,
+            "--expected-base-sha",
+            base,
+            "--expected-head-sha",
+            head,
+        ],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        env=os.environ.copy(),
+    )
+    assert task == "84"
+    assert pr.isdigit()
+    assert completed.returncode in {0, 3}, completed.stderr
+    assert json.loads(completed.stdout)["task"] == 84

--- a/tests/tools/test_wsl2_github_evidence_runner.py
+++ b/tests/tools/test_wsl2_github_evidence_runner.py
@@ -19,8 +19,9 @@ TRUSTED_FILES = (
     Path("tools/agent_workflow/workflow_evidence.py"),
     Path("tools/agent_workflow/workflow_common.py"),
 )
-REAL_GIT = shutil.which("git")
-assert REAL_GIT is not None
+REAL_GIT_OPTIONAL = shutil.which("git")
+assert REAL_GIT_OPTIONAL is not None
+REAL_GIT: str = REAL_GIT_OPTIONAL
 
 
 def _git(repo: Path, *args: str) -> str:
@@ -106,8 +107,7 @@ def _write_fake_tools(bin_dir: Path, state_path: Path) -> None:
     state = json.loads(state_path.read_text(encoding="utf-8"))
     refs_path.write_text(
         "".join(
-            f"{sha}\trefs/heads/{name}\n"
-            for name, sha in state["remote_refs"].items()
+            f"{sha}\trefs/heads/{name}\n" for name, sha in state["remote_refs"].items()
         ),
         encoding="utf-8",
     )
@@ -207,7 +207,13 @@ def _prepare_repo(
     _git(repo, "commit", "-q", "-m", "main baseline")
     _git(repo, "branch", "-M", "main")
     main_sha = _git(repo, "rev-parse", "HEAD")
-    _git(repo, "remote", "add", "origin", "https://github.com/PhoenixSss/quant-system.git")
+    _git(
+        repo,
+        "remote",
+        "add",
+        "origin",
+        "https://github.com/PhoenixSss/quant-system.git",
+    )
     _git(repo, "update-ref", "refs/remotes/origin/main", main_sha)
     _git(repo, "switch", "-q", "-c", "84-task-evidence-runner")
     (repo / "task84.txt").write_text("task 84\n", encoding="utf-8")
@@ -278,7 +284,9 @@ def _sync_remote_files(state_path: Path, state: dict[str, Any]) -> None:
 
 def _result(repo: Path, stdout: str) -> dict[str, Any]:
     digest = json.loads(stdout)
-    return json.loads((repo / digest["result_path"]).read_text(encoding="utf-8"))
+    result = json.loads((repo / digest["result_path"]).read_text(encoding="utf-8"))
+    assert isinstance(result, dict)
+    return result
 
 
 def test_review_profile_returns_required_schema_and_compact_digest(
@@ -315,9 +323,7 @@ def test_review_profile_returns_required_schema_and_compact_digest(
 
 
 @pytest.mark.parametrize("profile", ["delivery-readiness", "review", "pre-merge"])
-def test_task_pr_profiles_are_fixed_and_pass(
-    tmp_path: Path, profile: str
-) -> None:
+def test_task_pr_profiles_are_fixed_and_pass(tmp_path: Path, profile: str) -> None:
     repo, _, env, main_sha, head_sha = _prepare_repo(tmp_path)
     completed = _run(repo, env, *_review_args(main_sha, head_sha, profile))
     assert completed.returncode == 0, completed.stderr
@@ -354,9 +360,10 @@ def test_plan_limit_is_partial_not_success(tmp_path: Path) -> None:
     digest = json.loads(completed.stdout)
     assert digest["status"] == "partial"
     value = _result(repo, completed.stdout)
-    assert "required_checks_configuration" in value["evidence"]["gate_summary"][
-        "unknown_gates"
-    ]
+    assert (
+        "required_checks_configuration"
+        in value["evidence"]["gate_summary"]["unknown_gates"]
+    )
 
 
 def test_missing_issue_and_rate_limit_are_partial_and_redacted(tmp_path: Path) -> None:
@@ -398,9 +405,10 @@ def test_remote_ref_drift_is_fail(tmp_path: Path) -> None:
     completed = _run(repo, env, *_review_args(main_sha, head_sha))
     assert completed.returncode == 4
     value = _result(repo, completed.stdout)
-    assert "origin_main_vs_remote_main" in value["evidence"]["gate_summary"][
-        "remote_ref_conflicts"
-    ]
+    assert (
+        "origin_main_vs_remote_main"
+        in value["evidence"]["gate_summary"]["remote_ref_conflicts"]
+    )
 
 
 def test_remote_query_failure_is_partial(tmp_path: Path) -> None:
@@ -422,27 +430,21 @@ def test_recheck_detects_head_checks_and_thread_drift(tmp_path: Path) -> None:
     state = json.loads(state_path.read_text(encoding="utf-8"))
     new_head = "e" * 40
     state["pr"]["headRefOid"] = new_head
-    state["pr"]["statusCheckRollup"] = [
-        {"name": "quality", "conclusion": "FAILURE"}
-    ]
+    state["pr"]["statusCheckRollup"] = [{"name": "quality", "conclusion": "FAILURE"}]
     state["threads"]["nodes"] = [
         {"isResolved": False, "isOutdated": False, "comments": {"totalCount": 1}}
     ]
     state["remote_refs"]["84-task-evidence-runner"] = new_head
     state_path.write_text(json.dumps(state), encoding="utf-8")
     _sync_remote_files(state_path, state)
-    second = _run(
-        repo, env, "recheck", "--snapshot-id", first_digest["snapshot_id"]
-    )
+    second = _run(repo, env, "recheck", "--snapshot-id", first_digest["snapshot_id"])
     assert second.returncode == 4, second.stderr
     value = _result(repo, second.stdout)
     changed = value["stability"]["changed_fields"]["items"]
     assert "head_sha" in changed
     assert "checks" in changed
     assert "unresolved_threads" in changed
-    assert "snapshot_stability" in value["evidence"]["gate_summary"][
-        "failed_gates"
-    ]
+    assert "snapshot_stability" in value["evidence"]["gate_summary"]["failed_gates"]
 
 
 def test_tampered_recheck_snapshot_fails_before_github(tmp_path: Path) -> None:
@@ -451,9 +453,7 @@ def test_tampered_recheck_snapshot_fails_before_github(tmp_path: Path) -> None:
     assert first.returncode == 0, first.stderr
     digest = json.loads(first.stdout)
     snapshot = (
-        repo
-        / ".agents/evidence.local/snapshots"
-        / f"{digest['snapshot_id']}.json"
+        repo / ".agents/evidence.local/snapshots" / f"{digest['snapshot_id']}.json"
     )
     value = json.loads(snapshot.read_text(encoding="utf-8"))
     value["repository"] = "other/repo"

--- a/tools/agent_workflow/workflow_evidence.py
+++ b/tools/agent_workflow/workflow_evidence.py
@@ -9,6 +9,7 @@ workflow verdicts remain the responsibility of the governing Skill.
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 import unicodedata
 from collections.abc import Mapping, Sequence
@@ -170,12 +171,15 @@ def _git_snapshot(
     runner: CommandRunner,
     warnings: list[dict[str, Any]],
 ) -> dict[str, Any]:
-    fetch = runner.run(
-        ["git", "fetch", "--prune", "origin"],
-        command_id="git-fetch-origin",
-    )
-    if fetch.returncode != 0:
-        warnings.append(command_warning(fetch))
+    read_only_local_refs = os.environ.get("WORKFLOW_EVIDENCE_READ_ONLY") == "1"
+    fetch: CommandResult | None = None
+    if not read_only_local_refs:
+        fetch = runner.run(
+            ["git", "fetch", "--prune", "origin"],
+            command_id="git-fetch-origin",
+        )
+        if fetch.returncode != 0:
+            warnings.append(command_warning(fetch))
     branch = _git_value(
         runner,
         ["branch", "--show-current"],
@@ -186,6 +190,12 @@ def _git_snapshot(
         runner,
         ["rev-parse", "HEAD"],
         command_id="git-head",
+        warnings=warnings,
+    )
+    local_main = _git_value(
+        runner,
+        ["rev-parse", "refs/heads/main"],
+        command_id="git-local-main",
         warnings=warnings,
     )
     origin_main = _git_value(
@@ -219,9 +229,19 @@ def _git_snapshot(
         warnings=warnings,
     )
     return {
-        "origin_fetch": "pass" if fetch.returncode == 0 else "unknown",
+        "origin_fetch": (
+            "pass"
+            if read_only_local_refs
+            else "pass"
+            if fetch is not None and fetch.returncode == 0
+            else "unknown"
+        ),
+        "origin_refresh": (
+            "skipped-read-only" if read_only_local_refs else "attempted"
+        ),
         "branch": safe_text(branch),
         "head_sha": head if is_sha(head) else None,
+        "local_main_sha": local_main if is_sha(local_main) else None,
         "origin_main_sha": origin_main if is_sha(origin_main) else None,
         "clean": len(status_lines) == 0,
         "status_entries": len(status_lines),

--- a/tools/agent_workflow/wsl2_github_evidence_profiles.json
+++ b/tools/agent_workflow/wsl2_github_evidence_profiles.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": 1,
+  "runner_version": "1.0.0",
+  "repository": "PhoenixSss/quant-system",
+  "profiles": {
+    "delivery": {
+      "operation": "delivery-preflight",
+      "required_arguments": [
+        "task",
+        "expected_main_sha"
+      ],
+      "description": "Task and synchronized-main preflight before Delivery writes."
+    },
+    "delivery-readiness": {
+      "operation": "delivery-readiness",
+      "required_arguments": [
+        "task",
+        "pr",
+        "expected_base_sha",
+        "expected_head_sha"
+      ],
+      "description": "Delivery handoff snapshot for a review-ready Task PR."
+    },
+    "review": {
+      "operation": "pr-review-snapshot",
+      "required_arguments": [
+        "task",
+        "pr",
+        "expected_base_sha",
+        "expected_head_sha"
+      ],
+      "description": "Independent review snapshot from the trusted control plane."
+    },
+    "pre-merge": {
+      "operation": "pr-review-snapshot",
+      "required_arguments": [
+        "task",
+        "pr",
+        "expected_base_sha",
+        "expected_head_sha"
+      ],
+      "description": "Final read-only identity, checks, threads, and drift snapshot before manual merge."
+    },
+    "closeout-readonly": {
+      "operation": "closeout-plan",
+      "required_arguments": [
+        "task",
+        "pr",
+        "expected_head_sha",
+        "expected_merge_sha"
+      ],
+      "description": "Read-only post-merge Task/PR/main convergence evidence."
+    },
+    "recheck": {
+      "operation": "recheck",
+      "required_arguments": [
+        "snapshot_id"
+      ],
+      "description": "Recollect a stored snapshot using its supported stability recheck operation."
+    }
+  }
+}

--- a/tools/agent_workflow/wsl2_github_evidence_runner.py
+++ b/tools/agent_workflow/wsl2_github_evidence_runner.py
@@ -100,9 +100,10 @@ class RunnerError(RuntimeError):
 def _json_dumps(value: Any, *, pretty: bool = False) -> str:
     if pretty:
         return json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
-    return json.dumps(
-        value, ensure_ascii=False, sort_keys=True, separators=(",", ":")
-    ) + "\n"
+    return (
+        json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        + "\n"
+    )
 
 
 def _sha256_bytes(value: bytes) -> str:
@@ -366,9 +367,7 @@ def _evidence_argv(args: argparse.Namespace, repo_root: Path) -> list[str]:
     ]
     if profile == "recheck":
         snapshot_path = (
-            repo_root
-            / ".agents/evidence.local/snapshots"
-            / f"{args.snapshot_id}.json"
+            repo_root / ".agents/evidence.local/snapshots" / f"{args.snapshot_id}.json"
         )
         if snapshot_path.is_symlink():
             raise RunnerError("recheck snapshot must not be a symlink")
@@ -400,6 +399,8 @@ def _evidence_argv(args: argparse.Namespace, repo_root: Path) -> list[str]:
             ):
                 raise RunnerError("recheck snapshot subject identity is invalid")
         previous_operation = previous.get("operation")
+        if not isinstance(previous_operation, str):
+            raise RunnerError("recheck snapshot operation is invalid")
         recheck_command = RECHECK_COMMANDS.get(previous_operation)
         if recheck_command is None:
             raise RunnerError(
@@ -740,9 +741,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         _atomic_write(result_path, payload)
         result_sha = _sha256_bytes(payload)
         compact = {
-            "api_calls": result.get("evidence", {}).get("operations", {}).get(
-                "github_queries"
-            ),
+            "api_calls": result.get("evidence", {})
+            .get("operations", {})
+            .get("github_queries"),
             "base_sha": result["identity"]["base_sha"],
             "duration_ms": duration_ms,
             "head_sha": result["identity"]["head_sha"],

--- a/tools/agent_workflow/wsl2_github_evidence_runner.py
+++ b/tools/agent_workflow/wsl2_github_evidence_runner.py
@@ -1,0 +1,776 @@
+#!/usr/bin/env python3
+"""Fixed, read-only WSL2 GitHub and Git workflow evidence runner."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+import uuid
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Final
+
+SCHEMA_VERSION: Final = 1
+RUNNER_VERSION: Final = "1.0.0"
+REPOSITORY: Final = "PhoenixSss/quant-system"
+OUTPUT_ROOT: Final = ".agents/evidence.local/wsl2-github-runs"
+RUNNER_PATH: Final = "tools/agent_workflow/wsl2_github_evidence_runner.py"
+SPEC_PATH: Final = "tools/agent_workflow/wsl2_github_evidence_profiles.json"
+RULES_PATH: Final = ".codex/rules/quant-system-wsl-evidence.rules"
+EVIDENCE_TOOL_PATH: Final = "tools/agent_workflow/workflow_evidence.py"
+COMMON_TOOL_PATH: Final = "tools/agent_workflow/workflow_common.py"
+STDIO_LIMIT_BYTES: Final = 8192
+SHA_PATTERN: Final = re.compile(r"^[0-9a-f]{40}$")
+SNAPSHOT_ID_PATTERN: Final = re.compile(r"^ev-[0-9a-f]{16}$")
+REPOSITORY_PATTERN: Final = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+WINDOWS_PATH_PATTERN: Final = re.compile(r"(?<![A-Za-z0-9])[A-Za-z]:[\\/][^\s\"']+")
+POSIX_PATH_PATTERN: Final = re.compile(r"(?<![:/A-Za-z0-9])/(?!/)[^\s\"']+")
+SENSITIVE_PATTERNS: Final = (
+    re.compile(r"gh[pousr]_[A-Za-z0-9]{20,}"),
+    re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._~-]{16,}"),
+    re.compile(r"-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----"),
+    re.compile(
+        r"(?i)(authorization|cookie|api[_-]?key|token|password|secret)\s*[:=]\s*\S+"
+    ),
+)
+TRUSTED_PATHS: Final = (
+    RUNNER_PATH,
+    SPEC_PATH,
+    RULES_PATH,
+    EVIDENCE_TOOL_PATH,
+    COMMON_TOOL_PATH,
+)
+ALLOWED_ENV: Final = (
+    "PATH",
+    "HOME",
+    "LANG",
+    "LC_ALL",
+    "XDG_CONFIG_HOME",
+    "GH_CONFIG_DIR",
+    "GH_HOST",
+    "GH_TOKEN",
+    "GITHUB_TOKEN",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "ALL_PROXY",
+    "NO_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "all_proxy",
+    "no_proxy",
+)
+CANONICAL_PROFILES: Final[dict[str, tuple[str, tuple[str, ...]]]] = {
+    "delivery": ("delivery-preflight", ("task", "expected_main_sha")),
+    "delivery-readiness": (
+        "delivery-readiness",
+        ("task", "pr", "expected_base_sha", "expected_head_sha"),
+    ),
+    "review": (
+        "pr-review-snapshot",
+        ("task", "pr", "expected_base_sha", "expected_head_sha"),
+    ),
+    "pre-merge": (
+        "pr-review-snapshot",
+        ("task", "pr", "expected_base_sha", "expected_head_sha"),
+    ),
+    "closeout-readonly": (
+        "closeout-plan",
+        ("task", "pr", "expected_head_sha", "expected_merge_sha"),
+    ),
+    "recheck": ("recheck", ("snapshot_id",)),
+}
+RECHECK_COMMANDS: Final = {
+    "delivery-readiness": "pr-review-recheck",
+    "pr-review-snapshot": "pr-review-recheck",
+    "closeout-plan": "closeout-final",
+}
+
+
+class RunnerError(RuntimeError):
+    """Expected fail-closed runner error."""
+
+
+def _json_dumps(value: Any, *, pretty: bool = False) -> str:
+    if pretty:
+        return json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    return json.dumps(
+        value, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ) + "\n"
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _sha256_json(value: Any) -> str:
+    return _sha256_bytes(
+        json.dumps(
+            value, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+        ).encode("utf-8")
+    )
+
+
+def _redact(text: str) -> str:
+    value = text.replace("\x00", "")
+    for pattern in SENSITIVE_PATTERNS:
+        value = pattern.sub("<redacted>", value)
+    value = WINDOWS_PATH_PATTERN.sub("<absolute-path-redacted>", value)
+    return POSIX_PATH_PATTERN.sub("<absolute-path-redacted>", value)
+
+
+def _bounded(text: str) -> tuple[str, bool, str]:
+    sanitized = _redact(text)
+    digest = _sha256_bytes(sanitized.encode("utf-8", errors="replace"))
+    payload = sanitized.encode("utf-8", errors="replace")
+    if len(payload) <= STDIO_LIMIT_BYTES:
+        return sanitized, False, digest
+    truncated = payload[:STDIO_LIMIT_BYTES].decode("utf-8", errors="ignore")
+    return truncated + "\n<truncated>\n", True, digest
+
+
+def _atomic_write(path: Path, payload: bytes, *, mode: int = 0o600) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp = path.with_name(f".{path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
+    fd = os.open(temp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, mode)
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(payload)
+        os.replace(temp, path)
+    except BaseException:
+        try:
+            temp.unlink()
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def _command_env() -> dict[str, str]:
+    env = {
+        key: value for key in ALLOWED_ENV if (value := os.environ.get(key)) is not None
+    }
+    env.setdefault("PYTHONUTF8", "1")
+    env.setdefault("PYTHONIOENCODING", "utf-8")
+    env.setdefault("PYTHONDONTWRITEBYTECODE", "1")
+    env.setdefault("NO_COLOR", "1")
+    env["WORKFLOW_EVIDENCE_READ_ONLY"] = "1"
+    return env
+
+
+def _run(
+    argv: Sequence[str], repo_root: Path, *, env: Mapping[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(item) for item in argv],
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=dict(env) if env is not None else _command_env(),
+    )
+
+
+def _run_bytes(
+    argv: Sequence[str], repo_root: Path
+) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(
+        [str(item) for item in argv],
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        env=_command_env(),
+    )
+
+
+def _read_tracked_file(repo_root: Path, relative_path: str) -> bytes:
+    path = repo_root / relative_path
+    if path.is_symlink():
+        raise RunnerError(f"trusted file must not be a symlink: {relative_path}")
+    try:
+        actual = path.read_bytes()
+    except FileNotFoundError as exc:
+        raise RunnerError(f"required trusted file is missing: {relative_path}") from exc
+    for argv, label in (
+        (("git", "diff", "--quiet", "--", relative_path), "working tree"),
+        (("git", "diff", "--cached", "--quiet", "--", relative_path), "index"),
+    ):
+        result = _run_bytes(argv, repo_root)
+        if result.returncode == 1:
+            raise RunnerError(
+                f"trusted file differs from HEAD in the {label}: {relative_path}"
+            )
+        if result.returncode != 0:
+            error = _redact(result.stderr.decode("utf-8", errors="replace")).strip()
+            raise RunnerError(f"unable to verify trusted file {relative_path}: {error}")
+    head = _run_bytes(("git", "show", f"HEAD:{relative_path}"), repo_root)
+    if head.returncode != 0:
+        raise RunnerError(f"trusted file is not tracked at HEAD: {relative_path}")
+    if actual != head.stdout:
+        raise RunnerError(f"trusted file content does not match HEAD: {relative_path}")
+    return actual
+
+
+def _load_trusted_inputs(repo_root: Path) -> tuple[dict[str, Any], dict[str, str]]:
+    payloads = {path: _read_tracked_file(repo_root, path) for path in TRUSTED_PATHS}
+    try:
+        spec = json.loads(payloads[SPEC_PATH].decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise RunnerError("profile specification is not valid UTF-8 JSON") from exc
+    if not isinstance(spec, dict):
+        raise RunnerError("profile specification must be a JSON object")
+    _validate_spec(spec)
+    return spec, {path: _sha256_bytes(payload) for path, payload in payloads.items()}
+
+
+def _validate_spec(spec: Mapping[str, Any]) -> None:
+    if spec.get("schema_version") != SCHEMA_VERSION:
+        raise RunnerError("profile specification schema version is unsupported")
+    if spec.get("runner_version") != RUNNER_VERSION:
+        raise RunnerError("profile specification runner version does not match")
+    if spec.get("repository") != REPOSITORY:
+        raise RunnerError("profile specification repository is not allowed")
+    raw_profiles = spec.get("profiles")
+    if not isinstance(raw_profiles, dict) or set(raw_profiles) != set(
+        CANONICAL_PROFILES
+    ):
+        raise RunnerError("profile specification names do not match canonical profiles")
+    for name, (operation, required) in CANONICAL_PROFILES.items():
+        raw = raw_profiles.get(name)
+        if not isinstance(raw, dict):
+            raise RunnerError(f"invalid profile specification: {name}")
+        if raw.get("operation") != operation:
+            raise RunnerError(f"profile operation drift: {name}")
+        if raw.get("required_arguments") != list(required):
+            raise RunnerError(f"profile argument contract drift: {name}")
+
+
+def _parse_repository_slug(remote: str) -> str | None:
+    value = remote.strip().removesuffix(".git")
+    if value.startswith("git@github.com:"):
+        value = value.split(":", 1)[1]
+    elif "github.com/" in value:
+        value = value.split("github.com/", 1)[1]
+    value = value.strip("/")
+    return value if REPOSITORY_PATTERN.fullmatch(value) else None
+
+
+def _find_repo_root(script_path: Path) -> Path:
+    if script_path.is_symlink():
+        raise RunnerError("runner entry must not be invoked through a symlink")
+    repo_root = script_path.resolve().parents[2]
+    expected = repo_root / RUNNER_PATH
+    if script_path.resolve() != expected.resolve():
+        raise RunnerError("runner entry path is not the trusted repository entry")
+    if Path.cwd().resolve() != repo_root.resolve():
+        raise RunnerError("runner must be started from the repository root")
+    if repo_root.resolve().as_posix().startswith("/mnt/"):
+        raise RunnerError("repository must be on the WSL2 Linux filesystem, not /mnt")
+    git_root = _run(("git", "rev-parse", "--show-toplevel"), repo_root)
+    if git_root.returncode != 0 or Path(git_root.stdout.strip()).resolve() != repo_root:
+        raise RunnerError("current directory is not the runner Git repository root")
+    gh_host = os.environ.get("GH_HOST")
+    if gh_host and gh_host.casefold() != "github.com":
+        raise RunnerError("GH_HOST must be github.com for this fixed repository")
+    origin = _run(("git", "remote", "get-url", "origin"), repo_root)
+    if origin.returncode != 0:
+        raise RunnerError("origin remote is required")
+    actual_repository = _parse_repository_slug(origin.stdout)
+    if actual_repository != REPOSITORY:
+        raise RunnerError(
+            f"origin repository is not allowed: {actual_repository or 'unrecognized'}"
+        )
+    return repo_root
+
+
+def _require_output_root_ignored(repo_root: Path) -> None:
+    ignore_path = repo_root / ".gitignore"
+    try:
+        patterns = {
+            line.strip().removeprefix("./")
+            for line in ignore_path.read_text(encoding="utf-8-sig").splitlines()
+            if line.strip() and not line.lstrip().startswith(("#", "!"))
+        }
+    except FileNotFoundError as exc:
+        raise RunnerError(".gitignore is required") from exc
+    if ".agents/evidence.local/" not in patterns:
+        raise RunnerError(
+            "local evidence root requires the exact .agents/evidence.local/ ignore rule"
+        )
+
+
+def _positive_int(value: str) -> int:
+    try:
+        number = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a positive integer") from exc
+    if number <= 0 or number > 2_147_483_647:
+        raise argparse.ArgumentTypeError("must be a positive 32-bit integer")
+    return number
+
+
+def _sha(value: str) -> str:
+    normalized = value.casefold()
+    if SHA_PATTERN.fullmatch(normalized) is None:
+        raise argparse.ArgumentTypeError("must be a full 40-character Git SHA")
+    return normalized
+
+
+def _snapshot_id(value: str) -> str:
+    if SNAPSHOT_ID_PATTERN.fullmatch(value) is None:
+        raise argparse.ArgumentTypeError("must be an ev- snapshot ID")
+    return value
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Collect fixed, read-only GitHub and Git workflow evidence."
+    )
+    sub = parser.add_subparsers(dest="profile", required=True)
+
+    delivery = sub.add_parser("delivery")
+    delivery.add_argument("--task", type=_positive_int, required=True)
+    delivery.add_argument("--expected-main-sha", type=_sha, required=True)
+
+    for name in ("delivery-readiness", "review", "pre-merge"):
+        item = sub.add_parser(name)
+        item.add_argument("--task", type=_positive_int, required=True)
+        item.add_argument("--pr", type=_positive_int, required=True)
+        item.add_argument("--expected-base-sha", type=_sha, required=True)
+        item.add_argument("--expected-head-sha", type=_sha, required=True)
+
+    closeout = sub.add_parser("closeout-readonly")
+    closeout.add_argument("--task", type=_positive_int, required=True)
+    closeout.add_argument("--pr", type=_positive_int, required=True)
+    closeout.add_argument("--expected-head-sha", type=_sha, required=True)
+    closeout.add_argument("--expected-merge-sha", type=_sha, required=True)
+
+    recheck = sub.add_parser("recheck")
+    recheck.add_argument("--snapshot-id", type=_snapshot_id, required=True)
+    return parser
+
+
+def _evidence_argv(args: argparse.Namespace, repo_root: Path) -> list[str]:
+    profile = str(args.profile)
+    operation = CANONICAL_PROFILES[profile][0]
+    base = [
+        sys.executable,
+        str(repo_root / EVIDENCE_TOOL_PATH),
+    ]
+    if profile == "recheck":
+        snapshot_path = (
+            repo_root
+            / ".agents/evidence.local/snapshots"
+            / f"{args.snapshot_id}.json"
+        )
+        if snapshot_path.is_symlink():
+            raise RunnerError("recheck snapshot must not be a symlink")
+        try:
+            previous = json.loads(snapshot_path.read_text(encoding="utf-8"))
+        except FileNotFoundError as exc:
+            raise RunnerError("recheck snapshot does not exist") from exc
+        except json.JSONDecodeError as exc:
+            raise RunnerError("recheck snapshot is invalid JSON") from exc
+        if not isinstance(previous, dict):
+            raise RunnerError("recheck snapshot must be a JSON object")
+        if previous.get("repository") != REPOSITORY:
+            raise RunnerError("recheck snapshot repository is not allowed")
+        stored_snapshot_id = previous.get("snapshot_id")
+        core = {key: value for key, value in previous.items() if key != "snapshot_id"}
+        expected_snapshot_id = f"ev-{_sha256_json(core)[:16]}"
+        if (
+            stored_snapshot_id != args.snapshot_id
+            or stored_snapshot_id != expected_snapshot_id
+        ):
+            raise RunnerError("recheck snapshot fingerprint is invalid")
+        subject = previous.get("subject")
+        if not isinstance(subject, dict):
+            raise RunnerError("recheck snapshot subject is invalid")
+        for key in ("task_number", "pr_number"):
+            value = subject.get(key)
+            if value is not None and (
+                not isinstance(value, int) or isinstance(value, bool) or value <= 0
+            ):
+                raise RunnerError("recheck snapshot subject identity is invalid")
+        previous_operation = previous.get("operation")
+        recheck_command = RECHECK_COMMANDS.get(previous_operation)
+        if recheck_command is None:
+            raise RunnerError(
+                "snapshot operation does not support this recheck profile"
+            )
+        return [
+            *base,
+            recheck_command,
+            "--snapshot-id",
+            args.snapshot_id,
+            "--repo-root",
+            ".",
+            "--repository",
+            REPOSITORY,
+        ]
+
+    result = [
+        *base,
+        operation,
+        "--repo-root",
+        ".",
+        "--repository",
+        REPOSITORY,
+        "--task",
+        str(args.task),
+    ]
+    if profile == "delivery":
+        result.extend(["--expected-main-sha", args.expected_main_sha])
+    elif profile in {"delivery-readiness", "review", "pre-merge"}:
+        result.extend(
+            [
+                "--pr",
+                str(args.pr),
+                "--expected-base-sha",
+                args.expected_base_sha,
+                "--expected-head-sha",
+                args.expected_head_sha,
+            ]
+        )
+    elif profile == "closeout-readonly":
+        result.extend(
+            [
+                "--pr",
+                str(args.pr),
+                "--expected-head-sha",
+                args.expected_head_sha,
+                "--expected-merge-sha",
+                args.expected_merge_sha,
+            ]
+        )
+    else:
+        raise RunnerError("unsupported profile")
+    return result
+
+
+def _recursive_truncation(value: Any) -> bool:
+    if isinstance(value, dict):
+        if value.get("truncated") is True:
+            return True
+        return any(_recursive_truncation(item) for item in value.values())
+    if isinstance(value, list):
+        return any(_recursive_truncation(item) for item in value)
+    return False
+
+
+def _gate_summary(snapshot: Mapping[str, Any]) -> dict[str, Any]:
+    raw = snapshot.get("gates")
+    gates = raw if isinstance(raw, dict) else {}
+    names: dict[str, list[str]] = {"pass": [], "fail": [], "unknown": []}
+    for name, value in gates.items():
+        status = value.get("status") if isinstance(value, dict) else None
+        if status in names:
+            names[status].append(str(name))
+        else:
+            names["unknown"].append(str(name))
+    return {
+        "pass": len(names["pass"]),
+        "fail": len(names["fail"]),
+        "unknown": len(names["unknown"]),
+        "failed_gates": sorted(names["fail"]),
+        "unknown_gates": sorted(names["unknown"]),
+    }
+
+
+def _derive_status(snapshot: Mapping[str, Any]) -> tuple[str, dict[str, Any]]:
+    gates = _gate_summary(snapshot)
+    warning_count = snapshot.get("warning_count")
+    limitation_count = snapshot.get("limitation_count")
+    warning_count = warning_count if isinstance(warning_count, int) else 0
+    limitation_count = limitation_count if isinstance(limitation_count, int) else 0
+    truncated = _recursive_truncation(snapshot.get("observed"))
+    if gates["fail"]:
+        status = "fail"
+    elif gates["unknown"] or warning_count or truncated:
+        status = "partial"
+    else:
+        status = "pass"
+    return status, {
+        **gates,
+        "warning_count": warning_count,
+        "limitation_count": limitation_count,
+        "observed_truncated": truncated,
+    }
+
+
+def _remote_refs(
+    repo_root: Path, *, head_branch: str | None
+) -> tuple[dict[str, Any], list[str]]:
+    refs = ["main"]
+    if head_branch and head_branch != "main":
+        refs.append(head_branch)
+    result = _run(("git", "ls-remote", "--heads", "origin", *refs), repo_root)
+    warnings: list[str] = []
+    if result.returncode != 0:
+        warnings.append(_redact(result.stderr or result.stdout).strip())
+        return {"available": False, "main_sha": None, "head_sha": None}, warnings
+    values: dict[str, str] = {}
+    for line in result.stdout.splitlines():
+        parts = line.split("\t", 1)
+        if len(parts) != 2 or SHA_PATTERN.fullmatch(parts[0].casefold()) is None:
+            continue
+        values[parts[1].removeprefix("refs/heads/")] = parts[0].casefold()
+    return {
+        "available": "main" in values,
+        "main_sha": values.get("main"),
+        "head_sha": values.get(head_branch) if head_branch else None,
+    }, warnings
+
+
+def _compact_result(
+    snapshot: Mapping[str, Any],
+    *,
+    profile: str,
+    status: str,
+    status_details: Mapping[str, Any],
+    started_at: datetime,
+    duration_ms: int,
+    run_id: str,
+    result_path: str,
+    integrity: Mapping[str, str],
+    remote_refs: Mapping[str, Any],
+    remote_warnings: Sequence[str],
+) -> dict[str, Any]:
+    observed = snapshot.get("observed")
+    observed = observed if isinstance(observed, dict) else {}
+    issue = observed.get("issue")
+    issue = issue if isinstance(issue, dict) else {}
+    pr = observed.get("pr")
+    pr = pr if isinstance(pr, dict) else {}
+    git = observed.get("git")
+    git = git if isinstance(git, dict) else {}
+    threads = observed.get("review_threads")
+    threads = threads if isinstance(threads, dict) else {}
+    diff = observed.get("effective_diff")
+    diff = diff if isinstance(diff, dict) else {}
+    checks = pr.get("checks")
+    checks = checks if isinstance(checks, dict) else {}
+    stability = snapshot.get("stability")
+    stability = stability if isinstance(stability, dict) else {}
+    source_core = {
+        key: value for key, value in snapshot.items() if key != "details_path"
+    }
+    subject = snapshot.get("subject")
+    subject = subject if isinstance(subject, dict) else {}
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "runner_version": RUNNER_VERSION,
+        "profile": profile,
+        "status": status,
+        "partial": status == "partial",
+        "started_at": started_at.isoformat(),
+        "duration_ms": duration_ms,
+        "identity": {
+            "task": issue.get("number") or subject.get("task_number"),
+            "pr": pr.get("number") or subject.get("pr_number"),
+            "repository": snapshot.get("repository"),
+            "base_sha": pr.get("base_sha"),
+            "head_sha": pr.get("head_sha"),
+            "merge_sha": pr.get("merge_commit_sha"),
+        },
+        "issue": {
+            "available": bool(issue),
+            "state": issue.get("state"),
+            "labels": issue.get("labels"),
+            "project_status": issue.get("project_status"),
+            "content_sha256": issue.get("content_sha256"),
+        },
+        "pull_request": {
+            "available": bool(pr),
+            "state": pr.get("state"),
+            "draft": pr.get("is_draft"),
+            "mergeable": pr.get("mergeable"),
+            "review_decision": pr.get("review_decision"),
+            "checks": checks,
+            "unresolved_threads": threads.get("unresolved"),
+            "threads_available": threads.get("available"),
+        },
+        "scope": {
+            "changed_files": pr.get("changed_files"),
+            "commits": pr.get("commits"),
+            "diff_digest": diff.get("sha256"),
+            "diff_bytes": diff.get("bytes"),
+        },
+        "git": {
+            "current_branch": git.get("branch"),
+            "working_tree_clean": git.get("clean"),
+            "current_head": git.get("head_sha"),
+            "local_main": git.get("local_main_sha"),
+            "origin_main": git.get("origin_main_sha"),
+            "origin_refresh": git.get("origin_refresh"),
+            "remote_main": remote_refs.get("main_sha"),
+            "remote_head": remote_refs.get("head_sha"),
+        },
+        "stability": {
+            "snapshot_id": snapshot.get("snapshot_id"),
+            "snapshot_fingerprint": _sha256_json(source_core),
+            "stable": stability.get("stable"),
+            "changed_fields": stability.get("changed_fields"),
+            "partial": status == "partial",
+        },
+        "evidence": {
+            "source_operation": snapshot.get("operation"),
+            "source_details_path": snapshot.get("details_path"),
+            "gate_summary": dict(status_details),
+            "operations": snapshot.get("operations"),
+            "runner_operations": {"git_commands": 1, "github_queries": 0},
+            "warnings": snapshot.get("warnings"),
+            "limitations": snapshot.get("limitations"),
+            "remote_ref_warnings": list(remote_warnings),
+        },
+        "artifacts": {
+            "run_id": run_id,
+            "result_json": result_path,
+            "raw_api_responses_committed": False,
+        },
+        "integrity": {
+            "verification": "tracked-head-pre-execution",
+            "trusted_files": dict(integrity),
+        },
+    }
+
+
+def _exit_code(status: str) -> int:
+    return {"pass": 0, "partial": 3, "fail": 4}.get(status, 2)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    try:
+        repo_root = _find_repo_root(Path(__file__))
+        _, trusted_hashes = _load_trusted_inputs(repo_root)
+        _require_output_root_ignored(repo_root)
+        command = _evidence_argv(args, repo_root)
+        started_at = datetime.now(UTC)
+        started = time.monotonic()
+        run_id = f"{started_at.strftime('%Y%m%dT%H%M%SZ')}-{uuid.uuid4().hex[:12]}"
+        run_dir = repo_root / OUTPUT_ROOT / run_id
+        result_path = run_dir / "result.json"
+        stdout_path = run_dir / "workflow-evidence.stdout.json"
+        stderr_path = run_dir / "workflow-evidence.stderr.log"
+        run_dir.mkdir(parents=True, exist_ok=False)
+
+        completed = _run(command, repo_root, env=_command_env())
+        bounded_stdout, stdout_truncated, stdout_digest = _bounded(completed.stdout)
+        bounded_stderr, stderr_truncated, stderr_digest = _bounded(completed.stderr)
+        _atomic_write(stdout_path, bounded_stdout.encode("utf-8"))
+        _atomic_write(stderr_path, bounded_stderr.encode("utf-8"))
+        if completed.returncode != 0:
+            raise RunnerError(
+                f"workflow evidence exited {completed.returncode}: "
+                f"{bounded_stderr.strip() or bounded_stdout.strip()}"
+            )
+        try:
+            snapshot = json.loads(completed.stdout)
+        except json.JSONDecodeError as exc:
+            raise RunnerError("workflow evidence returned invalid JSON") from exc
+        if not isinstance(snapshot, dict):
+            raise RunnerError("workflow evidence result is not a JSON object")
+
+        pr_value = snapshot.get("observed", {}).get("pr")
+        head_branch = (
+            pr_value.get("head_branch") if isinstance(pr_value, dict) else None
+        )
+        remote_refs, remote_warnings = _remote_refs(
+            repo_root, head_branch=head_branch if isinstance(head_branch, str) else None
+        )
+        status, status_details = _derive_status(snapshot)
+        status_details = dict(status_details)
+        observed_value = snapshot.get("observed")
+        observed_value = observed_value if isinstance(observed_value, dict) else {}
+        git_value = observed_value.get("git")
+        git_value = git_value if isinstance(git_value, dict) else {}
+        pr_value = observed_value.get("pr")
+        pr_value = pr_value if isinstance(pr_value, dict) else {}
+        remote_conflicts: list[str] = []
+        if remote_warnings or remote_refs.get("available") is not True:
+            if status == "pass":
+                status = "partial"
+        else:
+            origin_main = git_value.get("origin_main_sha")
+            if (
+                isinstance(origin_main, str)
+                and remote_refs.get("main_sha") != origin_main
+            ):
+                remote_conflicts.append("origin_main_vs_remote_main")
+            pr_state = str(pr_value.get("state") or "").upper()
+            pr_head = pr_value.get("head_sha")
+            if pr_state == "OPEN" and isinstance(pr_head, str):
+                if remote_refs.get("head_sha") != pr_head:
+                    remote_conflicts.append("pr_head_vs_remote_head")
+        if remote_conflicts:
+            status = "fail"
+        status_details["remote_ref_warning_count"] = len(remote_warnings)
+        status_details["remote_ref_conflicts"] = remote_conflicts
+        duration_ms = round((time.monotonic() - started) * 1000)
+        result = _compact_result(
+            snapshot,
+            profile=args.profile,
+            status=status,
+            status_details=status_details,
+            started_at=started_at,
+            duration_ms=duration_ms,
+            run_id=run_id,
+            result_path=result_path.relative_to(repo_root).as_posix(),
+            integrity=trusted_hashes,
+            remote_refs=remote_refs,
+            remote_warnings=remote_warnings,
+        )
+        result["evidence"]["subprocess"] = {
+            "exit_code": completed.returncode,
+            "stdout_digest": stdout_digest,
+            "stderr_digest": stderr_digest,
+            "stdout_truncated": stdout_truncated,
+            "stderr_truncated": stderr_truncated,
+        }
+        payload = _json_dumps(result, pretty=True).encode("utf-8")
+        _atomic_write(result_path, payload)
+        result_sha = _sha256_bytes(payload)
+        compact = {
+            "api_calls": result.get("evidence", {}).get("operations", {}).get(
+                "github_queries"
+            ),
+            "base_sha": result["identity"]["base_sha"],
+            "duration_ms": duration_ms,
+            "head_sha": result["identity"]["head_sha"],
+            "partial": result["partial"],
+            "pr": result["identity"]["pr"],
+            "profile": args.profile,
+            "result_path": result_path.relative_to(repo_root).as_posix(),
+            "result_sha256": result_sha,
+            "snapshot_id": result["stability"]["snapshot_id"],
+            "status": status,
+            "task": result["identity"]["task"],
+            "unknown_gate_count": status_details.get("unknown", 0),
+        }
+        print(_json_dumps(compact), end="")
+        return _exit_code(status)
+    except RunnerError as exc:
+        print(
+            f"WSL2 GitHub evidence runner error: {_redact(str(exc))}",
+            file=sys.stderr,
+        )
+        return 2
+    except OSError as exc:
+        print(
+            f"WSL2 GitHub evidence runner I/O error: {_redact(str(exc))}",
+            file=sys.stderr,
+        )
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add the fixed read-only WSL2 GitHub evidence runner, profiles, minimal Codex rules, and runner/material contract tests.
- Document the Git/GitHub approval boundary, security/troubleshooting guidance, publication readiness, and live evidence capture plan.
- Backfill bounded material-capture summaries and update the read-only workflow evidence test contract after independent review found the command-count assertion was environment-sensitive.

## Final identity
- Task: #84
- Base: 74a75872078221c38dbd132a1d438b0bb05c1870
- Final delivery head: 61a2f0d085e411bf5ed614f0d8703a9c0f122fa2
- Delivery readiness snapshot: ev-c85e324bd5265423
- Final live profile snapshot: ev-6d0c7b93b48fab74
- Final live profile: partial, api_calls=6, result_sha256=61d41e8a9836f93a64b28675a629b00f61da544a55e4d05b6213fb188b04ee66
- Final recheck: partial/stable, api_calls=6, result_sha256=69eaab3623ccbecd9a07444f9f2f464046b4937084749c68024d59e7eafff67c
- Remaining unknown gate: Required Checks configuration, plan-limited HTTP 403; actual quality check is SUCCESS.

## Evidence relationship
- Committed material-capture head: 3814af3d95ece48ef03c59536dd025f5fb5511fb
- The committed bounded summaries preserve the material-capture run associated with that head.
- The final delivery-head readiness evidence for 61a2f0d085e411bf5ed614f0d8703a9c0f122fa2 remains external and is identified in this PR by:
  - readiness snapshot: ev-c85e324bd5265423
  - profile snapshot: ev-6d0c7b93b48fab74
  - profile result SHA-256: 61d41e8a9836f93a64b28675a629b00f61da544a55e4d05b6213fb188b04ee66
  - recheck result SHA-256: 69eaab3623ccbecd9a07444f9f2f464046b4937084749c68024d59e7eafff67c
- The final-head evidence is not committed because committing lifecycle evidence containing the current head would create a new head and invalidate that identity.
- Raw evidence under .agents/evidence.local/ remains uncommitted.

## Validation
- uv lock --check
- uv run --frozen pytest tests/tools/test_workflow_evidence.py::test_read_only_mode_skips_fetch_and_reports_local_main
- uv run --frozen pytest tests/tools
- python3 tools/agent_workflow/workflow_validation.py run --phase delivery --base-sha 74a75872078221c38dbd132a1d438b0bb05c1870 --pretty
- GitHub Actions quality: SUCCESS

Closes #84