### PR TITLE
chore: clarify repository licensing posture

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+TraceQuant
+
+Copyright (c) 2026 PhoenixSss
+
+All rights reserved.
+
+This repository is publicly available for viewing, cloning, and forking.
+Public availability does not constitute an open-source license, and no
+rights are granted under any open-source license.
+
+Unless expressly permitted by applicable law or with the prior written
+authorization of the copyright holder, no permission is granted to use,
+copy, modify, distribute, sublicense, sell, or create derivative works
+from this software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES,
+OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT, OR OTHERWISE,
+ARISING FROM, OUT OF, OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -182,3 +182,7 @@ review, independent PR review, manual Merge, or Feature closeout.
 - [Validation Runner](docs/workflows/wsl2-validation-runner/README.md): fixed validation profiles, compact artifacts, exact argv, and process cleanup.
 - [Skill variants](docs/workflows/task-skill-ab.md): preserved historical Skill family and current Runner Skill family for controlled comparison.
 - [Task Skill runner migration](docs/workflows/task-skill-runner-migration/README.md): historical migration record only; not an operational guide.
+
+## License
+
+TraceQuant is publicly accessible but is not currently distributed under an open-source license. All rights are reserved. See `LICENSE`.


### PR DESCRIPTION
## Summary

Clarifies TraceQuant's pre-public licensing posture.

## Changes

- Adds an explicit all-rights-reserved license notice.
- Documents that the public repository is not currently distributed under an open-source license.

## Validation

- `git diff --check` — PASS
- `uv lock --check` — PASS
- `uv run --frozen pytest` — 288 passed, 72 skipped
- `uv run --frozen ruff check .` — PASS
- `uv run --frozen ruff format --check .` — PASS
- `uv run --frozen mypy src tests` — PASS

Local `refs/codex/*` checkpoint refs were removed separately as local-only hygiene and are not part of the repository diff.

Co-Authored-By: Claude <noreply@anthropic.com>