### PR TITLE
[Task] 完成 Task #65 Round 2 v2 正式基准 Pre-run Hygiene #127

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ desktop.ini
 
 # Conductor-local benchmark fixture store (task-65-round-2-v2; never committed)
 .agents/benchmark-fixtures.local/
+
+# Local benchmark rollout / transcript artifacts (task-65-round-2-v2; never committed)
+.agents/rollout.local/

--- a/benchmarks/task-65-round-2-v2/schemas/context-input.schema.json
+++ b/benchmarks/task-65-round-2-v2/schemas/context-input.schema.json
@@ -21,10 +21,14 @@
         "attachment:file",
         "attachment:agent_listing_delta",
         "attachment:skill_listing",
+        "attachment:command_permissions",
         "attachment:todo_reminder",
         "summary",
         "user-prompt",
-        "last-prompt"
+        "last-prompt",
+        "ai-title",
+        "system:compact_boundary",
+        "system:api_error"
       ]
     },
     "target": {"type": "string"},

--- a/benchmarks/task-65-round-2-v2/tooling/observability_preflight.py
+++ b/benchmarks/task-65-round-2-v2/tooling/observability_preflight.py
@@ -178,12 +178,21 @@ def _archive_isolation_failure(
     must be under an approved evidence/archive root, must never point at the
     fixture store (``.agents/benchmark-fixtures.local/**``), and its path
     identity must explicitly contain the current arm component and the
-    current session component.  Returns a failure reason, or ``None`` when
-    the destination is isolated for this Arm/session.
+    current session component.  Any path component equal to ``.`` or ``..``
+    fails closed before the approved-root / arm / session judgment: traversal
+    components are never normalized into a legal path and never bypass
+    isolation.  Returns a failure reason, or ``None`` when the destination is
+    isolated for this Arm/session.
     """
     normalized = archive.strip().lower().rstrip("/")
     if not normalized:
         return "archive destination is empty"
+    components = [part for part in normalized.split("/") if part]
+    if "." in components or ".." in components:
+        return (
+            "archive destination contains a traversal path component "
+            f"({'.'!r} or {'..'!r}): {archive}"
+        )
     if normalized == ".agents/benchmark-fixtures.local" or normalized.startswith(
         ".agents/benchmark-fixtures.local/"
     ):
@@ -200,7 +209,6 @@ def _archive_isolation_failure(
         )
     if not session_id.strip():
         return "session identity unresolved (cannot verify archive isolation)"
-    components = [part for part in normalized.split("/") if part]
     arm_expected = {arm_id.strip().lower(), f"arm-{arm_id.strip().lower()}"}
     if not arm_expected.intersection(components):
         return (

--- a/tests/benchmarks/test_adapters.py
+++ b/tests/benchmarks/test_adapters.py
@@ -6,10 +6,26 @@ import json
 
 import pytest
 
-from benchmark_common import BenchmarkError  # type: ignore[import-not-found]
+from _benchmark_helpers import REPO_ROOT  # noqa: F401  (wires tooling onto sys.path)
+
+from benchmark_common import BenchmarkError, load_json  # type: ignore[import-not-found]
 from claude_transcript_adapter import (  # type: ignore[import-not-found]
     parse_record as parse_claude_record,
     parse_transcript,
+)
+from claude_transcript_fixtures import (
+    FIXTURE_SESSION_ID,
+    agent_listing_attachment_record,
+    ai_title_record,
+    command_permissions_attachment_record,
+    compact_summary_user_record,
+    file_attachment_record,
+    last_prompt_record,
+    prompt_user_record,
+    skill_listing_attachment_record,
+    summary_record,
+    system_record,
+    todo_reminder_attachment_record,
 )
 from codex_rollout_adapter import (  # type: ignore[import-not-found]
     parse_record as parse_codex_record,
@@ -228,3 +244,48 @@ def test_claude_transcript_parse() -> None:
     assert events[0]["arm_id"] == "D"
     assert events[0]["tool"] == "read"
     assert events[0]["session_id"] == "s"
+
+
+def test_context_input_source_types_have_no_known_drift_with_schema() -> None:
+    # Every adapter context-input emission path, exercised through the REAL
+    # adapter over the observed-transcript fixtures.  The emitted source_type
+    # set must equal the context-input schema enum exactly: no adapter type
+    # may be missing from the schema, and no schema enum value may be stale
+    # (a type the adapter never emits).
+    fixture_records: list[tuple[str, dict[str, object]]] = [
+        ("attachment:file", file_attachment_record("<scrubbed content>")),
+        (
+            "attachment:agent_listing_delta",
+            agent_listing_attachment_record(),
+        ),
+        ("attachment:skill_listing", skill_listing_attachment_record()),
+        (
+            "attachment:command_permissions",
+            command_permissions_attachment_record(),
+        ),
+        ("attachment:todo_reminder", todo_reminder_attachment_record()),
+        ("summary", summary_record()),
+        ("summary", compact_summary_user_record()),
+        ("user-prompt", prompt_user_record("<scrubbed prompt>")),
+        ("last-prompt", last_prompt_record()),
+        ("ai-title", ai_title_record()),
+        ("system:compact_boundary", system_record("compact_boundary")),
+        ("system:api_error", system_record("api_error")),
+    ]
+    emitted: set[str] = set()
+    for expected, record in fixture_records:
+        _events, context_inputs = parse_claude_record(
+            record, session_id=FIXTURE_SESSION_ID
+        )
+        types = {c["source_type"] for c in context_inputs}
+        assert types == {expected}, f"fixture emitted {types}, expected {expected!r}"
+        emitted.update(types)
+    schema = load_json(
+        REPO_ROOT / "benchmarks/task-65-round-2-v2/schemas/context-input.schema.json"
+    )
+    schema_types = set(schema["properties"]["source_type"]["enum"])
+    assert emitted == schema_types, (
+        "adapter/schema source-type drift: "
+        f"adapter-only={sorted(emitted - schema_types)} "
+        f"schema-only={sorted(schema_types - emitted)}"
+    )

--- a/tests/benchmarks/test_inventory_and_contracts.py
+++ b/tests/benchmarks/test_inventory_and_contracts.py
@@ -5,9 +5,15 @@ from __future__ import annotations
 import subprocess
 from typing import Any, cast
 
+import pytest
+
 from _benchmark_helpers import REPO_ROOT
 
-from benchmark_common import load_json, validate_basic  # type: ignore[import-not-found]
+from benchmark_common import (  # type: ignore[import-not-found]
+    BenchmarkError,
+    load_json,
+    validate_basic,
+)
 
 NAMESPACE = REPO_ROOT / "benchmarks" / "task-65-round-2-v2"
 
@@ -133,10 +139,14 @@ def test_context_input_schema_validates_normalized_inputs() -> None:
     for source_type in (
         "attachment:agent_listing_delta",
         "attachment:skill_listing",
+        "attachment:command_permissions",
         "attachment:todo_reminder",
         "summary",
         "user-prompt",
         "last-prompt",
+        "ai-title",
+        "system:compact_boundary",
+        "system:api_error",
     ):
         validate_basic(
             {
@@ -149,6 +159,30 @@ def test_context_input_schema_validates_normalized_inputs() -> None:
             schema,
             f"context-input/{source_type}",
         )
+
+
+def test_context_input_schema_rejects_unknown_source_type() -> None:
+    # Unknown source types must fail closed: the schema never widens to
+    # accept arbitrary source_type values.
+    schema = _schema("context-input.schema.json")
+    for source_type in (
+        "attachment:something_else",
+        "attachment:command_permissions_extra",
+        "system:unknown",
+        "",
+    ):
+        with pytest.raises(BenchmarkError):
+            validate_basic(
+                {
+                    "session_id": "s",
+                    "timestamp": "t",
+                    "source_type": source_type,
+                    "target": "x",
+                    "raw_event_reference": "r",
+                },
+                schema,
+                "context-input/unknown-source-type",
+            )
 
 
 def test_contracts_present_and_covers_required_topics() -> None:

--- a/tests/benchmarks/test_observability_preflight.py
+++ b/tests/benchmarks/test_observability_preflight.py
@@ -234,6 +234,84 @@ def test_preflight_archive_generic_arm_substring_fails(tmp_path) -> None:  # typ
     assert "arm" in str(check.get("detail", ""))
 
 
+def test_preflight_archive_dot_component_fails(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    # Any path component equal to "." fails closed (path-component
+    # semantics, never substring, never normalized into a legal path).
+    config = _good_codex_config(tmp_path)
+    config["archive_destination"] = (
+        ".agents/evidence.local/./task-65-round-2-v2/C/sess-c-1"
+    )
+    report = run_preflight(config)
+    assert report["verified"] is False
+    check = next(
+        c for c in report["checks"] if c["name"] == "archive_destination_isolated"
+    )
+    assert check["status"] == "fail"
+    assert "traversal" in str(check.get("detail", ""))
+
+
+def test_preflight_archive_dotdot_component_fails(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    # Any path component equal to ".." fails closed, even when the
+    # remainder of the path is a normal approved archive destination.
+    config = _good_codex_config(tmp_path)
+    config["archive_destination"] = (
+        ".agents/evidence.local/task-65-round-2-v2/C/sess-c-1/.."
+    )
+    report = run_preflight(config)
+    assert report["verified"] is False
+    check = next(
+        c for c in report["checks"] if c["name"] == "archive_destination_isolated"
+    )
+    assert check["status"] == "fail"
+    assert "traversal" in str(check.get("detail", ""))
+
+
+def test_preflight_archive_traversal_toward_fixture_store_fails(  # type: ignore[no-untyped-def]
+    tmp_path,
+) -> None:
+    # ".." traversal from the evidence root toward the fixture store must
+    # fail closed WITHOUT path normalization: the traversal component is
+    # rejected before any approved-root / fixture-store judgment.
+    config = _good_codex_config(tmp_path)
+    config["archive_destination"] = (
+        ".agents/evidence.local/../benchmark-fixtures.local/"
+        "task-65-round-2-v2/C/sess-c-1"
+    )
+    report = run_preflight(config)
+    assert report["verified"] is False
+    check = next(
+        c for c in report["checks"] if c["name"] == "archive_destination_isolated"
+    )
+    assert check["status"] == "fail"
+    assert "traversal" in str(check.get("detail", ""))
+
+
+def test_preflight_archive_traversal_across_arm_fails(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    # ".." traversal across arms/sessions must fail closed: the archive
+    # would resolve to a different arm/session than the current one.
+    config = _good_codex_config(tmp_path)  # arm C, session sess-c-1
+    config["archive_destination"] = (
+        ".agents/evidence.local/task-65-round-2-v2/D/../C/sess-c-1"
+    )
+    report = run_preflight(config)
+    assert report["verified"] is False
+    check = next(
+        c for c in report["checks"] if c["name"] == "archive_destination_isolated"
+    )
+    assert check["status"] == "fail"
+    assert "traversal" in str(check.get("detail", ""))
+
+
+def test_preflight_archive_validation_root_passes(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    # A normal archive under the approved validation root passes.
+    config = _good_codex_config(tmp_path)
+    config["archive_destination"] = (
+        ".agents/validation.local/task-65-round-2-v2/C/sess-c-1"
+    )
+    report = run_preflight(config)
+    assert report["verified"] is True
+
+
 # --------------------------------------------------------------------------
 # M3 remediation: controlled probe found in the REAL parser's events.
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## 概述

Task #127 — Task #65 Round 2 v2 正式基准 Pre-run Hygiene。三个最小修复，不改变任何 Arm 语义、业务代码或 benchmark treatment。

Closes #127

## 修复内容

1. **Context-input schema 对齐**（`benchmarks/task-65-round-2-v2/schemas/context-input.schema.json`）：将 Claude transcript adapter 已正式产生的四个 source types（`attachment:command_permissions`、`ai-title`、`system:compact_boundary`、`system:api_error`）补入 `source_type` enum；未放宽 `additionalProperties` / structural validation 边界，unknown source type 仍 fail closed。
2. **Archive path traversal 拒绝**（`benchmarks/task-65-round-2-v2/tooling/observability_preflight.py`）：`_archive_isolation_failure` 在 approved-root / arm / session 判断前，以 path-component 语义显式拒绝 `.` / `..` component，不做路径归一化；现有 fixture-store / wrong-arm / wrong-session guard 全部保留。
3. **Rollout namespace git-ignore**（`.gitignore`）：新增 `.agents/rollout.local/`，与现有 `.agents/evidence.local/`、`.agents/validation.local/`、`.agents/benchmark-fixtures.local/` 风格一致；`git check-ignore .agents/rollout.local/task-65-round-2-v2/A/example` 已机械验证命中。

## 测试

- 新增 adapter↔schema source-type drift regression test：通过真实 adapter 与已观察 transcript fixtures 运行全部 11 个 emission path，与 schema enum 双向比对。
- 新增 schema unknown source type fail-closed 测试。
- 新增 archive `.` / `..` component、traversal 至 fixture store、traversal 跨 Arm 的 FAIL 测试，以及 validation-root PASS 测试。
- `uv run --frozen pytest tests/benchmarks`：173 passed。
- 全量 `uv run --frozen pytest`：498 passed, 72 skipped。
- `uv run ruff check .`、`uv run ruff format --check .`、`uv run mypy src tests`、`uv lock --check`、`git diff --check`：全部通过。
- `workflow-delivery` Runner 验证：pass。

## 风险与限制

- 无已知风险：纯 tooling / schema / gitignore hygiene。未修改 `src/**`、`apps/**`、`packages/**`、`tools/agent_workflow/**`、existing production Skills、A/B pinned historical blobs 及 Task #65 业务实现。
- 未运行任何正式 benchmark Arm；未 freeze 任何 #86 shared identity；未产生 benchmark data。

## 变更文件

- `.gitignore`
- `benchmarks/task-65-round-2-v2/schemas/context-input.schema.json`
- `benchmarks/task-65-round-2-v2/tooling/observability_preflight.py`
- `tests/benchmarks/test_adapters.py`
- `tests/benchmarks/test_inventory_and_contracts.py`
- `tests/benchmarks/test_observability_preflight.py`
