### PR TITLE
[Task] 定义初始公共领域模型与共享测试 Fixtures (#65)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,39 @@ Pull requests targeting `main` and pushes to `main` automatically run CI. The wo
 
 Internal datetimes must be timezone-aware and use UTC as the standard timezone. Naive datetimes are explicitly rejected. Time utilities are provided by `tracequant.core.time`.
 
+## Research MVP domain models
+
+The initial internal public models are imported from `tracequant.domain`:
+
+```python
+from tracequant.domain import InstrumentId, OHLCVBar, TimeRange
+```
+
+`InstrumentId` is a normalized uppercase ASCII alphanumeric identifier with a
+32-character maximum; it deliberately carries no venue or contract metadata.
+`TimeRange` is an immutable UTC half-open interval `[start, end)`. Direct model
+construction rejects naive and non-UTC datetimes. Deserialization uses the
+existing `tracequant.core.time.parse_utc` API, so aware ISO 8601 offsets are
+normalized to UTC while naive strings are rejected. `OHLCVBar` validates finite
+Python `float` values, non-negative volume, and OHLC relationships. Zero and
+negative prices remain valid for research data and are not an assertion about
+tradable exchange prices.
+
+The explicit serialization methods return stable JSON-compatible primitives;
+they are the Research MVP's initial internal protocol, not a versioned external
+compatibility promise. They do not use pickle.
+
+Shared pytest data follows these rules:
+
+- reusable fixtures live in `tests/conftest.py` and retain pytest's default
+  function scope;
+- deterministic, explicitly overridable factories live in
+  `tests/fixtures/domain.py`;
+- factories use fixed UTC timestamps and do not read the clock, randomness,
+  environment variables, the network, or files;
+- single-test data stays in its test module, and no mutable result is shared
+  between factory calls.
+
 ## Configuration
 
 Application configuration is loaded explicitly with `tracequant.config.load_settings`.

--- a/src/tracequant/domain.py
+++ b/src/tracequant/domain.py
@@ -1,0 +1,190 @@
+"""Small shared domain models for the Research MVP."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from math import isfinite
+from re import fullmatch
+from typing import ClassVar
+
+from tracequant.core.time import format_utc, is_utc, parse_utc, to_utc
+
+__all__ = ["InstrumentId", "OHLCVBar", "TimeRange"]
+
+
+def _require_exact_fields(data: object, expected: frozenset[str]) -> dict[str, object]:
+    if not isinstance(data, dict):
+        raise TypeError("serialized value must be a dict")
+    actual = set(data)
+    if actual != expected:
+        missing = sorted(expected - actual)
+        extra = sorted(actual - expected)
+        raise ValueError(
+            f"serialized fields mismatch: missing={missing}, extra={extra}"
+        )
+    return data
+
+
+def _require_float(name: str, value: object) -> float:
+    if type(value) is not float:
+        raise TypeError(f"{name} must be a float")
+    if not isfinite(value):
+        raise ValueError(f"{name} must be finite")
+    return value
+
+
+@dataclass(frozen=True, slots=True, order=True)
+class InstrumentId:
+    """A normalized instrument identifier without exchange metadata."""
+
+    MAX_LENGTH: ClassVar[int] = 32
+
+    value: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.value, str):
+            raise TypeError("instrument identifier must be a string")
+        normalized = self.value.strip().upper()
+        if not normalized:
+            raise ValueError("instrument identifier must not be empty")
+        if len(normalized) > self.MAX_LENGTH:
+            raise ValueError(
+                f"instrument identifier must be at most {self.MAX_LENGTH} characters"
+            )
+        if fullmatch(r"[A-Z0-9]+", normalized, flags=0) is None:
+            raise ValueError(
+                "instrument identifier must contain only ASCII uppercase letters and digits"
+            )
+        object.__setattr__(self, "value", normalized)
+
+    def __str__(self) -> str:
+        return self.value
+
+    def to_json_value(self) -> str:
+        """Return the JSON-compatible scalar representation."""
+        return self.value
+
+    @classmethod
+    def from_json_value(cls, value: object) -> InstrumentId:
+        """Build an identifier from its JSON-compatible scalar representation."""
+        if not isinstance(value, str):
+            raise TypeError("serialized instrument identifier must be a string")
+        return cls(value)
+
+
+@dataclass(frozen=True, slots=True)
+class TimeRange:
+    """A timezone-aware UTC half-open interval ``[start, end)``."""
+
+    start: datetime
+    end: datetime
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.start, datetime) or not isinstance(self.end, datetime):
+            raise TypeError("start and end must be datetime values")
+        if not is_utc(self.start) or not is_utc(self.end):
+            raise ValueError("start and end must be timezone-aware UTC datetimes")
+        start = to_utc(self.start)
+        end = to_utc(self.end)
+        if start >= end:
+            raise ValueError("start must be earlier than end")
+        object.__setattr__(self, "start", start)
+        object.__setattr__(self, "end", end)
+
+    @property
+    def duration(self) -> timedelta:
+        """Return the interval duration."""
+        return self.end - self.start
+
+    def contains(self, value: datetime) -> bool:
+        """Return whether a UTC datetime falls within ``[start, end)``."""
+        if not isinstance(value, datetime):
+            raise TypeError("value must be a datetime")
+        if not is_utc(value):
+            raise ValueError("value must be a timezone-aware UTC datetime")
+        normalized = to_utc(value)
+        return self.start <= normalized < self.end
+
+    def to_dict(self) -> dict[str, object]:
+        """Return the stable JSON-compatible representation."""
+        return {"start": format_utc(self.start), "end": format_utc(self.end)}
+
+    @classmethod
+    def from_dict(cls, data: object) -> TimeRange:
+        """Build an interval from its serialized representation."""
+        values = _require_exact_fields(data, frozenset({"start", "end"}))
+        start = values["start"]
+        end = values["end"]
+        if not isinstance(start, str) or not isinstance(end, str):
+            raise TypeError("serialized start and end must be strings")
+        return cls(start=parse_utc(start), end=parse_utc(end))
+
+
+@dataclass(frozen=True, slots=True)
+class OHLCVBar:
+    """An immutable OHLCV bar for one instrument and UTC interval."""
+
+    instrument: InstrumentId
+    start: datetime
+    end: datetime
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float
+
+    _SERIALIZED_FIELDS: ClassVar[frozenset[str]] = frozenset(
+        {"instrument", "start", "end", "open", "high", "low", "close", "volume"}
+    )
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.instrument, InstrumentId):
+            raise TypeError("instrument must be an InstrumentId")
+        interval = TimeRange(self.start, self.end)
+        object.__setattr__(self, "start", interval.start)
+        object.__setattr__(self, "end", interval.end)
+
+        open_price = _require_float("open", self.open)
+        high = _require_float("high", self.high)
+        low = _require_float("low", self.low)
+        close = _require_float("close", self.close)
+        volume = _require_float("volume", self.volume)
+        if volume < 0.0:
+            raise ValueError("volume must be non-negative")
+        if high < max(open_price, low, close):
+            raise ValueError("high must not be below open, low, or close")
+        if low > min(open_price, high, close):
+            raise ValueError("low must not be above open, high, or close")
+
+    def to_dict(self) -> dict[str, object]:
+        """Return the stable JSON-compatible representation."""
+        return {
+            "instrument": self.instrument.to_json_value(),
+            "start": format_utc(self.start),
+            "end": format_utc(self.end),
+            "open": self.open,
+            "high": self.high,
+            "low": self.low,
+            "close": self.close,
+            "volume": self.volume,
+        }
+
+    @classmethod
+    def from_dict(cls, data: object) -> OHLCVBar:
+        """Build a bar from its serialized representation."""
+        values = _require_exact_fields(data, cls._SERIALIZED_FIELDS)
+        start = values["start"]
+        end = values["end"]
+        if not isinstance(start, str) or not isinstance(end, str):
+            raise TypeError("serialized start and end must be strings")
+        return cls(
+            instrument=InstrumentId.from_json_value(values["instrument"]),
+            start=parse_utc(start),
+            end=parse_utc(end),
+            open=_require_float("open", values["open"]),
+            high=_require_float("high", values["high"]),
+            low=_require_float("low", values["low"]),
+            close=_require_float("close", values["close"]),
+            volume=_require_float("volume", values["volume"]),
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+from collections.abc import Iterator
+
+import pytest
+from fixtures.domain import make_ohlcv_bar
+
+from tracequant.domain import OHLCVBar
+
+
+@pytest.fixture
+def sample_bar() -> Iterator[OHLCVBar]:
+    """Provide a fresh, deterministic OHLCV bar with function scope."""
+    yield make_ohlcv_bar()

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,0 +1,1 @@
+"""Deterministic shared test factories."""

--- a/tests/fixtures/domain.py
+++ b/tests/fixtures/domain.py
@@ -1,0 +1,58 @@
+"""Explicit deterministic factories for shared domain test data."""
+
+from datetime import UTC, datetime
+
+from tracequant.domain import InstrumentId, OHLCVBar, TimeRange
+
+SAMPLE_START = datetime(2024, 2, 29, 23, 45, tzinfo=UTC)
+SAMPLE_END = datetime(2024, 3, 1, 0, 0, tzinfo=UTC)
+
+
+def make_instrument_id(value: str = "BTCUSDT") -> InstrumentId:
+    return InstrumentId(value)
+
+
+def make_time_range(
+    *, start: datetime = SAMPLE_START, end: datetime = SAMPLE_END
+) -> TimeRange:
+    return TimeRange(start=start, end=end)
+
+
+def make_ohlcv_bar(
+    *,
+    instrument: InstrumentId | None = None,
+    start: datetime = SAMPLE_START,
+    end: datetime = SAMPLE_END,
+    open: float = 60_000.0,
+    high: float = 61_000.0,
+    low: float = 59_500.0,
+    close: float = 60_500.0,
+    volume: float = 125.5,
+) -> OHLCVBar:
+    return OHLCVBar(
+        instrument=instrument if instrument is not None else make_instrument_id(),
+        start=start,
+        end=end,
+        open=open,
+        high=high,
+        low=low,
+        close=close,
+        volume=volume,
+    )
+
+
+def invalid_instrument_values() -> list[object]:
+    """Return a fresh collection of representative invalid identifier inputs."""
+    return ["", "   ", "BTC-USDT", "BTC/USDT", "比特币", "A" * 33, None, 123]
+
+
+def invalid_bar_overrides() -> list[dict[str, float]]:
+    """Return fresh invalid numeric overrides for parameterized tests."""
+    return [
+        {"open": float("nan")},
+        {"high": float("inf")},
+        {"low": float("-inf")},
+        {"volume": -1.0},
+        {"high": 59_000.0},
+        {"low": 62_000.0},
+    ]

--- a/tests/test_domain_models.py
+++ b/tests/test_domain_models.py
@@ -1,0 +1,105 @@
+from dataclasses import FrozenInstanceError
+from datetime import UTC, datetime, timedelta, timezone
+
+import pytest
+from fixtures.domain import (
+    SAMPLE_END,
+    SAMPLE_START,
+    invalid_bar_overrides,
+    invalid_instrument_values,
+    make_instrument_id,
+    make_ohlcv_bar,
+    make_time_range,
+)
+
+from tracequant.domain import InstrumentId, OHLCVBar, TimeRange
+
+
+def test_instrument_id_normalizes_and_supports_value_semantics() -> None:
+    instrument = InstrumentId("  btcusdt  ")
+
+    assert str(instrument) == "BTCUSDT"
+    assert instrument == InstrumentId("BTCUSDT")
+    assert hash(instrument) == hash(InstrumentId("BTCUSDT"))
+    assert {instrument, InstrumentId("btcusdt")} == {instrument}
+    assert repr(instrument) == "InstrumentId(value='BTCUSDT')"
+
+
+@pytest.mark.parametrize("value", invalid_instrument_values())
+def test_instrument_id_rejects_invalid_values(value: object) -> None:
+    with pytest.raises((TypeError, ValueError)):
+        InstrumentId(value)  # type: ignore[arg-type]
+
+
+def test_models_are_frozen(sample_bar: OHLCVBar) -> None:
+    with pytest.raises(FrozenInstanceError):
+        sample_bar.close = 1.0  # type: ignore[misc]
+    with pytest.raises(FrozenInstanceError):
+        sample_bar.instrument.value = "ETHUSDT"  # type: ignore[misc]
+
+
+def test_time_range_has_half_open_semantics_and_duration() -> None:
+    interval = make_time_range()
+
+    assert interval.duration == timedelta(minutes=15)
+    assert interval.contains(SAMPLE_START)
+    assert interval.contains(SAMPLE_END - timedelta(microseconds=1))
+    assert not interval.contains(SAMPLE_END)
+
+
+@pytest.mark.parametrize(
+    ("start", "end"),
+    [
+        (datetime(2024, 1, 1), SAMPLE_END),
+        (SAMPLE_START, datetime(2024, 3, 1)),
+        (
+            datetime(2024, 3, 1, tzinfo=timezone(timedelta(hours=8))),
+            SAMPLE_END,
+        ),
+        (SAMPLE_START, SAMPLE_START),
+        (SAMPLE_END, SAMPLE_START),
+    ],
+)
+def test_time_range_rejects_non_utc_and_invalid_intervals(
+    start: datetime, end: datetime
+) -> None:
+    with pytest.raises(ValueError):
+        TimeRange(start=start, end=end)
+
+
+def test_time_range_accepts_cross_month_leap_day_interval() -> None:
+    interval = TimeRange(
+        start=datetime(2024, 2, 29, 23, 59, tzinfo=UTC),
+        end=datetime(2024, 3, 1, 0, 1, tzinfo=UTC),
+    )
+
+    assert interval.duration == timedelta(minutes=2)
+
+
+@pytest.mark.parametrize("overrides", invalid_bar_overrides())
+def test_ohlcv_bar_rejects_invalid_numeric_values(
+    overrides: dict[str, float],
+) -> None:
+    with pytest.raises(ValueError):
+        make_ohlcv_bar(**overrides)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("price", [0.0, -1.0])
+def test_ohlcv_bar_allows_zero_and_negative_prices(price: float) -> None:
+    bar = make_ohlcv_bar(open=price, high=price, low=price, close=price)
+
+    assert bar.open == price
+    assert bar.close == price
+
+
+def test_ohlcv_bar_rejects_non_float_numeric_fields() -> None:
+    with pytest.raises(TypeError, match="open must be a float"):
+        make_ohlcv_bar(open=1)
+
+
+def test_shared_factory_returns_independent_objects(sample_bar: OHLCVBar) -> None:
+    another = make_ohlcv_bar(instrument=make_instrument_id("ETHUSDT"))
+
+    assert another is not sample_bar
+    assert another.instrument is not sample_bar.instrument
+    assert another.instrument == InstrumentId("ETHUSDT")

--- a/tests/test_domain_serialization.py
+++ b/tests/test_domain_serialization.py
@@ -1,0 +1,108 @@
+import json
+from datetime import UTC, datetime
+
+import pytest
+from fixtures.domain import make_instrument_id, make_ohlcv_bar, make_time_range
+
+from tracequant.domain import InstrumentId, OHLCVBar, TimeRange
+
+
+def test_instrument_id_scalar_round_trip() -> None:
+    instrument = make_instrument_id("ethusdt")
+
+    encoded = instrument.to_json_value()
+
+    assert encoded == "ETHUSDT"
+    assert InstrumentId.from_json_value(encoded) == instrument
+    assert json.loads(json.dumps(encoded)) == encoded
+
+
+def test_time_range_stable_json_round_trip() -> None:
+    interval = make_time_range()
+
+    encoded = interval.to_dict()
+
+    assert encoded == {
+        "start": "2024-02-29T23:45:00Z",
+        "end": "2024-03-01T00:00:00Z",
+    }
+    assert TimeRange.from_dict(json.loads(json.dumps(encoded))) == interval
+
+
+def test_deserialization_uses_existing_utc_parser_to_normalize_offsets() -> None:
+    interval = TimeRange.from_dict(
+        {
+            "start": "2024-03-01T07:45:00+08:00",
+            "end": "2024-03-01T08:00:00+08:00",
+        }
+    )
+
+    assert interval.start == datetime(2024, 2, 29, 23, 45, tzinfo=UTC)
+    assert interval.end == datetime(2024, 3, 1, 0, 0, tzinfo=UTC)
+
+
+def test_ohlcv_bar_stable_json_round_trip(sample_bar: OHLCVBar) -> None:
+    encoded = sample_bar.to_dict()
+
+    assert encoded == {
+        "instrument": "BTCUSDT",
+        "start": "2024-02-29T23:45:00Z",
+        "end": "2024-03-01T00:00:00Z",
+        "open": 60_000.0,
+        "high": 61_000.0,
+        "low": 59_500.0,
+        "close": 60_500.0,
+        "volume": 125.5,
+    }
+    assert OHLCVBar.from_dict(json.loads(json.dumps(encoded))) == sample_bar
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        {"start": "2024-01-01T00:00:00Z"},
+        {
+            "start": "2024-01-01T00:00:00Z",
+            "end": "2024-01-01T00:15:00Z",
+            "extra": True,
+        },
+        {"start": 1, "end": "2024-01-01T00:15:00Z"},
+        {"start": "2024-01-01T00:00:00", "end": "2024-01-01T00:15:00Z"},
+    ],
+)
+def test_time_range_deserialization_rejects_invalid_data(data: object) -> None:
+    with pytest.raises((TypeError, ValueError)):
+        TimeRange.from_dict(data)
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        ("missing", None),
+        ("extra", True),
+        ("volume", 1),
+        ("instrument", None),
+        ("start", "2024-02-29T23:45:00"),
+    ],
+)
+def test_bar_deserialization_rejects_invalid_data(
+    sample_bar: OHLCVBar, mutation: tuple[str, object]
+) -> None:
+    data = sample_bar.to_dict()
+    field, value = mutation
+    if field == "missing":
+        del data["close"]
+    else:
+        data[field] = value
+
+    with pytest.raises((TypeError, ValueError)):
+        OHLCVBar.from_dict(data)
+
+
+def test_factory_calls_do_not_share_serialized_state(sample_bar: OHLCVBar) -> None:
+    first = sample_bar.to_dict()
+    second = make_ohlcv_bar().to_dict()
+
+    first["instrument"] = "ETHUSDT"
+
+    assert second["instrument"] == "BTCUSDT"


### PR DESCRIPTION
EXPERIMENTAL ARM B — ABORTED BY WORKFLOW DEFECT

Refs #65

## 实现摘要

- 新增不可变 `InstrumentId`、`TimeRange` 与 `OHLCVBar` 公共领域模型。
- 提供严格校验、稳定 JSON-compatible 序列化和 round-trip 反序列化。
- 建立固定 UTC、可覆盖且无共享可变状态的 pytest fixture/factory 规范。
- 在 README 记录 Research MVP 公共导入路径、时间与价格边界及兼容性限制。

## 修改范围

- `src/tracequant/domain.py`
- `tests/conftest.py` 与 `tests/fixtures/domain.py`
- 领域校验和序列化测试
- README 最小使用与边界说明

## 关键设计决定

- 公共导入路径仅为 `tracequant.domain`，未在包根暴露未来类型。
- 直接构造只接受 aware UTC；反序列化复用现有 `parse_utc`，将 aware ISO 8601 offset 规范化为 UTC 并拒绝 naive 字符串。
- OHLCV 只接受 finite Python `float`；volume 非负，但零和负价格仍允许用于研究数据。
- 未引入 Pydantic、ORM、pickle、交易所抽象或其他生产依赖。

## 验证结果

| 命令 | 结果 | 说明 |
| --- | --- | --- |
| `workflow-delivery --base-sha 1683f987...` | PASS | 当前完整 CI 等价验证及仓库技能验证通过 |
| 领域与 UTC 定向 pytest | PASS | 73 passed |
| Ruff lint / format | PASS | 本次批准 Python 文件通过 |
| `mypy src tests` | PASS | 29 个 source files 无问题 |
| `git diff --cached --check` | PASS | 无空白错误 |

## 验收覆盖

- 三个模型、最小公共导入、不可变和 value semantics
- instrument 规范化及空白、字符、长度、类型失败路径
- UTC 半开区间、duration/containment、naive/非 UTC/非法区间失败路径
- finite float、非负 volume、OHLC 关系与零/负价格语义
- 精确 schema、JSON-compatible 输出、非法数据与 round-trip
- function-scope fixture、显式 factory 覆盖、跨模块复用和隔离
- 文档化当前内部协议边界与已知限制

## 风险检查

- [x] 未引入实盘交易或订单行为
- [x] 未提交或记录凭据
- [x] 未引入无时区领域 datetime
- [x] 未进行范围外重构
- [x] 已覆盖正常和失败路径

## 范围外内容

订单、账户、策略、交易所适配、存储 schema、Decimal/timeframe、fixture 平台及 CI workflow 均未实现或修改。

## 已知限制

- 这是 Research MVP 的初始内部序列化协议，不承诺长期外部版本兼容。
- `InstrumentId` 不解析 base/quote，也不携带 venue 或合约元数据。
- 模型刻意不校验交易所 tick/lot 规则或价格严格为正。

