### PR TITLE
[Task #136] 使独立 PR 审查支持 implementation-bearing Bug leaf

### DIFF
--- a/.agents/skills/task-delivery-runner/SKILL.md
+++ b/.agents/skills/task-delivery-runner/SKILL.md
@@ -166,7 +166,7 @@ unrelated, generated, secret-bearing, or prohibited files → fail.
 
 Generate the `delivery` snapshot. The snapshot provides deterministic
 identity facts: repository/origin, workspace, refs/worktrees, synchronized
-main identity, Task type/title/state, Parent identity,
+main identity, implementation-bearing leaf type/title/state, Parent identity,
 dependencies/Relationships metadata, labels, Project fields, blocker state,
 and PR head/base/checks when applicable. Verifying these mechanical facts
 does not require reading the full text of any source into the model context.

--- a/.agents/skills/task-pr-review-runner/SKILL.md
+++ b/.agents/skills/task-pr-review-runner/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: task-pr-review-runner
-description: Independently and strictly read-only review one maintainer-specified Task PR in a fresh session. Lock base/head/effective diff, inspect the complete change, run Review Runners, classify findings, output one fixed verdict, and when the verdict is not passing emit a bounded remediation handoff for task-delivery-runner. Never fix, write GitHub state, submit a review, merge, close Issues, perform closeout, or assess Feature completion.
+description: Independently and strictly read-only review one maintainer-specified implementation-bearing leaf PR in a fresh session. Lock base/head/effective diff, inspect the complete change, run Review Runners, classify findings, output one fixed verdict, and when the verdict is not passing emit a bounded remediation handoff for task-delivery-runner. Never fix, write GitHub state, submit a review, merge, close Issues, perform closeout, or assess Feature completion.
 ---
 
 # Task PR review runner
 
-Use this Skill for one existing Task PR in a new session that did not
+Use this Skill for one existing implementation-bearing leaf PR in a new session that did not
 participate in specification interpretation, implementation, fixes, commit,
 push, or PR creation. Otherwise stop with:
 
@@ -118,9 +118,13 @@ deletion, closeout, or Feature completion assessment.
 
 ## Phase 1: identify and lock
 
-Generate `review`. Verify same-repository Task/PR, Task type/state, exact closing
-linkage, PR open and non-Draft, expected base/head, complete files/commits,
-checks, reviews, threads, mergeability, and Required-Checks classification.
+Generate `review`. Verify same-repository implementation-bearing leaf/PR,
+canonical Issue type/state, exact closing linkage, PR open and non-Draft,
+expected base/head, complete files/commits, checks, reviews, threads,
+mergeability, and Required-Checks classification. Issue Specification v2 admits
+`type:task` and `type:bug` for this lifecycle; the shared Runner contract uses
+the authoritative `type:*` label and fails closed on missing, conflicting,
+unknown, or non-reviewable types.
 
 Lock and report:
 

--- a/.claude/skills/task-delivery-runner/SKILL.md
+++ b/.claude/skills/task-delivery-runner/SKILL.md
@@ -225,7 +225,7 @@ Dirty with unrelated, generated, secret-bearing, or prohibited files → fail.
 
 Generate the `delivery` snapshot. The snapshot provides deterministic
 identity facts: repository/origin, workspace, refs/worktrees, synchronized
-main identity, Task type/title/state, Parent identity,
+main identity, implementation-bearing leaf type/title/state, Parent identity,
 dependencies/Relationships metadata, labels, Project fields, blocker state,
 and PR head/base/checks when applicable. Verifying these mechanical facts
 does not require reading the full text of any source into the model context.

--- a/.claude/skills/task-pr-review-runner/SKILL.md
+++ b/.claude/skills/task-pr-review-runner/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: task-pr-review-runner
-description: Independently and strictly read-only review one maintainer-specified Task PR in a fresh session. Lock base/head/effective diff, inspect the complete change, run Review Runners, classify findings, output one fixed verdict, and when the verdict is not passing emit a bounded remediation handoff for task-delivery-runner. Never fix, write GitHub state, submit a review, merge, close Issues, perform closeout, or assess Feature completion.
+description: Independently and strictly read-only review one maintainer-specified implementation-bearing leaf PR in a fresh session. Lock base/head/effective diff, inspect the complete change, run Review Runners, classify findings, output one fixed verdict, and when the verdict is not passing emit a bounded remediation handoff for task-delivery-runner. Never fix, write GitHub state, submit a review, merge, close Issues, perform closeout, or assess Feature completion.
 ---
 
 # Task PR review runner
 
-Use this Skill for one existing Task PR in a new session that did not
+Use this Skill for one existing implementation-bearing leaf PR in a new session that did not
 participate in specification interpretation, implementation, fixes, commit,
 push, or PR creation. Otherwise stop with:
 
@@ -163,9 +163,13 @@ deletion, closeout, or Feature completion assessment.
 
 ## Phase 1: identify and lock
 
-Generate `review`. Verify same-repository Task/PR, Task type/state, exact closing
-linkage, PR open and non-Draft, expected base/head, complete files/commits,
-checks, reviews, threads, mergeability, and Required-Checks classification.
+Generate `review`. Verify same-repository implementation-bearing leaf/PR,
+canonical Issue type/state, exact closing linkage, PR open and non-Draft,
+expected base/head, complete files/commits, checks, reviews, threads,
+mergeability, and Required-Checks classification. Issue Specification v2 admits
+`type:task` and `type:bug` for this lifecycle; the shared Runner contract uses
+the authoritative `type:*` label and fails closed on missing, conflicting,
+unknown, or non-reviewable types.
 
 Lock and report:
 

--- a/docs/development/issue-workflow.md
+++ b/docs/development/issue-workflow.md
@@ -52,11 +52,19 @@ GitHub native metadata 是其机械事实。
 | Parent / Sub-issues / blocked-by / blocking | GitHub native metadata | 不在正文重复机械 metadata |
 | PR / merge identity | GitHub native（Squash Merge） | closeout 验证对象 |
 
+Issue Specification v2 的 `type:*` label 是 Issue classification 的权威 carrier。
+在本仓库的 personal-account 配置中，native Issue Type 不可用；如果机械 API
+同时返回 native type，Runner 只将其作为一致性校验。缺失 canonical label、多个
+互斥 type labels、native/label 冲突或未知 type 都必须 fail closed。`type:task`
+与 `type:bug` 是 implementation-bearing leaf，可进入 Delivery、PR 与
+Independent Review；`type:epic`、`type:feature`、`type:research` 不属于该
+implementation PR lifecycle。
+
 不得在 Issue 正文重复维护与 native relationship 等价的机械 metadata。
 
 ## 4. Readiness
 
-一个 Task 满足以下条件才可开始 Delivery：
+一个 implementation-bearing leaf 满足以下条件才可开始 Delivery：
 
 - `codex:ready` label 存在且无 `codex:blocked`；
 - Project Status = Ready（或等效 lifecycle 状态）；
@@ -117,7 +125,7 @@ intent 无法可靠解析时：**不要猜**。回退到 explicit Skill-name fal
   targeted validation → commit → push → PR → CI checks → delivery readiness →
   handoff for Independent Review。
 - 一个 Task 通常产生一个 PR（base = `main`）。
-- 实现只处理当前 leaf Task；不进行无关重构。
+- 实现只处理当前 implementation-bearing leaf；不进行无关重构。
 - 提交前必须完成 target validation；PR 创建前必须完成 delivery readiness
   验证（Runner 快照）。
 - Human Gate 事项未决时不得继续 Delivery（§9）。

--- a/docs/development/pr-review.md
+++ b/docs/development/pr-review.md
@@ -11,9 +11,9 @@ executable procedure（命令序列、权限行为、Runner argv 等）。
 
 ## 1. Purpose / Independence
 
-- Review 是对一个 Task PR 的**独立**质量门禁：fresh session 中由未参与
+- Review 是对一个 implementation-bearing leaf PR 的**独立**质量门禁：fresh session 中由未参与
   该 head 实现或 remediation 的 session 执行。
-- Review 的结论基于 current Task specification + effective diff +
+- Review 的结论基于 current leaf specification + effective diff +
   relevant code/tests/checks 的完整证据，不继承 Delivery 的 self-check
   结论（no Delivery verdict inheritance）。
 - Review 不修复 findings、不改变 Issue/PR/Project state、不 merge。
@@ -33,9 +33,14 @@ Review 对 repository / Issue / PR / Project 完全只读：不写文件、
 
 Review 锁定以下身份（确定性验证，非模型解读）：
 
-- target Task（number 为主键，current title 为 canonical）；
+- target implementation-bearing leaf（number 为主键，current title 为
+  canonical；Issue Specification v2 的 `type:task` 与 `type:bug` 均可审查）；
 - target PR（base / head SHA）；
-- 当前 Task specification（leaf body + 有效 spec）。
+- 当前 leaf specification（body + 有效 spec）。
+
+Review admission 使用与 Delivery 相同的 canonical Issue type contract：`type:*`
+label 是权威 carrier，native Issue Type（若可见）必须与 label 一致；缺失、冲突、
+未知或非 implementation-bearing leaf type 均 fail closed。
 
 ## 5. Head lock
 

--- a/tests/tools/test_workflow_evidence.py
+++ b/tests/tools/test_workflow_evidence.py
@@ -7,6 +7,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 SCRIPT = Path(__file__).parents[2] / "tools" / "agent_workflow" / "workflow_evidence.py"
 PYTHON = os.environ.get("WORKFLOW_TEST_PYTHON", sys.executable)
 
@@ -1244,6 +1246,175 @@ def test_delivery_preflight_delivery_start_passes_with_ready_status(
     assert value["gates"]["lifecycle_labels_exclusive"]["status"] == "pass"
     assert value["gates"]["project_status_known"]["status"] == "pass"
     assert value["gates"]["parent_blocking"]["status"] == "pass"
+
+
+def _review_snapshot_for_type(
+    tmp_path: Path,
+    *,
+    labels: list[dict[str, str]],
+    native_type: str | None,
+) -> dict[str, Any]:
+    state = _base_state()
+    state["issues"]["70"]["labels"] = labels
+    state["issues"]["70"]["projectItems"] = [{"status": {"name": "Review"}}]
+    state["relationships"]["issueType"] = (
+        {"name": native_type} if native_type is not None else None
+    )
+    repo, _, env = _write_repo(tmp_path, state)
+    result = _run(
+        repo,
+        env,
+        "pr-review-snapshot",
+        "--task",
+        "70",
+        "--pr",
+        "71",
+        "--expected-base-sha",
+        "2" * 40,
+        "--expected-head-sha",
+        "4" * 40,
+    )
+    assert result.returncode == 0, result.stderr
+    value = json.loads(result.stdout)
+    assert isinstance(value, dict)
+    return value
+
+
+def test_review_admission_accepts_canonical_task_leaf(tmp_path: Path) -> None:
+    value = _review_snapshot_for_type(
+        tmp_path,
+        labels=[{"name": "type:task"}, {"name": "codex:ready"}],
+        native_type="Task",
+    )
+    assert value["gates"]["issue_type"]["status"] == "pass"
+
+
+def test_review_admission_accepts_canonical_bug_leaf(tmp_path: Path) -> None:
+    value = _review_snapshot_for_type(
+        tmp_path,
+        labels=[{"name": "type:bug"}, {"name": "codex:ready"}],
+        native_type="Bug",
+    )
+    assert value["gates"]["issue_type"]["status"] == "pass"
+    assert value["gates"]["project_status_review"]["status"] == "pass"
+    for gate_name in (
+        "issue_state",
+        "label:codex:ready",
+        "label-not:codex:blocked",
+        "closing_linkage",
+        "base_sha",
+        "head_sha",
+    ):
+        assert value["gates"][gate_name]["status"] == "pass"
+
+
+def test_review_admission_accepts_real_issue_134_metadata_shape(
+    tmp_path: Path,
+) -> None:
+    value = _review_snapshot_for_type(
+        tmp_path,
+        labels=[
+            {"name": "type:bug"},
+            {"name": "area:foundation"},
+            {"name": "codex:ready"},
+        ],
+        native_type="Bug",
+    )
+    assert value["gates"]["issue_type"]["status"] == "pass"
+
+
+@pytest.mark.parametrize(
+    ("canonical_type", "native_type"),
+    [("feature", "Feature"), ("epic", "Epic"), ("research", "Research")],
+)
+def test_review_admission_rejects_non_reviewable_leaf_types(
+    tmp_path: Path,
+    canonical_type: str,
+    native_type: str,
+) -> None:
+    value = _review_snapshot_for_type(
+        tmp_path,
+        labels=[{"name": f"type:{canonical_type}"}, {"name": "codex:ready"}],
+        native_type=native_type,
+    )
+    assert value["gates"]["issue_type"]["status"] == "fail"
+
+
+def test_review_admission_rejects_missing_canonical_type(tmp_path: Path) -> None:
+    value = _review_snapshot_for_type(
+        tmp_path,
+        labels=[{"name": "codex:ready"}],
+        native_type=None,
+    )
+    assert value["gates"]["issue_type"]["status"] == "fail"
+    assert "missing" in value["gates"]["issue_type"]["detail"]
+
+
+def test_review_admission_rejects_conflicting_type_identity(tmp_path: Path) -> None:
+    value = _review_snapshot_for_type(
+        tmp_path,
+        labels=[
+            {"name": "type:task"},
+            {"name": "type:bug"},
+            {"name": "codex:ready"},
+        ],
+        native_type="Task",
+    )
+    assert value["gates"]["issue_type"]["status"] == "fail"
+    assert "conflicting" in value["gates"]["issue_type"]["detail"]
+
+
+def test_review_admission_rejects_native_type_conflict(tmp_path: Path) -> None:
+    value = _review_snapshot_for_type(
+        tmp_path,
+        labels=[{"name": "type:bug"}, {"name": "codex:ready"}],
+        native_type="Task",
+    )
+    assert value["gates"]["issue_type"]["status"] == "fail"
+    assert "conflicts" in value["gates"]["issue_type"]["detail"]
+
+
+def test_delivery_and_review_accept_the_same_bug_leaf_contract(
+    tmp_path: Path,
+) -> None:
+    state = _base_state()
+    state["issues"]["70"]["labels"] = [
+        {"name": "type:bug"},
+        {"name": "codex:ready"},
+    ]
+    state["issues"]["70"]["projectItems"] = [{"status": {"name": "Ready"}}]
+    state["relationships"]["issueType"] = {"name": "Bug"}
+    repo, state_path, env = _write_repo(tmp_path, state)
+    delivery = _run(
+        repo,
+        env,
+        "delivery-preflight",
+        "--task",
+        "70",
+        "--expected-main-sha",
+        "2" * 40,
+        "--entry-point",
+        "delivery-start",
+    )
+    assert delivery.returncode == 0, delivery.stderr
+    assert json.loads(delivery.stdout)["gates"]["issue_type"]["status"] == "pass"
+    state["issues"]["70"]["projectItems"] = [{"status": {"name": "Review"}}]
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    review = _run(
+        repo,
+        env,
+        "pr-review-snapshot",
+        "--task",
+        "70",
+        "--pr",
+        "71",
+        "--expected-base-sha",
+        "2" * 40,
+        "--expected-head-sha",
+        "4" * 40,
+    )
+    assert review.returncode == 0, review.stderr
+    assert json.loads(review.stdout)["gates"]["issue_type"]["status"] == "pass"
 
 
 def test_delivery_preflight_lifecycle_conflict_ready_and_needs_spec(

--- a/tests/tools/test_wsl2_github_evidence_runner.py
+++ b/tests/tools/test_wsl2_github_evidence_runner.py
@@ -421,6 +421,24 @@ def test_review_profile_returns_required_schema_and_compact_digest(
     }
 
 
+def test_review_profile_accepts_bug_implementation_leaf(
+    tmp_path: Path,
+) -> None:
+    repo, state_path, env, main_sha, head_sha = _prepare_repo(tmp_path)
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["issue"]["labels"] = [
+        {"name": "type:bug"},
+        {"name": "codex:ready"},
+    ]
+    state["relationships"]["issueType"] = {"name": "Bug"}
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    completed = _run(repo, env, *_review_args(main_sha, head_sha))
+    assert completed.returncode == 0, completed.stderr
+    result = _result(repo, completed.stdout)
+    assert result["status"] == "pass"
+    assert result["identity"]["head_sha"] == head_sha
+
+
 @pytest.mark.parametrize("profile", ["delivery-readiness", "review", "pre-merge"])
 def test_task_pr_profiles_are_fixed_and_pass(tmp_path: Path, profile: str) -> None:
     repo, _, env, main_sha, head_sha = _prepare_repo(tmp_path)

--- a/tools/agent_workflow/workflow_evidence.py
+++ b/tools/agent_workflow/workflow_evidence.py
@@ -74,6 +74,8 @@ query($owner:String!, $name:String!, $number:Int!) {
 LIFECYCLE_LABELS: Final = frozenset(
     {"codex:needs-spec", "codex:ready", "codex:blocked"}
 )
+CANONICAL_ISSUE_TYPES: Final = frozenset({"epic", "feature", "task", "bug", "research"})
+IMPLEMENTATION_BEARING_LEAF_TYPES: Final = ("type:task", "type:bug")
 KNOWN_PROJECT_STATUSES: Final = frozenset(
     {"Inbox", "Specifying", "Ready", "In Progress", "Review", "Blocked", "Done"}
 )
@@ -1678,7 +1680,7 @@ def _issue_gates(
     expected_state: str | None,
     required_label: str | None,
     forbidden_label: str | None,
-    expected_type_label: str | None,
+    expected_type_label: str | Sequence[str] | None,
 ) -> dict[str, Any]:
     gates: dict[str, Any] = {}
     if issue is None:
@@ -1709,17 +1711,76 @@ def _issue_gates(
             "pass" if forbidden_label not in labels else "fail"
         )
     if expected_type_label:
-        issue_type = relationships.get("issue_type")
-        matches_type = expected_type_label in labels or (
-            isinstance(issue_type, str)
-            and issue_type.casefold()
-            == expected_type_label.removeprefix("type:").casefold()
+        expected_types = (
+            [expected_type_label]
+            if isinstance(expected_type_label, str)
+            else list(expected_type_label)
         )
-        gates["issue_type"] = _gate(
-            "pass" if matches_type else "unknown", expected_type_label
+        gates["issue_type"] = _issue_type_gate(
+            labels,
+            relationships.get("issue_type"),
+            expected_types,
         )
     gates["formal_blockers"] = _formal_blockers_gate(relationships)
     return gates
+
+
+def _issue_type_gate(
+    labels: set[str],
+    native_issue_type: Any,
+    expected_types: Sequence[str],
+) -> dict[str, Any]:
+    """Validate the Issue Specification v2 type carrier and lifecycle kind.
+
+    Issue Specification v2 assigns classification semantics to ``type:*``
+    labels because native Issue Types are unavailable for the repository's
+    personal-account setup.  A native type, when returned by GitHub, is only
+    an independent consistency check; it cannot silently replace a missing
+    authoritative label.  This keeps Delivery and Review on the same
+    fail-closed contract.
+    """
+    label_types = sorted(
+        label.removeprefix("type:").casefold()
+        for label in labels
+        if isinstance(label, str) and label.startswith("type:")
+    )
+    native_type = (
+        native_issue_type.removeprefix("type:").casefold()
+        if isinstance(native_issue_type, str) and native_issue_type.strip()
+        else None
+    )
+    expected = sorted(
+        value.removeprefix("type:").casefold()
+        for value in expected_types
+        if isinstance(value, str)
+    )
+    if len(label_types) != 1:
+        if not label_types:
+            return _gate(
+                "fail",
+                "canonical type label is missing; native Issue Type cannot replace it",
+            )
+        return _gate(
+            "fail",
+            f"conflicting canonical type labels: {label_types}",
+        )
+    label_type = label_types[0]
+    if label_type not in CANONICAL_ISSUE_TYPES:
+        return _gate("fail", f"unsupported canonical Issue type: {label_type}")
+    if native_type is not None:
+        if native_type not in CANONICAL_ISSUE_TYPES:
+            return _gate("fail", f"unsupported native Issue Type: {native_type}")
+        if native_type != label_type:
+            return _gate(
+                "fail",
+                f"native Issue Type {native_type!r} conflicts with label type {label_type!r}",
+            )
+    if label_type not in expected:
+        return _gate(
+            "fail",
+            f"Issue type {label_type!r} is not allowed here; expected one of {expected}",
+        )
+    return _gate("pass", f"canonical Issue type: {label_type}")
 
 
 def _formal_blockers_gate(relationships: Mapping[str, Any]) -> dict[str, Any]:
@@ -2032,7 +2093,7 @@ def _collect_task_pr(
         expected_state=issue_expected_state,
         required_label="codex:ready",
         forbidden_label="codex:blocked",
-        expected_type_label="type:task",
+        expected_type_label=IMPLEMENTATION_BEARING_LEAF_TYPES,
     )
     gates["origin_fetch"] = _gate(observed["git"].get("origin_fetch", "unknown"))
     if pr_number is not None:
@@ -2287,7 +2348,7 @@ def _delivery_preflight(args: argparse.Namespace, repo_root: Path) -> dict[str, 
             expected_state="OPEN",
             required_label="codex:ready",
             forbidden_label="codex:blocked",
-            expected_type_label="type:task",
+            expected_type_label=IMPLEMENTATION_BEARING_LEAF_TYPES,
         )
         gates = dict(issue_gates)
         gates["repository"] = _gate("pass")
@@ -2953,12 +3014,15 @@ def _build_parser() -> argparse.ArgumentParser:
     delivery.add_argument("--expected-head-sha", help="expected branch head SHA")
     delivery.add_argument("--pr", type=int, help="expected PR number")
 
-    readiness = sub.add_parser("delivery-readiness", help="Task PR readiness snapshot")
+    readiness = sub.add_parser(
+        "delivery-readiness", help="implementation-bearing leaf PR readiness snapshot"
+    )
     _common(readiness)
     _pr_args(readiness)
 
     review = sub.add_parser(
-        "pr-review-snapshot", help="independent PR review metadata snapshot"
+        "pr-review-snapshot",
+        help="independent implementation-bearing leaf PR review metadata snapshot",
     )
     _common(review)
     _pr_args(review)

--- a/tools/agent_workflow/wsl2_github_evidence_profiles.json
+++ b/tools/agent_workflow/wsl2_github_evidence_profiles.json
@@ -24,7 +24,7 @@
         "expected_base_sha",
         "expected_head_sha"
       ],
-      "description": "Delivery handoff snapshot for a review-ready Task PR."
+      "description": "Delivery handoff snapshot for a review-ready implementation-bearing leaf PR."
     },
     "review": {
       "operation": "pr-review-snapshot",
@@ -34,7 +34,7 @@
         "expected_base_sha",
         "expected_head_sha"
       ],
-      "description": "Independent review snapshot for the locked PR base and head."
+      "description": "Independent review admission snapshot for the locked implementation-bearing leaf PR base and head."
     },
     "pre-merge": {
       "operation": "pr-review-snapshot",


### PR DESCRIPTION
Closes #136

## Implementation

- Define one canonical Issue Specification v2 type gate for Delivery and Independent Review.
- Admit `type:task` and `type:bug` implementation-bearing leaves.
- Keep missing, conflicting, unknown, native/label-conflicting, and non-reviewable types fail-closed.
- Update the shared workflow docs, both Skill variants, Runner profile descriptions, and regression coverage.

## Validation

- `targeted:tools-tests` — PASS (344 tests collected; 1 skipped)
- `current-ci-equivalent` — PASS
- `workflow-delivery` — PASS
- `git diff --check` — PASS

## Risks and limitations

- This is limited to canonical type admission parity; branch bootstrap, remediation handoff, evidence schema, #135 F1–F5, Task #65, and benchmark evidence are out of scope.
- `targeted:workflow-tests` remains unavailable on baseline because its fixed command references the absent `tests/tools/test_skill_variant_provenance.py`; the complete `targeted:tools-tests` and CI-equivalent profiles pass.
