### PR TITLE
feat(domain): define initial public models and shared fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,25 @@ Pull requests targeting `main` and pushes to `main` automatically run CI. The wo
 
 Internal datetimes must be timezone-aware and use UTC as the standard timezone. Naive datetimes are explicitly rejected. Time utilities are provided by `tracequant.core.time`.
 
+## Initial domain models
+
+The Research MVP exposes `InstrumentId`, `TimeRange`, and `OHLCVBar` from
+`tracequant.domain`. These immutable internal public models normalize aware
+datetimes to UTC, validate instrument and OHLCV invariants, and provide stable
+JSON-compatible `to_dict` / `from_dict` representations. They intentionally do
+not model venues, timeframes, price precision, orders, accounts, or persistence.
+Instrument identifiers are trimmed, uppercased, limited to 32 ASCII letters or
+digits, and serialized as strings. Aware non-UTC inputs follow the shared time
+API and are normalized to UTC; naive datetimes are rejected.
+Zero and negative prices remain valid when the OHLC relationships are valid;
+volume must be non-negative.
+
+Reusable deterministic test factories live in `tests/fixtures/domain.py`.
+Only fixtures used by multiple test modules belong in `tests/conftest.py`, where
+the default function scope keeps tests isolated. Factories use fixed UTC values,
+accept explicit field overrides, and must not depend on clocks, randomness,
+environment variables, network access, or the filesystem.
+
 ## Configuration
 
 Application configuration is loaded explicitly with `tracequant.config.load_settings`.

--- a/src/tracequant/domain/__init__.py
+++ b/src/tracequant/domain/__init__.py
@@ -1,0 +1,5 @@
+"""Initial public domain models for the Research MVP."""
+
+from tracequant.domain.models import InstrumentId, OHLCVBar, TimeRange
+
+__all__ = ["InstrumentId", "OHLCVBar", "TimeRange"]

--- a/src/tracequant/domain/models.py
+++ b/src/tracequant/domain/models.py
@@ -1,0 +1,165 @@
+"""Small immutable domain models shared by research components."""
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime
+from math import isfinite
+from typing import Final
+
+from tracequant.core.time import format_utc, parse_utc, to_utc
+
+_INSTRUMENT_MAX_LENGTH: Final = 32
+_TIME_RANGE_FIELDS: Final = frozenset({"start", "end"})
+_BAR_FIELDS: Final = frozenset(
+    {"instrument", "start", "end", "open", "high", "low", "close", "volume"}
+)
+
+
+def _require_exact_fields(data: Mapping[str, object], expected: frozenset[str]) -> None:
+    actual = set(data)
+    if actual != expected:
+        missing = sorted(expected - actual)
+        extra = sorted(actual - expected)
+        raise ValueError(f"invalid fields: missing={missing}, extra={extra}")
+
+
+def _require_string(value: object, field: str) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{field} must be a string")
+    return value
+
+
+def _as_finite_float(value: object, field: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise TypeError(f"{field} must be a number")
+    result = float(value)
+    if not isfinite(result):
+        raise ValueError(f"{field} must be finite")
+    return result
+
+
+@dataclass(frozen=True, slots=True, order=True)
+class InstrumentId:
+    """A normalized symbol for the current single-market-data context."""
+
+    value: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.value, str):
+            raise TypeError("instrument must be a string")
+        stripped = self.value.strip()
+        if not stripped:
+            raise ValueError("instrument must not be empty")
+        if not stripped.isascii():
+            raise ValueError("instrument must contain only ASCII letters and digits")
+        normalized = stripped.upper()
+        if not normalized.isalnum():
+            raise ValueError("instrument must contain only ASCII letters and digits")
+        if len(normalized) > _INSTRUMENT_MAX_LENGTH:
+            raise ValueError(
+                f"instrument must be at most {_INSTRUMENT_MAX_LENGTH} characters"
+            )
+        object.__setattr__(self, "value", normalized)
+
+    def __str__(self) -> str:
+        return self.value
+
+    def to_dict(self) -> str:
+        """Return the stable JSON-compatible representation."""
+        return self.value
+
+    @classmethod
+    def from_dict(cls, value: object) -> "InstrumentId":
+        """Build an instrument from its JSON-compatible representation."""
+        return cls(_require_string(value, "instrument"))
+
+
+@dataclass(frozen=True, slots=True)
+class TimeRange:
+    """A UTC half-open time interval ``[start, end)``."""
+
+    start: datetime
+    end: datetime
+
+    def __post_init__(self) -> None:
+        start = to_utc(self.start)
+        end = to_utc(self.end)
+        if start >= end:
+            raise ValueError("start must be earlier than end")
+        object.__setattr__(self, "start", start)
+        object.__setattr__(self, "end", end)
+
+    def to_dict(self) -> dict[str, str]:
+        """Return the stable JSON-compatible representation."""
+        return {"start": format_utc(self.start), "end": format_utc(self.end)}
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, object]) -> "TimeRange":
+        """Build a time range from its JSON-compatible representation."""
+        _require_exact_fields(data, _TIME_RANGE_FIELDS)
+        return cls(
+            start=parse_utc(_require_string(data["start"], "start")),
+            end=parse_utc(_require_string(data["end"], "end")),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class OHLCVBar:
+    """A validated OHLCV bar over a UTC half-open time interval."""
+
+    instrument: InstrumentId
+    start: datetime
+    end: datetime
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.instrument, InstrumentId):
+            raise TypeError("instrument must be an InstrumentId")
+
+        interval = TimeRange(self.start, self.end)
+        object.__setattr__(self, "start", interval.start)
+        object.__setattr__(self, "end", interval.end)
+
+        for field in ("open", "high", "low", "close", "volume"):
+            object.__setattr__(
+                self, field, _as_finite_float(getattr(self, field), field)
+            )
+
+        if self.volume < 0:
+            raise ValueError("volume must be non-negative")
+        if self.high < max(self.open, self.low, self.close):
+            raise ValueError("high must not be below open, low, or close")
+        if self.low > min(self.open, self.high, self.close):
+            raise ValueError("low must not be above open, high, or close")
+
+    def to_dict(self) -> dict[str, str | float]:
+        """Return the stable JSON-compatible representation."""
+        return {
+            "instrument": self.instrument.to_dict(),
+            "start": format_utc(self.start),
+            "end": format_utc(self.end),
+            "open": self.open,
+            "high": self.high,
+            "low": self.low,
+            "close": self.close,
+            "volume": self.volume,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, object]) -> "OHLCVBar":
+        """Build a bar from its JSON-compatible representation."""
+        _require_exact_fields(data, _BAR_FIELDS)
+        return cls(
+            instrument=InstrumentId.from_dict(data["instrument"]),
+            start=parse_utc(_require_string(data["start"], "start")),
+            end=parse_utc(_require_string(data["end"], "end")),
+            open=_as_finite_float(data["open"], "open"),
+            high=_as_finite_float(data["high"], "high"),
+            low=_as_finite_float(data["low"], "low"),
+            close=_as_finite_float(data["close"], "close"),
+            volume=_as_finite_float(data["volume"], "volume"),
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+from collections.abc import Iterator
+
+import pytest
+from fixtures.domain import make_bar
+
+from tracequant.domain import InstrumentId, OHLCVBar
+
+
+@pytest.fixture
+def instrument_id() -> InstrumentId:
+    return InstrumentId("BTCUSDT")
+
+
+@pytest.fixture
+def invalid_instrument_values() -> tuple[str, ...]:
+    return ("", "   ", "BTC-USDT", "BTC/USDT", "比特币", "ß", "A" * 33)
+
+
+@pytest.fixture
+def sample_bar(instrument_id: InstrumentId) -> Iterator[OHLCVBar]:
+    yield make_bar(instrument=instrument_id)

--- a/tests/domain/test_instrument_id.py
+++ b/tests/domain/test_instrument_id.py
@@ -1,0 +1,39 @@
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from tracequant.domain import InstrumentId
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [(" btcusdt ", "BTCUSDT"), ("Eth123", "ETH123")],
+)
+def test_instrument_id_normalizes_input(raw: str, expected: str) -> None:
+    instrument = InstrumentId(raw)
+
+    assert str(instrument) == expected
+    assert instrument.to_dict() == expected
+
+
+def test_instrument_id_rejects_invalid_shared_inputs(
+    invalid_instrument_values: tuple[str, ...],
+) -> None:
+    for raw in invalid_instrument_values:
+        with pytest.raises(ValueError):
+            InstrumentId(raw)
+
+
+def test_instrument_id_rejects_non_string_input() -> None:
+    with pytest.raises(TypeError, match="instrument must be a string"):
+        InstrumentId.from_dict(123)
+
+
+def test_instrument_id_is_immutable_comparable_and_hashable(
+    instrument_id: InstrumentId,
+) -> None:
+    assert instrument_id == InstrumentId("btcusdt")
+    assert {instrument_id, InstrumentId("BTCUSDT")} == {InstrumentId("BTCUSDT")}
+
+    with pytest.raises(FrozenInstanceError):
+        instrument_id.value = "ETHUSDT"  # type: ignore[misc]

--- a/tests/domain/test_ohlcv_bar.py
+++ b/tests/domain/test_ohlcv_bar.py
@@ -1,0 +1,79 @@
+from dataclasses import FrozenInstanceError
+from math import inf, nan
+from typing import Literal
+
+import pytest
+from fixtures.domain import SAMPLE_END, SAMPLE_START, make_bar
+
+from tracequant.domain import InstrumentId, OHLCVBar
+
+
+@pytest.mark.parametrize("field", ["open", "high", "low", "close", "volume"])
+@pytest.mark.parametrize("value", [nan, inf, -inf])
+def test_bar_rejects_non_finite_numbers(
+    field: Literal["open", "high", "low", "close", "volume"], value: float
+) -> None:
+    with pytest.raises(ValueError, match=f"{field} must be finite"):
+        if field == "open":
+            make_bar(open=value)
+        elif field == "high":
+            make_bar(high=value)
+        elif field == "low":
+            make_bar(low=value)
+        elif field == "close":
+            make_bar(close=value)
+        else:
+            make_bar(volume=value)
+
+
+def test_bar_rejects_negative_volume() -> None:
+    with pytest.raises(ValueError, match="volume must be non-negative"):
+        make_bar(volume=-0.1)
+
+
+@pytest.mark.parametrize(
+    ("high", "low"),
+    [(99.0, 90.0), (110.0, 106.0)],
+)
+def test_bar_rejects_invalid_ohlc_relationships(high: float, low: float) -> None:
+    with pytest.raises(ValueError):
+        make_bar(high=high, low=low)
+
+
+@pytest.mark.parametrize(
+    ("open_price", "high", "low", "close"),
+    [
+        (0.0, 1.0, -1.0, 0.5),
+        (-2.0, -1.0, -3.0, -1.5),
+    ],
+)
+def test_bar_allows_zero_and_negative_prices_when_ohlc_is_valid(
+    open_price: float, high: float, low: float, close: float
+) -> None:
+    bar = make_bar(open=open_price, high=high, low=low, close=close)
+
+    assert bar.open == open_price
+
+
+def test_bar_requires_instrument_id() -> None:
+    with pytest.raises(TypeError, match="instrument must be an InstrumentId"):
+        OHLCVBar(
+            instrument="BTCUSDT",  # type: ignore[arg-type]
+            start=SAMPLE_START,
+            end=SAMPLE_END,
+            open=100.0,
+            high=110.0,
+            low=90.0,
+            close=105.0,
+            volume=12.5,
+        )
+
+
+def test_bar_is_immutable_hashable_and_fixture_is_function_scoped(
+    sample_bar: OHLCVBar, instrument_id: InstrumentId
+) -> None:
+    assert sample_bar.instrument == instrument_id
+    assert hash(sample_bar) == hash(make_bar(instrument=instrument_id))
+
+    with pytest.raises(FrozenInstanceError):
+        sample_bar.close = 0.0  # type: ignore[misc]

--- a/tests/domain/test_serialization.py
+++ b/tests/domain/test_serialization.py
@@ -1,0 +1,65 @@
+import json
+
+import pytest
+from fixtures.domain import make_bar, make_time_range
+
+from tracequant.domain import InstrumentId, OHLCVBar, TimeRange
+
+
+def test_all_models_round_trip_through_json() -> None:
+    instrument = InstrumentId("BTCUSDT")
+    interval = make_time_range()
+    bar = make_bar(instrument=instrument)
+
+    assert (
+        InstrumentId.from_dict(json.loads(json.dumps(instrument.to_dict())))
+        == instrument
+    )
+    assert TimeRange.from_dict(json.loads(json.dumps(interval.to_dict()))) == interval
+    assert OHLCVBar.from_dict(json.loads(json.dumps(bar.to_dict()))) == bar
+
+
+def test_serialized_instrument_rejects_invalid_shared_inputs(
+    invalid_instrument_values: tuple[str, ...],
+) -> None:
+    for raw in invalid_instrument_values:
+        with pytest.raises(ValueError):
+            InstrumentId.from_dict(json.loads(json.dumps(raw)))
+
+
+def test_bar_serialization_has_stable_public_fields() -> None:
+    assert list(make_bar().to_dict()) == [
+        "instrument",
+        "start",
+        "end",
+        "open",
+        "high",
+        "low",
+        "close",
+        "volume",
+    ]
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        {"instrument": "BTCUSDT"},
+        {**make_bar().to_dict(), "trade_count": 1},
+        {**make_bar().to_dict(), "volume": "12.5"},
+        {**make_bar().to_dict(), "open": True},
+    ],
+)
+def test_bar_from_dict_rejects_invalid_fields_and_types(
+    data: dict[str, object],
+) -> None:
+    with pytest.raises((TypeError, ValueError)):
+        OHLCVBar.from_dict(data)
+
+
+def test_factories_return_isolated_objects() -> None:
+    first = make_bar()
+    second = make_bar()
+
+    assert first == second
+    assert first is not second
+    assert first.instrument is not second.instrument

--- a/tests/domain/test_time_range.py
+++ b/tests/domain/test_time_range.py
@@ -1,0 +1,72 @@
+from dataclasses import FrozenInstanceError
+from datetime import UTC, datetime, timedelta, timezone
+
+import pytest
+from fixtures.domain import SAMPLE_END, SAMPLE_START, make_time_range
+
+from tracequant.domain import TimeRange
+
+
+def test_time_range_is_half_open_and_serializes_stably() -> None:
+    interval = make_time_range()
+
+    assert interval.start == SAMPLE_START
+    assert interval.end == SAMPLE_END
+    assert interval.to_dict() == {
+        "start": "2026-02-28T23:59:00Z",
+        "end": "2026-03-01T00:00:00Z",
+    }
+
+
+def test_time_range_normalizes_aware_offsets_via_utc_api() -> None:
+    interval = TimeRange(
+        start=datetime(2026, 3, 1, 7, 59, tzinfo=timezone(timedelta(hours=8))),
+        end=datetime(2026, 3, 1, 8, 0, tzinfo=timezone(timedelta(hours=8))),
+    )
+
+    assert interval.start == SAMPLE_START
+    assert interval.start.tzinfo is UTC
+
+
+@pytest.mark.parametrize("field", ["start", "end"])
+def test_time_range_rejects_naive_datetime(field: str) -> None:
+    values = {"start": SAMPLE_START, "end": SAMPLE_END}
+    values[field] = datetime(2026, 3, 1, 0, 0)
+
+    with pytest.raises(ValueError, match="datetime must be timezone-aware"):
+        TimeRange(**values)
+
+
+@pytest.mark.parametrize(
+    ("start", "end"),
+    [(SAMPLE_START, SAMPLE_START), (SAMPLE_END, SAMPLE_START)],
+)
+def test_time_range_rejects_empty_or_reversed_interval(
+    start: datetime, end: datetime
+) -> None:
+    with pytest.raises(ValueError, match="start must be earlier than end"):
+        TimeRange(start=start, end=end)
+
+
+def test_time_range_from_dict_rejects_missing_extra_and_naive_data() -> None:
+    with pytest.raises(ValueError, match="invalid fields"):
+        TimeRange.from_dict({"start": "2026-01-01T00:00:00Z"})
+    with pytest.raises(ValueError, match="invalid fields"):
+        TimeRange.from_dict(
+            {
+                "start": "2026-01-01T00:00:00Z",
+                "end": "2026-01-01T00:01:00Z",
+                "timezone": "UTC",
+            }
+        )
+    with pytest.raises(ValueError, match="datetime must be timezone-aware"):
+        TimeRange.from_dict(
+            {"start": "2026-01-01T00:00:00", "end": "2026-01-01T00:01:00Z"}
+        )
+
+
+def test_time_range_is_immutable() -> None:
+    interval = make_time_range()
+
+    with pytest.raises(FrozenInstanceError):
+        interval.start = SAMPLE_END  # type: ignore[misc]

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,0 +1,1 @@
+"""Deterministic test factories shared across test modules."""

--- a/tests/fixtures/domain.py
+++ b/tests/fixtures/domain.py
@@ -1,0 +1,37 @@
+"""Deterministic factories for public domain models."""
+
+from datetime import UTC, datetime
+
+from tracequant.domain import InstrumentId, OHLCVBar, TimeRange
+
+SAMPLE_START = datetime(2026, 2, 28, 23, 59, tzinfo=UTC)
+SAMPLE_END = datetime(2026, 3, 1, 0, 0, tzinfo=UTC)
+
+
+def make_time_range(
+    *, start: datetime = SAMPLE_START, end: datetime = SAMPLE_END
+) -> TimeRange:
+    return TimeRange(start=start, end=end)
+
+
+def make_bar(
+    *,
+    instrument: InstrumentId | None = None,
+    start: datetime = SAMPLE_START,
+    end: datetime = SAMPLE_END,
+    open: float = 100.0,
+    high: float = 110.0,
+    low: float = 90.0,
+    close: float = 105.0,
+    volume: float = 12.5,
+) -> OHLCVBar:
+    return OHLCVBar(
+        instrument=instrument if instrument is not None else InstrumentId("BTCUSDT"),
+        start=start,
+        end=end,
+        open=open,
+        high=high,
+        low=low,
+        close=close,
+        volume=volume,
+    )


### PR DESCRIPTION
Closes #65

## Summary

- add immutable `InstrumentId`, `TimeRange`, and `OHLCVBar` models under the minimal `tracequant.domain` public import path
- validate symbol normalization, UTC intervals, finite numeric values, volume, and OHLC relationships
- add stable JSON-compatible serialization, deterministic shared factories/fixtures, and boundary/round-trip/isolation tests
- document Research MVP scope, price semantics, and fixture conventions

## Validation

- `tools/agent_workflow/wsl2_validation_runner.py targeted` — pass
- `uv run --frozen pytest tests/domain` — 43 passed
- `uv run --frozen ruff check src/tracequant/domain tests/conftest.py tests/fixtures tests/domain` — pass
- `uv run --frozen mypy src tests` — pass
- `tools/agent_workflow/wsl2_validation_runner.py workflow-delivery --base-sha 31e1db3839e0a1b74ef2494804739b228e1b7685` — pass

## Risks and limitations

- These are initial internal public Research MVP models; no external schema-version compatibility is promised.
- Aware non-UTC datetimes are normalized through the existing UTC API; naive datetimes are rejected.
- Price precision, venues, timeframes, orders, persistence, and other explicitly out-of-scope abstractions are unchanged.
