### PR TITLE
[Task] 修复 Closeout Cleanup Eligibility 对已合并 PR 关闭关联的识别

### DIFF
--- a/.agents/policies/workflow-evidence.md
+++ b/.agents/policies/workflow-evidence.md
@@ -200,14 +200,17 @@ exact Task branch cleanup. This derived judgment never changes Required Checks
 semantics and must not be reused for Merge, push, Issue, Project, label, review,
 or other writes.
 
-Eligibility requires a merged PR, correct closing linkage, final Task metadata,
-stable recheck, successful observed check runs, synchronized local and remote
-main at the merge SHA, exact local and remote branch names and tips, merge-tree
-equality with the reviewed head, a clean worktree, fixed repository identity, no
-target-branch worktree use, and a cleanup plan containing only the verified Task
-branch. Authentication, scope, permission, rate-limit, network, schema, service,
-unknown Required Checks failures, missing check runs, failed/pending/stale
-checks, ref drift, tree drift, or worktree conflicts keep cleanup blocked.
+Eligibility requires a merged PR, correct PR-declared closing linkage, complete
+Issue-side proof that the latest effective closure was caused by the locked PR,
+non-conflicting reverse linkage, final Task metadata, stable recheck, successful
+observed check runs, synchronized local and remote main at the merge SHA, exact
+local and remote branch names and tips, merge-tree equality with the reviewed
+head, a clean worktree, fixed repository identity, no target-branch worktree use,
+and a cleanup plan containing only the verified Task branch. Authentication,
+scope, permission, rate-limit, network, schema, service, unknown or partial
+closure evidence, unknown Required Checks failures, missing check runs,
+failed/pending/stale checks, ref drift, tree drift, or worktree conflicts keep
+cleanup blocked.
 
 ## Skill integration and reports
 

--- a/.agents/skills/task-closeout/SKILL.md
+++ b/.agents/skills/task-closeout/SKILL.md
@@ -122,7 +122,11 @@ completion.
 Resolve the exact branch from verified PR facts. Before deletion verify branch
 ownership, expected head, no worktree use, merged result, Issue closure,
 synchronized main, validation/checks, final metadata, and no unrelated/default/
-protected/ambiguous target.
+protected/ambiguous target. Treat PR-declared closing linkage, the Issue's
+latest effective closure cause, and the PR merge identity as separate facts:
+unknown or partial closure evidence blocks cleanup, conflicts block cleanup, and
+only complete Issue-side proof that the locked merged PR closed the Task may
+satisfy the closure portion of cleanup eligibility.
 
 If Required Checks configuration is unavailable only because of a recognized
 GitHub plan-limit `403`, branch cleanup may continue only when the snapshot's
@@ -134,7 +138,9 @@ are all successful terminal states, the final recheck is stable, local
 the reviewed PR head, the PR head tree equals the merge tree, the target branch
 is not used by any worktree, and the cleanup plan contains no other branch.
 Any authentication, scope, permission, rate-limit, network, schema, service, or
-unknown Required Checks failure keeps cleanup blocked.
+unknown Required Checks failure keeps cleanup blocked. Missing Issue-side PR
+state, `merged`, or `mergedAt` metadata must be reported as unknown/partial
+closure evidence, not as an explicit not-linked relationship.
 
 Delete only the exact remote branch and verify absence. For local cleanup, try
 `git branch -d` first. Exact `-D` is allowed only after verified Squash Merge,

--- a/docs/workflows/workflow-evidence.md
+++ b/docs/workflows/workflow-evidence.md
@@ -135,12 +135,14 @@ GitHub Required Checks 配置查询若被明确分类为 plan-limit `403`，Evid
 eligible-under-capability-limited-policy`，但该字段只允许作为精确任务分支清理输入，
 不得用于 Merge、push、Issue、Project、label、Review 或其他写操作。
 
-该资格要求已合并 PR、正确 closing linkage、Task 最终元数据、稳定 final recheck、
-至少一个实际 check run 且全部为成功终态、`main == origin/main == merge SHA`、
-精确 local/remote 分支名和 tip、PR head tree 与 merge tree 相等、工作区干净、目标
-分支未被 worktree 占用，且 cleanup plan 只包含该 Task 分支。认证、scope、权限、
-rate limit、网络、schema、服务或未知错误，以及无 checks、失败/等待/stale checks、
-ref drift、tree drift 或 worktree 冲突，均保持 cleanup blocked。
+该资格要求已合并 PR、正确 PR-declared closing linkage、Issue 侧完整证明 latest
+effective closure 由锁定 PR 触发、反向关联无冲突、Task 最终元数据、稳定 final
+recheck、至少一个实际 check run 且全部为成功终态、`main == origin/main == merge
+SHA`、精确 local/remote 分支名和 tip、PR head tree 与 merge tree 相等、工作区干净、
+目标分支未被 worktree 占用，且 cleanup plan 只包含该 Task 分支。认证、scope、权限、
+rate limit、网络、schema、服务、closing evidence unknown/partial、无 checks、
+失败/等待/stale checks、ref drift、tree drift 或 worktree 冲突，均保持 cleanup
+blocked。
 
 ## Validation Runner
 

--- a/tests/tools/test_workflow_evidence.py
+++ b/tests/tools/test_workflow_evidence.py
@@ -95,6 +95,13 @@ elif args[:2] == ['api','graphql']:
     query=' '.join(args)
     if 'pullRequest' in query and 'reviewThreads' in query:
         dump({{'data':{{'repository':{{'pullRequest':{{'reviewThreads':state.get('threads',{{'nodes':[],'pageInfo':{{'hasNextPage':False}}}})}}}}}}}})
+    elif 'timelineItems' in query:
+        number_value=None
+        for arg in args:
+            if arg.startswith('number='):
+                number_value=arg.split('=',1)[1]
+        issue=state.get('issues',{{}}).get(number_value)
+        dump({{'data':{{'repository':{{'issue':issue}}}}}})
     else:
         number_value=None
         for arg in args:
@@ -135,6 +142,7 @@ def _base_state() -> dict[str, Any]:
         "url": "https://github.com/owner/repo/issues/70",
         "closedAt": None,
         "closedByPullRequestsReferences": [],
+        "timelineItems": {"nodes": [], "pageInfo": {"hasPreviousPage": False}},
     }
     child_issue = {
         "number": 63,
@@ -150,8 +158,28 @@ def _base_state() -> dict[str, Any]:
                 "state": "MERGED",
                 "mergedAt": "2026-07-26T00:00:00Z",
                 "url": "https://github.com/owner/repo/pull/67",
+                "merged": True,
+                "repository": {"nameWithOwner": "owner/repo"},
             }
         ],
+        "timelineItems": {
+            "nodes": [
+                {
+                    "__typename": "ClosedEvent",
+                    "createdAt": "2026-07-26T00:00:00Z",
+                    "closer": {
+                        "__typename": "PullRequest",
+                        "number": 67,
+                        "state": "MERGED",
+                        "merged": True,
+                        "mergedAt": "2026-07-26T00:00:00Z",
+                        "url": "https://github.com/owner/repo/pull/67",
+                        "repository": {"nameWithOwner": "owner/repo"},
+                    },
+                }
+            ],
+            "pageInfo": {"hasPreviousPage": False},
+        },
     }
     return {
         "branch": "task-70",
@@ -540,10 +568,30 @@ def _completed_closeout_state() -> dict[str, Any]:
         {
             "number": 71,
             "state": "MERGED",
+            "merged": True,
             "mergedAt": "2026-07-26T00:00:00Z",
             "url": "https://github.com/owner/repo/pull/71",
+            "repository": {"nameWithOwner": "owner/repo"},
         }
     ]
+    state["issues"]["70"]["timelineItems"] = {
+        "nodes": [
+            {
+                "__typename": "ClosedEvent",
+                "createdAt": "2026-07-26T00:00:00Z",
+                "closer": {
+                    "__typename": "PullRequest",
+                    "number": 71,
+                    "state": "MERGED",
+                    "merged": True,
+                    "mergedAt": "2026-07-26T00:00:00Z",
+                    "url": "https://github.com/owner/repo/pull/71",
+                    "repository": {"nameWithOwner": "owner/repo"},
+                },
+            }
+        ],
+        "pageInfo": {"hasPreviousPage": False},
+    }
     state["pr"].update(
         state="MERGED",
         mergeCommit={"oid": "8" * 40},
@@ -625,6 +673,126 @@ def test_closeout_final_plan_limit_cleanup_eligibility_requires_stable_recheck(
     eligibility = value["observed"]["branch_cleanup"]["cleanup_eligibility"]
     assert eligibility["status"] == "eligible-under-capability-limited-policy"
     assert value["gates"]["capability_limited_cleanup_eligibility"]["status"] == "pass"
+
+
+def test_closeout_cleanup_reports_null_closing_pr_metadata_as_unknown(
+    tmp_path: Path,
+) -> None:
+    state = _completed_closeout_state()
+    state["issues"]["70"]["closedByPullRequestsReferences"] = [
+        {
+            "number": 71,
+            "state": None,
+            "merged": None,
+            "mergedAt": None,
+            "url": "https://github.com/owner/repo/pull/71",
+            "repository": {"nameWithOwner": "owner/repo"},
+        }
+    ]
+    repo, _, env = _write_repo(tmp_path, state)
+    result = _run(
+        repo,
+        env,
+        "closeout-plan",
+        "--task",
+        "70",
+        "--pr",
+        "71",
+        "--expected-head-sha",
+        "4" * 40,
+        "--expected-merge-sha",
+        "8" * 40,
+    )
+    assert result.returncode == 0, result.stderr
+    value = json.loads(result.stdout)
+    assert value["gates"]["issue_closure"]["status"] == "unknown"
+    eligibility = value["observed"]["branch_cleanup"]["cleanup_eligibility"]
+    assert eligibility["status"] == "blocked"
+    reasons = " ".join(eligibility["reasons"]["items"])
+    assert "incomplete-closing-pr-metadata" in reasons
+    assert "Issue closure is not linked to the merged PR" not in reasons
+
+
+def test_closeout_cleanup_blocks_reopened_issue(tmp_path: Path) -> None:
+    state = _completed_closeout_state()
+    state["issues"]["70"]["state"] = "OPEN"
+    state["issues"]["70"]["timelineItems"]["nodes"].append(
+        {"__typename": "ReopenedEvent", "createdAt": "2026-07-26T01:00:00Z"}
+    )
+    repo, _, env = _write_repo(tmp_path, state)
+    result = _run(
+        repo,
+        env,
+        "closeout-plan",
+        "--task",
+        "70",
+        "--pr",
+        "71",
+        "--expected-head-sha",
+        "4" * 40,
+        "--expected-merge-sha",
+        "8" * 40,
+    )
+    assert result.returncode == 0, result.stderr
+    value = json.loads(result.stdout)
+    assert value["gates"]["issue_state"]["status"] == "fail"
+    assert value["gates"]["issue_closure"]["status"] == "fail"
+    assert "issue-not-closed" in value["gates"]["issue_closure"]["detail"]
+    assert (
+        value["observed"]["branch_cleanup"]["cleanup_eligibility"]["status"]
+        == "blocked"
+    )
+
+
+def test_closeout_cleanup_blocks_issue_closed_by_different_pr(tmp_path: Path) -> None:
+    state = _completed_closeout_state()
+    state["issues"]["70"]["closedByPullRequestsReferences"].append(
+        {
+            "number": 72,
+            "state": "MERGED",
+            "merged": True,
+            "mergedAt": "2026-07-26T02:00:00Z",
+            "url": "https://github.com/owner/repo/pull/72",
+            "repository": {"nameWithOwner": "owner/repo"},
+        }
+    )
+    state["issues"]["70"]["timelineItems"]["nodes"].append(
+        {
+            "__typename": "ClosedEvent",
+            "createdAt": "2026-07-26T02:00:00Z",
+            "closer": {
+                "__typename": "PullRequest",
+                "number": 72,
+                "state": "MERGED",
+                "merged": True,
+                "mergedAt": "2026-07-26T02:00:00Z",
+                "url": "https://github.com/owner/repo/pull/72",
+                "repository": {"nameWithOwner": "owner/repo"},
+            },
+        }
+    )
+    repo, _, env = _write_repo(tmp_path, state)
+    result = _run(
+        repo,
+        env,
+        "closeout-plan",
+        "--task",
+        "70",
+        "--pr",
+        "71",
+        "--expected-head-sha",
+        "4" * 40,
+        "--expected-merge-sha",
+        "8" * 40,
+    )
+    assert result.returncode == 0, result.stderr
+    value = json.loads(result.stdout)
+    assert value["gates"]["issue_closure"]["status"] == "fail"
+    assert "closer-pr-number-mismatch" in value["gates"]["issue_closure"]["detail"]
+    assert (
+        value["observed"]["branch_cleanup"]["cleanup_eligibility"]["status"]
+        == "blocked"
+    )
 
 
 def test_cleanup_eligibility_blocks_failed_pending_and_missing_checks(

--- a/tests/tools/test_wsl2_github_evidence_runner.py
+++ b/tests/tools/test_wsl2_github_evidence_runner.py
@@ -64,6 +64,7 @@ def _state(main_sha: str, head_sha: str) -> dict[str, Any]:
             "url": "https://github.com/PhoenixSss/quant-system/issues/84",
             "closedAt": None,
             "closedByPullRequestsReferences": [],
+            "timelineItems": {"nodes": [], "pageInfo": {"hasPreviousPage": False}},
         },
         "relationships": {
             "number": 84,
@@ -178,6 +179,8 @@ elif args[:2] == ['api','graphql']:
         dump({{'data':{{'repository':{{'pullRequest':{{
             'reviewThreads':state['threads']
         }}}}}}}})
+    elif 'timelineItems' in joined:
+        dump({{'data':{{'repository':{{'issue':state['issue']}}}}}})
     else:
         dump({{'data':{{'repository':{{'issue':state['relationships']}}}}}})
 elif (
@@ -323,6 +326,39 @@ def _sync_remote_files(state_path: Path, state: dict[str, Any]) -> None:
     state_path.with_name("remote-error.txt").write_text(
         str(state.get("remote_error") or ""), encoding="utf-8"
     )
+
+
+def _mark_issue_closed_by_pr(
+    state: dict[str, Any],
+    *,
+    pr_number: int = 102,
+    closed_at: str = "2026-08-02T16:00:00Z",
+) -> None:
+    url = f"https://github.com/PhoenixSss/quant-system/pull/{pr_number}"
+    pr_ref = {
+        "number": pr_number,
+        "state": "MERGED",
+        "merged": True,
+        "mergedAt": closed_at,
+        "url": url,
+        "repository": {"nameWithOwner": "PhoenixSss/quant-system"},
+    }
+    state["issue"]["state"] = "CLOSED"
+    state["issue"]["closedAt"] = closed_at
+    state["issue"]["closedByPullRequestsReferences"] = [pr_ref]
+    state["issue"]["timelineItems"] = {
+        "nodes": [
+            {
+                "__typename": "ClosedEvent",
+                "createdAt": closed_at,
+                "closer": {
+                    "__typename": "PullRequest",
+                    **pr_ref,
+                },
+            }
+        ],
+        "pageInfo": {"hasPreviousPage": False},
+    }
 
 
 def _result(repo: Path, stdout: str) -> dict[str, Any]:
@@ -630,17 +666,8 @@ def test_closeout_readonly_profile(tmp_path: Path) -> None:
     merge_sha = _git(repo, "rev-parse", "HEAD")
     _git(repo, "update-ref", "refs/remotes/origin/main", merge_sha)
     state = json.loads(state_path.read_text(encoding="utf-8"))
-    state["issue"]["state"] = "CLOSED"
     state["issue"]["projectItems"] = [{"status": {"name": "Done"}}]
-    state["issue"]["closedAt"] = "2026-08-02T16:00:00Z"
-    state["issue"]["closedByPullRequestsReferences"] = [
-        {
-            "number": 102,
-            "state": "MERGED",
-            "mergedAt": "2026-08-02T16:00:00Z",
-            "url": "https://github.com/PhoenixSss/quant-system/pull/102",
-        }
-    ]
+    _mark_issue_closed_by_pr(state)
     state["pr"].update(
         state="MERGED",
         mergeCommit={"oid": merge_sha},
@@ -680,17 +707,8 @@ def test_closeout_plan_limit_cleanup_eligibility_digest_remains_partial(
     _git(repo, "update-ref", "refs/remotes/origin/main", merge_sha)
     state = json.loads(state_path.read_text(encoding="utf-8"))
     state["required_checks_mode"] = "plan-limit-403"
-    state["issue"]["state"] = "CLOSED"
     state["issue"]["projectItems"] = [{"status": {"name": "Done"}}]
-    state["issue"]["closedAt"] = "2026-08-02T16:00:00Z"
-    state["issue"]["closedByPullRequestsReferences"] = [
-        {
-            "number": 102,
-            "state": "MERGED",
-            "mergedAt": "2026-08-02T16:00:00Z",
-            "url": "https://github.com/PhoenixSss/quant-system/pull/102",
-        }
-    ]
+    _mark_issue_closed_by_pr(state)
     state["pr"].update(
         state="MERGED",
         mergeCommit={"oid": merge_sha},
@@ -753,11 +771,8 @@ def test_required_checks_403_failure_types_do_not_enable_cleanup(
         _git(repo, "update-ref", "refs/remotes/origin/main", merge_sha)
         state = json.loads(state_path.read_text(encoding="utf-8"))
         state["required_checks_mode"] = mode
-        state["issue"]["state"] = "CLOSED"
         state["issue"]["projectItems"] = [{"status": {"name": "Done"}}]
-        state["issue"]["closedByPullRequestsReferences"] = [
-            {"number": 102, "state": "MERGED", "mergedAt": "2026-08-02T16:00:00Z"}
-        ]
+        _mark_issue_closed_by_pr(state)
         state["pr"].update(
             state="MERGED",
             mergeCommit={"oid": merge_sha},

--- a/tools/agent_workflow/workflow_evidence.py
+++ b/tools/agent_workflow/workflow_evidence.py
@@ -84,6 +84,50 @@ query($owner:String!, $name:String!, $number:Int!) {
 }
 """
 
+ISSUE_CLOSURE_QUERY: Final = r"""
+query($owner:String!, $name:String!, $number:Int!) {
+  repository(owner:$owner, name:$name) {
+    issue(number:$number) {
+      number
+      state
+      closedAt
+      closedByPullRequestsReferences(first:20, includeClosedPrs:true) {
+        nodes {
+          number
+          state
+          merged
+          mergedAt
+          url
+          repository { nameWithOwner }
+        }
+        pageInfo { hasNextPage }
+      }
+      timelineItems(last:50, itemTypes:[CLOSED_EVENT, REOPENED_EVENT]) {
+        nodes {
+          __typename
+          ... on ClosedEvent {
+            createdAt
+            closer {
+              __typename
+              ... on PullRequest {
+                number
+                state
+                merged
+                mergedAt
+                url
+                repository { nameWithOwner }
+              }
+            }
+          }
+          ... on ReopenedEvent { createdAt }
+        }
+        pageInfo { hasPreviousPage }
+      }
+    }
+  }
+}
+"""
+
 
 def _normalize_title(value: str) -> str:
     normalized = unicodedata.normalize("NFKC", value)
@@ -263,7 +307,10 @@ def _issue_view(
     number: int,
     warnings: list[dict[str, Any]],
 ) -> dict[str, Any] | None:
-    fields = "number,title,body,comments,state,labels,projectItems,url,closedAt,closedByPullRequestsReferences"
+    fields = (
+        "number,title,body,comments,state,labels,projectItems,url,closedAt,"
+        "closedByPullRequestsReferences"
+    )
     result = runner.run(
         [
             "gh",
@@ -324,8 +371,12 @@ def _issue_view(
                 {
                     "number": pr.get("number"),
                     "state": safe_text(pr.get("state")),
+                    "merged": pr.get("merged")
+                    if isinstance(pr.get("merged"), bool)
+                    else None,
                     "merged_at": safe_text(pr.get("mergedAt")),
                     "url": safe_text(pr.get("url")),
+                    "repository": _repository_name(pr),
                 }
             )
     body = value.get("body") if isinstance(value.get("body"), str) else None
@@ -347,7 +398,7 @@ def _issue_view(
                 }
             )
     content_facts = {"body": body, "comments": comment_facts}
-    return {
+    issue = {
         "number": value.get("number"),
         "title": safe_text(value.get("title")),
         "content_sha256": sha256_json(content_facts),
@@ -360,6 +411,10 @@ def _issue_view(
         "closed_at": safe_text(value.get("closedAt")),
         "closing_pull_requests": bounded_list(pull_refs),
     }
+    issue["issue_closure"] = _issue_closure_snapshot(
+        runner, repository, number, warnings
+    )
+    return issue
 
 
 def _find_project_status(value: Any) -> str | None:
@@ -431,6 +486,170 @@ def _graphql(
         )
         return None
     return value
+
+
+def _repository_name(value: Mapping[str, Any]) -> str | None:
+    repository = value.get("repository")
+    if isinstance(repository, Mapping):
+        return safe_text(repository.get("nameWithOwner"))
+    return None
+
+
+def _normalize_closing_pr(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, Mapping):
+        return None
+    return {
+        "number": value.get("number"),
+        "state": safe_text(value.get("state")),
+        "merged": value.get("merged")
+        if isinstance(value.get("merged"), bool)
+        else None,
+        "merged_at": safe_text(value.get("mergedAt")),
+        "url": safe_text(value.get("url")),
+        "repository": _repository_name(value),
+    }
+
+
+def _issue_closure_snapshot(
+    runner: CommandRunner,
+    repository: str,
+    number: int,
+    warnings: list[dict[str, Any]],
+) -> dict[str, Any]:
+    value = _graphql(
+        runner,
+        repository,
+        number,
+        ISSUE_CLOSURE_QUERY,
+        command_id=f"gh-issue-closure-{number}",
+        warnings=warnings,
+    )
+    if not isinstance(value, dict):
+        return {
+            "status": "unknown",
+            "reason": "issue-closure-query-unavailable",
+            "evidence_status": "partial",
+        }
+    data = value.get("data")
+    repo = data.get("repository") if isinstance(data, Mapping) else None
+    issue = repo.get("issue") if isinstance(repo, Mapping) else None
+    if not isinstance(issue, Mapping):
+        return {
+            "status": "unknown",
+            "reason": "issue-closure-metadata-unavailable",
+            "evidence_status": "partial",
+        }
+
+    refs = issue.get("closedByPullRequestsReferences")
+    if isinstance(refs, Mapping):
+        ref_nodes = refs.get("nodes")
+    elif isinstance(refs, list):
+        ref_nodes = refs
+    else:
+        ref_nodes = []
+    ref_items = (
+        [
+            normalized
+            for normalized in (_normalize_closing_pr(item) for item in ref_nodes)
+            if normalized is not None
+        ]
+        if isinstance(ref_nodes, list)
+        else []
+    )
+    ref_page = refs.get("pageInfo") if isinstance(refs, Mapping) else None
+    refs_truncated = (
+        isinstance(ref_page, Mapping) and ref_page.get("hasNextPage") is True
+    )
+
+    timeline = issue.get("timelineItems")
+    timeline_nodes = timeline.get("nodes") if isinstance(timeline, Mapping) else []
+    timeline_page = timeline.get("pageInfo") if isinstance(timeline, Mapping) else None
+    timeline_truncated = (
+        isinstance(timeline_page, Mapping)
+        and timeline_page.get("hasPreviousPage") is True
+    )
+
+    events: list[dict[str, Any]] = []
+    if isinstance(timeline_nodes, list):
+        for item in timeline_nodes:
+            if not isinstance(item, Mapping):
+                continue
+            typename = safe_text(item.get("__typename"))
+            created_at = safe_text(item.get("createdAt"))
+            if typename == "ClosedEvent":
+                closer = item.get("closer")
+                closer_type = (
+                    safe_text(closer.get("__typename"))
+                    if isinstance(closer, Mapping)
+                    else None
+                )
+                event: dict[str, Any] = {
+                    "type": "closed",
+                    "created_at": created_at,
+                    "closer_type": closer_type,
+                }
+                if closer_type == "PullRequest" and isinstance(closer, Mapping):
+                    event["closer"] = _normalize_closing_pr(closer)
+                events.append(event)
+            elif typename == "ReopenedEvent":
+                events.append({"type": "reopened", "created_at": created_at})
+
+    latest_closure: dict[str, Any] | None = None
+    for event in sorted(events, key=lambda item: str(item.get("created_at") or "")):
+        if event.get("type") == "closed":
+            latest_closure = event
+        elif event.get("type") == "reopened":
+            latest_closure = None
+
+    state = safe_text(issue.get("state"))
+    closed_at = safe_text(issue.get("closedAt"))
+    evidence_status = "complete"
+    reason = "closed-by-pr"
+    status = "closed-by-pr"
+    if refs_truncated:
+        evidence_status = "partial"
+        reason = "closing-pr-references-truncated"
+        status = "unknown"
+    elif timeline_truncated:
+        evidence_status = "partial"
+        reason = "timeline-truncated"
+        status = "unknown"
+    elif state != "CLOSED":
+        reason = "issue-not-closed"
+        status = "not-closed"
+    elif latest_closure is None:
+        evidence_status = "partial"
+        reason = "latest-effective-close-event-unavailable"
+        status = "unknown"
+    elif latest_closure.get("closer_type") != "PullRequest":
+        reason = "latest-closer-is-not-pull-request"
+        status = "not-pr-closer"
+    elif not isinstance(latest_closure.get("closer"), Mapping):
+        evidence_status = "partial"
+        reason = "latest-closer-pr-metadata-unavailable"
+        status = "unknown"
+
+    closer = (
+        latest_closure.get("closer") if isinstance(latest_closure, Mapping) else None
+    )
+    return {
+        "status": status,
+        "reason": reason,
+        "state": state,
+        "closed_at": closed_at,
+        "latest_effective_event": latest_closure,
+        "closer_type": latest_closure.get("closer_type")
+        if isinstance(latest_closure, Mapping)
+        else None,
+        "closer_repository": closer.get("repository")
+        if isinstance(closer, Mapping)
+        else None,
+        "closer_number": closer.get("number") if isinstance(closer, Mapping) else None,
+        "closed_by_pull_requests": bounded_list(ref_items),
+        "evidence_status": evidence_status,
+        "evidence_complete": evidence_status == "complete",
+        "conflict": False,
+    }
 
 
 def _relationship_snapshot(
@@ -857,6 +1076,8 @@ def _closeout_cleanup_eligibility(
     for name in (
         "pr_state",
         "closing_linkage",
+        "issue_closure",
+        "pull_request_merge",
         "head_sha",
         "merge_sha",
         "main_contains_merge",
@@ -894,19 +1115,20 @@ def _closeout_cleanup_eligibility(
         if isinstance(branch, str) and branch in branch_items:
             reasons.append("target branch is occupied by a worktree")
     if isinstance(issue, Mapping) and isinstance(pr, Mapping):
-        issue_refs = issue.get("closing_pull_requests")
-        ref_items = issue_refs.get("items") if isinstance(issue_refs, Mapping) else []
-        expected_pr = pr.get("number")
-        if not (
-            isinstance(ref_items, list)
-            and any(
-                isinstance(item, Mapping)
-                and item.get("number") == expected_pr
-                and str(item.get("state", "")).upper() == "MERGED"
-                for item in ref_items
+        closure_gate = _issue_closure_gate(issue, pr, repository=repository)
+        if closure_gate.get("status") == "unknown":
+            reasons.append(
+                f"issue_closure_linkage unknown: {closure_gate.get('detail')}"
             )
-        ):
-            reasons.append("Issue closure is not linked to the merged PR")
+        elif closure_gate.get("status") == "fail":
+            reasons.append(
+                f"issue_closure_linkage blocked: {closure_gate.get('detail')}"
+            )
+        merge_gate = _pull_request_merge_gate(pr)
+        if merge_gate.get("status") == "unknown":
+            reasons.append(f"pull_request_merge unknown: {merge_gate.get('detail')}")
+        elif merge_gate.get("status") == "fail":
+            reasons.append(f"pull_request_merge blocked: {merge_gate.get('detail')}")
     expected_head = pr.get("head_sha") if isinstance(pr, Mapping) else None
     if not isinstance(branch, str) or not branch:
         reasons.append("exact PR head branch unavailable")
@@ -1257,6 +1479,73 @@ def _closing_linkage_gate(closing_issues: Any, *, task_number: int) -> dict[str,
     return _gate("pass" if exact else "fail", detail)
 
 
+def _pull_request_merge_gate(pr: Mapping[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(pr, Mapping):
+        return _gate("unknown", "PR metadata unavailable")
+    state = str(pr.get("state", "")).upper()
+    if state != "MERGED":
+        return _gate("fail", f"PR state is {state or 'unknown'}")
+    if not isinstance(pr.get("merged_at"), str):
+        return _gate("unknown", "PR mergedAt unavailable")
+    if not isinstance(pr.get("merge_commit_sha"), str):
+        return _gate("unknown", "PR merge commit unavailable")
+    return _gate("pass")
+
+
+def _issue_closure_gate(
+    issue: Mapping[str, Any] | None,
+    pr: Mapping[str, Any] | None,
+    *,
+    repository: str | None,
+) -> dict[str, Any]:
+    if not isinstance(issue, Mapping):
+        return _gate("unknown", "Issue metadata unavailable")
+    if not isinstance(pr, Mapping):
+        return _gate("unknown", "PR metadata unavailable")
+    closure = issue.get("issue_closure")
+    if not isinstance(closure, Mapping):
+        return _gate("unknown", "issue closure evidence unavailable")
+    if closure.get("evidence_status") != "complete":
+        return _gate("unknown", str(closure.get("reason") or "partial evidence"))
+    if str(issue.get("state", "")).upper() != "CLOSED":
+        return _gate("fail", "issue-not-closed")
+    if closure.get("status") != "closed-by-pr":
+        return _gate("fail", str(closure.get("reason") or "not-closed-by-pr"))
+    if closure.get("closer_repository") != repository:
+        return _gate("fail", "closer-repository-mismatch")
+    if closure.get("closer_number") != pr.get("number"):
+        return _gate("fail", "closer-pr-number-mismatch")
+
+    refs = closure.get("closed_by_pull_requests")
+    ref_items = refs.get("items") if isinstance(refs, Mapping) else []
+    matching_refs = (
+        [
+            item
+            for item in ref_items
+            if isinstance(item, Mapping) and item.get("number") == pr.get("number")
+        ]
+        if isinstance(ref_items, list)
+        else []
+    )
+    if not matching_refs:
+        return _gate("fail", "closed-by-pr-reference-missing")
+    for item in matching_refs:
+        if (
+            item.get("repository") == repository
+            and str(item.get("state", "")).upper() == "MERGED"
+            and item.get("merged") is True
+            and isinstance(item.get("merged_at"), str)
+        ):
+            return _gate("pass")
+        if (
+            item.get("state") is None
+            or item.get("merged") is None
+            or item.get("merged_at") is None
+        ):
+            return _gate("unknown", "incomplete-closing-pr-metadata")
+    return _gate("fail", "closed-by-pr-reference-not-merged")
+
+
 def _pr_gates(
     pr: Mapping[str, Any] | None,
     threads: Mapping[str, Any],
@@ -1557,6 +1846,14 @@ def _closeout_plan(args: argparse.Namespace, repo_root: Path) -> dict[str, Any]:
         git = observed.get("git", {})
         merge_sha = pr.get("merge_commit_sha") if isinstance(pr, dict) else None
         gates["merge_sha"] = _sha_gate(merge_sha, args.expected_merge_sha, "merge SHA")
+        gates["issue_closure"] = _issue_closure_gate(
+            issue if isinstance(issue, dict) else None,
+            pr if isinstance(pr, dict) else None,
+            repository=repository,
+        )
+        gates["pull_request_merge"] = _pull_request_merge_gate(
+            pr if isinstance(pr, dict) else None
+        )
         if isinstance(merge_sha, str):
             ancestry = runner.run(
                 [
@@ -1915,6 +2212,10 @@ def _stability_projection(snapshot: Mapping[str, Any]) -> dict[str, Any]:
         "issue_number": issue.get("number") if isinstance(issue, dict) else None,
         "issue_title": issue.get("title") if isinstance(issue, dict) else None,
         "issue_state": issue.get("state") if isinstance(issue, dict) else None,
+        "issue_closed_at": issue.get("closed_at") if isinstance(issue, dict) else None,
+        "issue_closure": issue.get("issue_closure")
+        if isinstance(issue, dict)
+        else None,
         "issue_content_sha256": issue.get("content_sha256")
         if isinstance(issue, dict)
         else None,

--- a/tools/agent_workflow/wsl2_github_evidence_runner.py
+++ b/tools/agent_workflow/wsl2_github_evidence_runner.py
@@ -616,6 +616,8 @@ def _compact_result(
     observed = observed if isinstance(observed, dict) else {}
     issue = observed.get("issue")
     issue = issue if isinstance(issue, dict) else {}
+    issue_closure = issue.get("issue_closure")
+    issue_closure = issue_closure if isinstance(issue_closure, dict) else {}
     pr = observed.get("pr")
     pr = pr if isinstance(pr, dict) else {}
     git = observed.get("git")
@@ -659,6 +661,14 @@ def _compact_result(
             "labels": issue.get("labels"),
             "project_status": issue.get("project_status"),
             "content_sha256": issue.get("content_sha256"),
+            "closure": {
+                "status": issue_closure.get("status"),
+                "reason": issue_closure.get("reason"),
+                "evidence_status": issue_closure.get("evidence_status"),
+                "closer_type": issue_closure.get("closer_type"),
+                "closer_repository": issue_closure.get("closer_repository"),
+                "closer_number": issue_closure.get("closer_number"),
+            },
         },
         "pull_request": {
             "available": bool(pr),


### PR DESCRIPTION
Closes #106

## Summary
- add bounded Issue closure GraphQL evidence for closed PR references and close/reopen timeline events
- split PR closing declaration, Issue latest effective closure, and merged PR identity gates for closeout cleanup eligibility
- preserve unknown/partial semantics for missing closing PR metadata and expose compact closure diagnostics
- update closeout workflow docs and regression tests for null metadata, reopen, and different-PR closure cases

## Validation
- uv lock --check
- uv run --frozen pytest tests/tools/test_workflow_evidence.py tests/tools/test_wsl2_github_evidence_runner.py
- uv run --frozen pytest tests/tools/test_workflow_skills.py tests/tools/test_wsl2_github_evidence_rules.py
- uv run --frozen pytest tests/tools/test_workflow_validation.py tests/tools/test_wsl2_github_evidence_materials.py
- uv run --frozen pytest tests/tools
- uv run --frozen ruff check .
- uv run --frozen ruff format --check .
- uv run --frozen mypy src tests tools
- uv run --frozen pytest
- git diff --check
- tools/agent_workflow/wsl2_validation_runner.py workflow-delivery --base-sha 48763926c3139e618a8e203fb5c9eca39ac994fa

## Risks and limitations
- Task #104 cleanup-only branch deletion was not executed during Delivery; it remains post-merge work after this PR is independently reviewed and merged.
- Required Checks plan-limit 403 remains unknown/partial and is only used for exact branch cleanup eligibility, not for merge or other writes.