### PR TITLE
[Task] 建立 Issue Specification v2 并迁移未开始 Issue 正文 #115

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,92 +1,82 @@
 name: Bug report
-description: 用于报告可复现或可验证的软件缺陷。
+description: 用于报告具有明确实际行为、预期行为和可验证证据的软件缺陷。
 title: "[Bug] "
 labels:
-  - type:bug
-  - codex:needs-spec
+  - "type:bug"
+  - "codex:needs-spec"
 body:
-  - type: textarea
-    id: problem_description
+  - type: markdown
     attributes:
-      label: 问题描述
-      description: 简要说明出现了什么问题。
-    validations:
-      required: true
+      value: |
+        Bug 是可直接对应修复 PR 的 leaf work item，不需要额外 wrapper Task。
+        描述恢复后的系统 contract，而不是只要求“错误消失”。
+        Parent、blocked-by 和 Project metadata 使用 GitHub native state；不要在公开 Issue 中粘贴凭据或敏感运行信息。
+
   - type: textarea
-    id: impact
+    id: observed
     attributes:
-      label: 影响范围
-      description: 描述受影响的模块、数据、流程、用户或交易安全边界。
-    validations:
-      required: true
-  - type: textarea
-    id: reproduction_steps
-    attributes:
-      label: 复现步骤
-      description: 提供可以复现问题的最小步骤。
+      label: Observed
+      description: 描述实际观察到的错误行为、错误状态或违反 contract 的结果。
       placeholder: |
+        实际发生：
+        ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected
+      description: 描述正确的系统行为或 contract；避免只写“应该不报错”。
+      placeholder: |
+        正确行为应为：
+        ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction_evidence
+    attributes:
+      label: Reproduction / Evidence
+      description: 提供最小复现步骤、失败测试、日志片段、截图或其他足以识别问题的证据；不要包含 credential、token 或 private trading information。
+      placeholder: |
+        复现步骤或证据：
         1. ...
         2. ...
-        3. ...
     validations:
       required: true
-  - type: textarea
-    id: expected_behavior
-    attributes:
-      label: 预期行为
-      description: 描述系统原本应该如何表现。
-    validations:
-      required: true
-  - type: textarea
-    id: actual_behavior
-    attributes:
-      label: 实际行为
-      description: 描述实际观察到的行为。
-    validations:
-      required: true
-  - type: textarea
-    id: environment
-    attributes:
-      label: 环境信息
-      description: 说明操作系统、运行模式、数据范围、配置和相关版本。
-    validations:
-      required: true
-  - type: textarea
-    id: logs
-    attributes:
-      label: 日志或错误信息
-      description: 粘贴相关日志、错误信息或截图说明；不要包含凭据。
-      render: shell
-    validations:
-      required: true
-  - type: textarea
-    id: workaround
-    attributes:
-      label: 临时解决方式
-      description: 如有临时规避方式，请说明；若无，请写“无”。
-    validations:
-      required: true
-  - type: checkboxes
-    id: risk_flags
-    attributes:
-      label: 风险复选项
-      description: 请选择所有相关风险。不要依赖自动风险标签，创建者应后续选择合适标签。
-      options:
-        - label: 数据完整性
-        - label: 未来数据泄漏
-        - label: 实盘交易
-        - label: 凭据安全
-        - label: 订单状态
-        - label: 无上述风险
-    validations:
-      required: true
+
   - type: textarea
     id: acceptance_criteria
     attributes:
-      label: 验收标准
-      description: 描述修复完成后必须满足的可验证条件。
+      label: Acceptance Criteria
+      description: 描述修复后必须恢复的可验证行为，并在适用时覆盖 regression；不要把通用 CI 命令作为验收标准。
       placeholder: |
-        - [ ] ...
         - [ ] ...
     validations:
       required: true
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional defect context
+      description: 可选。仅补充与本缺陷实际相关的信息，例如 Impact、Environment、Logs / Screenshots、Scope Boundary / Non-goals 或特殊 Regression Evidence。
+      placeholder: |
+        仅在需要时填写，例如：
+
+        ### Impact
+        ...
+
+        ### Environment
+        ...
+
+        ### Logs / Screenshots
+        ...
+
+        ### Scope Boundary / Non-goals
+        - ...
+
+        ### Regression Evidence
+        - ...
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,54 +1,83 @@
 name: Epic
-description: 用于规划由多个 Feature 或 Task 子 Issue 组成的较大成果。
+description: 用于定义由多个 Feature / leaf work item 共同实现的较大结果与边界。
 title: "[Epic] "
 labels:
-  - type:epic
-  - codex:needs-spec
+  - "type:epic"
+  - "codex:needs-spec"
 body:
   - type: markdown
     attributes:
       value: |
-        Epic 应由多个 Feature 或 Task 子 Issue 组成，用于描述较大的目标成果和边界。
-        Epic 本身通常不直接对应实现 PR。
+        Epic 描述结果与边界，不直接作为普通实现单元。
+        子项使用 GitHub Parent/Sub-issues 管理；不要在正文复制完整 Feature 规格、Project metadata、标准验证或 Git/PR 流程。
+        只保留会改变 outcome、scope、success 判断或跨 Feature 约束的信息。
+
   - type: textarea
-    id: target_outcome
+    id: outcome
     attributes:
-      label: 目标成果
-      description: 描述 Epic 完成后项目应具备的能力或状态。
+      label: Outcome
+      description: 描述 Epic 完成后项目应达到的明确状态或结果，不列实现步骤或完整子项规格。
+      placeholder: |
+        完成后，TraceQuant 将能够……
     validations:
       required: true
+
   - type: textarea
-    id: background_value
+    id: why
     attributes:
-      label: 背景与价值
-      description: 说明为什么需要这个 Epic，以及它对研究、交易安全或工程质量的价值。
+      label: Why
+      description: 简洁说明为什么需要这个结果，以及它解决的核心问题或带来的长期价值。
+      placeholder: |
+        当前问题：
+        预期价值：
     validations:
       required: true
+
   - type: textarea
     id: scope
     attributes:
-      label: 范围
-      description: 列出 Epic 包含的主要能力、模块或子问题。
+      label: Scope
+      description: 列出本 Epic 覆盖的主要能力边界；保持 outcome-level，不展开 child Feature 的完整规格。
+      placeholder: |
+        - ...
     validations:
       required: true
+
   - type: textarea
-    id: out_of_scope
+    id: non_goals
     attributes:
-      label: 范围外
-      description: 明确不属于本 Epic 的内容。
+      label: Non-goals
+      description: 明确不属于本 Epic 的相邻目标，防止后续 Feature / leaf work item 扩大范围。
+      placeholder: |
+        - ...
     validations:
       required: true
+
   - type: textarea
-    id: completion_conditions
+    id: success_exit_criteria
     attributes:
-      label: 完成条件
-      description: 描述哪些子 Issue、文档或验证结果完成后，Epic 可关闭。
+      label: Success / Exit Criteria
+      description: 使用可观察、可判断的 Epic-level 结果说明何时可以关闭本 Epic；不要复制通用 CI / PR Definition of Done。
+      placeholder: |
+        - [ ] ...
     validations:
       required: true
+
   - type: textarea
-    id: major_risks
+    id: additional_context
     attributes:
-      label: 主要风险
-      description: 列出数据正确性、回测偏差、实盘安全、凭据安全、订单状态或架构范围风险。
+      label: Additional context
+      description: 可选。仅补充真正影响跨 Feature 决策的信息，例如 Constraints / Decisions、material Risks 或必要 References；优先链接 ADR / canonical docs，不复制全文。
+      placeholder: |
+        仅在需要时填写，例如：
+
+        ### Constraints / Decisions
+        - ...
+
+        ### Risks
+        - ...
+
+        ### References
+        - ...
     validations:
-      required: true
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,155 +1,75 @@
 name: Feature
-description: A coherent system capability composed of one or more implementation tasks
+description: 用于定义一个需要一个或多个 leaf work item 实现的完整行为能力。
 title: "[Feature] "
 labels:
-  - type:feature
-  - codex:needs-spec
+  - "type:feature"
+  - "codex:needs-spec"
 body:
   - type: markdown
     attributes:
       value: |
-        Feature 表示一个完整但仍需拆分的系统能力。
-        Feature 通常属于某个 Epic。
-        Feature 可以包含多个 Task 子 Issue。
-        Feature 通常不应直接交给 Codex 一次性实现。
-        只有足够小且验收边界清晰时，Feature 才可以直接对应一个 PR。
-  - type: textarea
-    id: background
-    attributes:
-      label: 背景
-      description: 说明为什么需要该能力，以及当前系统缺少什么。
-    validations:
-      required: true
+        Feature 负责描述 WHAT：系统应具备什么行为或能力，而不是逐文件 HOW。
+        Parent 使用 GitHub Parent/Sub-issues，正式阻塞使用 blocked-by/blocking；不要在正文重复 Project metadata、标准验证或 Git/PR 流程。
+        如果一个能力只有一个主要实现目标且一个 PR 即可完成，应优先直接创建 Task。
+
   - type: textarea
     id: capability
     attributes:
-      label: 目标能力
-      description: 描述完成后系统具备什么明确能力，而不是列实现步骤。
+      label: Capability
+      description: 描述完成后系统能够做什么，以及关键可观察行为；不要写 implementation sequence。
+      placeholder: |
+        系统应能够……
     validations:
       required: true
-  - type: textarea
-    id: value
-    attributes:
-      label: 用户或系统价值
-      description: 说明该能力对研究正确性、可复现性、风控、安全性或开发效率的价值。
-    validations:
-      required: true
-  - type: textarea
-    id: inputs
-    attributes:
-      label: 输入
-      description: 描述该 Feature 接收的数据、接口、配置或上游能力。
-    validations:
-      required: true
-  - type: textarea
-    id: outputs
-    attributes:
-      label: 输出
-      description: 描述完成后提供的数据、接口、命令、报告或系统行为。
-    validations:
-      required: true
+
   - type: textarea
     id: scope
     attributes:
-      label: 功能范围
-      description: 使用可验证的列表说明包含哪些能力。
+      label: Scope
+      description: 明确本 Feature 覆盖的能力、场景和边界；Inputs / Outputs 只有在属于行为 contract 时才写入这里或 Acceptance Criteria。
+      placeholder: |
+        - ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: non_goals
+    attributes:
+      label: Non-goals
+      description: 明确不属于本 Feature 的相邻能力，避免 leaf work item 顺手实现。
+      placeholder: |
+        - ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance Criteria
+      description: 描述可观察、可测试或可明确判断的完成条件；不要把文件修改步骤、pytest/Ruff/mypy 或 PR 流程当作验收标准。
       placeholder: |
         - [ ] ...
-        - [ ] ...
     validations:
       required: true
+
   - type: textarea
-    id: non_functional
+    id: additional_context
     attributes:
-      label: 非功能要求
-      description: 说明与正确性、可复现性、性能、可观测性、安全性、可维护性相关的约束；允许填写“不适用”，但必须说明原因。
-    validations:
-      required: true
-  - type: textarea
-    id: edge_cases
-    attributes:
-      label: 异常与边界情况
-      description: 描述缺失数据、非法输入、外部服务异常、重复执行和部分失败等情况。
-    validations:
-      required: true
-  - type: textarea
-    id: out_of_scope
-    attributes:
-      label: 范围外
-      description: 必须明确禁止本 Feature 顺手实现的相关功能。
-    validations:
-      required: true
-  - type: textarea
-    id: completion
-    attributes:
-      label: 完成条件
-      description: 使用 Markdown checklist 描述 Feature 完成条件。
+      label: Additional context
+      description: 可选。只补充理解行为所必需的信息，例如 Context、关键 Edge Cases、approved Constraints / Decisions 或 References；优先链接 canonical docs / ADR。
       placeholder: |
-        - [ ] 所有必需 Task 子 Issue 已关闭
-        - [ ] 集成测试或阶段验收通过
-        - [ ] 文档已更新
-        - [ ] 风险和限制已记录
-        - [ ] 没有遗留未说明的占位实现
+        仅在需要时填写，例如：
+
+        ### Context
+        ...
+
+        ### Key Scenarios / Edge Cases
+        - ...
+
+        ### Constraints / Decisions
+        - ...
+
+        ### References
+        - ...
     validations:
-      required: true
-  - type: textarea
-    id: suggested_tasks
-    attributes:
-      label: 建议子任务
-      description: 列出初步预计需要拆出的 Task；创建 Feature 时不要求所有 Task 已经存在。
-    validations:
-      required: true
-  - type: input
-    id: dependencies
-    attributes:
-      label: 依赖 Issue
-      description: 填写依赖 Issue 编号；没有则填写“无”。
-      placeholder: "Depends on #"
-    validations:
-      required: true
-  - type: input
-    id: parent_epic
-    attributes:
-      label: 父 Epic
-      description: 填写所属 Epic Issue 编号；没有则说明原因。
-      placeholder: "Part of #"
-    validations:
-      required: true
-  - type: textarea
-    id: risks
-    attributes:
-      label: 主要风险
-      description: 列出可能涉及的数据完整性、未来数据泄漏、凭据、实盘交易、订单状态、架构复杂度或其他风险。
-    validations:
-      required: true
-  - type: dropdown
-    id: size
-    attributes:
-      label: 预计规模
-      description: 选择预计 Feature 规模。
-      options:
-        - S：较小的完整能力，可能直接对应一个 PR
-        - M：需要多个相关 Task
-        - L：需要继续拆分为多个 Feature 或较多 Task
-    validations:
-      required: true
-  - type: checkboxes
-    id: readiness
-    attributes:
-      label: Ready 检查
-      description: 全部满足后，维护者才应将标签从 codex:needs-spec 调整为 codex:ready。
-      options:
-        - label: 目标能力清晰
-          required: true
-        - label: 输入和输出明确
-          required: true
-        - label: 完成条件可以验证
-          required: true
-        - label: 已明确范围外内容
-          required: true
-        - label: 已识别父 Epic 和依赖
-          required: true
-        - label: 不需要实施者猜测关键架构决定
-          required: true
-    validations:
-      required: true
+      required: false

--- a/.github/ISSUE_TEMPLATE/research.yml
+++ b/.github/ISSUE_TEMPLATE/research.yml
@@ -1,75 +1,101 @@
 name: Research
-description: 用于需要先验证事实、假设、数据或方法的研究任务。
+description: 用于在实施决策前进行证据驱动的调查、比较、验证或可行性研究。
 title: "[Research] "
 labels:
-  - type:research
-  - codex:needs-spec
+  - "type:research"
+  - "codex:needs-spec"
 body:
   - type: markdown
     attributes:
       value: |
-        研究结果必须明确区分：已验证事实、推断、假设、未解决问题。
-        如涉及回测，必须说明数据范围、交易成本、样本外验证和潜在未来数据泄漏。
+        Research 是 evidence / decision leaf work item：当“是否应该实施”仍需要证据时使用；若实现目标已经决定，应创建 Task。
+        研究结果可以是 IMPLEMENT、DO NOT IMPLEMENT、NEEDS MORE EVIDENCE 或 ARCHITECTURE DECISION。
+        Parent、blocked-by 和 Project metadata 使用 GitHub native state。研究正文定义 pre-research specification，不要把完整过程日志永久堆入 Issue body。
+
   - type: textarea
-    id: research_question
+    id: question_decision
     attributes:
-      label: 研究问题
-      description: 用一个清晰问题描述本次研究要回答什么。
+      label: Question / Decision Needed
+      description: 用一个清晰问题或待决事项说明本研究最终必须回答什么。
+      placeholder: |
+        需要回答：
+        ...
     validations:
       required: true
+
   - type: textarea
-    id: background
+    id: context
     attributes:
-      label: 背景
-      description: 说明研究动机、上下文和相关 Issue。
+      label: Context
+      description: 简洁说明为什么现在需要这项研究，以及结论将支持什么后续判断；不要复制大段 Parent 或文档。
+      placeholder: |
+        当前背景：
+        ...
     validations:
       required: true
+
   - type: textarea
-    id: known_facts
+    id: scope
     attributes:
-      label: 已知事实
-      description: 列出现阶段已经确认的事实，并说明来源。
+      label: Scope
+      description: 明确本研究覆盖的系统、方案、数据、时间范围或调查边界。
+      placeholder: |
+        - ...
     validations:
       required: true
+
   - type: textarea
-    id: hypotheses
+    id: non_goals
     attributes:
-      label: 待验证假设
-      description: 列出需要通过数据、实验或文档验证的假设。
+      label: Non-goals
+      description: 明确本研究不包含的实现、调参、生产变更或相邻问题。
+      placeholder: |
+        - ...
     validations:
       required: true
+
   - type: textarea
-    id: data_requirements
+    id: evidence_evaluation
     attributes:
-      label: 数据需求
-      description: 描述所需数据、时间范围、字段、质量要求和数据不可用时的处理方式。
+      label: Evidence / Evaluation Criteria
+      description: 说明需要什么证据，以及如何判断证据足以支持继续、停止、比较方案或形成 decision。
+      placeholder: |
+        - ...
     validations:
       required: true
+
   - type: textarea
-    id: research_method
+    id: expected_outcome_artifact
     attributes:
-      label: 研究方法
-      description: 描述将如何验证事实和假设；涉及回测时说明数据范围、交易成本、样本外验证和潜在未来数据泄漏。
+      label: Expected Outcome / Artifact
+      description: 定义研究完成时应产出的结论或载体，例如 concise recommendation、benchmark result、versioned research report、ADR input 或 follow-up Task。
+      placeholder: |
+        预期结果：
+        - ...
     validations:
       required: true
+
   - type: textarea
-    id: deliverables
+    id: additional_context
     attributes:
-      label: 输出产物
-      description: 列出研究报告、实验记录、数据摘要、图表或后续 Issue。
+      label: Optional research details
+      description: 可选。仅在确实改变研究设计时补充 Hypotheses、Data Requirements、Method、Constraints 或 References；不要为了模板完整填写 N/A。
+      placeholder: |
+        仅在需要时填写，例如：
+
+        ### Hypotheses
+        - ...
+
+        ### Data Requirements
+        - ...
+
+        ### Method
+        - ...
+
+        ### Constraints
+        - ...
+
+        ### References
+        - ...
     validations:
-      required: true
-  - type: textarea
-    id: decision_criteria
-    attributes:
-      label: 判定标准
-      description: 说明什么结果支持继续实现、调整方向或停止投入。
-    validations:
-      required: true
-  - type: textarea
-    id: out_of_scope
-    attributes:
-      label: 范围外
-      description: 明确本研究不包含的实现、调参或生产行为。
-    validations:
-      required: true
+      required: false

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,113 +1,68 @@
 name: Implementation task
-description: 用于一个可由单个 PR 完成的实现任务。
+description: 用于一个通常可由单个 PR 完成、可独立验收的实现任务。
 title: "[Task] "
 labels:
-  - type:task
-  - codex:needs-spec
+  - "type:task"
+  - "codex:needs-spec"
 body:
-  - type: textarea
-    id: background
+  - type: markdown
     attributes:
-      label: 背景
-      description: 说明为什么需要这个任务，以及它与项目目标或上级 Issue 的关系。
+      value: |
+        Task 是主要 coding-agent execution contract，遵循 Minimum sufficient specification。
+        默认目标是 1 Task ≈ 1 PR ≈ 1 main squash commit。
+        Parent、blocked-by、Status、Priority、Size 使用 GitHub native metadata；不要在正文复制 repository-wide rules、标准 CI 或 Git/PR 流程。
+
+  - type: textarea
+    id: objective
+    attributes:
+      label: Objective
+      description: 用一句清晰目标描述本 Task 要完成的唯一主要变化；若存在多个可独立 merge/review 的目标，应继续拆分。
+      placeholder: |
+        实现……
     validations:
       required: true
+
   - type: textarea
-    id: goal
+    id: requirements
     attributes:
-      label: 目标
-      description: 描述本任务唯一的主要目标。
+      label: Requirements
+      description: 只写本 Task 特有、会改变实现决策或行为的要求，包括必要边界和非显而易见 edge cases；不要复制 Parent、架构全文或通用 workflow。
+      placeholder: |
+        - ...
     validations:
       required: true
-  - type: textarea
-    id: inputs
-    attributes:
-      label: 输入
-      description: 列出实现所需的输入、配置、数据、接口或文档。
-    validations:
-      required: true
-  - type: textarea
-    id: outputs
-    attributes:
-      label: 输出
-      description: 列出任务完成后应产生的代码、文档、配置或行为变化。
-    validations:
-      required: true
-  - type: textarea
-    id: behavior_requirements
-    attributes:
-      label: 行为要求
-      description: 描述必须满足的业务行为、约束和交互规则。
-    validations:
-      required: true
-  - type: textarea
-    id: edge_cases
-    attributes:
-      label: 异常与边界情况
-      description: 描述错误路径、边界输入、状态不一致或其他需要显式处理的情况。
-    validations:
-      required: true
-  - type: textarea
-    id: out_of_scope
-    attributes:
-      label: 范围外
-      description: 明确本任务不应处理的内容，避免实现时扩展范围。
-    validations:
-      required: true
+
   - type: textarea
     id: acceptance_criteria
     attributes:
-      label: 验收标准
-      description: 使用可测试、可核对的条目描述完成条件。
+      label: Acceptance Criteria
+      description: 使用可观察、可测试或可明确判断的结果定义完成；不要写 implementation checklist、通用 pytest/Ruff/mypy、CI green 或 PR created。
       placeholder: |
-        - [ ] ...
         - [ ] ...
     validations:
       required: true
+
   - type: textarea
-    id: verification_commands
+    id: additional_context
     attributes:
-      label: 验证命令
-      description: 列出完成后必须运行的测试、lint、type-check 或其他验证命令。
+      label: Additional execution context
+      description: 可选。仅补充当前 Task 独有且确有必要的信息，例如 Context、Scope Boundary / Non-goals、task-specific Constraints / Decisions、References 或标准 CI 之外的特殊 Verification。
       placeholder: |
-        ```powershell
-        dotnet test
-        ```
+        仅在需要时填写，例如：
+
+        ### Context
+        ...
+
+        ### Scope Boundary / Non-goals
+        - ...
+
+        ### Constraints / Decisions
+        - ...
+
+        ### References
+        - ...
+
+        ### Task-specific Verification
+        - ...
     validations:
-      required: true
-  - type: input
-    id: dependencies
-    attributes:
-      label: 依赖 Issue
-      description: 列出父 Issue、阻塞 Issue 或相关 Issue；若无，请写“无”。
-      placeholder: "Depends on #"
-    validations:
-      required: true
-  - type: dropdown
-    id: estimated_size
-    attributes:
-      label: 预计规模
-      description: 选择预计实现规模；L 通常表示应继续拆分。
-      options:
-        - XS：局部小修改
-        - S：一个清晰的小能力
-        - M：多个相关文件，但可由一个 PR 完成
-        - L：应继续拆分
-    validations:
-      required: true
-  - type: checkboxes
-    id: ready_check
-    attributes:
-      label: Ready 检查
-      description: 全部满足后，维护者才应将标签从 codex:needs-spec 调整为 codex:ready。
-      options:
-        - label: 任务只有一个主要目标
-          required: true
-        - label: 验收标准清晰且可以测试
-          required: true
-        - label: 已明确范围外内容
-          required: true
-        - label: 不需要开发者猜测关键架构决定
-          required: true
-    validations:
-      required: true
+      required: false

--- a/docs/development/issue-authoring.md
+++ b/docs/development/issue-authoring.md
@@ -242,6 +242,11 @@ observable behavior、meaningful edge cases、acceptance、important scope bound
   修复明显 active stale naming；禁止改变产品目标、新增 requirement、删除 safety
   constraint / observable behavior / Non-goal / 重要 edge case、改变 AC 语义、
   根据当前代码重新设计旧 specification、把实现建议升级为 requirement。
+- **Form `type: markdown` guidance 不得进入 Issue body**：Form 顶部的 authoring
+  guidance 只用于创建 Issue 时向作者显示辅助说明（`type: markdown` 不会作为用户
+  输入提交），迁移/shadow conversion 只生成由可提交 form fields 对应的
+  specification 内容；migrated Issue body 必须直接从第一个实际 specification
+  section（`### Outcome` / `### Capability` / `### Objective` 等）开始。
 - 缺失信息（Non-goals、AC、Evidence criteria 等）只能从原正文、current canonical
   parent、明确引用且仍 active 的 ADR / architecture contract 恢复；无法确定时标记
   `NEEDS MAINTAINER REVIEW`，不自动创造 requirement。

--- a/docs/development/issue-authoring.md
+++ b/docs/development/issue-authoring.md
@@ -1,0 +1,263 @@
+# Issue Authoring (Issue Specification v2)
+
+本文件定义 TraceQuant 的 Issue Specification v2：五类 Issue（Epic / Feature / Task /
+Bug / Research）的职责、正文结构、authoring 规则和信息所有权。它与
+`.github/ISSUE_TEMPLATE/*.yml` 保持一致，是创建和迁移 Issue 的唯一 authoring 参考。
+
+> **核心原则：Minimum sufficient specification。**
+> 让 fresh Codex / Claude session 获得正确完成当前工作所需的最少但充分的信息。
+> 不设固定字符数或 Token 上限；正文中每段文字至少承担一个作用：change scope、
+> change expected behavior、change acceptance、impose a real constraint、
+> point to necessary source of truth。否则 **remove or link instead of copy**。
+
+## 1. 统一语义模型
+
+```text
+Epic
+→ program / product outcome and boundaries
+
+Feature
+→ coherent behavioral capability (WHAT)
+
+Leaf work item
+├── Task      → implementation contract
+├── Bug       → defect contract
+└── Research  → evidence / decision contract
+```
+
+- Task、Bug、Research 是不同 work kind，但处于相同 leaf-work 层级，可作为 Feature 的
+  Sub-issue。
+- 少数情况下 Bug / Research 可直接挂在 Epic 下，但不是默认结构。
+- **不得**把五种类型理解为五个互斥层级。
+- 普通实现工作默认保持 `1 Task ≈ 1 PR ≈ 1 main squash commit`。
+
+## 2. 信息所有权
+
+一条事实只能有一个 canonical owner，其他位置只引用、不复制（除非当前工作在缺少该
+信息时无法正确理解）。
+
+| 信息 | Canonical owner |
+|---|---|
+| Repository hard safety / agent routing | `AGENTS.md` |
+| Claude-specific guidance | `CLAUDE.md` |
+| Reusable development workflow | `docs/development/*` |
+| Stable architecture invariants | `docs/architecture/*` |
+| Durable architecture decisions | ADR |
+| Program / product outcome | Epic |
+| Behavioral capability | Feature |
+| Implementation contract | Task |
+| Defect contract | Bug |
+| Evidence / decision investigation | Research |
+| Current Issue specification | Issue body |
+| Discussion / change history | Issue comments |
+| Parent hierarchy | GitHub Parent / Sub-issues |
+| Blocking dependency | GitHub blocked-by / blocking |
+| Status / Priority / Size | Private GitHub Project |
+| Classification / lifecycle | Labels |
+| Implementation evidence | PR |
+| Standard automated validation | CI |
+| Merge enforcement | Ruleset |
+
+Issue body 中不得复制 repository-wide rules、标准验证、Git/PR workflow、Project
+metadata 或完整 Parent specification。
+
+## 3. 五类 Issue 的职责与正文结构
+
+### Epic — outcome + boundaries
+
+> 为什么做，以及完成后整个系统达到什么状态。Epic 不是普通 coding-agent
+> implementation unit。
+
+REQUIRED：`Outcome`、`Why`、`Scope`、`Non-goals`、`Success / Exit Criteria`
+OPTIONAL：`Constraints / Decisions`、`Risks`、`References`
+
+- Outcome 描述最终状态，不是 Feature/Task 清单。
+- Success / Exit Criteria 描述 Epic-level result。
+- 不复制各 Feature 的完整 specification；不维护 child task checklist。
+- 不包含标准 pytest / Ruff / mypy / CI、Git workflow、Priority / Size / Status、
+  Parent / Dependency 文本字段。
+- Constraints / Decisions 只保存真正跨 Feature 且已批准的约束，优先引用 ADR。
+- Agent 收到“实现 Epic #N”时不应直接编码：若没有可执行 leaf work item，应报告需要
+  拆分或指定 Task/Bug。
+
+### Feature — behavioral capability (WHAT)
+
+> 系统需要具备什么行为或能力。明显偏 WHAT，不偏 HOW。
+
+REQUIRED：`Capability`、`Scope`、`Non-goals`、`Acceptance Criteria`
+OPTIONAL：`Context`、`Key Scenarios / Edge Cases`、`Constraints / Decisions`、
+`References`
+
+- 不写文件名、class、function、implementation sequence、逐文件修改方案；只有实现
+  方式本身已是 approved architecture / compatibility contract 时才进入
+  Constraints / Decisions。
+- 只有一个主要实现目标、一个 PR 即可完成、无需多个独立 leaf work item、没有长期
+  独立 behavioral specification 价值的“Feature”应直接创建 Task。
+
+### Task — implementation contract（主要 coding-agent execution contract）
+
+REQUIRED：`Objective`、`Requirements`、`Acceptance Criteria`
+OPTIONAL：`Context`、`Scope Boundary / Non-goals`、`Constraints / Decisions`、
+`References`、`Task-specific Verification`
+
+Task 必须满足：one primary objective、bounded scope、independently verifiable、
+normally one PR、minimal unrelated context、observable acceptance。
+
+Task 不得复制：parent Feature / Epic 完整正文、repository architecture summary、
+Git workflow、branch/commit/PR/merge instruction、标准 pytest / Ruff / mypy、
+Project metadata、historical discussion。
+
+`Task-specific Verification` 只用于标准 CI 之外确有必要的特殊验证。
+
+### Bug — defect contract（独立 Form，本身就是 leaf work item）
+
+REQUIRED：`Observed`、`Expected`、`Reproduction / Evidence`、`Acceptance Criteria`
+OPTIONAL：`Impact`、`Environment`、`Logs / Screenshots`、
+`Scope Boundary / Non-goals`、`Regression Evidence`
+
+- Reproduction / Evidence 可以是复现步骤、失败测试、日志或其他足以定位问题的证据。
+- Environment / Logs 非普适字段，均为 optional，不强迫填写 `N/A`。
+- Acceptance Criteria 描述恢复后的 contract，而不是简单“错误消失”。
+
+### Research — evidence / decision contract
+
+> 适用于 technical selection、exchange/API investigation、architecture spike、
+> benchmark、performance investigation、quantitative hypothesis、dependency /
+> security / feasibility / data-quality investigation。
+
+REQUIRED：`Question / Decision Needed`、`Context`、`Scope`、`Non-goals`、
+`Evidence / Evaluation Criteria`、`Expected Outcome / Artifact`
+OPTIONAL：`Hypotheses`、`Data Requirements`、`Method`、`Constraints`、`References`
+
+边界：已经决定实施 → Task；是否应该实施仍需证据 → Research。
+
+Research 有效结果可以是 `IMPLEMENT` / `DO NOT IMPLEMENT` / `NEEDS MORE EVIDENCE` /
+`ARCHITECTURE DECISION`。“决定不做”属于有效完成结果。不强制所有调查填写
+Hypotheses / Data Requirements / Method。
+
+## 4. Acceptance Criteria authoring
+
+AC 必须描述**可以观察、测试或明确判断的完成事实**。允许简洁 checklist、
+Given/When/Then 或等价 behavioral statements；不强制 Gherkin。
+
+禁止：
+
+- generic Definition of Done（`pytest passes`、`Ruff passes`、`mypy passes`、
+  `CI green`、`PR created`）——由 repository workflow / CI 负责；
+- 把 implementation plan 当 AC（除非具体结构本身就是 contract）。
+
+优先描述：externally observable behavior、invariant、failure behavior、
+state transition、regression condition。
+
+## 5. Non-goals 规则
+
+| Type | Non-goals |
+|---|---|
+| Epic | REQUIRED |
+| Feature | REQUIRED |
+| Task | OPTIONAL（存在明显 scope-creep 风险时填写） |
+| Bug | OPTIONAL |
+| Research | REQUIRED |
+
+不得为了模板完整强迫填写 `None` / `N/A` / `无`。
+
+## 6. Metadata 从正文移除
+
+正文不包含：Parent、Dependency、Priority、Size、Status、Ready checklist、
+standard validation、branch/PR workflow。目标 ownership：
+
+```text
+Parent                  → GitHub Parent/Sub-issues
+hard dependency         → GitHub blocked-by/blocking
+Status / Priority / Size → Private GitHub Project
+classification / lifecycle → labels
+standard validation     → CI / repository rules
+branch / PR / Squash workflow → development docs / Ruleset
+```
+
+标题前缀 `[Epic] / [Feature] / [Task] / [Bug] / [Research]` 和 `type:*` labels
+保留（personal account 下 native Issue Types 不可用，前缀对 notification、PR
+reference 和 plain-text Agent input 有辨识价值）。
+
+## 7. Issue body 与 comments
+
+- Issue body = current specification；comments = discussion / decision history。
+- 讨论导致 requirement 变化时：更新 body 使其表达最新 canonical specification，
+  并添加一条简短 comment 说明 changed what / why。
+- Comment 不得长期作为 silent specification override。
+
+## 8. Requirement precedence
+
+```text
+1. Platform / maintainer / security hard boundaries
+2. Repository hard invariants and active durable decisions
+   (applicable AGENTS.md, active architecture contracts, accepted ADRs)
+3. Current leaf Issue body (Task / Bug / Research)
+4. Parent Feature current specification
+5. Parent Epic current outcome / constraints
+6. General conventions / background docs
+7. Historical discussion / comments
+```
+
+- specific Task 不得静默违反 safety invariant / active ADR。
+- current canonical source 优先于复制到下级 Issue 的旧文本。
+- comment 改 requirement 后必须 canonicalize 回 body。
+- 同级 source 冲突且无法确定权威时触发 Human Gate。
+
+## 9. Research closeout
+
+Research body 表达 pre-research specification；不把完整过程日志堆入正文。
+
+- 小型调查：Issue final comment 记录 Conclusion / Evidence / Recommendation /
+  Follow-up。
+- 有长期复用价值：提交 versioned repository research report，由 PR review；
+  Issue 只保留简短结果和报告链接。
+- Architecture decision：`Research → evidence → ADR`，Issue 链接 ADR。
+- 如需实现：`Research → new Task(s)`。
+
+## 10. Semantic information budget（Token 效率）
+
+不设字符数 / Token 上限。优先消除：
+
+- **Very high**：Epic 中复制 child Feature specs；Task 中复制 repository-wide
+  rules；permanent body 中保存大段 workflow boilerplate。
+- **High**：standard validation；Git workflow；Parent / Dependency duplication；
+  Project metadata duplication。
+- **Medium**：Ready checklist；required `N/A` 字段；over-structured Research
+  fields。
+
+不得为了节省 Token 删除：safety constraints、task-specific requirements、
+observable behavior、meaningful edge cases、acceptance、important scope boundary。
+
+## 11. 迁移规则（历史 Issue 改写时适用）
+
+- 只迁移**明确尚未开始实施**的 Issue（OPEN + Project/lifecycle state 尚未开始 +
+  无 active/merged implementation PR + 无 implementation-in-progress evidence）。
+- Closed / Done / In Progress / Review / 已完成但 metadata 漂移 / 已产生正式
+  implementation history 的 Issue 一律不改写。
+- Epic / Feature 不能只看自身 Status：如果任何 descendant 已进入 implementation、
+  已完成或已产生实际 PR，默认 `DO NOT AUTO-MIGRATE`，除非维护者明确批准。
+- **Normalize structure, preserve meaning**：允许调整章节、合并重复、删除
+  repository-wide boilerplate、删除已由 native GitHub/Project 正确表达的 metadata、
+  修复明显 active stale naming；禁止改变产品目标、新增 requirement、删除 safety
+  constraint / observable behavior / Non-goal / 重要 edge case、改变 AC 语义、
+  根据当前代码重新设计旧 specification、把实现建议升级为 requirement。
+- 缺失信息（Non-goals、AC、Evidence criteria 等）只能从原正文、current canonical
+  parent、明确引用且仍 active 的 ADR / architecture contract 恢复；无法确定时标记
+  `NEEDS MAINTAINER REVIEW`，不自动创造 requirement。
+- 正文中的 Parent/Dependency 只有已被 native GitHub relationships 正确表达时才可
+  移除；否则标记 `NEEDS MAINTAINER REVIEW`，不得静默删除。
+- 迁移默认只修改 Issue body；title、state、labels、assignee、milestone、Parent、
+  Sub-issues、blocked-by/blocking、Project fields、comments、linked PR 一律不动。
+- 批量改写前必须经过 Human Gate；正式迁移逐个进行：重新读取最新 body → 与
+  snapshot hash 比较（已变化则 SKIP 并报告）→ 转换 → 更新 → 重新读取做 semantic
+  comparison。
+
+## 12. 相关文档
+
+- `AGENTS.md` — repository hard safety、agent routing、issue-driven workflow。
+- `CLAUDE.md` — Claude Code 开发命令与架构上下文。
+- `.github/ISSUE_TEMPLATE/*.yml` — 五类 Issue Form 的字段定义（本文档的机器可执行
+  对应物）。
+- `docs/architecture/*` — 稳定架构不变量。
+- `docs/development/*` — 可复用开发工作流（本文件即其一）。


### PR DESCRIPTION
# Pull Request

## 关联 Issue

Closes #115

## 实现摘要

- Issue Specification v2 已完成：正式采用 `Epic → Feature → leaf work item（Task / Bug / Research）` 语义模型，五类 Issue 职责为 outcome / WHAT / implementation contract / defect contract / evidence-decision contract。
- Epic / Feature / Task / Bug / Research 五个 Issue Form 已更新至 v2（`.github/ISSUE_TEMPLATE/*.yml`），正文 metadata（Parent / Dependency / Priority / Size / Status / Ready checklist / 标准验证 / Git workflow）已移除，optional 字段真正 optional。
- `docs/development/issue-authoring.md` 已建立：统一 authoring 参考，覆盖信息所有权、五类 Issue 结构、AC authoring、Non-goals 规则、body/comments 职责边界、requirement precedence、Research closeout、semantic information budget 与迁移规则。
- 未开始 Issue 的正文迁移已按分批 Human Gate 批准执行；Epics #12/#13/#14/#61、Features #11/#15–#44/#78/#79、Tasks #87–#97 已迁移至 v2 结构，semantic-preserving（无 Form guidance 泄漏、无 boilerplate、依赖语义与 Suggested Tasks/分解规划保留）。
- #61 / #78 / #79 等需要维护者裁决的迁移范围均经过明确 Human Gate 授权。
- historical / frozen / implemented Issues（#1 #2 #65 #66 #77 #86 及全部 Closed/Done 记录，含 Task #65 frozen body hash）按授权边界保持原样，未被改写。
- final acceptance audit verdict = **READY FOR PR / REVIEW**（BLOCKER=0, HIGH=0, MEDIUM=0；LOW findings 依指示不修改）。

## 修改范围

- `.github/ISSUE_TEMPLATE/epic.yml`
- `.github/ISSUE_TEMPLATE/feature.yml`
- `.github/ISSUE_TEMPLATE/task.yml`
- `.github/ISSUE_TEMPLATE/bug.yml`
- `.github/ISSUE_TEMPLATE/research.yml`
- `docs/development/issue-authoring.md`（新增）

## 关键设计决定

- Minimum sufficient specification：不设固定字符数/Token 上限，以 semantic information budget 消除重复上下文。
- 信息所有权：Parent → GitHub Sub-issues；blocked-by → native 关系；Status/Priority/Size → Private Project；classification → labels；validation → CI/Ruleset。
- Form `type: markdown` authoring guidance 只显示给创建者，不进入 Issue body（已提交 commit `b65260f` 明确此规则）。
- 迁移只改 Issue body：title / labels / state / relationships / Project fields 全部未动（final audit 已核验）。

## 验证结果

| 命令 | 结果 | 说明 |
| --- | --- | --- |
| git diff --check | PASS | |
| uv lock --check | PASS | |
| uv run --frozen pytest | 288 passed / 72 skipped / 0 failed | |
| uv run --frozen ruff check . | PASS | All checks passed |
| uv run --frozen ruff format --check . | PASS | 32 files already formatted |
| uv run --frozen mypy src tests | PASS | no issues in 22 files |
| Issue Forms validation（YAML parse / schema / component id 唯一 / prefix / labels） | PASS | 5/5 Forms |

## 从 Issue 复制的验收标准

- [x] Specification v2 模型、五类 Form、authoring documentation 完成并与 Forms 一致
- [x] Metadata / Token reduction：Parent/Dependency/Priority/Size/Status/Ready checklist/标准验证/Git workflow 移出正文
- [x] Existing Issue migration：仅迁移未开始 Issue；历史/冻结/已实施 Issue 保持原样；无凭空创造 requirement
- [x] Repository quality：标准验证全部通过；最终 diff 仅含 5 个 Form + authoring guide；AGENTS/CLAUDE retrieval strategy 未修改

## 风险检查

- [x] 未引入未授权实盘交易行为
- [x] 未提交或记录 API 密钥
- [x] 未引入无时区 datetime
- [x] 未引入未来数据泄漏
- [x] 未将缺失数据静默填零
- [x] 未绕过风险模块
- [x] 未进行范围外重构
- [x] 已测试失败路径（pytest 288 passed）

## 范围外内容

- 未修改 PR template / CI / Ruleset / Project schema / Private Project fields
- 未删除 `[Type]` title prefix 或 `type:*` labels
- 未修改 Issue hierarchy 或创建/删除 blocked-by relationships
- 未重构 AGENTS.md / CLAUDE.md retrieval policy（留待独立 Task）
- 未修改任何业务代码；未清理历史 Issue

## 已知限制

- final audit 的 LOW findings（#61 迁移授权边界、Human Gate 证据为 channel 外、`.claude/settings.json` 本地 attribution 修改未纳入本 PR）按指示仅记录、不修改。
- 迁移 snapshot 按 Task 设计未 commit，before/after 字节级对比依赖迁移期执行核验；语义层已由 final acceptance audit 抽样确认。
