### PR TITLE
[Task] 完成 Agent-neutral Workflow / Instruction Architecture 迁移与统一入口 #120

### DIFF
--- a/.agents/skills/feature-completion-audit/SKILL.md
+++ b/.agents/skills/feature-completion-audit/SKILL.md
@@ -49,6 +49,10 @@ Read applicable `AGENTS.md` / `AGENTS.override.md` and:
 .agents/policies/workflow-evidence.md
 ```
 
+Shared lifecycle semantics are owned by `docs/development/issue-workflow.md`
+(§14 Feature Completion). Read the minimal needed section for the current
+phase; do not duplicate audit-semantic prose in this Skill.
+
 Audit the exact locked `origin/main` implementation and current Feature facts.
 Use the repository-defined operations:
 

--- a/.agents/skills/task-closeout/SKILL.md
+++ b/.agents/skills/task-closeout/SKILL.md
@@ -32,6 +32,11 @@ Read applicable agent rules and:
 .agents/policies/workflow-evidence.md
 ```
 
+Shared lifecycle semantics are owned by `docs/development/issue-workflow.md`
+(§11 manual Squash Merge boundary, §13 Closeout). Read the minimal needed
+section for the current phase; do not duplicate closeout-semantic prose in this
+Skill.
+
 Use the current repository Runner interfaces:
 
 ```bash

--- a/.agents/skills/task-delivery-runner/SKILL.md
+++ b/.agents/skills/task-delivery-runner/SKILL.md
@@ -40,6 +40,11 @@ stop at the requested boundary.
 Read applicable `AGENTS.md` / `AGENTS.override.md` and
 `.agents/policies/command-execution.md`, `.agents/policies/workflow-evidence.md`.
 
+Shared lifecycle semantics are owned by `docs/development/issue-workflow.md`
+(§3 lifecycle metadata, §4 readiness, §6 Delivery, §10 remediation). Read the
+minimal needed section for the current phase; do not duplicate lifecycle prose
+in this Skill.
+
 Use the current repository Runner interfaces:
 
 ```bash
@@ -99,20 +104,11 @@ maintainer authorization.
 
 ## Lifecycle state
 
-Keep Codex labels separate from Project `Status`:
-
-| State | Codex label | Project Status |
-| --- | --- | --- |
-| specification incomplete | `codex:needs-spec` | `Inbox` / `Specifying` |
-| ready | `codex:ready` | `Ready` |
-| implementation active | `codex:ready` | `In Progress` |
-| PR or review active | `codex:ready` | `Review` |
-| blocked | `codex:blocked` | `Blocked` |
-| verified post-merge | `codex:ready` | `Done` |
-
-Implementation requires an open Task, `Ready` or `In Progress`,
-`codex:ready`, no `codex:blocked`, and this invocation. Stop before a state
-write if actual Project options differ.
+The label / Project `Status` mapping and readiness conditions are defined in
+`docs/development/issue-workflow.md` §3–§4; do not re-derive the table here.
+Implementation requires an open Task, `Ready` or `In Progress`, `codex:ready`,
+no `codex:blocked`, and this invocation. Stop before a state write if actual
+Project options differ.
 
 `codex:ready` and `codex:needs-spec` are mutually exclusive lifecycle labels.
 Their coexistence is a lifecycle conflict that fails Preflight; do not proceed.

--- a/.agents/skills/task-pr-review-runner/SKILL.md
+++ b/.agents/skills/task-pr-review-runner/SKILL.md
@@ -13,7 +13,8 @@ push, or PR creation. Otherwise stop with:
 本会话不能提供独立审查
 ```
 
-A Delivery handoff locates the object but is not correctness evidence.
+A Delivery handoff locates the object but is not correctness evidence
+(no-verdict-inheritance, `docs/development/pr-review.md` §1).
 
 ## Standard invocation
 
@@ -38,6 +39,11 @@ Read applicable agent rules and:
 .agents/policies/command-execution.md
 .agents/policies/workflow-evidence.md
 ```
+
+Shared review semantics (fresh session, head lock, independent judgement,
+verdict semantics, remediation handoff) are owned by
+`docs/development/pr-review.md`. Read the minimal needed section for the
+current phase; do not duplicate review-semantic prose in this Skill.
 
 Use the current repository Runner interfaces in this order:
 

--- a/.agents/skills/task-pr-review-runner/SKILL.md
+++ b/.agents/skills/task-pr-review-runner/SKILL.md
@@ -260,82 +260,50 @@ independent session. Evaluate check/thread-only changes under current gates.
 Verify the recheck uses the same Skill identity as the initial review (same
 `--skill-path`). Skill identity drift invalidates the review.
 
-## Evidence status to verdict matrix
+## Evidence status and verdict mapping
 
 The Evidence Runner produces a process exit code and a `status` field
-(`pass`, `partial`, `fail`). Process success (exit code 0) is not gate pass.
-The Reviewer must read the `status` field and map it deterministically.
+(`pass`, `partial`, `fail`). Process success (exit code 0) is not gate pass:
+read the `status` field and map it deterministically.
 
-### Deterministic mapping
+Verdict conditions and the full mapping from evidence status, objective
+gates, and findings to PASS / CONDITIONAL / FAIL are authoritative in
+`docs/development/pr-review.md` §8. Read §8 when reaching a verdict; do not
+re-derive the mapping here.
 
-| Evidence `status` | Permitted verdict ceiling | Constraints |
-| --- | --- | --- |
-| `pass` | Pass | Only when all other gates also pass. |
-| `partial` (any cause) | Conditional pass — do not merge | Never upgrades to unconditional pass. |
-| `unknown` (plan-limit `403`) | Conditional pass — do not merge | Unless a formally committed fallback policy exists. |
-| `unknown` (other cause) | Review incomplete / failing | Insufficient evidence. |
-| `fail` | Review incomplete / failing | Cannot pass. |
-| Identity drift | Review incomplete / failing | Review identity compromised. |
-| Unsupported schema | Review incomplete / failing | Cannot evaluate. |
-| Lifecycle conflict | Review incomplete / failing | Cannot proceed. |
-
-### Plan-limit 403 — default disposition
-
-```text
-required_checks_configuration = unknown
-reason = github-plan-limit-403
-```
-
-**Default**: `Conditional pass — do not merge`.
-
-The Reviewer must not self-approve a fallback. Only apply a fallback when the
-repository has a formally committed, version-controlled policy that explicitly
-authorizes it, defines conditions and evidence burden deterministically, and
-the current evidence satisfies every condition.
-
-The fact that the `quality` check succeeded is not sufficient to prove the
-required-check configuration.
-
-### Recheck partial
-
-A `recheck` that returns `partial` keeps the evidence ceiling at Conditional.
-A `recheck` that returns `fail` or detects diff drift invalidates the review.
+Plan-limit `403` (`required_checks_configuration = unknown`) defaults to
+`Conditional pass — do not merge`; never self-approve a fallback without a
+formally committed capability-limited policy (pr-review.md §8). A `recheck`
+that returns `fail` or detects diff drift invalidates the review.
 
 ## Findings and verdicts
 
 Use exactly: Blocking, High, Medium, Low, and Nit. Cite precise files/lines, Task
 clauses, state, or validation evidence. Any unresolved Blocking/High/Medium
-finding prevents pass.
+finding prevents pass (pr-review.md §8).
 
-Output exactly one:
+Output exactly one verdict; the verdict conditions and severity-to-verdict
+mapping are authoritative in `docs/development/pr-review.md` §8:
 
 ```text
 通过，可以人工合并
 ```
 
-Only when all of: semantic review complete, acceptance criteria verified,
-no Blocking/High/Medium findings, all evidence gates pass, no identity drift.
-
 ```text
 有条件通过，不得合并
 ```
-
-When no Blocking/High/Medium code defect exists but an objective gate is
-`partial` or `unknown` under the plan-limit 403 default.
 
 ```text
 不通过，需要修复
 ```
 
-When a Blocking/High/Medium finding remains, scope/acceptance/validation fails,
-semantic review is incomplete, or identity/permission/safety boundaries fail.
+Minimal summary — apply the authoritative verdict mapping from pr-review.md
+§8: PASS is the only mergeable state; CONDITIONAL is never mergeable;
+incomplete evidence or an incomplete evidence matrix cannot produce PASS.
 
-### Verdict rules
-
-- No unconditional pass when any evidence gate is `partial`, `unknown`, or `fail`.
-- No unconditional pass when evidence matrix has `not_verified` groups or criteria.
-- Incomplete evidence matrix → ceiling is `不通过`.
-- Incomplete semantic review → do not claim "no Medium-or-above findings".
+Head change during review is review invalidation, not a verdict:
+`REVIEW INVALIDATED — HEAD CHANGED` (pr-review.md §8). The Reviewer never
+merges.
 
 ## Remediation handoff
 
@@ -362,7 +330,8 @@ Maintainer decision required:
 
 Rules:
 
-- include only findings that caused the non-passing verdict;
+- include only findings that caused the non-passing verdict; the bounded
+  handoff semantics are authoritative in `docs/development/pr-review.md` §9;
 - include objective gates that require recheck or waiting;
 - include decisions that cannot be resolved without maintainer authorization;
 - exclude Low and Nit findings unless the maintainer explicitly made them

--- a/.claude/skills/feature-completion-audit/SKILL.md
+++ b/.claude/skills/feature-completion-audit/SKILL.md
@@ -51,6 +51,10 @@ Read applicable `AGENTS.md` / `AGENTS.override.md` and:
 .agents/policies/workflow-evidence.md
 ```
 
+Shared lifecycle semantics are owned by `docs/development/issue-workflow.md`
+(§14 Feature Completion). Read the minimal needed section for the current
+phase; do not duplicate audit-semantic prose in this Skill.
+
 Audit the exact locked `origin/main` implementation and current Feature facts.
 Use the repository-defined operations:
 

--- a/.claude/skills/task-closeout/SKILL.md
+++ b/.claude/skills/task-closeout/SKILL.md
@@ -34,6 +34,11 @@ Read applicable `AGENTS.md` / `AGENTS.override.md` and:
 .agents/policies/workflow-evidence.md
 ```
 
+Shared lifecycle semantics are owned by `docs/development/issue-workflow.md`
+(§11 manual Squash Merge boundary, §13 Closeout). Read the minimal needed
+section for the current phase; do not duplicate closeout-semantic prose in this
+Skill.
+
 Use the current repository Runner interfaces:
 
 ```bash

--- a/.claude/skills/task-delivery-runner/SKILL.md
+++ b/.claude/skills/task-delivery-runner/SKILL.md
@@ -46,6 +46,11 @@ Read applicable `AGENTS.md` / `AGENTS.override.md` and:
 .agents/policies/workflow-evidence.md
 ```
 
+Shared lifecycle semantics are owned by `docs/development/issue-workflow.md`
+(§3 lifecycle metadata, §4 readiness, §6 Delivery, §10 remediation). Read the
+minimal needed section for the current phase; do not duplicate lifecycle prose
+in this Skill.
+
 Use the current repository Runner interfaces:
 
 ```bash
@@ -157,20 +162,11 @@ maintainer authorization.
 
 ## Lifecycle state
 
-Keep lifecycle labels separate from Project `Status`:
-
-| State | Codex label | Project Status |
-| --- | --- | --- |
-| specification incomplete | `codex:needs-spec` | `Inbox` / `Specifying` |
-| ready | `codex:ready` | `Ready` |
-| implementation active | `codex:ready` | `In Progress` |
-| PR or review active | `codex:ready` | `Review` |
-| blocked | `codex:blocked` | `Blocked` |
-| verified post-merge | `codex:ready` | `Done` |
-
-Implementation requires an open Task, `Ready` or `In Progress`,
-`codex:ready`, no `codex:blocked`, and this invocation. Stop before a state
-write if actual Project options differ.
+The label / Project `Status` mapping and readiness conditions are defined in
+`docs/development/issue-workflow.md` §3–§4; do not re-derive the table here.
+Implementation requires an open Task, `Ready` or `In Progress`, `codex:ready`,
+no `codex:blocked`, and this invocation. Stop before a state write if actual
+Project options differ.
 
 `codex:ready` and `codex:needs-spec` are mutually exclusive lifecycle labels.
 Their coexistence is a lifecycle conflict that fails Preflight; do not proceed.

--- a/.claude/skills/task-pr-review-runner/SKILL.md
+++ b/.claude/skills/task-pr-review-runner/SKILL.md
@@ -13,7 +13,8 @@ push, or PR creation. Otherwise stop with:
 本会话不能提供独立审查
 ```
 
-A Delivery handoff locates the object but is not correctness evidence.
+A Delivery handoff locates the object but is not correctness evidence
+(no-verdict-inheritance, `docs/development/pr-review.md` §1).
 
 ## Standard invocation
 
@@ -39,6 +40,11 @@ Read applicable `AGENTS.md` / `AGENTS.override.md` and:
 ```text
 .agents/policies/workflow-evidence.md
 ```
+
+Shared review semantics (fresh session, head lock, independent judgement,
+verdict semantics, remediation handoff) are owned by
+`docs/development/pr-review.md`. Read the minimal needed section for the
+current phase; do not duplicate review-semantic prose in this Skill.
 
 Use the current repository Runner interfaces in this order:
 

--- a/.claude/skills/task-pr-review-runner/SKILL.md
+++ b/.claude/skills/task-pr-review-runner/SKILL.md
@@ -313,106 +313,51 @@ independent session. Evaluate check/thread-only changes under current gates.
 Verify the recheck uses the same Skill identity as the initial review (same
 `--skill-path`). Skill identity drift invalidates the review.
 
-## Evidence status to verdict matrix
+## Evidence status and verdict mapping
 
 The Evidence Runner produces a **process** exit code (0, 3, 4) and a **status**
 field in the output (`pass`, `partial`, `fail`). Process success (exit code 0)
-is not gate pass. The Reviewer must read the `status` field and map it
-deterministically.
+is not gate pass: read the `status` field and map it deterministically.
 
-### Deterministic mapping
+Verdict conditions and the full mapping from evidence status, objective
+gates, and findings to PASS / CONDITIONAL / FAIL are authoritative in
+`docs/development/pr-review.md` §8. Read §8 when reaching a verdict; do not
+re-derive the mapping here.
 
-| Evidence `status` | Permitted verdict ceiling | Constraints |
-| --- | --- | --- |
-| `pass` | Pass | Only when semantic review, acceptance criteria, check runs, threads, stability, and Skill identity are also satisfied. |
-| `partial` (any cause) | Conditional pass — do not merge | `partial` **never** upgrades to an unconditional pass. Even when the unreachable gate is a plan-limit `403`, the ceiling is Conditional. |
-| `unknown` (plan-limit `403`) | Conditional pass — do not merge | Unless the repository has a formally committed capability-limited fallback policy that defines exact conditions, evidence burden, and verdict, `required_checks_configuration = unknown` + `reason = github-plan-limit-403` *cannot* be auto-passed. |
-| `unknown` (other cause) | Review incomplete / failing | Treat as insufficient evidence. |
-| `fail` | Review incomplete / failing | Cannot pass. |
-| Identity drift | Review incomplete / failing | Review identity is compromised. |
-| Unsupported schema | Review incomplete / failing | Cannot evaluate. |
-| Lifecycle conflict | Review incomplete / failing | Cannot proceed. |
-
-### Plan-limit 403 — default disposition
-
-```text
-required_checks_configuration = unknown
-reason = github-plan-limit-403
-```
-
-**Default**: `Conditional pass — do not merge`.
-
-The Reviewer **must not** self-approve a fallback. Only apply a fallback when:
-
-1. The repository has a formally committed, version-controlled policy that
-   explicitly authorizes it;
-2. The fallback conditions, evidence burden, and verdict outcome are
-   deterministically defined in that policy;
-3. The current evidence satisfies every condition;
-4. The final report clearly states the fallback source, its remaining
-   limitations, and why the evidence meets the policy.
-
-The fact that the `quality` check succeeded is not sufficient to prove the
-required-check configuration. The Reviewer must not infer it.
-
-### Recheck partial
-
-A `recheck` that returns `partial` (for any reason) keeps the evidence ceiling
-at Conditional — the same as the initial snapshot's `partial`. A `recheck`
-that returns `fail` or detects diff drift invalidates the review entirely.
+Plan-limit `403` (`required_checks_configuration = unknown`) defaults to
+`Conditional pass — do not merge`; never self-approve a fallback without a
+formally committed capability-limited policy (pr-review.md §8). A `recheck`
+that returns `fail` or detects diff drift invalidates the review; a `recheck`
+`partial` keeps the evidence ceiling at Conditional.
 
 ## Findings and verdicts
 
 Use exactly: Blocking, High, Medium, Low, and Nit. Cite precise files/lines, Task
 clauses, state, or validation evidence. Any unresolved Blocking/High/Medium
-finding prevents pass.
+finding prevents pass (pr-review.md §8).
 
-Output exactly one:
+Output exactly one verdict; the verdict conditions and severity-to-verdict
+mapping are authoritative in `docs/development/pr-review.md` §8:
 
 ```text
 通过，可以人工合并
 ```
 
-Only when **all** of:
-
-- Semantic review is complete (every changed file in a group, every group
-  reviewed);
-- All acceptance criteria are `verified` (or a formally committed policy
-  documents a permitted non-blocking exception);
-- No Blocking, High, or Medium findings remain;
-- Review Evidence gate = `pass`;
-- Validation gate = `pass`;
-- Recheck gate = `pass`;
-- No identity drift, no schema mismatch, no lifecycle conflict.
-
 ```text
 有条件通过，不得合并
 ```
-
-When semantic review is complete, no Blocking/High/Medium code defect exists,
-but an objective evidence gate is `partial` or `unknown` under the plan-limit
-403 default (or another capability-limited gap with no formal fallback).
 
 ```text
 不通过，需要修复
 ```
 
-When a Blocking/High/Medium finding remains, scope/acceptance is wrong,
-validation fails, semantic review is incomplete, or identity/permission/safety
-boundaries fail.
+Minimal summary — apply the authoritative verdict mapping from pr-review.md
+§8: PASS is the only mergeable state; CONDITIONAL is never mergeable;
+incomplete evidence or an incomplete evidence matrix cannot produce PASS.
 
-### Verdict rules
-
-- A verdict of `通过，可以人工合并` must not be issued when any evidence gate
-  is `partial`, `unknown`, or `fail`.
-- A verdict of `通过，可以人工合并` must not be issued when the semantic review
-  evidence matrix has any `not_verified` group or criterion.
-- If the evidence matrix is incomplete at verdict time (missing groups,
-  unassigned files, or unmapped criteria), the verdict ceiling is
-  `不通过，需要修复`.
-- The Reviewer must not report "no Medium-or-above findings" when the semantic
-  review was incomplete — only "no Medium-or-above findings in the scope
-  reviewed" is permitted.
+Head change during review is review invalidation, not a verdict:
+`REVIEW INVALIDATED — HEAD CHANGED` (pr-review.md §8). The Reviewer never
+merges.
 
 ## Remediation handoff
 
@@ -439,7 +384,8 @@ Maintainer decision required:
 
 Rules:
 
-- include only findings that caused the non-passing verdict;
+- include only findings that caused the non-passing verdict; the bounded
+  handoff semantics are authoritative in `docs/development/pr-review.md` §9;
 - include objective gates that require recheck or waiting;
 - include decisions that cannot be resolved without maintainer authorization;
 - exclude Low and Nit findings unless the maintainer explicitly made them

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,76 +150,85 @@ implementation / validation evidence. The leaf-Issue-first default does not
 apply to it. It must still limit acquisition to the hierarchy, state, and
 evidence the audit needs — not historical comments, unrelated docs / ADRs,
 the roadmap, sibling Feature history, or general workflow reports.
+## Natural-language workflow entry
 
-When the user explicitly invokes `task-delivery-runner`, first read
-`.agents/skills/task-delivery-runner/SKILL.md`. When the user explicitly invokes
-`task-pr-review-runner`, first read
-`.agents/skills/task-pr-review-runner/SKILL.md`.
+Workflow Skills start only after the user identifies an existing Task, Task PR,
+or Feature. They do not identify, split, plan, draft, choose, or create new
+Tasks. No workflow Skill may merge a Pull Request.
+
+Maintainers can start a workflow with Agent-neutral natural language:
+
+- `实现 Issue #N` → Delivery (readiness, implementation, PR, review handoff)
+- `审查 PR #N` → Independent Review (fresh session, read-only)
+- `PR #N 已人工合并，请完成 closeout` → Closeout (merge identity, convergence)
+- Feature completion audit request → `feature-completion-audit` (hierarchy-aware)
+
+Entry resolution contract and lifecycle semantics:
+`docs/development/issue-workflow.md` — read only the minimum relevant section.
+Independent Review shared semantics: `docs/development/pr-review.md`.
+
+Explicit Skill-name fallback (maintenance windows and edge cases): invoke
+`task-delivery-runner`, `task-pr-review-runner`, `task-closeout`, or
+`feature-completion-audit` by name (Codex: `.agents/skills/`, Claude:
+`.claude/skills/`).
 
 Historical `.agents/skills/task-delivery/SKILL.md` and
 `.agents/skills/task-pr-review/SKILL.md` are retained only as explicit benchmark
 baselines. Never select, combine, or fall back to them unless the maintainer
 names that exact Skill.
 
-When the user states that a Pull Request was manually merged and requests
-post-merge verification, state convergence, validation, or Task-branch cleanup,
-first read `.agents/skills/task-closeout/SKILL.md`.
-
-When the user requests an independent read-only completion audit of a specified
-open GitHub Feature before maintainer closeout, first read
-`.agents/skills/feature-completion-audit/SKILL.md`.
-
-Workflow Skills start only after the user identifies an existing Task, Task PR,
-or Feature. They do not identify, split, plan, draft, choose, or create new
-Tasks. No workflow Skill may merge a Pull Request.
-
-Independent PR Review must run in a fresh session that did not participate in
-implementation or remediation of the reviewed head. It is strictly read-only,
-does not submit a GitHub Review, does not fix findings, does not change
-Issue/PR/Project state, and does not merge. A non-passing Review may emit a
-bounded remediation handoff for `task-delivery-runner`; any new commit requires
-a new independent Review session.
-
 When the user provides both a number and title, treat the number as the primary
 key and the current GitHub title as canonical. Stop before writes when they
 clearly identify different work.
 
-A final merge decision requires a passing `task-pr-review-runner` result for the
-current PR head, followed by maintainer manual merge.
+## Independent Review
 
-Before a repository workflow Skill executes a command, it must read
-`.agents/policies/command-execution.md` and may read the optional ignored
-`.agents/execution-profile.local.toml`. The local profile selects an execution
-context only after the active Skill authorizes a command; it never expands
-workflow permissions.
+Independent PR Review runs in a fresh session that did not participate in
+implementation or remediation of the reviewed head. It is strictly read-only,
+does not submit a GitHub Review, does not fix findings, and never merges. A
+non-passing Review emits a bounded remediation handoff for the Delivery Skill;
+any new commit requires a fresh independent Review session. Detailed shared
+semantics: `docs/development/pr-review.md`.
 
-The repository does not run Task workflow Token telemetry. Token analysis is
-performed outside this repository from Codex rollout logs and maintainer-supplied
-Task metadata. Raw rollout logs and external Token reports must not be committed.
-External analysis never changes permissions, gates, findings, verdicts, Merge
-authorization, or completion evidence.
+A final merge decision requires a passing Review for the current PR head,
+followed by maintainer manual merge.
+
+## Policies and evidence
 
 Deterministic workflow facts and compact validation are governed by
-`.agents/policies/workflow-evidence.md`. Runner Skills use the current repository
-front doors:
+`.agents/policies/workflow-evidence.md`; workflow command execution by
+`.agents/policies/command-execution.md`. Runner front doors:
 
 ```text
 tools/agent_workflow/wsl2_github_evidence_runner.py
 tools/agent_workflow/wsl2_validation_runner.py
 ```
 
-The executed Skill, Runner, profile/schema, repository head, and content hashes
-are recorded for reproducibility. Workflow object identities remain locked as
-required: Task base, PR base/head/effective diff, audited main, and merge SHA.
-There is no requirement to load a Skill or Runner from `main`, a PR base, or
-another commit.
-
-Local evidence and validation artifacts remain in exact ignored
+Local evidence and validation artifacts stay in the exact ignored
 `.agents/evidence.local/` and `.agents/validation.local/` directories.
 
-This root `AGENTS.md` remains the repository-level rule source. Repository Skills
-supplement these rules and do not override system, developer, user, or more
-specific scoped instructions.
+The repository does not run Task workflow Token telemetry. Token analysis is
+performed outside this repository from Codex rollout logs and
+maintainer-supplied Task metadata. Raw rollout logs and external Token reports
+are never committed; external analysis never changes permissions, gates,
+findings, verdicts, Merge authorization, or completion evidence.
+
+## Source-of-truth principle
+
+Normative / semantic authority and mechanical / factual authority are separate
+layers. Current GitHub / Git / CI / Runner facts — Issue state, labels, Project
+Status, Parent, blocked-by / blocking, PR identity, base / head SHA, review
+head, merge identity, checks — are mechanical evidence: they can invalidate
+stale textual assumptions and trigger fail closed / Human Gate, but they are
+not business specification. The current leaf Issue body is the current
+work-item business specification and never overrides system / platform
+constraints, maintainer constraints, safety, repository hard invariants, or
+active durable architecture decisions. Full model:
+`docs/development/issue-workflow.md`.
+
+This root `AGENTS.md` remains the repository-level rule source. Repository
+Skills supplement these rules and do not override system, developer, user, or
+more specific scoped instructions.
 
 ## Implementation rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,10 @@ The `AGENTS.md` file at the repo root is the primary behavior rule source: it de
 
 ## Commands
 
+`README.md` is the shared canonical repository guide (layout, commands, CI).
+The commands below are the Claude-side quick reference; keep them in sync with
+README and do not maintain a second complete copy.
+
 ```bash
 # Install dependencies (requires Python 3.13 and uv)
 uv sync --locked --dev
@@ -90,14 +94,10 @@ All internal datetimes must be timezone-aware UTC. Naive datetimes are explicitl
 
 ### Agent workflow tools (`tools/agent_workflow/`)
 
-Deterministic runner scripts for workflow evidence and validation:
-
-- `wsl2_github_evidence_runner.py` — captures read-only GitHub/Task/PR snapshots with content hashes
-- `wsl2_validation_runner.py` — compact validation profiles with exact argv and process cleanup
-- `workflow_common.py` — shared helpers: `CommandRunner`, JSON utilities, SHA hashing, path redaction, secret redaction
-- `workflow_evidence.py` / `workflow_validation.py` — evidence and validation domain logic
-
-Local outputs go only to Git-ignored `.agents/evidence.local/` and `.agents/validation.local/`.
+Deterministic runner scripts for workflow evidence and validation; see
+`.agents/policies/workflow-evidence.md` for the authoritative evidence /
+validation contract. Local outputs go only to Git-ignored
+`.agents/evidence.local/` and `.agents/validation.local/`.
 
 ### Claude Code skills (`.claude/skills/`)
 
@@ -110,7 +110,7 @@ Claude Code 专用的四个 Skill，与 `.agents/skills/` 中 Codex 的对应 Sk
 | `task-closeout` | Post-merge verification, state convergence, and Task-branch cleanup |
 | `feature-completion-audit` | Read-only audit of an open Feature against current main |
 
-Skills start only after the user identifies an existing Task, PR, or Feature. None may merge a PR.
+Skills start only after the user identifies an existing Task, PR, or Feature. None may merge a PR. Natural-language entries (`实现 Issue #N` / `审查 PR #N` / `PR #N 已人工合并，请完成 closeout`) resolve through `AGENTS.md` routing and `docs/development/issue-workflow.md`; this table is the Claude-side Skill discovery reference.
 
 ### Permissions (`.claude/settings.json`)
 
@@ -146,5 +146,6 @@ Prohibited without an approved architecture Issue: microservices, Kubernetes, di
 All work is tracked in GitHub Issues (the `PhoenixSss/tracequant` repo). The
 issue-driven workflow, leaf-Issue-first context acquisition, expansion
 triggers, and comments / Parent / Epic policies are defined in `AGENTS.md`
-and apply unchanged to Claude Code sessions. Current work scope is read from
+and apply unchanged to Claude Code sessions; detailed lifecycle semantics
+live in `docs/development/issue-workflow.md`. Current work scope is read from
 the active GitHub Issue and Project state, not from this file.

--- a/docs/development/issue-workflow.md
+++ b/docs/development/issue-workflow.md
@@ -234,6 +234,23 @@ mechanical facts 可以使 stale textual assumption 失效，并触发
 fail-closed / Human Gate；但 **不得成为 business specification**，
 不得覆盖 current Issue requirement。
 
+### Workflow identity locking
+
+与当前 phase 相关的 workflow object identity 必须锁定并验证：Task / Issue
+identity、PR base、PR head、effective diff、reviewed head、audited main、
+merge SHA 等。这些 identity 在要求稳定的 phase 中发生变化时，必须
+invalidation / fail closed / Human Gate，不得静默继续。
+
+### Skill / Runner version is not itself a workflow gate
+
+除非 current Task、repository hard rule 或 approved workflow policy 明确
+要求，否则不要求为了执行 workflow 将 Skill / Runner 强制从 `main`、PR base
+或特定 trusted commit 重新加载。当前 worktree 中适用的 active Skill / Runner
+可以作为执行工具；workflow correctness 由 locked workflow object
+identities + current canonical specification + deterministic evidence 保证。
+不重新引入 trusted Skill、main-only Skill、Skill hash as workflow state 等
+已明确不采用的旧设计。
+
 `AGENTS.md` 只保留 fresh Agent 必须知道的简洁原则；本文件承载完整模型。
 
 ## 16. 与其它 instruction 的关系

--- a/docs/development/issue-workflow.md
+++ b/docs/development/issue-workflow.md
@@ -1,0 +1,248 @@
+# Issue Workflow（Agent-neutral Lifecycle Specification）
+
+本文件是 TraceQuant Agent-neutral Issue lifecycle 的 **shared semantic owner**：
+Issue 从建立到完成的所有 shared lifecycle semantics（readiness、Delivery、
+PR/CI、Independent Review 引用、Human Gate、Closeout、Feature completion、
+natural-language entry resolution、source-of-truth 模型、failure/ambiguity
+handling）由本文件权威定义。
+
+Codex 与 Claude Code 的 workflow Skills 引用本文件作为生命周期语义来源，
+各自保留 agent-specific executable procedure。本文件不复制 Retrieval v2 规则
+（其 authoritative owner 是根目录 `AGENTS.md`）。
+
+> **共享文档读取纪律**：shared document 的存在 ≠ 每次全文加载。
+> Skill / Agent 应按 current intent / phase 读取本文件最小必要 section，
+> 评估充分性后再按需扩展。Delivery 不应因本文件存在而默认加载
+> Review / Closeout / Feature Completion 全部章节。
+
+## 1. Lifecycle overview
+
+```text
+Issue (Specifying)
+  → Ready（codex:ready + Project Ready + 无 blocker）
+  → Delivery（branch → implementation/tests → commit/push → PR）
+  → CI checks
+  → Independent Review（fresh session，read-only）
+  → maintainer manual Squash Merge
+  → Closeout（merge identity / state convergence / branch cleanup）
+  → Feature completion（hierarchy-aware audit）
+```
+
+GitHub Issue、Parent/Sub-issues、blocked-by/blocking、Pull Request、Project
+Status 与 labels 是 durable workflow state 的载体；本文件定义其语义，
+GitHub native metadata 是其机械事实。
+
+## 2. Issue specification ownership
+
+- Issue 正文的 authoring 规则与信息所有权由 `docs/development/issue-authoring.md`
+  （Issue Specification v2）权威定义。
+- 本文件不重复 authoring 规则；specification 编写 / 修订时按需引用
+  `issue-authoring.md`。
+- 当前 leaf Issue body 是 current work-item business specification
+  （见 §15 Source-of-truth authority model）。
+
+## 3. Lifecycle metadata ownership
+
+| Metadata | Owner | 说明 |
+|---|---|---|
+| Issue body | issue-authoring.md（authoring 规则）+ maintainer | body 是 canonical specification |
+| type/area labels | maintainer / issue-authoring | issue type 语义 |
+| `codex:ready` / `codex:blocked` / `codex:needs-spec` | lifecycle 状态标签，本文件定义语义 | ready = 可实施；blocked = 不得实施；needs-spec = 规格不完整 |
+| Project Status（Inbox/Specifying/Ready/In Progress/Review/Blocked/Done） | lifecycle 状态，与 labels 配合 | 本文件定义含义；Runner 提供机械事实 |
+| Parent / Sub-issues / blocked-by / blocking | GitHub native metadata | 不在正文重复机械 metadata |
+| PR / merge identity | GitHub native（Squash Merge） | closeout 验证对象 |
+
+不得在 Issue 正文重复维护与 native relationship 等价的机械 metadata。
+
+## 4. Readiness
+
+一个 Task 满足以下条件才可开始 Delivery：
+
+- `codex:ready` label 存在且无 `codex:blocked`；
+- Project Status = Ready（或等效 lifecycle 状态）；
+- 无未解决的 blocked-by；
+- body 具有完整 Objective / Requirements / Acceptance Criteria / Non-goals；
+- 无 Human Gate 未决事项。
+
+readiness 由 deterministic Runner 快照验证（机械事实），
+不由模型对全文的解读决定。
+
+## 5. Natural-language entry resolution
+
+维护者可使用以下 Agent-neutral 自然语言入口，无需知道内部 Skill 名称。
+详细解析契约：
+
+### `实现 Issue #N`
+
+- intent = **Delivery**
+- 解析：target Issue → readiness 验证 → shared Delivery lifecycle semantics
+  （§6）→ 正确 Delivery Skill（Codex: `.agents/skills/task-delivery-runner/`；
+  Claude: `.claude/skills/task-delivery-runner/`）→ 需要时 deterministic Runner。
+- 不要求维护者提供内部 Skill 名称。
+
+### `审查 PR #N`
+
+- intent = **Independent Review**
+- 解析：target PR → fresh-session expectation → read-only independent review
+  → head lock → 当前 Task specification + effective diff →
+  no Delivery verdict inheritance。shared semantics 见
+  `docs/development/pr-review.md`；执行 Skill：`task-pr-review-runner`
+  （Codex: `.agents/skills/task-pr-review-runner/`；
+  Claude: `.claude/skills/task-pr-review-runner/`）。
+
+### `PR #N 已人工合并，请完成 closeout`
+
+- intent = **Closeout**
+- 解析：merge identity 验证 → reviewed head == merged head →
+  Issue / Project lifecycle convergence → canonical main 同步 →
+  branch lifecycle → post-merge validation。执行 Skill：`task-closeout`
+  （Codex: `.agents/skills/task-closeout/`；Claude: `.claude/skills/task-closeout/`）。
+
+### Feature completion
+
+维护者请求对指定 open Feature 执行独立只读 completion audit 时：
+intent = **Feature Completion Audit**，执行 Skill：`feature-completion-audit`
+（Codex: `.agents/skills/feature-completion-audit/`；
+Claude: `.claude/skills/feature-completion-audit/`；
+hierarchy-aware exception，见 `AGENTS.md`）。
+
+### 解析失败 / 歧义
+
+intent 无法可靠解析时：**不要猜**。回退到 explicit Skill-name fallback，
+或进入 Human Gate（§12）。
+
+## 6. Delivery semantics
+
+- 一次 Delivery 覆盖：readiness → branch → implementation → tests →
+  targeted validation → commit → push → PR → CI checks → delivery readiness →
+  handoff for Independent Review。
+- 一个 Task 通常产生一个 PR（base = `main`）。
+- 实现只处理当前 leaf Task；不进行无关重构。
+- 提交前必须完成 target validation；PR 创建前必须完成 delivery readiness
+  验证（Runner 快照）。
+- Human Gate 事项未决时不得继续 Delivery（§9）。
+- Delivery 不执行 Independent Review、不 merge、不 close Issue、不 closeout。
+
+## 7. PR / CI lifecycle
+
+- PR base = `main`，Squash-only merge policy 由 GitHub Ruleset 定义
+  （本文件不重定义）。
+- CI（`.github/workflows/ci.yml`）运行 pytest / ruff / mypy；required checks
+  由 Ruleset 强制。
+- PR 关联 `Closes #N` 仅当 maintainer 预期 merge 后 close。
+- merge 决策：passing Independent Review for current PR head
+  + maintainer manual Squash Merge。
+
+## 8. Independent Review
+
+shared semantics 由 `docs/development/pr-review.md` 权威定义：
+fresh session、strict read-only、head lock、independent judgement、
+no Delivery verdict inheritance、verdict semantics、remediation handoff、
+new head → fresh re-review。
+
+本文件只声明其在 lifecycle 中的位置：Review 在 CI checks 通过后、
+maintainer merge 前执行；review 未通过时进入 remediation（§10）。
+
+## 9. Human Gate
+
+以下情形必须 STOP 并进入显式 Human Gate（维护者批准前不得 repository
+write 或继续）：
+
+- Task body / Audit 揭示 target architecture 与当前 contract 重大冲突；
+- 实现必须扩大到 Non-goal（Runner 大改、Context Compiler、Ruleset 等）；
+- 规格歧义在 expansion trigger 顺序内无法解决；
+- fail-closed 条件触发且无法安全定位冲突源；
+- 维护者显式要求。
+
+Human Gate 批准默认在同一执行会话记录；跨会话恢复时维护者必须显式提供
+或指向已批准的 gate evidence。**不得**为寻找批准记录而默认读取全部
+Issue comments（Retrieval v2 comments default-off 仍适用）。
+
+## 10. Remediation after failed Review
+
+- Review 非 passing 时输出 bounded remediation handoff（仅包含修复所需
+  的最小信息）。
+- Delivery Skill 按 handoff 修复，产生 new head。
+- 任何新 commit 都需要 **fresh independent re-review**；不得复用旧 verdict。
+
+## 11. Manual Squash Merge boundary
+
+- 只有 maintainer 可以执行 Squash Merge。
+- 任何 workflow Skill / Agent 都不得 merge（包括自动 merge）。
+- merge 前必须存在当前 PR head 的 passing Independent Review。
+
+## 12. Failure / Ambiguity handling
+
+| 场景 | 行为 |
+|---|---|
+| Specification ambiguity | 按 expansion trigger 顺序展开 → 仍不 resolve → **Human Gate**，绝不猜测 |
+| Conflict（body / parent / ADR / 实现） | **fail closed**；无法安全定位 → Human Gate |
+| Missing dependency | native relationship / 最小相关源 → unresolved → Human Gate |
+| Review failure | bounded remediation handoff → new head → fresh re-review |
+| Head changed during Review | **invalidate review**，重新锁定后重审 |
+| Merge head ≠ reviewed head | **block closeout**，人工介入 |
+| NL entry 无法解析 | explicit Skill-name fallback / Human Gate |
+
+## 13. Closeout semantics
+
+Closeout 仅在 maintainer 已人工 Squash Merge 后执行：
+
+1. 验证 merge identity：reviewed head == 实际 merged head；
+2. Issue / Project lifecycle 收敛（state、Status、labels）；
+3. canonical `main` 同步与验证；
+4. branch lifecycle：仅删除已验证的 Task branch；
+5. post-merge validation。
+
+Closeout 不 repair 代码、不手动 close Issue、不清理无关 branch、
+不评估 Feature completion。
+
+## 14. Feature Completion
+
+Feature Completion Audit 是 hierarchy-aware exception（普通 leaf-Issue-first
+不适用于它）：读取 target Feature + 相关 child hierarchy + completion state +
+implementation/validation evidence，但保持有界（不读无关 comments / docs /
+roadmap）。verdict 供 maintainer closeout 决策使用。
+
+## 15. Source-of-truth authority model
+
+Normative / semantic authority 与 Mechanical / factual authority 是两层，
+不做单一线性排序：
+
+### Normative / semantic authority（自上而下）
+
+1. system / platform constraints（`.codex/rules`、`.claude/settings.json`、CI、Ruleset）
+2. maintainer explicit current instruction / approved Human Gate
+3. repository hard rules + active durable architecture decisions / ADR
+   （`AGENTS.md` hard sections、`docs/architecture/*`）
+4. current leaf Issue body —— **current work-item business specification**
+5. Agent-neutral workflow specification（本文件、`pr-review.md`）
+6. agent-specific executable Skill
+7. historical Issue comments / reports（默认不可见，显式 trigger 才读，
+   永不 override 4）
+
+current leaf Issue body 不得覆盖：system/platform、maintainer constraint、
+safety、repository hard invariant、active durable architecture decision。
+
+### Mechanical / factual authority
+
+current GitHub / Git / CI / deterministic Runner facts 对其事实域具有
+authority：Issue state、labels、Project Status、Parent、blocked-by/blocking、
+PR identity、base/head SHA、review head、merge identity、CI/check status、
+branch/main state。
+
+mechanical facts 可以使 stale textual assumption 失效，并触发
+fail-closed / Human Gate；但 **不得成为 business specification**，
+不得覆盖 current Issue requirement。
+
+`AGENTS.md` 只保留 fresh Agent 必须知道的简洁原则；本文件承载完整模型。
+
+## 16. 与其它 instruction 的关系
+
+- `AGENTS.md`：always-loaded control plane（hard rules、Retrieval v2、
+  routing 原则）。本文件是 AGENTS 中 lifecycle 细节的 on-demand 展开层。
+- `docs/development/pr-review.md`：Independent Review shared semantics。
+- `docs/development/issue-authoring.md`：Issue specification authoring。
+- `.agents/policies/*`：deterministic mechanics / evidence policy
+  （Runner 与证据的权威规则）。
+- Codex / Claude workflow Skills：各自 agent-specific executable procedure，
+  引用本文件相应 section（按需，非全文）。

--- a/docs/development/pr-review.md
+++ b/docs/development/pr-review.md
@@ -62,18 +62,46 @@ Review 的对象是 effective diff（base → head 的全部变更），而非�
 
 ## 8. Verdict semantics
 
-固定 verdict 集合：
+Review 输出**三态** verdict（与两套 `task-pr-review-runner` Skills 的
+executable contract 一致）：
 
-- **PASSING**：当前 head 满足 Task 的 Objective / Requirements /
-  Acceptance Criteria，无 blocker 级 findings。
-- **NON-PASSING**：存在必须修复的 findings；输出 bounded remediation
-  handoff（§9）。
-- 不产出「conditional pass」或模糊状态；每个 Review 只有一个最终 verdict。
+### 1. PASS / `通过，可以人工合并`
+
+只在 semantic review PASS、objective gates PASS、review identity / head
+stable 时允许。这是唯一允许进入 maintainer manual merge decision 的状态。
+
+### 2. CONDITIONAL / `有条件通过，不得合并`
+
+当 semantic review 本身无 BLOCKER / HIGH / MEDIUM finding，但一个或多个
+objective gate 为 `partial` / `unknown` / temporarily unverifiable，且不
+存在已证明的 semantic failure 或 identity drift 时使用。
+
+- CONDITIONAL ≠ semantic approval for merge；它仍然 **DO NOT MERGE**。
+- 必须先恢复 / 重新验证客观 gate。典型例子：remote-ref / GitHub network
+  verification 因瞬时网络故障变为 `partial`。
+
+### 3. FAIL / `不通过，需要修复`
+
+当存在 BLOCKER / HIGH / MEDIUM finding、identity / head / diff drift、
+required semantic requirement FAIL、或其他确定性 gate 明确 fail 时使用。
+
+CONDITIONAL 与 FAIL 都输出 bounded remediation handoff（§9）；
+每个 Review 只有一个最终 verdict。
+
+### Deterministic mapping principle
+
+- gate = `pass` + no blocking findings → **PASS**
+- gate = `partial` / `unknown` + no blocking findings + identity stable →
+  **CONDITIONAL — DO NOT MERGE**
+- semantic failure / gate `fail` / identity drift → **FAIL**（review invalid
+  as applicable）
+- head changed during review → **REVIEW INVALIDATED — HEAD CHANGED**
+  （是 review invalidation，不是普通 conditional pass）
 
 ## 9. Remediation handoff
 
-NON-PASSING Review 输出 bounded remediation handoff，仅包含 Delivery
-Skill 修复所需的最小信息：
+非 PASS 的 Review（CONDITIONAL / FAIL，见 §8）输出 bounded remediation
+handoff，仅包含 Delivery Skill 修复所需的最小信息：
 
 - findings（severity、位置、失败场景、最小修改方向）；
 - 当前锁定的 base/head；

--- a/docs/development/pr-review.md
+++ b/docs/development/pr-review.md
@@ -93,6 +93,12 @@ CONDITIONAL 与 FAIL 都输出 bounded remediation handoff（§9）；
 - gate = `pass` + no blocking findings → **PASS**
 - gate = `partial` / `unknown` + no blocking findings + identity stable →
   **CONDITIONAL — DO NOT MERGE**
+- `unknown` 因 plan-limit `403`：默认 **CONDITIONAL — DO NOT MERGE**。403
+  本身不等于 Required-Checks 查询成功；只有仓库存在正式版本化、明确授权、
+  并确定性定义条件与证据负担的 capability-limited fallback policy，且
+  当前证据满足全部条件时，才允许 upgrade 至 pass。
+- `unknown`（其他原因）/ unsupported schema / lifecycle conflict →
+  review incomplete / failing（证据不足，不产生 passing verdict）。
 - semantic failure / gate `fail` / identity drift → **FAIL**（review invalid
   as applicable）
 - head changed during review → **REVIEW INVALIDATED — HEAD CHANGED**

--- a/docs/development/pr-review.md
+++ b/docs/development/pr-review.md
@@ -1,0 +1,101 @@
+# PR Independent Review（Agent-neutral Review Semantics）
+
+本文件是 TraceQuant Independent PR Review 的 **shared semantic owner**：
+fresh-session、strict read-only、head lock、independent judgement、
+verdict semantics 与 remediation 规则由本文件权威定义，Codex / Claude 的
+`task-pr-review-runner` Skills 引用本文件，各自保留 agent-specific
+executable procedure（命令序列、权限行为、Runner argv 等）。
+
+> **读取纪律**：Review Skill 启动时按 intent 读取本文件最小必要 section；
+> 不因本文件存在而默认加载 Delivery / Closeout / Feature Completion 内容。
+
+## 1. Purpose / Independence
+
+- Review 是对一个 Task PR 的**独立**质量门禁：fresh session 中由未参与
+  该 head 实现或 remediation 的 session 执行。
+- Review 的结论基于 current Task specification + effective diff +
+  relevant code/tests/checks 的完整证据，不继承 Delivery 的 self-check
+  结论（no Delivery verdict inheritance）。
+- Review 不修复 findings、不改变 Issue/PR/Project state、不 merge。
+
+## 2. Fresh-session requirement
+
+Review 必须在 fresh session 执行：该 session 未参与 implementation 或
+remediation of the reviewed head。任何新 commit 后都必须由新的独立
+Review session 重新审查；不得复用旧 session 或旧 verdict。
+
+## 3. Strict read-only
+
+Review 对 repository / Issue / PR / Project 完全只读：不写文件、
+不修改 GitHub state、不提交 GitHub Review、不 merge。
+
+## 4. Review identity
+
+Review 锁定以下身份（确定性验证，非模型解读）：
+
+- target Task（number 为主键，current title 为 canonical）；
+- target PR（base / head SHA）；
+- 当前 Task specification（leaf body + 有效 spec）。
+
+## 5. Head lock
+
+- 必须锁定 reviewed head：base SHA / head SHA / effective diff 在审查期间
+  保持不变。
+- 审查期间 head 若发生变化：**invalidate review**；重新锁定后重审，
+  旧结论无效。
+- merge 时 merged head ≠ reviewed head：**block closeout**（见 §10）。
+
+## 6. Effective diff
+
+Review 的对象是 effective diff（base → head 的全部变更），而非部分 commit
+或摘要。必须完整阅读变更，并检查变更涉及的代码、测试、文档与相关调用方。
+
+## 7. Evidence expectations
+
+- 机械事实（Issue state、labels、Status、PR identity、checks、diff digest）
+  以 deterministic Runner 快照为准（.agents/policies/workflow-evidence.md）。
+- 语义证据（正确性、范围、验收覆盖）由 Review session 独立形成
+  evidence matrix：逐项对照 Acceptance Criteria、scope boundary、
+  相关代码与测试。
+- evidence status 与 verdict 的映射必须确定性：不完整证据不得产生
+  passing verdict。
+
+## 8. Verdict semantics
+
+固定 verdict 集合：
+
+- **PASSING**：当前 head 满足 Task 的 Objective / Requirements /
+  Acceptance Criteria，无 blocker 级 findings。
+- **NON-PASSING**：存在必须修复的 findings；输出 bounded remediation
+  handoff（§9）。
+- 不产出「conditional pass」或模糊状态；每个 Review 只有一个最终 verdict。
+
+## 9. Remediation handoff
+
+NON-PASSING Review 输出 bounded remediation handoff，仅包含 Delivery
+Skill 修复所需的最小信息：
+
+- findings（severity、位置、失败场景、最小修改方向）；
+- 当前锁定的 base/head；
+- 重新 review 的要求（new head → fresh re-review）。
+
+handoff 不得包含完整历史、无关 findings 或主观偏好。
+
+## 10. Merge / Closeout interaction
+
+- merge 前必须存在当前 PR head 的 passing Review + maintainer manual
+  Squash Merge。
+- merged head ≠ reviewed head → closeout 必须被阻塞，人工介入。
+- merge 后如需验证（closeout），由 closeout Skill 独立执行
+  （docs/development/issue-workflow.md §13）。
+
+## 11. Relationship to Skills and policies
+
+- shared semantics：本文件。
+- executable procedure：Codex `.agents/skills/task-pr-review-runner/`、
+  Claude `.claude/skills/task-pr-review-runner/`（含工具纪律、Runner argv、
+  权限行为）。
+- mechanical gates / evidence：`.agents/policies/workflow-evidence.md` +
+  `tools/agent_workflow/`。
+- `AGENTS.md` 仅保留必须 always-loaded 的 hard invariant（fresh independent
+  session、review independence、fail closed / head identity safety）。

--- a/docs/workflows/agent-skills.md
+++ b/docs/workflows/agent-skills.md
@@ -1,5 +1,11 @@
 # Agent Workflow Skills
 
+本文件是 Agent-neutral workflow Skills 的**注册表 / 导航 / 兼容性入口**：
+列出当前 Skills、历史基准、共享语义 owner 与验证入口。共享生命周期语义由
+`docs/development/issue-workflow.md`（lifecycle 规范）与
+`docs/development/pr-review.md`（Independent Review 规范）权威定义；
+本文件不再复制生命周期语义或执行 procedure。
+
 ## Skill 集合
 
 当前 Runner 工作流：
@@ -11,6 +17,15 @@
 .agents/skills/feature-completion-audit/SKILL.md
 ```
 
+Claude Code 对应 Skill：
+
+```text
+.claude/skills/task-delivery-runner/SKILL.md
+.claude/skills/task-pr-review-runner/SKILL.md
+.claude/skills/task-closeout/SKILL.md
+.claude/skills/feature-completion-audit/SKILL.md
+```
+
 历史基准，仅在维护者明确点名时使用：
 
 ```text
@@ -20,88 +35,25 @@
 
 不要在一个会话中组合历史基准与 Runner Skill。
 
-## Runner Delivery
+## 共享语义与导航
+
+- Agent-neutral lifecycle 规范：`docs/development/issue-workflow.md`
+  （readiness、Delivery、PR/CI、Independent Review 位置、Human Gate、
+  remediation、manual Squash Merge、Closeout、Feature Completion、
+  natural-language entry、source-of-truth 模型）。
+- Independent Review 规范：`docs/development/pr-review.md`
+  （fresh session、head lock、verdict semantics、remediation handoff）。
+- Issue specification authoring：`docs/development/issue-authoring.md`。
+- 自然语言入口（无需维护者提供内部 Skill 名称）：
 
 ```text
-请按 task-delivery-runner 完整处理
-[Task] <当前完整标题> #<Task编号>，
-直到 PR 准备好接受独立审查。
+实现 Issue #N
+审查 PR #N
+PR #N 已人工合并，请完成 closeout
 ```
 
-Delivery 负责 readiness、实现、targeted validation、提交、最终
-`workflow-delivery`、push、PR、checks、`delivery-readiness` 和独立 Review handoff。
-它不执行独立 Review、Merge、Issue close 或 Closeout。
-
-Skill 支持只执行一个指定 Phase。前置事实必须验证，完成后在指定边界停止。
-
-## Independent Review
-
-```text
-请使用 task-pr-review-runner，独立只读审查
-[Task] <当前完整标题> #<Task编号>
-对应的 PR #<PR编号>。
-
-Expected base SHA: <base SHA>
-Expected head SHA: <head SHA>
-```
-
-Review 必须在未参与实现/修复的新会话中运行，严格只读，锁定 base/head/effective
- diff，完整阅读变更，运行独立 `workflow-review` 和 recheck，输出一个固定 verdict：
-
-```text
-通过，可以人工合并
-有条件通过，不得合并
-不通过，需要修复
-```
-
-## Review remediation
-
-非通过 Review 输出 `Remediation handoff`。标准修复调用：
-
-```text
-请按 task-delivery-runner 修复
-[Task] <当前完整标题> #<Task编号>
-对应 PR #<PR编号> 的独立审查问题，
-并继续处理，直到 PR 再次准备好接受新的独立审查。
-
-Review remediation handoff:
-
-<粘贴 handoff>
-```
-
-Delivery 默认修复 Blocking/High/Medium。Low/Nit 仅在维护者明确要求时处理。客观
-pending/unavailable gate 只重查或等待；涉及 Task 范围、验收标准、公共行为或架构
-决策时停止等待维护者授权。新 head 必须由新的独立 Review 会话审查。
-
-## Manual Merge 与 Closeout
-
-Review 通过后，维护者核对当前 PR head 与 reviewed head，确认 checks 和 threads，
-在 GitHub 人工 Squash Merge。
-
-```text
-PR #<PR编号> 已由我人工 Squash Merge。
-
-请使用 task-closeout，完成
-[Task] <当前完整标题> #<Task编号>
-及 PR #<PR编号> 的合并后核验与分支清理。
-```
-
-Closeout 验证真实 Merge、自动 Issue closure、同步 main、post-merge validation、最终
-Project/label 状态，并只删除精确验证过的 Task branch。它不会 Merge 或手工关闭
-Issue。
-
-## Feature Completion Audit
-
-```text
-请使用 feature-completion-audit，独立只读审计
-[Feature] <当前完整标题> #<Feature编号>。
-
-Expected main SHA: <当前 main SHA>
-```
-
-Feature Audit 锁定 audited main、完整 direct-child set 和 Feature 内容，映射每项
-验收标准，审查 current-main integration/safety，运行验证与 recheck，输出一个固定
-结论。Feature closeout 仍由维护者人工执行。
+- 每个 Skill 保留自足的 executable procedure；生命周期语义按需从上述 shared
+  docs 读取最小必要 section。
 
 ## Runner 与证据
 
@@ -113,9 +65,6 @@ Feature Audit 锁定 audited main、完整 direct-child set 和 Feature 内容�
 docs/workflows/workflow-evidence.md
 ```
 
-当前 Skill/Runner 内容哈希用于复现，不形成来自 main/base 才可执行的版本门禁。
-业务对象 SHA 锁定、独立 Review 和人工 Merge 边界保持不变。
-
 本地 artifacts：
 
 ```text
@@ -123,7 +72,7 @@ docs/workflows/workflow-evidence.md
 .agents/validation.local/
 ```
 
-不得提交。Token 分析只在仓库外读取 Codex rollout JSONL。
+不得提交。
 
 ## Skill provenance 与对比入口
 

--- a/tests/tools/test_agent_neutral_workflow.py
+++ b/tests/tools/test_agent_neutral_workflow.py
@@ -1,0 +1,178 @@
+"""Focused validation for the Agent-neutral workflow / instruction architecture.
+
+Task #120: shared semantic owner docs (docs/development/issue-workflow.md,
+docs/development/pr-review.md), natural-language routing, dual-layer
+source-of-truth model, and Codex / Claude skill semantic parity.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).parents[2]
+
+PATH_AUDIT = ROOT / "tools/agent_workflow/skill_path_audit.py"
+
+ISSUE_WORKFLOW = ROOT / "docs/development/issue-workflow.md"
+PR_REVIEW = ROOT / "docs/development/pr-review.md"
+AGENTS = ROOT / "AGENTS.md"
+CLAUDE_MD = ROOT / "CLAUDE.md"
+AGENT_SKILLS_GUIDE = ROOT / "docs/workflows/agent-skills.md"
+
+ACTIVE_SKILL_ROOTS = (
+    ROOT / ".agents" / "skills",
+    ROOT / ".claude" / "skills",
+)
+
+REVIEW_SKILLS = ("task-pr-review-runner",)
+LIFECYCLE_SKILLS = ("task-delivery-runner", "task-closeout", "feature-completion-audit")
+
+
+def _skill_text(name: str) -> tuple[str, str]:
+    return (
+        (ROOT / ".agents" / "skills" / name / "SKILL.md").read_text(encoding="utf-8"),
+        (ROOT / ".claude" / "skills" / name / "SKILL.md").read_text(encoding="utf-8"),
+    )
+
+
+def test_shared_semantic_owner_docs_exist() -> None:
+    assert ISSUE_WORKFLOW.is_file()
+    assert PR_REVIEW.is_file()
+
+
+def test_nl_routing_contract_resolves_to_dual_skill_paths() -> None:
+    text = ISSUE_WORKFLOW.read_text(encoding="utf-8")
+    for entry in ("实现 Issue #N", "审查 PR #N", "PR #N 已人工合并，请完成 closeout"):
+        assert entry in text
+    for path in (
+        "docs/development/pr-review.md",
+        ".agents/skills/task-delivery-runner/",
+        ".claude/skills/task-delivery-runner/",
+        ".agents/skills/task-pr-review-runner/",
+        ".claude/skills/task-pr-review-runner/",
+        ".agents/skills/task-closeout/",
+        ".claude/skills/task-closeout/",
+        ".agents/skills/feature-completion-audit/",
+        ".claude/skills/feature-completion-audit/",
+    ):
+        assert path in text
+    assert "解析失败 / 歧义" in text
+    assert "不要猜" in text
+    assert "Human Gate" in text
+
+
+def test_agents_md_routing_principle_is_shared_entry() -> None:
+    text = AGENTS.read_text(encoding="utf-8")
+    assert "## Natural-language workflow entry" in text
+    for entry in ("实现 Issue #N", "审查 PR #N", "PR #N 已人工合并，请完成 closeout"):
+        assert entry in text
+    assert "docs/development/issue-workflow.md" in text
+
+
+def test_source_of_truth_is_dual_layer_not_linear_precedence() -> None:
+    text = ISSUE_WORKFLOW.read_text(encoding="utf-8")
+    assert "Normative / semantic authority" in text
+    assert "Mechanical / factual authority" in text
+    assert "current leaf Issue body" in text
+    assert "不得成为 business specification" in text
+    assert "不得覆盖 current Issue requirement" in text
+
+
+def test_failure_and_ambiguity_handling_is_defined() -> None:
+    text = ISSUE_WORKFLOW.read_text(encoding="utf-8")
+    assert "Failure / Ambiguity handling" in text
+    assert "fail closed" in text
+    assert "invalidate review" in text
+    assert "block closeout" in text
+    assert "bounded remediation handoff" in text
+
+
+def test_closeout_entry_owns_merge_identity_and_convergence() -> None:
+    text = ISSUE_WORKFLOW.read_text(encoding="utf-8")
+    assert "Closeout" in text
+    assert "merge identity" in text
+    assert "reviewed head == 实际 merged head" in text
+
+
+def test_pr_review_doc_owns_review_semantics() -> None:
+    text = PR_REVIEW.read_text(encoding="utf-8")
+    for marker in (
+        "fresh session",
+        "完全只读",
+        "Head lock",
+        "Effective diff",
+        "Verdict semantics",
+        "Remediation handoff",
+        "block closeout",
+    ):
+        assert marker in text
+
+
+def test_every_active_skill_references_its_shared_semantic_owner() -> None:
+    for name in LIFECYCLE_SKILLS:
+        codex, claude = _skill_text(name)
+        assert "docs/development/issue-workflow.md" in codex
+        assert "docs/development/issue-workflow.md" in claude
+    for name in REVIEW_SKILLS:
+        codex, claude = _skill_text(name)
+        assert "docs/development/pr-review.md" in codex
+        assert "docs/development/pr-review.md" in claude
+
+
+def test_skill_path_audit_covers_both_roots_and_shared_docs() -> None:
+    result = subprocess.run(
+        [sys.executable, str(PATH_AUDIT)],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    value = json.loads(result.stdout)
+    assert value["status"] == "pass"
+    assert set(value["claude_skills"]) == set(value["active_skills"])
+    for entry in value["active_skills"].values():
+        assert entry["missing_shared_doc_refs"] == []
+    for entry in value["claude_skills"].values():
+        assert entry["missing_shared_doc_refs"] == []
+        assert entry["direct_command_paths"] == []
+        assert entry["evolution_traces"] == []
+    assert value["shared_docs"] == {"issue-workflow": True, "pr-review": True}
+    assert value["totals"]["shared_doc_ref_violations"] == 0
+    assert value["totals"]["shared_doc_existence_violations"] == 0
+
+
+def test_claude_md_is_thin_adapter_with_shared_navigation() -> None:
+    text = CLAUDE_MD.read_text(encoding="utf-8")
+    assert "docs/development/issue-workflow.md" in text
+    assert "README" in text
+    assert "### Permissions" in text
+    assert "## Natural-language workflow entry" not in text
+
+
+def test_agent_skills_guide_is_registry_and_navigation_only() -> None:
+    text = AGENT_SKILLS_GUIDE.read_text(encoding="utf-8")
+    assert "导航" in text
+    assert ".agents/skills/task-delivery-runner/SKILL.md" in text
+    assert ".claude/skills/task-delivery-runner/SKILL.md" in text
+    assert "docs/development/issue-workflow.md" in text
+    assert "docs/development/pr-review.md" in text
+    assert "仓库外 Token 消耗分析边界" in text
+    assert "## Review remediation" not in text
+    assert "## Runner Delivery" not in text
+    assert "## Independent Review" not in text
+
+
+def test_legacy_skills_are_preserved_not_deleted() -> None:
+    for relative in (
+        ".agents/skills/task-delivery/SKILL.md",
+        ".agents/skills/task-pr-review/SKILL.md",
+    ):
+        assert (ROOT / relative).is_file(), relative
+    guide = AGENT_SKILLS_GUIDE.read_text(encoding="utf-8")
+    assert "task-delivery" in guide
+    assert "task-pr-review" in guide

--- a/tests/tools/test_agent_neutral_workflow.py
+++ b/tests/tools/test_agent_neutral_workflow.py
@@ -131,6 +131,35 @@ def test_pr_review_doc_has_tri_state_verdict_contract() -> None:
     assert "不产出「conditional pass」" not in text
 
 
+def test_pr_review_doc_owns_full_mapping_and_skills_do_not_duplicate() -> None:
+    owner = PR_REVIEW.read_text(encoding="utf-8")
+    codex, claude = _skill_text("task-pr-review-runner")
+    # The shared owner holds the full verdict mapping (incl. plan-limit 403).
+    assert "Deterministic mapping principle" in owner
+    assert "gate = `pass`" in owner
+    assert "plan-limit `403`" in owner
+    assert "REVIEW INVALIDATED — HEAD CHANGED" in owner
+    # Both Skills reference the owner sections for verdict / remediation.
+    for text in (codex, claude):
+        assert "docs/development/pr-review.md" in text
+        assert "§8" in text
+        assert "§9" in text
+    # Exact executable verdict tokens and the invalidation token are retained.
+    for text in (codex, claude):
+        for verdict in (
+            "通过，可以人工合并",
+            "有条件通过，不得合并",
+            "不通过，需要修复",
+        ):
+            assert verdict in text
+        assert "REVIEW INVALIDATED — HEAD CHANGED" in text
+    # Neither Skill duplicates the full shared mapping table.
+    for text in (codex, claude):
+        assert "### Deterministic mapping" not in text
+        assert "| Evidence `status` | Permitted verdict ceiling |" not in text
+        assert "### Verdict rules" not in text
+
+
 def test_issue_workflow_doc_keeps_identity_locking_and_no_version_gate() -> None:
     text = ISSUE_WORKFLOW.read_text(encoding="utf-8")
     # Workflow identity locking is owned by the shared doc.

--- a/tests/tools/test_agent_neutral_workflow.py
+++ b/tests/tools/test_agent_neutral_workflow.py
@@ -111,6 +111,53 @@ def test_pr_review_doc_owns_review_semantics() -> None:
         assert marker in text
 
 
+def test_pr_review_doc_has_tri_state_verdict_contract() -> None:
+    text = PR_REVIEW.read_text(encoding="utf-8")
+    # Tri-state verdict contract (aligned with the executable Review Skills).
+    for verdict in ("通过，可以人工合并", "有条件通过，不得合并", "不通过，需要修复"):
+        assert verdict in text
+    # Conditional is explicitly not merge approval.
+    assert "DO NOT MERGE" in text
+    assert "CONDITIONAL" in text
+    # partial / unknown objective gates map to conditional, not to pass.
+    assert "partial" in text
+    assert "unknown" in text
+    # Semantic failure / gate fail / identity drift must not map to conditional.
+    assert "identity drift" in text
+    assert "FAIL" in text
+    # Head change during review is invalidation, not conditional pass.
+    assert "REVIEW INVALIDATED" in text
+    # The binary-era claim that conditional pass does not exist must not return.
+    assert "不产出「conditional pass」" not in text
+
+
+def test_issue_workflow_doc_keeps_identity_locking_and_no_version_gate() -> None:
+    text = ISSUE_WORKFLOW.read_text(encoding="utf-8")
+    # Workflow identity locking is owned by the shared doc.
+    for marker in (
+        "Workflow identity locking",
+        "必须锁定",
+        "不得静默继续",
+        "reviewed head",
+        "merge SHA",
+    ):
+        assert marker in text
+    # Skill / Runner version is not a default reload gate.
+    for marker in (
+        "Skill / Runner version is not itself a workflow gate",
+        "不要求",
+        "重新加载",
+    ):
+        assert marker in text
+    # Old trusted-version mechanisms are named only as explicitly rejected.
+    assert "不重新引入" in text
+    assert "trusted Skill" in text
+    assert "main-only Skill" in text
+    assert "Skill hash as workflow state" in text
+    assert "trusted_runner.py" not in text
+    assert "--trusted-sha" not in text
+
+
 def test_every_active_skill_references_its_shared_semantic_owner() -> None:
     for name in LIFECYCLE_SKILLS:
         codex, claude = _skill_text(name)

--- a/tests/tools/test_workflow_skills.py
+++ b/tests/tools/test_workflow_skills.py
@@ -151,19 +151,24 @@ def test_local_workflow_artifact_directories_are_exactly_ignored() -> None:
 # --- Evidence verdict matrix tests ---
 
 
-def test_review_skill_has_evidence_status_to_verdict_matrix() -> None:
+def test_review_skill_has_shared_owner_contract_and_exact_tokens() -> None:
     text = ACTIVE_SKILLS["task-pr-review-runner"].read_text(encoding="utf-8")
-    assert "Evidence status" in text
-    assert "verdict matrix" in text
-    assert "partial" in text.casefold()
-    assert "any cause" in text.casefold()
-    assert "Conditional pass" in text
-    assert "never upgrades" in text.casefold()
-    assert "plan-limit 403" in text.casefold()
-    assert "do not merge" in text.casefold()
-    assert "Deterministic mapping" in text
-    assert "process success" in text.casefold()
-    assert "is not gate pass" in text
+    # Shared semantic owner referenced for verdict and remediation conditions.
+    assert "docs/development/pr-review.md" in text
+    assert "§8" in text
+    assert "§9" in text
+    # Exact executable verdict output tokens are retained.
+    assert "通过，可以人工合并" in text
+    assert "有条件通过，不得合并" in text
+    assert "不通过，需要修复" in text
+    # Head-change invalidation retained as a hard guard.
+    assert "REVIEW INVALIDATED — HEAD CHANGED" in text
+    # Executable procedure retained.
+    assert "workflow-review" in text
+    assert "recheck --snapshot-id" in text
+    # The full shared verdict mapping table is no longer duplicated in the Skill.
+    assert "### Deterministic mapping" not in text
+    assert "| Evidence `status` | Permitted verdict ceiling |" not in text
 
 
 def test_review_skill_requires_remediation_handoff_for_non_pass() -> None:
@@ -210,14 +215,13 @@ def test_review_skill_has_tool_discipline_section() -> None:
     assert "Search completeness" in text
 
 
-def test_review_skill_has_verdict_rules_subsection() -> None:
+def test_review_skill_has_minimal_verdict_summary_without_duplicated_rules() -> None:
     text = ACTIVE_SKILLS["task-pr-review-runner"].read_text(encoding="utf-8")
-    assert "Verdict rules" in text
-    assert "unconditional pass" in text.casefold()
-    assert "evidence gate" in text.casefold()
-    assert "not_verified" in text
-    assert "groups or criteria" in text
-    assert "incomplete" in text.casefold()
+    # Minimal semantic summary with authoritative reference, not a full rule set.
+    assert "pr-review.md" in text
+    assert "PASS is the only mergeable state" in text
+    assert "CONDITIONAL is never mergeable" in text
+    assert "### Verdict rules" not in text
 
 
 def test_review_skill_runner_command_includes_skill_path() -> None:

--- a/tools/agent_workflow/skill_path_audit.py
+++ b/tools/agent_workflow/skill_path_audit.py
@@ -8,13 +8,21 @@ import json
 from pathlib import Path
 from typing import Final
 
-SCHEMA_VERSION: Final = 2
+SCHEMA_VERSION: Final = 3
 ACTIVE_SKILLS: Final = {
     "task-delivery-runner": Path(".agents/skills/task-delivery-runner/SKILL.md"),
     "task-pr-review-runner": Path(".agents/skills/task-pr-review-runner/SKILL.md"),
     "task-closeout": Path(".agents/skills/task-closeout/SKILL.md"),
     "feature-completion-audit": Path(
         ".agents/skills/feature-completion-audit/SKILL.md"
+    ),
+}
+CLAUDE_SKILLS: Final = {
+    "task-delivery-runner": Path(".claude/skills/task-delivery-runner/SKILL.md"),
+    "task-pr-review-runner": Path(".claude/skills/task-pr-review-runner/SKILL.md"),
+    "task-closeout": Path(".claude/skills/task-closeout/SKILL.md"),
+    "feature-completion-audit": Path(
+        ".claude/skills/feature-completion-audit/SKILL.md"
     ),
 }
 BASELINE_SKILLS: Final = {
@@ -49,6 +57,16 @@ REQUIRED: Final = {
         "Audited main SHA",
     ),
 }
+SHARED_DOCS: Final = {
+    "issue-workflow": Path("docs/development/issue-workflow.md"),
+    "pr-review": Path("docs/development/pr-review.md"),
+}
+SHARED_DOC_REFS: Final = {
+    "task-delivery-runner": ("docs/development/issue-workflow.md",),
+    "task-pr-review-runner": ("docs/development/pr-review.md",),
+    "task-closeout": ("docs/development/issue-workflow.md",),
+    "feature-completion-audit": ("docs/development/issue-workflow.md",),
+}
 DIRECT_COMMAND_FRAGMENTS: Final = (
     "python tools/agent_workflow/workflow_evidence.py",
     "python -X utf8 tools/agent_workflow/workflow_evidence.py",
@@ -82,8 +100,54 @@ def _sha256(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
+def _audit_skill(
+    name: str,
+    relative: Path,
+    repo_root: Path,
+    violations: list[str],
+    totals: dict[str, int],
+) -> dict[str, object]:
+    path = repo_root / relative
+    text = path.read_text(encoding="utf-8")
+    lowered = text.casefold()
+    missing = [token for token in REQUIRED[name] if token not in text]
+    direct = [item for item in DIRECT_COMMAND_FRAGMENTS if item in text]
+    traces = [item for item in EVOLUTION_TRACES if item in lowered]
+    missing_refs = [ref for ref in SHARED_DOC_REFS[name] if ref not in text]
+    if missing:
+        violations.append(f"{relative}: missing {', '.join(missing)}")
+    if direct:
+        violations.append(f"{relative}: direct command path {', '.join(direct)}")
+    if traces:
+        violations.append(f"{relative}: evolution trace {', '.join(traces)}")
+    if missing_refs:
+        violations.append(
+            f"{relative}: missing shared-doc reference {', '.join(missing_refs)}"
+        )
+    entry = {
+        "path": relative.as_posix(),
+        "lines": len(text.splitlines()),
+        "bytes": len(text.encode("utf-8")),
+        "sha256": _sha256(text),
+        "evidence_runner_mentions": text.count("wsl2_github_evidence_runner.py"),
+        "validation_runner_mentions": text.count("wsl2_validation_runner.py"),
+        "direct_command_paths": direct,
+        "evolution_traces": traces,
+        "missing_contract_tokens": missing,
+        "missing_shared_doc_refs": missing_refs,
+    }
+    totals["lines"] += entry["lines"]
+    totals["evidence_runner_mentions"] += entry["evidence_runner_mentions"]
+    totals["validation_runner_mentions"] += entry["validation_runner_mentions"]
+    totals["direct_command_path_count"] += len(direct)
+    totals["evolution_trace_count"] += len(traces)
+    totals["shared_doc_ref_violations"] += len(missing_refs)
+    return entry
+
+
 def audit(repo_root: Path) -> tuple[dict[str, object], int]:
     results: dict[str, object] = {}
+    claude_results: dict[str, object] = {}
     violations: list[str] = []
     totals = {
         "lines": 0,
@@ -91,38 +155,24 @@ def audit(repo_root: Path) -> tuple[dict[str, object], int]:
         "validation_runner_mentions": 0,
         "direct_command_path_count": 0,
         "evolution_trace_count": 0,
+        "shared_doc_ref_violations": 0,
+        "shared_doc_existence_violations": 0,
     }
 
     for name, relative in ACTIVE_SKILLS.items():
-        path = repo_root / relative
-        text = path.read_text(encoding="utf-8")
-        lowered = text.casefold()
-        missing = [token for token in REQUIRED[name] if token not in text]
-        direct = [item for item in DIRECT_COMMAND_FRAGMENTS if item in text]
-        traces = [item for item in EVOLUTION_TRACES if item in lowered]
-        if missing:
-            violations.append(f"{name}: missing {', '.join(missing)}")
-        if direct:
-            violations.append(f"{name}: direct command path {', '.join(direct)}")
-        if traces:
-            violations.append(f"{name}: evolution trace {', '.join(traces)}")
-        entry = {
-            "path": relative.as_posix(),
-            "lines": len(text.splitlines()),
-            "bytes": len(text.encode("utf-8")),
-            "sha256": _sha256(text),
-            "evidence_runner_mentions": text.count("wsl2_github_evidence_runner.py"),
-            "validation_runner_mentions": text.count("wsl2_validation_runner.py"),
-            "direct_command_paths": direct,
-            "evolution_traces": traces,
-            "missing_contract_tokens": missing,
-        }
-        results[name] = entry
-        totals["lines"] += entry["lines"]
-        totals["evidence_runner_mentions"] += entry["evidence_runner_mentions"]
-        totals["validation_runner_mentions"] += entry["validation_runner_mentions"]
-        totals["direct_command_path_count"] += len(direct)
-        totals["evolution_trace_count"] += len(traces)
+        results[name] = _audit_skill(name, relative, repo_root, violations, totals)
+    for name, relative in CLAUDE_SKILLS.items():
+        claude_results[name] = _audit_skill(
+            name, relative, repo_root, violations, totals
+        )
+
+    shared_docs: dict[str, bool] = {}
+    for key, relative in SHARED_DOCS.items():
+        present = (repo_root / relative).is_file()
+        shared_docs[key] = present
+        if not present:
+            violations.append(f"missing shared doc {relative}")
+            totals["shared_doc_existence_violations"] += 1
 
     baseline: dict[str, object] = {}
     for name, relative in BASELINE_SKILLS.items():
@@ -141,6 +191,8 @@ def audit(repo_root: Path) -> tuple[dict[str, object], int]:
         "schema_version": SCHEMA_VERSION,
         "status": "pass" if not violations else "fail",
         "active_skills": results,
+        "claude_skills": claude_results,
+        "shared_docs": shared_docs,
         "baseline_skills": baseline,
         "totals": totals,
         "violations": violations,


### PR DESCRIPTION
## 关联 Issue

Closes #120

## 实现摘要

完成 Agent-neutral Workflow / Instruction Architecture 的正式迁移（Read-only Audit → Human Gate APPROVED → Implementation → Validation → PR）：

- **shared semantic owner docs（M1/M2）**：新增 `docs/development/issue-workflow.md`（Agent-neutral lifecycle 规范，16 节：readiness、Delivery、PR/CI、Independent Review、Human Gate、remediation、manual Squash Merge、Closeout、Feature Completion、NL entry resolution、dual-layer source-of-truth 模型、failure/ambiguity handling）与 `docs/development/pr-review.md`（Independent Review shared semantics：fresh session、head lock、verdict semantics、remediation handoff）。
- **AGENTS.md 收敛（M3/M4/M5/M8/M9）**：Retrieval v2 核心、hard rules、financial safety、data correctness 逐字保留；workflow-prose 替换为 Natural-language workflow entry（3 intents + FCA + fallback）、Independent Review hard invariant、Policies and evidence、Source-of-truth principle；修复 issue-authoring.md 引用链。
- **CLAUDE.md thin adapter（M7）**：Commands 引用 README canonical；保留 Claude-specific 工具/权限/Skill 发现信息。
- **Skills 收敛（M6）**：8 个 active Skills 删除复制的 lifecycle 语义（如 lifecycle-state 表格），添加 shared owner 引用；保留 self-sufficient executable procedure 与全部 test-pinned strings。
- **agent-skills.md 收敛（M12）**：改为 registry / navigation / compatibility 入口，删除复制的 lifecycle prose。
- **验证扩展（M10/M11）**：`skill_path_audit.py` 增加 Codex/Claude 双端 path/semantic-parity 与 shared-doc 存在性/引用校验；新增 12 个聚焦测试（routing contract、ownership、source-of-truth dual-layer、parity、legacy preservation）。

## 修改范围

| 类别 | 文件 |
| --- | --- |
| shared docs（新增） | `docs/development/issue-workflow.md`、`docs/development/pr-review.md` |
| 控制平面 | `AGENTS.md`、`CLAUDE.md` |
| Skills | `.agents/skills/` 与 `.claude/skills/` 各 4 个 active Skill |
| 注册表 | `docs/workflows/agent-skills.md` |
| 机械验证 | `tools/agent_workflow/skill_path_audit.py`（schema v3） |
| 测试（新增） | `tests/tools/test_agent_neutral_workflow.py` |

## 关键设计决定

- `repository-guide.md` 判定 **NOT NEEDED**：README.md "Development environment" 与 CLAUDE.md Commands 逐字等价，无独立存在价值。
- Source-of-truth 为 **dual-layer 模型**（issue-workflow.md §15）：Normative/semantic authority（system→maintainer→hard rules/ADR→leaf Issue→workflow spec→Skills→history）与 Mechanical/factual authority（GitHub/Git/CI/Runner facts）分层，不做单一线性 precedence；mechanical facts 可使 stale textual assumption 失效、触发 fail-closed / Human Gate，但不得成为 business specification。
- Skills 保留最小必要 semantic summary + executable procedure，shared docs 按 intent 按需读取（不全文 eager-load，遵守 Retrieval v2）。
- Runner 无 semantic rewrite：只做 skill_path_audit.py 的最小增量校验扩展。
- cleanup 候选（C1-C11）仅 inventory，本 Task 不删除任何 legacy machinery。

## 验证结果

| 命令 | 结果 | 说明 |
| --- | --- | --- |
| `uv run --frozen pytest` | ✅ 322 passed, 72 skipped | 含 46 个既有 workflow/retrieval/telemetry pin 测试 + 12 个新增聚焦测试 |
| `uv run --frozen ruff check .` | ✅ All checks passed | |
| `uv run --frozen ruff format --check .` | ✅ 34 files already formatted | |
| `uv run --frozen mypy src tests` | ✅ Success, no issues in 24 files | mypy --strict |
| `uv lock --check` | ✅ Resolved 14 packages | |
| `git diff --check` | ✅ PASS | |
| `python3 tools/agent_workflow/skill_path_audit.py` | ✅ status=pass | 双端 8 skills、shared docs 存在且被引用 |

## 从 Issue 复制的验收标准

- [x] repository write 前存在可审查的 architecture audit，并经 Human Gate 允许继续实施
- [x] Agent-neutral Issue lifecycle 有唯一且清晰的 shared semantic owner
- [x] `issue-workflow.md` / `repository-guide.md` / `pr-review.md` 均有基于实际仓库状态的明确 CREATE / REUSE / NOT NEEDED 决策
- [x] `AGENTS.md` 不再承担不必要的详细 lifecycle procedure，同时保留 Retrieval v2、安全、correctness 与 routing 所需 always-loaded information
- [x] `CLAUDE.md` 不再作为第二套 shared workflow / safety / data-correctness specification
- [x] Codex / Claude Skills 不再各自独立复制整套 shared lifecycle semantics，但仍能独立执行各自 procedure
- [x] shared docs、Skills、Runners 与 agent adapter 的 ownership 边界清楚且没有 circular-reference / instruction-loading hole
- [x] Codex 可以从 `实现 Issue #N` 进入正确 Delivery path
- [x] Claude 可以从同一句入口进入语义等价 Delivery path
- [x] Codex / Claude 均能从 `审查 PR #N` 识别 Independent Review path
- [x] merge 后 closeout entry 不要求维护者指定内部 Skill 名称
- [x] routing 不依赖旧 Codex-only / Claude-only workflow wording
- [x] routing 不允许绕过 lifecycle、safety 或 Human Gate
- [x] Task #87 Retrieval v2 policy / safety / review independence / FCA exception 没有回归
- [x] 不引入 Context Compiler、Canonical Spec、runtime telemetry 或新的 durable orchestration state machine
- [x] repository standard validation 与新增 workflow/instruction validation 通过
- [x] 本 Task 不删除 legacy execution/evidence machinery；删除工作留给 migration acceptance 之后的 cleanup Task

## 风险检查

- [x] 未引入未授权实盘交易行为
- [x] 未提交或记录 API 密钥
- [x] 未引入无时区 datetime
- [x] 未引入未来数据泄漏
- [x] 未将缺失数据静默填零
- [x] 未绕过风险模块
- [x] 未进行范围外重构
- [x] 已测试失败路径（Preflight/verdict/fail-closed 语义经既有 46 个 pin 测试验证）

## 范围外内容

- cleanup 候选 C1-C11（legacy execution/evidence machinery 删除）留待后续 cleanup Task
- `quick_validate.py` / PyYAML 环境问题（Non-goal）
- #121/#122/#123（下流 Task）
- Ruleset / CI / merge policy、Issue Forms、Issue dependency normalization（Non-goals）

## 已知限制

- `workflow_validation.py` 的 skill-validator hook 仍走 external `quick_validate.py`（Non-goal 不解决）；新校验以 `skill_path_audit.py`（独立确定性 checker，经测试强制）方式接入。
- 共享文档语义收敛按「shared docs 是 semantic owner、Skill 保留最小必要 summary + executable procedure」执行；Skill 两端文字不要求完全一致，以 semantic parity（测试 + 机械 audit 强制）为准。
