### PR TITLE
chore: disable Claude Code attribution in repository settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,5 +20,9 @@
       "Bash(gh pr view:*)",
       "Bash(gh run list:*)"
     ]
+  },
+  "attribution": {
+    "commit": "",
+    "pr": ""
   }
 }


### PR DESCRIPTION
## Summary

Formalize the maintainer-confirmed attribution-disabled configuration into the repository, as an independent small configuration change.

Adds to `.claude/settings.json`:

```json
"attribution": {
  "commit": "",
  "pr": ""
}
```

- **Unrelated to Task #87** — this is a standalone repository configuration change; no Issue is reopened (#87 remains closed), and Agent Context / Retrieval v2 (`.claude/skills/` etc.) is not touched.
- #78 / #88 are not modified.
- CI impact: none (config-only change).

## Verification

`git diff a1cec99..HEAD` contains only the 4-line `attribution` addition to `.claude/settings.json`.