### PR TITLE
[Task] 定义初始公共领域模型与共享测试 Fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,26 @@ Pull requests targeting `main` and pushes to `main` automatically run CI. The wo
 
 Internal datetimes must be timezone-aware and use UTC as the standard timezone. Naive datetimes are explicitly rejected. Time utilities are provided by `tracequant.core.time`.
 
+## Initial domain models
+
+The Research MVP exposes `InstrumentId`, `TimeRange`, and `OHLCVBar` from
+`tracequant.domain`. These are immutable internal public models with explicit
+validation and deterministic JSON-compatible `to_dict` / `from_dict` methods.
+
+`InstrumentId` is a single normalized ASCII identifier of at most 32 letters or
+digits, without venue or contract metadata. `TimeRange` and bar intervals use aware
+UTC half-open `[start, end)` semantics. OHLCV values are finite Python floats; volume
+is non-negative and OHLC relationships are validated. Zero and negative prices are
+intentionally accepted at this research-data boundary and may be constrained by
+later, more specific models.
+
+Shared tests keep reusable pytest fixtures in `tests/conftest.py` and deterministic,
+parameterizable factories in `tests/fixtures/domain.py`. Shared fixtures remain
+function-scoped, while one-test-only data stays in its test module. The factories use
+fixed UTC values and never read the clock, random state, environment, network, or
+filesystem. These initial models do not define an external versioned protocol and do
+not include exchange metadata, timeframes, precision rules, orders, or persistence.
+
 ## Configuration
 
 Application configuration is loaded explicitly with `tracequant.config.load_settings`.

--- a/src/tracequant/domain/__init__.py
+++ b/src/tracequant/domain/__init__.py
@@ -1,0 +1,5 @@
+"""Initial public domain models for the Research MVP."""
+
+from tracequant.domain.models import InstrumentId, OHLCVBar, TimeRange
+
+__all__ = ["InstrumentId", "OHLCVBar", "TimeRange"]

--- a/src/tracequant/domain/models.py
+++ b/src/tracequant/domain/models.py
@@ -1,0 +1,195 @@
+"""Immutable, validated domain values shared by research modules."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from math import isfinite
+from typing import Final
+
+from tracequant.core.time import format_utc, is_utc, parse_utc, to_utc
+
+_MAX_INSTRUMENT_LENGTH: Final = 32
+
+
+def _require_exact_fields(
+    value: Mapping[str, object], expected: frozenset[str], model: str
+) -> None:
+    actual = frozenset(value)
+    if actual != expected:
+        missing = sorted(expected - actual)
+        extra = sorted(actual - expected)
+        raise ValueError(f"invalid {model} fields: missing={missing}, extra={extra}")
+
+
+def _require_string(value: object, field: str) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{field} must be a string")
+    return value
+
+
+def _require_float(value: object, field: str) -> float:
+    if not isinstance(value, float):
+        raise TypeError(f"{field} must be a float")
+    if not isfinite(value):
+        raise ValueError(f"{field} must be finite")
+    return value
+
+
+def _require_utc(value: datetime, field: str) -> datetime:
+    if not isinstance(value, datetime):
+        raise TypeError(f"{field} must be a datetime")
+    if not is_utc(value):
+        raise ValueError(f"{field} must be timezone-aware UTC")
+    return to_utc(value)
+
+
+@dataclass(frozen=True, slots=True)
+class InstrumentId:
+    """A normalized instrument identifier without exchange metadata."""
+
+    value: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.value, str):
+            raise TypeError("instrument value must be a string")
+        normalized = self.value.strip()
+        if not normalized:
+            raise ValueError("instrument value must not be empty")
+        if not normalized.isascii():
+            raise ValueError(
+                "instrument value must contain only ASCII letters and digits"
+            )
+        normalized = normalized.upper()
+        if not normalized.isalnum():
+            raise ValueError(
+                "instrument value must contain only ASCII letters and digits"
+            )
+        if len(normalized) > _MAX_INSTRUMENT_LENGTH:
+            raise ValueError(
+                f"instrument value must be at most {_MAX_INSTRUMENT_LENGTH} characters"
+            )
+        object.__setattr__(self, "value", normalized)
+
+    def __str__(self) -> str:
+        return self.value
+
+    def to_dict(self) -> str:
+        """Return the stable JSON-compatible representation."""
+        return self.value
+
+    @classmethod
+    def from_dict(cls, value: object) -> InstrumentId:
+        """Build an identifier from its JSON-compatible representation."""
+        return cls(_require_string(value, "instrument"))
+
+
+@dataclass(frozen=True, slots=True)
+class TimeRange:
+    """A timezone-aware UTC half-open interval ``[start, end)``."""
+
+    start: datetime
+    end: datetime
+
+    def __post_init__(self) -> None:
+        start = _require_utc(self.start, "start")
+        end = _require_utc(self.end, "end")
+        if start >= end:
+            raise ValueError("start must be earlier than end")
+        object.__setattr__(self, "start", start)
+        object.__setattr__(self, "end", end)
+
+    @property
+    def duration(self) -> timedelta:
+        """Return the duration of the interval."""
+        return self.end - self.start
+
+    def contains(self, value: datetime) -> bool:
+        """Return whether an aware UTC datetime is inside ``[start, end)``."""
+        candidate = _require_utc(value, "value")
+        return self.start <= candidate < self.end
+
+    def to_dict(self) -> dict[str, str]:
+        """Return a stable JSON-compatible representation."""
+        return {"start": format_utc(self.start), "end": format_utc(self.end)}
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, object]) -> TimeRange:
+        """Build an interval from its JSON-compatible representation."""
+        _require_exact_fields(value, frozenset({"start", "end"}), "TimeRange")
+        return cls(
+            start=parse_utc(_require_string(value["start"], "start")),
+            end=parse_utc(_require_string(value["end"], "end")),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class OHLCVBar:
+    """A validated OHLCV bar for one instrument and half-open UTC interval."""
+
+    instrument: InstrumentId
+    start: datetime
+    end: datetime
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.instrument, InstrumentId):
+            raise TypeError("instrument must be an InstrumentId")
+        interval = TimeRange(self.start, self.end)
+        object.__setattr__(self, "start", interval.start)
+        object.__setattr__(self, "end", interval.end)
+
+        prices = {
+            "open": _require_float(self.open, "open"),
+            "high": _require_float(self.high, "high"),
+            "low": _require_float(self.low, "low"),
+            "close": _require_float(self.close, "close"),
+        }
+        volume = _require_float(self.volume, "volume")
+        if volume < 0:
+            raise ValueError("volume must be non-negative")
+        if prices["high"] < max(prices.values()):
+            raise ValueError("high must not be below open, low, or close")
+        if prices["low"] > min(prices.values()):
+            raise ValueError("low must not be above open, high, or close")
+
+    @property
+    def time_range(self) -> TimeRange:
+        """Return the bar's half-open time interval."""
+        return TimeRange(self.start, self.end)
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a stable JSON-compatible representation."""
+        return {
+            "instrument": self.instrument.to_dict(),
+            "start": format_utc(self.start),
+            "end": format_utc(self.end),
+            "open": self.open,
+            "high": self.high,
+            "low": self.low,
+            "close": self.close,
+            "volume": self.volume,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, object]) -> OHLCVBar:
+        """Build a bar from its JSON-compatible representation."""
+        fields = frozenset(
+            {"instrument", "start", "end", "open", "high", "low", "close", "volume"}
+        )
+        _require_exact_fields(value, fields, "OHLCVBar")
+        return cls(
+            instrument=InstrumentId.from_dict(value["instrument"]),
+            start=parse_utc(_require_string(value["start"], "start")),
+            end=parse_utc(_require_string(value["end"], "end")),
+            open=_require_float(value["open"], "open"),
+            high=_require_float(value["high"], "high"),
+            low=_require_float(value["low"], "low"),
+            close=_require_float(value["close"], "close"),
+            volume=_require_float(value["volume"], "volume"),
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+"""Shared pytest fixtures used by more than one test module."""
+
+import pytest
+from fixtures.domain import make_invalid_ohlcv_payload, make_ohlcv_bar
+
+from tracequant.domain import OHLCVBar
+
+
+@pytest.fixture
+def sample_bar() -> OHLCVBar:
+    """Return a fresh deterministic valid bar for each test."""
+    return make_ohlcv_bar()
+
+
+@pytest.fixture
+def invalid_bar_payload() -> dict[str, object]:
+    """Return a fresh deterministic invalid payload for each test."""
+    return make_invalid_ohlcv_payload()

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,0 +1,1 @@
+"""Deterministic test data factories shared across test modules."""

--- a/tests/fixtures/domain.py
+++ b/tests/fixtures/domain.py
@@ -1,0 +1,40 @@
+"""Small deterministic factories for public domain models."""
+
+from datetime import UTC, datetime
+
+from tracequant.domain import InstrumentId, OHLCVBar
+
+SAMPLE_START = datetime(2026, 2, 28, 23, 59, tzinfo=UTC)
+SAMPLE_END = datetime(2026, 3, 1, 0, 0, tzinfo=UTC)
+
+
+def make_ohlcv_bar(
+    *,
+    instrument: InstrumentId | None = None,
+    start: datetime = SAMPLE_START,
+    end: datetime = SAMPLE_END,
+    open: float = 100.0,
+    high: float = 110.0,
+    low: float = 90.0,
+    close: float = 105.0,
+    volume: float = 12.5,
+) -> OHLCVBar:
+    """Return a fresh valid bar while allowing every field to be explicit."""
+    return OHLCVBar(
+        instrument=instrument or InstrumentId("BTCUSDT"),
+        start=start,
+        end=end,
+        open=open,
+        high=high,
+        low=low,
+        close=close,
+        volume=volume,
+    )
+
+
+def make_invalid_ohlcv_payload(**overrides: object) -> dict[str, object]:
+    """Return a fresh invalid serialization payload with explicit overrides."""
+    payload = make_ohlcv_bar().to_dict()
+    payload["volume"] = -1.0
+    payload.update(overrides)
+    return payload

--- a/tests/test_domain_fixtures.py
+++ b/tests/test_domain_fixtures.py
@@ -1,0 +1,25 @@
+from fixtures.domain import make_invalid_ohlcv_payload, make_ohlcv_bar
+
+from tracequant.domain import OHLCVBar
+
+
+def test_factory_returns_equal_but_distinct_objects() -> None:
+    first = make_ohlcv_bar()
+    second = make_ohlcv_bar()
+
+    assert first == second
+    assert first is not second
+    assert first.instrument is not second.instrument
+
+
+def test_payload_factory_does_not_share_mutable_state() -> None:
+    first = make_invalid_ohlcv_payload()
+    second = make_invalid_ohlcv_payload()
+    first["volume"] = 10.0
+
+    assert second["volume"] == -1.0
+
+
+def test_shared_fixture_is_function_scoped_and_fresh(sample_bar: OHLCVBar) -> None:
+    assert sample_bar == make_ohlcv_bar()
+    assert sample_bar is not make_ohlcv_bar()

--- a/tests/test_domain_models.py
+++ b/tests/test_domain_models.py
@@ -1,0 +1,136 @@
+from dataclasses import FrozenInstanceError
+from datetime import UTC, datetime, timedelta, timezone
+
+import pytest
+from fixtures.domain import SAMPLE_END, SAMPLE_START, make_ohlcv_bar
+
+from tracequant.domain import InstrumentId, OHLCVBar, TimeRange
+
+
+def test_instrument_normalizes_is_hashable_and_stringifies() -> None:
+    instrument = InstrumentId("  btcusdt  ")
+
+    assert instrument == InstrumentId("BTCUSDT")
+    assert str(instrument) == "BTCUSDT"
+    assert {instrument} == {InstrumentId("btcusdt")}
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["", "   ", "BTC-USDT", "BTC/USDT", "ＢＴＣ", "ß", "A" * 33],
+)
+def test_instrument_rejects_invalid_values(value: str) -> None:
+    with pytest.raises(ValueError):
+        InstrumentId(value)
+
+
+def test_instrument_rejects_non_string() -> None:
+    with pytest.raises(TypeError, match="must be a string"):
+        InstrumentId(123)  # type: ignore[arg-type]
+
+
+def test_time_range_is_half_open_and_exposes_duration() -> None:
+    interval = TimeRange(SAMPLE_START, SAMPLE_END)
+
+    assert interval.duration == timedelta(minutes=1)
+    assert interval.contains(SAMPLE_START)
+    assert interval.contains(SAMPLE_END - timedelta(microseconds=1))
+    assert not interval.contains(SAMPLE_END)
+
+
+@pytest.mark.parametrize(
+    ("start", "end"),
+    [
+        (datetime(2026, 1, 1), SAMPLE_END),
+        (SAMPLE_START, datetime(2026, 3, 1)),
+        (
+            datetime(2026, 3, 1, tzinfo=timezone(timedelta(hours=8))),
+            SAMPLE_END,
+        ),
+        (SAMPLE_START, SAMPLE_START),
+        (SAMPLE_END, SAMPLE_START),
+    ],
+)
+def test_time_range_rejects_non_utc_and_invalid_intervals(
+    start: datetime, end: datetime
+) -> None:
+    with pytest.raises(ValueError):
+        TimeRange(start, end)
+
+
+def test_time_range_handles_leap_day_and_month_boundary() -> None:
+    interval = TimeRange(
+        datetime(2024, 2, 29, 23, 59, tzinfo=UTC),
+        datetime(2024, 3, 1, 0, 1, tzinfo=UTC),
+    )
+
+    assert interval.duration == timedelta(minutes=2)
+
+
+def test_time_range_is_immutable_hashable_and_comparable() -> None:
+    interval = TimeRange(SAMPLE_START, SAMPLE_END)
+
+    assert interval == TimeRange(SAMPLE_START, SAMPLE_END)
+    assert hash(interval) == hash(TimeRange(SAMPLE_START, SAMPLE_END))
+    with pytest.raises(FrozenInstanceError):
+        interval.end = SAMPLE_START  # type: ignore[misc]
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+@pytest.mark.parametrize("field", ["open", "high", "low", "close", "volume"])
+def test_bar_rejects_non_finite_numbers(field: str, value: float) -> None:
+    with pytest.raises(ValueError, match="must be finite"):
+        make_ohlcv_bar(**{field: value})  # type: ignore[arg-type]
+
+
+def test_bar_rejects_negative_volume() -> None:
+    with pytest.raises(ValueError, match="volume must be non-negative"):
+        make_ohlcv_bar(volume=-0.1)
+
+
+def test_bar_rejects_non_float_numeric_fields() -> None:
+    with pytest.raises(TypeError, match="open must be a float"):
+        OHLCVBar(
+            instrument=InstrumentId("BTCUSDT"),
+            start=SAMPLE_START,
+            end=SAMPLE_END,
+            open=100,
+            high=110.0,
+            low=90.0,
+            close=105.0,
+            volume=12.5,
+        )
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"high": 99.0},
+        {"low": 101.0},
+        {"high": 104.0, "close": 105.0},
+        {"low": 91.0, "close": 90.0},
+    ],
+)
+def test_bar_rejects_invalid_ohlc_relationships(overrides: dict[str, float]) -> None:
+    with pytest.raises(ValueError):
+        make_ohlcv_bar(**overrides)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("open_price", "high", "low", "close"),
+    [(0.0, 0.0, 0.0, 0.0), (-2.0, -1.0, -3.0, -2.5)],
+)
+def test_bar_allows_zero_and_negative_prices(
+    open_price: float, high: float, low: float, close: float
+) -> None:
+    bar = make_ohlcv_bar(open=open_price, high=high, low=low, close=close)
+
+    assert bar.open == open_price
+
+
+def test_models_are_immutable_and_comparable(sample_bar: OHLCVBar) -> None:
+    assert sample_bar == make_ohlcv_bar()
+    assert hash(sample_bar) == hash(make_ohlcv_bar())
+
+    with pytest.raises(FrozenInstanceError):
+        sample_bar.close = 101.0  # type: ignore[misc]

--- a/tests/test_domain_serialization.py
+++ b/tests/test_domain_serialization.py
@@ -1,0 +1,85 @@
+import json
+
+import pytest
+from fixtures.domain import make_ohlcv_bar
+
+from tracequant.domain import InstrumentId, OHLCVBar, TimeRange
+
+
+def test_instrument_serialization_round_trip() -> None:
+    instrument = InstrumentId("ethusdt")
+
+    assert InstrumentId.from_dict(instrument.to_dict()) == instrument
+
+
+def test_time_range_serialization_round_trip(sample_bar: OHLCVBar) -> None:
+    interval = sample_bar.time_range
+
+    assert interval.to_dict() == {
+        "start": "2026-02-28T23:59:00Z",
+        "end": "2026-03-01T00:00:00Z",
+    }
+    assert TimeRange.from_dict(interval.to_dict()) == interval
+
+
+def test_bar_serialization_is_stable_json_and_round_trips(sample_bar: OHLCVBar) -> None:
+    expected = {
+        "instrument": "BTCUSDT",
+        "start": "2026-02-28T23:59:00Z",
+        "end": "2026-03-01T00:00:00Z",
+        "open": 100.0,
+        "high": 110.0,
+        "low": 90.0,
+        "close": 105.0,
+        "volume": 12.5,
+    }
+
+    assert sample_bar.to_dict() == expected
+    assert json.loads(json.dumps(sample_bar.to_dict(), allow_nan=False)) == expected
+    assert OHLCVBar.from_dict(expected) == sample_bar
+
+
+def test_deserialization_normalizes_aware_offset_via_utc_tool() -> None:
+    payload = make_ohlcv_bar().to_dict()
+    payload["start"] = "2026-03-01T07:59:00+08:00"
+    payload["end"] = "2026-03-01T08:00:00+08:00"
+
+    assert OHLCVBar.from_dict(payload) == make_ohlcv_bar()
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"start": "2026-01-01T00:00:00Z"},
+        {
+            "start": "2026-01-01T00:00:00Z",
+            "end": "2026-01-02T00:00:00Z",
+            "extra": "value",
+        },
+        {"start": "2026-01-01T00:00:00", "end": "2026-01-02T00:00:00Z"},
+        {"start": 1, "end": "2026-01-02T00:00:00Z"},
+    ],
+)
+def test_time_range_rejects_invalid_serialized_data(payload: dict[str, object]) -> None:
+    with pytest.raises((TypeError, ValueError)):
+        TimeRange.from_dict(payload)
+
+
+def test_bar_rejects_missing_extra_and_wrong_type_fields(
+    sample_bar: OHLCVBar,
+) -> None:
+    missing = sample_bar.to_dict()
+    del missing["volume"]
+    extra = {**sample_bar.to_dict(), "trade_count": 1}
+    wrong_type = {**sample_bar.to_dict(), "volume": 1}
+
+    for payload in (missing, extra, wrong_type):
+        with pytest.raises((TypeError, ValueError)):
+            OHLCVBar.from_dict(payload)
+
+
+def test_bar_rejects_invalid_shared_payload(
+    invalid_bar_payload: dict[str, object],
+) -> None:
+    with pytest.raises(ValueError, match="volume must be non-negative"):
+        OHLCVBar.from_dict(invalid_bar_payload)


### PR DESCRIPTION
Closes #65

## Summary

- add immutable `InstrumentId`, `TimeRange`, and `OHLCVBar` public models under `tracequant.domain`
- enforce normalized instrument IDs, aware UTC intervals, finite float values, non-negative volume, and OHLC relationships
- add deterministic JSON-compatible serialization, reusable function-scoped fixtures/factories, and boundary documentation

## Validation

- `tools/agent_workflow/wsl2_validation_runner.py workflow-delivery --base-sha 31e1db3839e0a1b74ef2494804739b228e1b7685`
- targeted domain tests: 54 passed
- full Ruff lint/format and strict mypy checks passed before the final Runner
- `git diff --check`

## Risks and limitations

- these are initial internal public Research MVP models, not an externally versioned wire protocol
- zero and negative prices remain valid at this research-data boundary by design
- exchange metadata, precision rules, timeframes, orders, storage, and future domain objects remain out of scope
