### PR TITLE
[Task] 建立 Agent Context / Retrieval v2 并改为按需加载规格上下文 #87

### DIFF
--- a/.agents/skills/feature-completion-audit/SKILL.md
+++ b/.agents/skills/feature-completion-audit/SKILL.md
@@ -31,6 +31,15 @@ The Feature number is the primary key; the current Issue title is canonical.
 A request may limit execution to one named Phase. Verify prior Phase facts and
 stop at the requested boundary.
 
+## Context acquisition (hierarchy-aware exception)
+
+This audit is a hierarchy-aware flow, not a leaf-Issue-first default: its
+purpose requires the target Feature body, the relevant direct-child Issue
+hierarchy, completion state, and implementation / validation evidence. Read
+what the audit phases below require. Do not default to historical comments,
+unrelated docs/ADRs, the roadmap, sibling Feature history, or general
+workflow reports.
+
 ## Policies and audit interface
 
 Read applicable `AGENTS.md` / `AGENTS.override.md` and:

--- a/.agents/skills/task-closeout/SKILL.md
+++ b/.agents/skills/task-closeout/SKILL.md
@@ -61,6 +61,16 @@ Branch cleanup may still use the separate
 `cleanup_eligibility.status = eligible-under-capability-limited-policy`; that
 field authorizes only exact branch cleanup under the conditions below.
 
+## Default context
+
+Normal closeout verifies: Task/PR identity, reviewed head, merge identity,
+CI/review status, Issue/Project lifecycle state, local/origin main, branch
+state, and post-merge validation requirements. It does not default to
+re-reading the complete business Issue hierarchy (Parent/Epic bodies),
+business comments, or full implementation context. Those are read only when
+an explicit anomaly trigger requires it — for example a linkage, closure, or
+merge-identity conflict that the deterministic facts cannot resolve.
+
 ## Permission boundary
 
 After all prerequisite gates pass, this Skill may fetch refs, fast-forward local

--- a/.agents/skills/task-delivery-runner/SKILL.md
+++ b/.agents/skills/task-delivery-runner/SKILL.md
@@ -168,15 +168,26 @@ unrelated, generated, secret-bearing, or prohibited files → fail.
 
 ## Phase 1: identity and readiness
 
-Generate the `delivery` snapshot. Verify repository/origin, workspace, refs,
-worktrees, synchronized main identity, Task type/title/body/comments,
-Parent/dependencies/Relationships, labels, Project fields, blockers,
-templates, workflows, validation sources, and affected architecture.
+Generate the `delivery` snapshot. The snapshot provides deterministic
+identity facts: repository/origin, workspace, refs/worktrees, synchronized
+main identity, Task type/title/state, Parent identity,
+dependencies/Relationships metadata, labels, Project fields, blocker state,
+and PR head/base/checks when applicable. Verifying these mechanical facts
+does not require reading the full text of any source into the model context.
 
-Confirm that goal, scope, acceptance criteria, exceptions, and out-of-scope
-work are implementable without guessing. The Issue title is canonical when a
-derived Project title lags. Apply and re-read lifecycle transitions only after
-readiness passes.
+The current Task body is the business specification: read it and confirm
+that goal, scope, acceptance criteria, exceptions, and out-of-scope work are
+implementable without guessing. Do not default to reading comments, complete
+Parent/Epic bodies, dependency bodies, templates, workflows, validation
+sources, or linked docs/ADRs. Expand those only when a trigger applies: the
+Task body explicitly references them, the specification is missing or
+ambiguous, a conflict must be located, a dependency's state/contract affects
+implementation, a safety/architecture constraint applies, or verification
+requires them. Read the minimum relevant source/section, evaluate
+sufficiency, and expand further only if still insufficient.
+
+The Issue title is canonical when a derived Project title lags. Apply and
+re-read lifecycle transitions only after readiness passes.
 
 ## Phase 2: branch and implementation
 

--- a/.agents/skills/task-pr-review-runner/SKILL.md
+++ b/.agents/skills/task-pr-review-runner/SKILL.md
@@ -131,13 +131,20 @@ Stop on material repository, Task, linkage, state, base, or head mismatch.
 
 ## Phase 2: read complete evidence
 
-Independently read the complete Task specification/comments/Relationships, PR
-body and effective diff, every changed file in context, commits,
-tests/docs/config/public interfaces, relevant unchanged code, current
-reviews/threads/checks, workflows, tooling, and safety rules.
+Independently read the current Task body, PR body and effective diff, every
+changed file in context, commits, tests/docs/config/public interfaces,
+relevant unchanged code, current reviews/threads/checks, and
+review-relevant repository constraints.
 
 Do not inherit Delivery conclusions or accept comments, test names, or green
 checks without inspecting coverage.
+
+Comments, Parent/Epic bodies, and other hierarchy/history are not default
+review input. Expand to them only when the review scope, risk, or ambiguity
+requires it — for example an acceptance criterion references a historical
+decision, the Task body is insufficient to judge a change, or a conflict
+must be located. Expansion is bounded: read the minimum relevant source or
+section and stop once the question is resolved.
 
 ## Phase 3: semantic review with evidence matrix
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,5 +20,9 @@
       "Bash(gh pr view:*)",
       "Bash(gh run list:*)"
     ]
+  },
+  "attribution": {
+    "commit": "",
+    "pr": ""
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,9 +20,5 @@
       "Bash(gh pr view:*)",
       "Bash(gh run list:*)"
     ]
-  },
-  "attribution": {
-    "commit": "",
-    "pr": ""
   }
 }

--- a/.claude/skills/feature-completion-audit/SKILL.md
+++ b/.claude/skills/feature-completion-audit/SKILL.md
@@ -34,6 +34,15 @@ the same audit operations that Phase would have produced
 stability) — do not substitute direct `gh` or `git` queries — and stop at the
 requested boundary.
 
+## Context acquisition (hierarchy-aware exception)
+
+This audit is a hierarchy-aware flow, not a leaf-Issue-first default: its
+purpose requires the target Feature body, the relevant direct-child Issue
+hierarchy, completion state, and implementation / validation evidence. Read
+what the audit phases below require. Do not default to historical comments,
+unrelated docs/ADRs, the roadmap, sibling Feature history, or general
+workflow reports.
+
 ## Policies and audit interface
 
 Read applicable `AGENTS.md` / `AGENTS.override.md` and:

--- a/.claude/skills/task-closeout/SKILL.md
+++ b/.claude/skills/task-closeout/SKILL.md
@@ -104,6 +104,16 @@ Runner's own output to classify:
 Never fall back to an equivalent direct command chain after a Runner result.
 Never retry a Runner command with modified arguments to work around a failure.
 
+## Default context
+
+Normal closeout verifies: Task/PR identity, reviewed head, merge identity,
+CI/review status, Issue/Project lifecycle state, local/origin main, branch
+state, and post-merge validation requirements. It does not default to
+re-reading the complete business Issue hierarchy (Parent/Epic bodies),
+business comments, or full implementation context. Those are read only when
+an explicit anomaly trigger requires it — for example a linkage, closure, or
+merge-identity conflict that the deterministic facts cannot resolve.
+
 ## Permission boundary
 
 After all prerequisite gates pass, this Skill may fetch refs, fast-forward local

--- a/.claude/skills/task-delivery-runner/SKILL.md
+++ b/.claude/skills/task-delivery-runner/SKILL.md
@@ -227,13 +227,25 @@ Dirty with unrelated, generated, secret-bearing, or prohibited files → fail.
 
 ## Phase 1: identity and readiness
 
-Generate the `delivery` snapshot. Verify repository/origin, workspace,
-refs/worktrees, synchronized main identity, Task type/title/body/comments,
-Parent/dependencies/Relationships, labels, Project fields, blockers, templates,
-workflows, validation sources, and affected architecture.
+Generate the `delivery` snapshot. The snapshot provides deterministic
+identity facts: repository/origin, workspace, refs/worktrees, synchronized
+main identity, Task type/title/state, Parent identity,
+dependencies/Relationships metadata, labels, Project fields, blocker state,
+and PR head/base/checks when applicable. Verifying these mechanical facts
+does not require reading the full text of any source into the model context.
 
-Independently confirm that goal, scope, acceptance criteria, exceptions, and
-out-of-scope work are implementable without guessing. The Issue title is
+The current Task body is the business specification: read it and confirm
+that goal, scope, acceptance criteria, exceptions, and out-of-scope work are
+implementable without guessing. Do not default to reading comments, complete
+Parent/Epic bodies, dependency bodies, templates, workflows, validation
+sources, or linked docs/ADRs. Expand those only when a trigger applies: the
+Task body explicitly references them, the specification is missing or
+ambiguous, a conflict must be located, a dependency's state/contract affects
+implementation, a safety/architecture constraint applies, or verification
+requires them. Read the minimum relevant source/section, evaluate
+sufficiency, and expand further only if still insufficient.
+
+Independently confirm the readiness conclusions. The Issue title is
 canonical when a derived Project title lags. Apply and re-read lifecycle
 transitions only after readiness passes.
 

--- a/.claude/skills/task-pr-review-runner/SKILL.md
+++ b/.claude/skills/task-pr-review-runner/SKILL.md
@@ -176,13 +176,20 @@ Stop on material repository, Task, linkage, state, base, or head mismatch.
 
 ## Phase 2: read complete evidence
 
-Independently read the complete Task specification/comments/Relationships, PR
-body and effective diff, every changed file in context, commits,
-tests/docs/config/public interfaces, relevant unchanged code, current
-reviews/threads/checks, workflows, tooling, and safety rules.
+Independently read the current Task body, PR body and effective diff, every
+changed file in context, commits, tests/docs/config/public interfaces,
+relevant unchanged code, current reviews/threads/checks, and
+review-relevant repository constraints.
 
 Do not inherit Delivery conclusions or accept comments, test names, or green
 checks without inspecting coverage.
+
+Comments, Parent/Epic bodies, and other hierarchy/history are not default
+review input. Expand to them only when the review scope, risk, or ambiguity
+requires it — for example an acceptance criterion references a historical
+decision, the Task body is insufficient to judge a change, or a conflict
+must be located. Expansion is bounded: read the minimum relevant source or
+section and stop once the question is resolved.
 
 ## Phase 3: semantic review with evidence matrix
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,15 +12,144 @@ All requirements and implementation tasks are tracked in GitHub Issues.
 
 Before changing code:
 
-1. Read the complete assigned GitHub Issue, including comments.
+1. Read the current assigned GitHub Issue body — it is the primary
+   specification for the work item.
 2. Confirm that the Issue has the `codex:ready` label.
-3. Read its parent Issue, blocking Issues, linked documentation, and ADRs.
-4. Do not implement an Issue that is blocked or insufficiently specified.
-5. Treat the Issue scope, acceptance criteria, and out-of-scope section as binding.
-6. One implementation Issue should normally produce one Pull Request.
+3. Read the applicable repository instructions in this file (and
+   `CLAUDE.md` when working in Claude Code).
+4. Read only the code, tests, and referenced sources needed to implement the
+   Objective / Requirements / Acceptance Criteria.
+5. Do not implement an Issue that is blocked or insufficiently specified.
+6. Treat the Issue scope, acceptance criteria, and out-of-scope section as binding.
+7. One implementation Issue should normally produce one Pull Request.
 
 GitHub Issues are the source of truth for planned work.
 Repository documentation is the source of truth for current implemented behavior.
+
+### Default context (leaf-Issue-first)
+
+The current leaf Issue body is the primary source of the current work item
+specification. A normal implementation Task starts with:
+
+- the current leaf Issue body;
+- applicable repository instructions (this file; the Claude-specific
+  supplement in `CLAUDE.md` when running Claude Code);
+- the code and tests relevant to the Task;
+- the minimum input required by an explicitly invoked workflow Skill;
+- the Git / GitHub object identities that must be verified at the current
+  stage (base/head SHAs, PR identity, branch identity).
+
+The leaf Issue body must not override platform constraints, maintainer
+constraints, security boundaries, repository hard invariants, active
+ADR / durable architecture decisions, or safety requirements. A Task must not
+be required to restate its Parent Feature, Epic, repository architecture, or
+standard workflow.
+
+### Default exclusions
+
+Unless an expansion trigger below applies, a normal Task start must not
+default to reading the full text of:
+
+- Issue comments (all history);
+- the complete Parent Feature body;
+- the complete Parent Epic body;
+- sibling or descendant Issues;
+- complete blocking / related Issue bodies;
+- all linked documentation;
+- all ADRs;
+- repository roadmap;
+- historical workflow reports, Skills, or benchmark / experiment archives;
+- Delivery / Review / Closeout history sessions;
+- architecture documentation unrelated to the current change.
+
+A link's existence does not by itself require reading the target's full text.
+
+### Context expansion triggers
+
+Expand another source only when the current Task needs it:
+
+- **Explicit reference**: the leaf Issue explicitly requires a Parent
+  requirement, dependency, document, ADR, report, benchmark, specification,
+  or code location — read only the part needed to complete that requirement.
+- **Missing or ambiguous specification**: the leaf Issue cannot safely
+  determine expected behavior, scope boundary, acceptance semantics,
+  compatibility requirement, or dependency contract — expand upstream by
+  requirement precedence. Never guess to fill a missing requirement.
+- **Conflict**: the leaf Issue, a Parent, an ADR, a repository invariant, or
+  the current implementation conflict — read enough to locate the conflict
+  source. Fail closed / Human Gate when it cannot be safely resolved.
+- **Hard dependency**: only when a dependency's state or contract affects
+  whether the current Task can be implemented, verified, or merged — prefer
+  native metadata and the necessary section over the dependency's full
+  history.
+- **Safety / architecture**: when the change may affect live-trading safety,
+  credentials, order/risk authority, data integrity, time-series leakage,
+  public compatibility, an architecture boundary, or irreversible state/data
+  mutation — load the applicable durable repository rule / ADR /
+  documentation. Never skip safety constraints to reduce context.
+- **Verification**: when Acceptance Criteria point at a test fixture,
+  benchmark, report, protocol, or frozen evidence — read only what that
+  verification requires.
+
+### Progressive retrieval
+
+Expand context only when necessary:
+
+1. Read the minimum relevant source or section.
+2. Evaluate whether the information is sufficient.
+3. Expand further only when still insufficient.
+
+Never expand one reference into a full document, then its Parent, then its
+comments, then recursively up the hierarchy. Unbounded recursive expansion
+is forbidden. When an extra source is read, be able to state why it is
+needed, what it is, and which requirement / ambiguity / risk it resolves.
+Ordinary code reads during implementation do not require a formal evidence
+artifact.
+
+### Comments policy
+
+Issue comments are discussion / decision history, not default startup
+context. Read comments only when:
+
+- the current Issue body explicitly references a historical decision;
+- the current specification has ambiguity the body alone cannot resolve;
+- provenance of a requirement change must be confirmed;
+- the maintainer explicitly asks;
+- the current body conflicts with another active source and the change origin
+  must be located.
+
+Never load all comments just because the Issue has comments. Historical
+comments never silently override the current Issue body.
+
+### Parent / Epic policy
+
+Parent Feature and Epic bodies are upstream scope/outcome sources, not full
+execution inputs. A normal Task does not default to reading them completely.
+When the leaf Issue already defines Objective, Requirements, Acceptance
+Criteria, Scope Boundary, and required References, execute directly. Expand
+to a Parent only when the Task cannot safely determine scope, behavior, or a
+durable constraint — and read only what resolves that question, not the
+complete Parent specification. A single Parent constraint never requires the
+Parent full body plus the Epic full body plus all siblings.
+
+### Deterministic facts vs model context
+
+Verifying a mechanical fact with a deterministic tool is not the same as the
+model consuming the full original text. Readiness, review, and closeout may
+verify Issue state, labels, Parent identity, blocker state, Project Status,
+PR head, and checks with deterministic queries (Runner snapshots). Doing so
+does not require injecting the complete Parent body, comments, or history
+into the agent context. The current leaf Issue body is the only default
+full-text business source.
+
+### feature-completion-audit exception
+
+`feature-completion-audit` is a hierarchy-aware audit: its purpose requires
+the target Feature, the relevant child Issue hierarchy, completion state, and
+implementation / validation evidence. The leaf-Issue-first default does not
+apply to it. It must still limit acquisition to the hierarchy, state, and
+evidence the audit needs — not historical comments, unrelated docs / ADRs,
+the roadmap, sibling Feature history, or general workflow reports.
 
 When the user explicitly invokes `task-delivery-runner`, first read
 `.agents/skills/task-delivery-runner/SKILL.md`. When the user explicitly invokes
@@ -104,6 +233,8 @@ specific scoped instructions.
 - Keep strategy logic independent from network and exchange clients.
 - Keep risk decisions independent from strategy decisions.
 - A strategy must never submit an exchange order directly.
+- Modules must not perform I/O, read env vars, create directories, or cache
+  global singletons on import.
 
 ## Financial safety
 
@@ -135,7 +266,7 @@ specific scoped instructions.
 - Include fees, funding, slippage, turnover, and fill assumptions.
 - Never assume every limit order is completely filled.
 - Distinguish signal time, order time, fill time, and return measurement time.
-- Use chronological validation rather than random train/test splitting.
+- Use chronological walk-forward validation with purging and embargo rather than random train/test splitting.
 - Record the data range, parameters, code version, and data fingerprint.
 
 ## Verification

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 TraceQuant is an auditable research-to-live quantitative trading system for cryptocurrency perpetual futures (Binance USDⓈ-M, starting with BTCUSDT/ETHUSDT). Currently in **Research MVP** stage — no live trading capability exists yet.
 
-The `AGENTS.md` file at the repo root defines issue-driven workflow rules, implementation constraints, financial safety rules, and data correctness requirements. It is the primary behavior rule source; this file supplements it with development commands and architecture context.
+The `AGENTS.md` file at the repo root is the primary behavior rule source: it defines the issue-driven workflow, context acquisition (leaf-Issue-first, trigger-based expansion), implementation constraints, financial safety rules, and data correctness requirements. This file supplements it with Claude Code–specific tooling, commands, permissions, and environment context; it does not duplicate AGENTS.md rules.
 
 ### Codex 与 Claude Code 共存说明
 
@@ -118,14 +118,13 @@ Claude Code 权限控制（与 Codex 的 `.codex/rules/` 并存）。当前 allo
 
 ## Key design constraints
 
-- **Separation of concerns**: Strategy, risk, execution, and exchange connectivity must remain independent. A strategy must never submit an exchange order directly. The risk module has final authority to reject or reduce orders.
-- **Exchange code behind adapters**: Keep exchange-specific logic behind adapters so strategy code doesn't couple to a specific venue.
-- **No import-time side effects**: Modules must not perform I/O, read env vars, create directories, or cache global singletons on import.
-- **Live trading disabled by default**: Must require explicit configuration and fail closed.
-- **Strict typing**: `mypy --strict` passes on `src` and `tests`. Python 3.13.
-- **Financial time-series validation only**: Never use random train/test splits. Chronological walk-forward with purging and embargo required.
-- **Raw data immutability**: Raw data must never be overwritten by cleaned or aggregated results.
-- **Gross and net results reported separately**: Fees, funding, slippage, and fill assumptions must be modeled.
+The repository-wide hard constraints — separation of concerns, exchange code
+behind adapters, no import-time side effects, live trading disabled by
+default (fail closed), financial time-series validation (chronological
+walk-forward with purging and embargo), raw data immutability, and separate
+gross/net reporting — are defined in `AGENTS.md` and are binding here.
+Claude Code additionally enforces **strict typing**: `mypy --strict` passes
+on `src` and `tests` (Python 3.13), per the Commands section below.
 
 ## Technical baseline (future architecture)
 
@@ -144,10 +143,8 @@ Prohibited without an approved architecture Issue: microservices, Kubernetes, di
 
 ## Issue-driven development
 
-All work is tracked in GitHub Issues (the `PhoenixSss/tracequant` repo). Before changing code:
-1. Read the complete assigned Issue and confirm it has the `codex:ready` label
-2. Read parent/blocking Issues, linked docs, and ADRs
-3. Treat Issue scope, acceptance criteria, and out-of-scope sections as binding
-4. One implementation Issue → one PR
-
-The project is organized as 4 Epics (#1 Research MVP, #12 Shadow & Demo MVP, #13 Live MVP, #14 Production Hardening). Current focus is Feature #2 (Engineering & Research Foundation) under Epic #1.
+All work is tracked in GitHub Issues (the `PhoenixSss/tracequant` repo). The
+issue-driven workflow, leaf-Issue-first context acquisition, expansion
+triggers, and comments / Parent / Epic policies are defined in `AGENTS.md`
+and apply unchanged to Claude Code sessions. Current work scope is read from
+the active GitHub Issue and Project state, not from this file.

--- a/docs/workflows/context-retrieval-v2/before-after-retrieval.md
+++ b/docs/workflows/context-retrieval-v2/before-after-retrieval.md
@@ -1,0 +1,210 @@
+# Agent Context / Retrieval v2 — Before / After baseline
+
+Task: [#87](https://github.com/PhoenixSss/tracequant/issues/87)
+Scope: default context acquisition of the repository workflow (AGENTS.md,
+CLAUDE.md, Delivery / Review / Closeout Skills, feature-completion-audit).
+
+This document is the compact versioned comparison evidence required by
+Requirement 11 and the Task-specific Verification of #87. The **BEFORE**
+section is frozen at Task base SHA `c032e65f2399d7d59b4afa844e85dacfb4135129`
+from the unmodified repository. The **AFTER** section is filled in after the
+implementation, using the same measurement definition.
+
+Measurement definition: for each scenario, record the sources that the current
+workflow instructions require the agent to read by default (full text into
+model context), the deterministic tool queries the workflow performs, and the
+sources that are only read after an explicit trigger. Context bytes / chars and
+Token counts are not reliably obtainable: this repository explicitly excludes
+Task workflow Token telemetry (`AGENTS.md`, "Token telemetry"), so they are not
+fabricated here.
+
+---
+
+## BEFORE (base SHA c032e65, unmodified repository)
+
+### Scenario A — Ordinary leaf Task (Delivery default path)
+
+Current default retrieval plan, as required by the unmodified instructions:
+
+| # | Source | Required by | Full text? |
+|---|---|---|---|
+| 1 | Assigned Task Issue body | AGENTS.md "Issue-driven workflow" step 1 | Yes |
+| 2 | All Issue comments | AGENTS.md step 1 "including comments" | Yes (all) |
+| 3 | Parent Feature body | AGENTS.md step 3 "Read its parent Issue" | Yes (complete) |
+| 4 | Blocking / related Issue bodies | AGENTS.md step 3 "blocking Issues" | Yes (complete) |
+| 5 | Linked documentation | AGENTS.md step 3 "linked documentation" | Yes (all linked) |
+| 6 | ADRs | AGENTS.md step 3 "and ADRs" | Yes (all) |
+| 7 | Templates, workflows, validation sources, affected architecture | task-delivery-runner Phase 1 | Yes (eager list) |
+| 8 | Skill instruction + policies | task-delivery-runner | SKILL.md + workflow-evidence.md |
+
+Deterministic queries performed by the Evidence Runner `delivery` snapshot
+(`workflow_evidence.py`): `gh issue view <task> --json
+number,title,body,comments,state,labels,projectItems,url,closedAt,
+closedByPullRequestsReferences` (fetches the full body and every comment body),
+relationships GraphQL (parent/blocking/sub-issue metadata), issue closure
+snapshot, git snapshot (status/log/rev-parse/merge-base/branches/worktrees),
+and, when a PR exists, PR view, review threads, required checks, and diff
+digest.
+
+Default full-text reads: 1 Task body + **all** comments + Parent body + all
+blocking bodies + all linked docs + all ADRs + templates/workflows/validation
+sources/architecture docs. Manual expansion count: 0 (everything is eager).
+
+### Scenario B — Parent / dependency expansion
+
+The current rules contain no trigger. AGENTS.md step 3 makes the full Parent
+body, every blocking body, all linked docs, and all ADRs unconditional reads
+for every Task. A leaf body that already defines Objective / Requirements /
+Acceptance Criteria still drags in the complete Parent Feature, the complete
+Parent Epic, and every sibling / related body whenever one constraint is
+mentioned. There is no "read the minimum relevant section" step and no
+sufficiency evaluation.
+
+### Scenario C — Independent Review (default path)
+
+task-pr-review-runner Phase 2 requires: "Independently read the **complete**
+Task specification/**comments**/Relationships, PR body and effective diff,
+every changed file in context, commits, tests/docs/config/public interfaces,
+relevant unchanged code, current reviews/threads/checks, **workflows, tooling**,
+and safety rules."
+
+Default full-text reads: Task body + **all** comments + Relationships +
+PR body + effective diff + all changed files + commits + tests/docs/config +
+unchanged related code + reviews/threads/checks + workflows + tooling + safety
+rules. The fresh-session, read-only, independent judgment properties are
+already present and must be preserved.
+
+### Scenario D — Closeout (default path)
+
+task-closeout is already the closest to the target: its default context is
+identity facts (Task/PR identity, closing linkage, actual `MERGED` state,
+reviewed head, merge SHA/method/time, Issue closure, Project/label facts,
+workspace/worktrees, exact branches, checks). The Runner's `closeout-readonly`
+snapshot fetches the Task body and comments for content hashing, but the Skill
+does not instruct re-reading the full business specification. Gap: the minimal
+business-context default is implicit rather than explicit, and the Skill does
+not state that a full hierarchy re-read is only an exception path.
+
+### Metric summary (BEFORE)
+
+| Metric | A Delivery leaf | B Parent/dep | C Review | D Closeout |
+|---|---|---|---|---|
+| Default Issue bodies (full text) | Task + Parent + blocking(s) | Task + full Parent + full Epic | Task + PR body | Task (identity/hash only) |
+| Default comments (full text) | all | all | all ("complete comments") | none |
+| Parent / Epic bodies | full | full | — | none |
+| Dependency bodies | full (blocking) | full | — | none |
+| Docs / ADR | all linked + all ADR | all linked + all ADR | workflows + tooling + docs | none |
+| Skill / instruction sources | SKILL.md + 2 policies | same | SKILL.md + policies | SKILL.md + policies |
+| Deterministic tool queries | issue view (body+comments), relationships, closure, git, (PR view/threads/checks/diff) | same | review snapshot, validation, recheck | closeout-readonly, validation, recheck |
+| Manual expansion count | 0 | 0 | 0 | 0 |
+| Triggered expansion sources | none defined | none defined | none defined | none defined |
+| Context chars / bytes | not reliably obtainable (no telemetry) | — | — | — |
+| Token data | not reliably obtainable (no telemetry) | — | — | — |
+
+The `gh issue view`/PR queries themselves are legitimate deterministic fact
+verification; the eager part is that the workflow instructions additionally
+require the model to consume the full text of comments, Parent, blocking,
+docs, and ADRs by default, and that the Delivery/Review Skills name these
+full-text sources in their Phase 1 / Phase 2 mandatory lists.
+
+---
+
+## AFTER (implementation head of #87, same measurement definition)
+
+Changed policy sources for this measurement: `AGENTS.md` (leaf-Issue-first
+default context, default exclusions, six expansion triggers, progressive
+retrieval, comments policy, Parent/Epic policy, deterministic-facts
+separation, feature-completion-audit exception), `CLAUDE.md` (ownership
+cleanup per Requirement 7), and the eight Delivery / Review / Closeout /
+feature-completion-audit Skills under `.agents/skills/` and `.claude/skills/`.
+
+### Scenario A — Ordinary leaf Task (Delivery default path)
+
+Default full-text reads: **the current Task body only**. Comments, Parent /
+Epic bodies, blocking bodies, linked docs/ADRs, templates, workflows,
+validation sources, and architecture docs are not default input (AGENTS.md
+"Default exclusions", Delivery Skill Phase 1). The Runner `delivery` snapshot
+continues to provide deterministic identity facts (state, labels, Project
+fields, Parent identity, relationships metadata, blocker state, PR head/checks)
+without full-text consumption of those sources.
+
+### Scenario B — Parent / dependency expansion
+
+Leaf-Issue-first: a self-sufficient leaf body executes directly. When a
+Parent-level constraint is missing, the agent detects the insufficiency,
+expands the minimum relevant Parent context, evaluates sufficiency, and stops
+— no unbounded hierarchy expansion (AGENTS.md "Parent / Epic policy" +
+"Progressive retrieval").
+
+### Scenario C — Independent Review (default path)
+
+Default full-text reads: current Task body + PR body + effective diff + every
+changed file + commits + relevant unchanged code + reviews/threads/checks +
+review-relevant constraints. Comments and Parent/Epic/hierarchy sources are
+expanded only when review scope, risk, or ambiguity requires it (Review Skill
+Phase 2). Fresh-session, read-only, independent judgment, and
+no-inheriting-Delivery-verdict are unchanged.
+
+### Scenario D — Closeout (default path)
+
+Explicit minimal-context default: Task/PR identity, reviewed head, merge
+identity, CI/review status, Issue/Project lifecycle state, main/branch state,
+post-merge validation (Closeout Skill "Default context"). Full business
+hierarchy re-read only on an explicit anomaly trigger.
+
+### Metric summary (AFTER)
+
+| Metric | A Delivery leaf | B Parent/dep | C Review | D Closeout |
+|---|---|---|---|---|
+| Default Issue bodies (full text) | 1 (current Task body) | 1 (current Task body) | Task body + PR body | Task (identity/hash only) |
+| Default comments (full text) | none | none | none | none |
+| Parent / Epic bodies | none (on demand, minimum section) | minimum necessary section only | none (on scope/risk trigger) | none |
+| Dependency bodies | metadata + on-demand section | metadata + on-demand | none (on trigger) | none |
+| Docs / ADR | on demand (explicit reference / safety / verification trigger) | on demand | on trigger | none |
+| Skill / instruction sources | SKILL.md + policies (unchanged) | same | same | same |
+| Deterministic tool queries | Runner snapshot sets (unchanged) | same | same | same |
+| Manual expansion count | 0 in default path; trigger-based on demand | 1 (bounded) | 0 in default path | 0 in default path |
+| Triggered expansion sources | 6 triggers defined | parent-constraint trigger | scope/risk/ambiguity trigger | anomaly trigger |
+| Context chars / bytes | not reliably obtainable (no telemetry) | — | — | — |
+| Token data | not reliably obtainable (no telemetry) | — | — | — |
+
+### Before → after comparison
+
+| Metric | Before | After | Interpretation |
+|---|---|---|---|
+| Default full-text Issue bodies | Task + Parent + blocking(s) (AGENTS.md step 1/3) | 1 (current leaf Task body) | Parent/blocking bodies removed from default; identity via Runner metadata |
+| Default full-text comments | all — mandated by AGENTS.md step 1, Delivery Phase 1, Review Phase 2 | none | comments default-off; read only under one of five defined triggers |
+| Default Parent / Epic bodies | complete (AGENTS.md step 3) | on demand, minimum relevant section | Parent/Epic moved from default to triggered |
+| Default dependency bodies | complete (blocking Issues, AGENTS.md step 3) | metadata + on-demand section | hard-dependency trigger only |
+| Default docs / ADR | all linked + all ADR (AGENTS.md step 3) | on demand | explicit-reference / safety / verification triggers |
+| Default templates/workflows/validation sources/architecture (Delivery) | eager Phase 1 list | not default; trigger-based | Delivery Skill Phase 1 rewritten |
+| Default workflows/tooling (Review) | Phase 2 mandatory list | review-relevant constraints only | Review Skill Phase 2 rewritten |
+| Skill / instruction sources | SKILL.md + policies | unchanged | no governance reduction |
+| Deterministic tool queries | Runner snapshot sets | unchanged | mechanical verification fully preserved |
+| Expansion triggers | none defined | six (explicit reference, missing/ambiguous spec, conflict, hard dependency, safety/architecture, verification) | bounded progressive retrieval replaces eager loading |
+| Bounded expansion / no unbounded recursion | not defined | explicit rule | "Progressive retrieval" forbids unbounded recursion |
+| Manual expansion count (default path) | 0 (all eager) | 0 (default), trigger-based on demand | fewer default reads; expansion still possible |
+| Context chars / bytes | not reliably obtainable | not reliably obtainable | no fabricated Token data |
+| Token data | not reliably obtainable | not reliably obtainable | repository excludes Task Token telemetry |
+
+Eliminated default full-text reads: all Issue comments; complete Parent /
+Epic bodies; blocking / related Issue bodies; all linked docs and ADRs;
+templates / workflows / validation sources / affected architecture docs
+(Delivery eager list); workflows / tooling (Review mandatory list).
+
+Retained deterministic queries (unchanged): Runner `delivery`, `review`,
+`closeout-readonly`, `recheck` snapshots — issue view (content hashing and
+identity), relationships metadata, closure, git snapshot, PR view, review
+threads, required checks, diff digest — plus the Validation Runner profiles.
+These remain the single mechanical path and never inject full source text
+into model context by themselves.
+
+Default → triggered transitions: comments; Parent/Epic full bodies; dependency
+bodies; linked docs/ADRs; templates/workflows/architecture docs; review-time
+workflow/tooling reads.
+
+Safety, financial, data-integrity, and architecture hard rules in AGENTS.md
+(Implementation rules, Financial safety, Data correctness, Backtesting,
+Verification, Prohibited premature complexity) are unchanged; the
+safety/architecture expansion trigger requires loading the applicable durable
+rule and fails closed when it cannot be confirmed.

--- a/tests/tools/test_retrieval_v2_policy.py
+++ b/tests/tools/test_retrieval_v2_policy.py
@@ -1,0 +1,324 @@
+"""Focused tests for Issue #87 — Agent Context / Retrieval v2 policy.
+
+These tests pin the retrieval semantics that #87 introduces in AGENTS.md,
+CLAUDE.md, and the eight workflow Skills: leaf-Issue-first default context,
+default exclusions, trigger-based expansion, bounded progressive retrieval,
+comments default-off, Parent/Epic on demand, deterministic-metadata vs
+full-text separation, preserved safety hard rules, the
+feature-completion-audit hierarchy-aware exception, and the before/after
+evidence document. They intentionally avoid a new harness: they reuse the
+existing tests/tools/ convention of reading the policy sources directly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).parents[2]
+
+AGENTS = ROOT / "AGENTS.md"
+CLAUDE = ROOT / "CLAUDE.md"
+EVIDENCE = ROOT / "docs/workflows/context-retrieval-v2/before-after-retrieval.md"
+
+SKILLS: dict[str, dict[str, Path]] = {
+    "delivery": {
+        "agents": ROOT / ".agents/skills/task-delivery-runner/SKILL.md",
+        "claude": ROOT / ".claude/skills/task-delivery-runner/SKILL.md",
+    },
+    "review": {
+        "agents": ROOT / ".agents/skills/task-pr-review-runner/SKILL.md",
+        "claude": ROOT / ".claude/skills/task-pr-review-runner/SKILL.md",
+    },
+    "closeout": {
+        "agents": ROOT / ".agents/skills/task-closeout/SKILL.md",
+        "claude": ROOT / ".claude/skills/task-closeout/SKILL.md",
+    },
+    "audit": {
+        "agents": ROOT / ".agents/skills/feature-completion-audit/SKILL.md",
+        "claude": ROOT / ".claude/skills/feature-completion-audit/SKILL.md",
+    },
+}
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _flat(path: Path) -> str:
+    return " ".join(_read(path).split())
+
+
+# --- AGENTS.md: leaf-Issue-first default context ---
+
+
+def test_agents_leaf_first_default_context() -> None:
+    text = _flat(AGENTS)
+    assert "leaf-Issue-first" in text
+    assert "Default context (leaf-Issue-first)" in text
+    assert "The current leaf Issue body is the primary source" in text
+
+
+def test_agents_default_exclusions_list_eager_full_read_sources() -> None:
+    text = _flat(AGENTS)
+    assert "Default exclusions" in text
+    for source in (
+        "Issue comments (all history)",
+        "the complete Parent Feature body",
+        "the complete Parent Epic body",
+        "sibling or descendant Issues",
+        "complete blocking / related Issue bodies",
+        "all linked documentation",
+        "all ADRs",
+        "architecture documentation unrelated to the current change",
+    ):
+        assert source in text
+    assert (
+        "A link's existence does not by itself require reading the target's full text"
+        in text
+    )
+
+
+def test_agents_eager_hierarchy_mandate_removed() -> None:
+    text = _read(AGENTS)
+    assert "including comments" not in text
+    assert (
+        "Read its parent Issue, blocking Issues, linked documentation, and ADRs"
+        not in text
+    )
+    assert "Read the complete assigned GitHub Issue" not in text
+
+
+def test_agents_defines_all_expansion_triggers() -> None:
+    text = _flat(AGENTS)
+    for trigger in (
+        "Explicit reference",
+        "Missing or ambiguous specification",
+        "Conflict",
+        "Hard dependency",
+        "Safety / architecture",
+        "Verification",
+    ):
+        assert trigger in text
+
+
+def test_agents_progressive_retrieval_is_bounded() -> None:
+    text = _flat(AGENTS)
+    assert "Progressive retrieval" in text
+    assert "Read the minimum relevant source or section" in text
+    assert "Evaluate whether the information is sufficient" in text
+    assert "Unbounded recursive expansion is forbidden" in text
+
+
+def test_agents_comments_policy_default_off() -> None:
+    text = _flat(AGENTS)
+    assert "Comments policy" in text
+    assert (
+        "Issue comments are discussion / decision history, not default startup context"
+        in text
+    )
+    assert "Never load all comments just because the Issue has comments" in text
+    assert "Historical comments never silently override the current Issue body" in text
+
+
+def test_agents_parent_epic_policy_on_demand() -> None:
+    text = _flat(AGENTS)
+    assert "Parent / Epic policy" in text
+    assert "A normal Task does not default to reading them completely" in text
+    assert "not the complete Parent specification" in text
+    assert (
+        "A single Parent constraint never requires the Parent full body plus the Epic full body plus all siblings"
+        in text
+    )
+
+
+def test_agents_deterministic_facts_separated_from_full_text() -> None:
+    text = _flat(AGENTS)
+    assert "Deterministic facts vs model context" in text
+    assert (
+        "Verifying a mechanical fact with a deterministic tool is not the same as the model consuming the full original text"
+        in text
+    )
+    assert (
+        "The current leaf Issue body is the only default full-text business source"
+        in text
+    )
+
+
+def test_agents_feature_audit_exception() -> None:
+    text = _flat(AGENTS)
+    assert "feature-completion-audit exception" in text
+    assert "`feature-completion-audit` is a hierarchy-aware audit" in text
+    assert "The leaf-Issue-first default does not apply to it" in text
+
+
+def test_agents_safety_and_data_hard_rules_preserved() -> None:
+    text = _flat(AGENTS)
+    for rule in (
+        "Never enable live trading by default",
+        "Never submit live orders from tests",
+        "Never print, log, commit, or expose credentials",
+        "The risk module has final authority to reject or reduce an order",
+        "Raw data must remain immutable",
+        "Use chronological walk-forward validation with purging and embargo rather than random train/test splitting",
+        "Modules must not perform I/O, read env vars, create directories, or cache global singletons on import",
+        "A strategy must never submit an exchange order directly",
+    ):
+        assert rule in text
+
+
+def test_agents_safety_trigger_fails_closed() -> None:
+    text = _flat(AGENTS)
+    assert "Never skip safety constraints to reduce context" in text
+    assert "Fail closed / Human Gate when it cannot be safely resolved" in text
+
+
+# --- CLAUDE.md: Requirement 7 ownership cleanup ---
+
+
+def test_claude_references_agents_instead_of_duplicating() -> None:
+    text = _flat(CLAUDE)
+    assert (
+        "The `AGENTS.md` file at the repo root is the primary behavior rule source"
+        in text
+    )
+    assert "it does not duplicate AGENTS.md rules" in text
+    assert "are defined in `AGENTS.md` and are binding here" in text
+
+
+def test_claude_duplicate_workflow_and_rule_maintenance_removed() -> None:
+    text = _read(CLAUDE)
+    assert "Read parent/blocking Issues, linked docs, and ADRs" not in text
+    assert "Read the complete assigned Issue" not in text
+    assert "Never use random train/test splits" not in text
+    assert "Raw data must never be overwritten" not in text
+    assert "The risk module has final authority" not in text
+
+
+def test_claude_stale_current_focus_removed_and_claude_specific_kept() -> None:
+    text = _read(CLAUDE)
+    assert "Current focus is Feature #2" not in text
+    for kept in (
+        "uv run pytest",
+        "uv run mypy src tests",
+        "### Permissions",
+        ".claude/settings.json",
+        "Claude Code 专用的四个 Skill",
+    ):
+        assert kept in text
+
+
+# --- Delivery Skills: leaf-Issue-first + trigger-based expansion ---
+
+
+def test_delivery_skills_leaf_first_and_trigger_expansion() -> None:
+    for path in SKILLS["delivery"].values():
+        text = _flat(path)
+        assert "The current Task body is the business specification" in text
+        assert (
+            "Do not default to reading comments, complete Parent/Epic bodies, dependency bodies, templates, workflows, validation sources, or linked docs/ADRs"
+            in text
+        )
+        assert (
+            "Verifying these mechanical facts does not require reading the full text of any source into the model context"
+            in text
+        )
+        assert (
+            "Read the minimum relevant source/section, evaluate sufficiency, and expand further only if still insufficient"
+            in text
+        )
+
+
+def test_delivery_skills_eager_phase1_verification_list_removed() -> None:
+    for path in SKILLS["delivery"].values():
+        text = _read(path)
+        assert "Task type/title/body/comments" not in text
+        assert (
+            "templates, workflows, validation sources, and affected architecture"
+            not in text
+        )
+
+
+# --- Review Skills: independent + lazy hierarchy ---
+
+
+def test_review_skills_independent_and_lazy_hierarchy() -> None:
+    for path in SKILLS["review"].values():
+        text = _flat(path)
+        assert (
+            "Independently read the current Task body, PR body and effective diff"
+            in text
+        )
+        assert (
+            "Comments, Parent/Epic bodies, and other hierarchy/history are not default review input"
+            in text
+        )
+        assert "Expansion is bounded" in text
+        assert "Do not inherit Delivery conclusions" in text
+        assert "fresh session" in text.casefold() or "new session" in text.casefold()
+        assert "read-only" in text
+
+
+def test_review_skills_no_longer_require_complete_comments() -> None:
+    for path in SKILLS["review"].values():
+        text = _read(path)
+        assert "complete Task specification/comments" not in text
+
+
+# --- Closeout Skills: minimal business context ---
+
+
+def test_closeout_skills_minimal_business_context() -> None:
+    for path in SKILLS["closeout"].values():
+        text = _flat(path)
+        assert "Default context" in text
+        assert (
+            "It does not default to re-reading the complete business Issue hierarchy (Parent/Epic bodies), business comments, or full implementation context"
+            in text
+        )
+        assert "explicit anomaly trigger" in text
+
+
+# --- feature-completion-audit: hierarchy-aware exception ---
+
+
+def test_feature_audit_skills_hierarchy_aware_exception() -> None:
+    for path in SKILLS["audit"].values():
+        text = _flat(path)
+        assert "Context acquisition (hierarchy-aware exception)" in text
+        assert "not a leaf-Issue-first default" in text
+        assert "direct-child Issue hierarchy" in text
+        assert (
+            "Do not default to historical comments, unrelated docs/ADRs, the roadmap, sibling Feature history, or general workflow reports"
+            in text
+        )
+
+
+# --- Codex / Claude semantic parity ---
+
+
+def test_codex_claude_retrieval_semantics_parity() -> None:
+    markers = {
+        "delivery": "Do not default to reading comments, complete Parent/Epic bodies",
+        "review": "hierarchy/history are not default review input",
+        "closeout": "does not default to re-reading the complete business Issue hierarchy",
+        "audit": "not a leaf-Issue-first default",
+    }
+    for group, marker in markers.items():
+        agents_text = _flat(SKILLS[group]["agents"])
+        claude_text = _flat(SKILLS[group]["claude"])
+        assert marker in agents_text
+        assert marker in claude_text
+
+
+# --- Before / after evidence document ---
+
+
+def test_retrieval_evidence_document_has_before_after_sections() -> None:
+    text = _read(EVIDENCE)
+    assert "## BEFORE" in text
+    assert "## AFTER" in text
+    for scenario in ("Scenario A", "Scenario B", "Scenario C", "Scenario D"):
+        assert scenario in text
+    assert "Before → after comparison" in text
+    assert "not reliably obtainable" in text
+    assert "no fabricated Token data" in text or "not fabricated" in text

--- a/tests/tools/test_runtime_telemetry_removed.py
+++ b/tests/tools/test_runtime_telemetry_removed.py
@@ -61,6 +61,9 @@ APPROVED_TELEMETRY_REFERENCE_FILES = {
     "docs/workflows/publication-materials/task-material-register.md": (
         "publication material register retaining historical workflow sample labels"
     ),
+    "docs/workflows/context-retrieval-v2/before-after-retrieval.md": (
+        "#87 retrieval before/after evidence noting Token telemetry remains disabled"
+    ),
 }
 
 LOCAL_ONLY_EXCLUSIONS = {


### PR DESCRIPTION
# Pull Request

## 关联 Issue

Closes #87

## 实现摘要

- **AGENTS.md → Retrieval v2（shared repository-wide retrieval semantics）**：改为 leaf-Issue-first 默认上下文（current leaf Issue body 为 work item specification 主要来源）、Default exclusions（comments / 完整 Parent Feature / 完整 Parent Epic / sibling / blocking bodies / linked docs / ADR / roadmap / 历史 workflow reports 等默认不全文读取）、六个 context expansion triggers（Explicit reference / Missing or ambiguous specification / Conflict / Hard dependency / Safety & architecture / Verification）、Progressive retrieval（最小相关来源 → sufficiency 评估 → 仍不足才继续展开；禁止无界递归）、Comments policy（默认关闭，五类 trigger）、Parent/Epic policy（按需最小展开）、Deterministic facts vs model context 分离、feature-completion-audit hierarchy-aware exception。
- **CLAUDE.md → Requirement 7 ownership cleanup**：移除对 Issue workflow、repository-wide implementation rules、safety rules、data correctness rules、generic development policy 的重复维护；删除易过期的静态 current-focus 声明；保留 Claude 专属 tooling / commands / permissions / skills 说明；引用 AGENTS.md 而非复制。
- **AGENTS.md hard rules 未削弱**：Financial safety / Data correctness / Backtesting / Verification / Prohibited complexity 全部保留；`no import-time side effects` 与 `chronological walk-forward with purging and embargo` 提升到 shared source（原仅存在于 CLAUDE.md 的 invariant 不丢失）。
- **Workflow Skills 对齐（Codex `.agents/skills/` + Claude `.claude/skills/` 各 4 个）**：
  - `task-delivery-runner`：Phase 1 改为 leaf-first —— Runner snapshot 提供 deterministic identity facts，Task body 是 business specification，comments / Parent / Epic / templates / workflows / linked docs 仅在 trigger 下展开。
  - `task-pr-review-runner`：Phase 2 保持 fresh-session、read-only、独立判断、不继承 Delivery verdict，但不再默认读取完整 comments / hierarchy；仅在 review scope / risk / ambiguity 需要时 bounded 展开。
  - `task-closeout`：新增 Default context —— 正常 closeout 只验证 Task/PR identity、reviewed head、merge identity、CI/review status、Issue/Project state、main/branch state、post-merge validation；完整业务 hierarchy 仅在明确异常 trigger 下重读。
  - `feature-completion-audit`：显式声明 hierarchy-aware exception（不适用 leaf-Issue-first 默认），context 限定于完成 audit 所需的 hierarchy / state / evidence。
- **Deterministic metadata 与 full-text injection 解耦（Requirement 9）**：绑定点在 Skill 散文层（Runner gates 本就只依赖 metadata），以最小 Skill 散文改动解耦；未重写 Runner state machine。
- **Evidence**：`docs/workflows/context-retrieval-v2/before-after-retrieval.md` — 四类 baseline 场景（leaf / parent-dep / Review / Closeout）的 BEFORE（base SHA 冻结）与 AFTER 对照，同一测量口径；Context bytes / Token 因 repository 明确排除 Token telemetry 而如实标注不可靠获取，未伪造。
- **Tests**：`tests/tools/test_retrieval_v2_policy.py`（22 个 focused tests：default exclusions、triggers、bounded expansion、comments default-off、Parent/Epic on-demand、determinism separation、Review independence、Closeout minimal context、feature-completion-audit exception、safety preserved、Codex/Claude semantic parity、evidence 文档存在性）；`test_runtime_telemetry_removed.py` allowlist 增加 evidence 文档条目（该文档合法引用 "Token telemetry 保持禁用" 作为测量边界，与 AGENTS.md normative statement 一致）。

## 修改范围

- `AGENTS.md`
- `CLAUDE.md`
- `.agents/skills/task-delivery-runner/SKILL.md`
- `.agents/skills/task-pr-review-runner/SKILL.md`
- `.agents/skills/task-closeout/SKILL.md`
- `.agents/skills/feature-completion-audit/SKILL.md`
- `.claude/skills/task-delivery-runner/SKILL.md`
- `.claude/skills/task-pr-review-runner/SKILL.md`
- `.claude/skills/task-closeout/SKILL.md`
- `.claude/skills/feature-completion-audit/SKILL.md`
- `docs/workflows/context-retrieval-v2/before-after-retrieval.md`（新增）
- `tests/tools/test_retrieval_v2_policy.py`（新增）
- `tests/tools/test_runtime_telemetry_removed.py`（allowlist 追加 1 条目）

## 关键设计决定

- **验证 policy 而非建设基础设施**：本 Task 验证简单 retrieval policy 是否足够；未创建 Canonical Spec、Context Compiler、context manifest、hash graph、RAG、vector DB 或 telemetry。
- **correctness > safety > independent verification > scope fidelity > context efficiency**：lazy retrieval 不得削弱 safety / financial / data-integrity hard rules；safety trigger fail closed。
- **same semantics ≠ same implementation mechanism**：Codex 与 Claude Skills 语义一致，各自保留工具特有执行方式。
- **feature-completion-audit 例外**（Human Spec Review LOW-2 澄清）：hierarchy-aware audit 不套用 leaf-Issue-first 默认。
- **Runner 不改**：`_issue_view` 获取 body/comments 仅用于 content hashing / identity evidence（gates 只依赖 metadata）；Skill 散文层完成"机械验证 ≠ 全文注入"的解耦（Requirement 9 最小改动）。

## 验证结果

| 命令 | 结果 | 说明 |
| --- | --- | --- |
| git diff --check | PASS | |
| uv lock --check | PASS | Resolved 14 packages |
| uv run --frozen pytest | PASS | 310 passed / 72 skipped / 0 failed |
| uv run --frozen ruff check . | PASS | All checks passed |
| uv run --frozen ruff format --check . | PASS | 33 files already formatted |
| uv run --frozen mypy src tests | PASS | no issues in 23 source files |
| skill_path_audit.py | PASS | status=pass, direct_command_path_count=0 |
| workflow-delivery（committed head，隔离 worktree） | PASS | 12/12 commands（含 6 个 skill validators） |
| tests/tools/test_retrieval_v2_policy.py | PASS | 22/22 |

环境备注：`workflow-delivery` 的 Codex skill-validator（repo 外部 `quick_validate.py`）需要 `yaml`；本机 venv 此前缺少该模块（PyYAML 不在 repo lock 内），已在本机 venv 层面安装（无 repo 改动、无 lock 改动）。CI 不运行该 profile（CI 仅 pytest/ruff/mypy）。

## 从 Issue 复制的验收标准

- [x] AGENTS.md 不再要求普通 Task 默认读取完整 Issue comments、完整 Parent、Epic 和全部 linked docs / ADRs
- [x] CLAUDE.md 与 AGENTS.md 的 retrieval semantics 一致，并按 Requirement 7 ownership 边界移除重复维护
- [x] Codex 与 Claude Code 的正式 Delivery Skill 均采用 leaf-Issue-first、trigger-based context expansion
- [x] Independent Review 保持 fresh-session、read-only、独立验证，不再默认加载无关完整 hierarchy/history
- [x] Closeout 正常路径默认不需要加载完整业务 Issue hierarchy
- [x] comments 默认不读取，除非满足明确 trigger
- [x] Parent / Epic 默认不读取全文，除非 leaf specification 不足或存在明确 requirement/risk trigger
- [x] linked docs / ADR 不因"存在链接"自动全部读取
- [x] safety、financial、data-integrity、architecture hard constraints 未被 lazy retrieval 弱化或跳过
- [x] deterministic metadata verification 与 LLM full-text context injection 已明确区分
- [x] 未建立第二份 Canonical Spec，未实现 Context Compiler
- [x] 代表性 Delivery、Review、Closeout 场景验证默认读取范围确实缩小（evidence 文档 Scenario A–D）
- [x] 上下文不足时按 trigger 正确展开而不是猜测
- [x] context expansion 无无界递归
- [x] before / after evidence 说明实际减少了哪些默认读取（非仅文档字符数）
- [x] repository standard validation 保持通过
- [x] 未修改 Issue Specification v2 的五类 Form 或已迁移 Issue bodies

## 风险检查

- [x] 未引入未授权实盘交易行为
- [x] 未提交或记录 API 密钥
- [x] 未引入无时区 datetime
- [x] 未引入未来数据泄漏
- [x] 未将缺失数据静默填零
- [x] 未绕过风险模块
- [x] 未进行范围外重构
- [x] 已测试失败路径

## 范围外内容

- 未实现 #88 Context Compiler；未创建 Canonical Spec / context manifest / hash graph
- 未修改 Issue Specification v2 Forms、未批量修改 Issue body、未修改 Parent/Sub-issues hierarchy
- 未删除 Independent Review、未合并 Delivery/Review 会话、未自动 Merge、未修改 GitHub Ruleset
- 未重写 Runner state machine、未删除 workflow evidence/validation infrastructure
- 未修复 task-closeout clean-worktree gate（按 #87 明确 Non-goals）
- 未实现 Review Profiles / Review Certificate / fixed-patch framework / runtime Telemetry / RAG / vector DB
- 未承诺固定 Token 降幅

## 已知限制

- Context chars / bytes 与 Token 数据不可靠获取（repository 明确排除 Task workflow Token telemetry，AGENTS.md）；before/after 对照使用可客观观察的读取来源清单与 deterministic query 集合。
- `workflow-delivery` 的 skill validator 依赖本机 venv 安装 PyYAML（环境层，非 repo 依赖）。
