### PR TITLE
[Task] 定义初始公共领域模型与共享测试 Fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,23 @@ Pull requests targeting `main` and pushes to `main` automatically run CI. The wo
 
 Internal datetimes must be timezone-aware and use UTC as the standard timezone. Naive datetimes are explicitly rejected. Time utilities are provided by `tracequant.core.time`.
 
+## Initial domain models
+
+The Research MVP exposes its initial internal public models from
+`tracequant.domain`: `InstrumentId`, `TimeRange`, and `OHLCVBar`. They are
+immutable value objects with explicit validation and deterministic
+JSON-compatible serialization. `TimeRange` and bar intervals use UTC half-open
+semantics (`[start, end)`). OHLCV prices are finite Python `float` values; zero
+and negative prices are currently accepted deliberately, while volume must be
+non-negative. This is an initial internal protocol and does not yet promise a
+long-term external schema version.
+
+Reusable pytest fixtures belong in `tests/conftest.py` only after at least two
+test modules need them. Deterministic factories with explicit field overrides
+belong in `tests/fixtures/`; they must use fixed UTC times and must not read the
+clock, randomness, environment variables, the network, or files. Fixtures stay
+function-scoped by default, and test-specific values stay in their test module.
+
 ## Configuration
 
 Application configuration is loaded explicitly with `tracequant.config.load_settings`.

--- a/src/tracequant/domain.py
+++ b/src/tracequant/domain.py
@@ -1,0 +1,195 @@
+"""Initial immutable domain models for TraceQuant Research MVP."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from math import isfinite
+from typing import Final, Self
+
+from tracequant.core.time import ensure_aware, format_utc, is_utc, parse_utc, to_utc
+
+__all__ = ["InstrumentId", "TimeRange", "OHLCVBar"]
+
+_INSTRUMENT_MAX_LENGTH: Final = 32
+
+
+def _require_exact_fields(data: Mapping[str, object], expected: frozenset[str]) -> None:
+    actual = frozenset(data)
+    if actual != expected:
+        missing = sorted(expected - actual)
+        extra = sorted(actual - expected)
+        raise ValueError(f"invalid fields: missing={missing}, extra={extra}")
+
+
+def _normalize_utc(value: datetime, *, field: str) -> datetime:
+    if not isinstance(value, datetime):
+        raise TypeError(f"{field} must be a datetime")
+    ensure_aware(value)
+    if not is_utc(value):
+        raise ValueError(f"{field} must use UTC")
+    return to_utc(value)
+
+
+def _parse_strict_utc(value: object, *, field: str) -> datetime:
+    if not isinstance(value, str):
+        raise TypeError(f"{field} must be an ISO 8601 string")
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise ValueError(f"{field} must be a valid ISO 8601 datetime") from exc
+    _normalize_utc(parsed, field=field)
+    return parse_utc(value)
+
+
+@dataclass(frozen=True, slots=True, order=True)
+class InstrumentId:
+    """A normalized symbol identifier for the current market-data context."""
+
+    value: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.value, str):
+            raise TypeError("instrument value must be a string")
+        stripped = self.value.strip()
+        if not stripped:
+            raise ValueError("instrument value must not be empty")
+        if not stripped.isascii():
+            raise ValueError(
+                "instrument value must contain only ASCII letters and digits"
+            )
+        normalized = stripped.upper()
+        if len(normalized) > _INSTRUMENT_MAX_LENGTH:
+            raise ValueError(
+                f"instrument value must be at most {_INSTRUMENT_MAX_LENGTH} characters"
+            )
+        if not normalized.isalnum():
+            raise ValueError(
+                "instrument value must contain only ASCII letters and digits"
+            )
+        object.__setattr__(self, "value", normalized)
+
+    def __str__(self) -> str:
+        return self.value
+
+    def to_json_value(self) -> str:
+        """Return the stable JSON-compatible string representation."""
+        return self.value
+
+    @classmethod
+    def from_json_value(cls, value: object) -> Self:
+        """Build an identifier from its JSON-compatible representation."""
+        if not isinstance(value, str):
+            raise TypeError("instrument JSON value must be a string")
+        return cls(value)
+
+
+@dataclass(frozen=True, slots=True, order=True)
+class TimeRange:
+    """A UTC half-open time interval ``[start, end)``."""
+
+    start: datetime
+    end: datetime
+
+    def __post_init__(self) -> None:
+        start = _normalize_utc(self.start, field="start")
+        end = _normalize_utc(self.end, field="end")
+        if start >= end:
+            raise ValueError("start must be earlier than end")
+        object.__setattr__(self, "start", start)
+        object.__setattr__(self, "end", end)
+
+    @property
+    def duration(self) -> timedelta:
+        """Return the interval duration."""
+        return self.end - self.start
+
+    def contains(self, value: datetime) -> bool:
+        """Return whether a UTC datetime is within the half-open interval."""
+        normalized = _normalize_utc(value, field="value")
+        return self.start <= normalized < self.end
+
+    def to_dict(self) -> dict[str, str]:
+        """Return the stable JSON-compatible representation."""
+        return {"start": format_utc(self.start), "end": format_utc(self.end)}
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, object]) -> Self:
+        """Build a range from a strict JSON-compatible mapping."""
+        _require_exact_fields(data, frozenset({"start", "end"}))
+        return cls(
+            start=_parse_strict_utc(data["start"], field="start"),
+            end=_parse_strict_utc(data["end"], field="end"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class OHLCVBar:
+    """An immutable OHLCV bar for one instrument and UTC interval."""
+
+    instrument: InstrumentId
+    start: datetime
+    end: datetime
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.instrument, InstrumentId):
+            raise TypeError("instrument must be an InstrumentId")
+        interval = TimeRange(self.start, self.end)
+        object.__setattr__(self, "start", interval.start)
+        object.__setattr__(self, "end", interval.end)
+
+        for field in ("open", "high", "low", "close", "volume"):
+            value = getattr(self, field)
+            if type(value) is not float:
+                raise TypeError(f"{field} must be a float")
+            if not isfinite(value):
+                raise ValueError(f"{field} must be finite")
+        if self.volume < 0.0:
+            raise ValueError("volume must be non-negative")
+        if self.high < max(self.open, self.low, self.close):
+            raise ValueError("high must not be below open, low, or close")
+        if self.low > min(self.open, self.high, self.close):
+            raise ValueError("low must not be above open, high, or close")
+
+    def to_dict(self) -> dict[str, object]:
+        """Return the stable JSON-compatible representation."""
+        return {
+            "instrument": self.instrument.to_json_value(),
+            "start": format_utc(self.start),
+            "end": format_utc(self.end),
+            "open": self.open,
+            "high": self.high,
+            "low": self.low,
+            "close": self.close,
+            "volume": self.volume,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, object]) -> Self:
+        """Build a bar from a strict JSON-compatible mapping."""
+        expected = frozenset(
+            {"instrument", "start", "end", "open", "high", "low", "close", "volume"}
+        )
+        _require_exact_fields(data, expected)
+        return cls(
+            instrument=InstrumentId.from_json_value(data["instrument"]),
+            start=_parse_strict_utc(data["start"], field="start"),
+            end=_parse_strict_utc(data["end"], field="end"),
+            open=_require_float(data["open"], field="open"),
+            high=_require_float(data["high"], field="high"),
+            low=_require_float(data["low"], field="low"),
+            close=_require_float(data["close"], field="close"),
+            volume=_require_float(data["volume"], field="volume"),
+        )
+
+
+def _require_float(value: object, *, field: str) -> float:
+    if type(value) is not float:
+        raise TypeError(f"{field} must be a float")
+    return value

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""TraceQuant test package."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+"""Shared pytest fixtures used by multiple test modules."""
+
+from collections.abc import Callable
+
+import pytest
+
+from tests.fixtures.domain import make_ohlcv_bar
+from tracequant.domain import OHLCVBar
+
+
+@pytest.fixture
+def bar_factory() -> Callable[..., OHLCVBar]:
+    """Return a function-scoped deterministic OHLCV bar factory."""
+    return make_ohlcv_bar

--- a/tests/domain/test_instrument.py
+++ b/tests/domain/test_instrument.py
@@ -1,0 +1,41 @@
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from tests.fixtures.domain import make_instrument
+from tracequant.domain import InstrumentId
+
+
+def test_instrument_normalizes_and_serializes_as_string() -> None:
+    instrument = make_instrument("  btcusdt  ")
+
+    assert str(instrument) == "BTCUSDT"
+    assert instrument.to_json_value() == "BTCUSDT"
+    assert InstrumentId.from_json_value("BTCUSDT") == instrument
+
+
+@pytest.mark.parametrize("value", ["", "   ", "BTC-USDT", "BTC/USDT", "比特币", "ß"])
+def test_instrument_rejects_empty_or_invalid_characters(value: str) -> None:
+    with pytest.raises(ValueError):
+        InstrumentId(value)
+
+
+def test_instrument_rejects_values_over_conservative_limit() -> None:
+    with pytest.raises(ValueError, match="at most 32"):
+        InstrumentId("A" * 33)
+
+
+def test_instrument_is_immutable_hashable_and_orderable() -> None:
+    first = InstrumentId("BTCUSDT")
+    second = InstrumentId("ETHUSDT")
+
+    assert sorted([second, first]) == [first, second]
+    assert {first, InstrumentId("btcusdt")} == {first}
+    with pytest.raises(FrozenInstanceError):
+        setattr(first, "value", "ETHUSDT")
+
+
+@pytest.mark.parametrize("value", [None, 1, True])
+def test_instrument_rejects_non_string_input(value: object) -> None:
+    with pytest.raises(TypeError):
+        InstrumentId.from_json_value(value)

--- a/tests/domain/test_ohlcv_bar.py
+++ b/tests/domain/test_ohlcv_bar.py
@@ -1,0 +1,113 @@
+import json
+from collections.abc import Callable
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from tests.fixtures.domain import invalid_ohlcv_numeric_values, make_ohlcv_bar
+from tracequant.domain import OHLCVBar
+
+
+def test_bar_is_immutable_and_factory_calls_are_isolated(
+    bar_factory: Callable[..., OHLCVBar],
+) -> None:
+    first = bar_factory()
+    second = bar_factory()
+
+    assert first == second
+    assert first is not second
+    assert first.instrument is not second.instrument
+    with pytest.raises(FrozenInstanceError):
+        setattr(first, "close", 99.0)
+
+
+@pytest.mark.parametrize(("field", "value"), invalid_ohlcv_numeric_values())
+def test_bar_rejects_invalid_numeric_values(field: str, value: float) -> None:
+    values = {
+        "open": 100.0,
+        "high": 105.0,
+        "low": 95.0,
+        "close": 102.0,
+        "volume": 12.5,
+    }
+    values[field] = value
+
+    with pytest.raises(ValueError):
+        make_ohlcv_bar(
+            open=values["open"],
+            high=values["high"],
+            low=values["low"],
+            close=values["close"],
+            volume=values["volume"],
+        )
+
+
+@pytest.mark.parametrize(
+    ("high", "low"),
+    [
+        (99.0, 95.0),
+        (105.0, 103.0),
+    ],
+)
+def test_bar_rejects_invalid_ohlc_relationships(high: float, low: float) -> None:
+    with pytest.raises(ValueError):
+        make_ohlcv_bar(high=high, low=low)
+
+
+@pytest.mark.parametrize(
+    ("open", "high", "low", "close"),
+    [
+        (0.0, 1.0, -1.0, 0.5),
+        (-3.0, -1.0, -4.0, -2.0),
+    ],
+)
+def test_bar_allows_zero_and_negative_finite_prices(
+    open: float,
+    high: float,
+    low: float,
+    close: float,
+) -> None:
+    bar = make_ohlcv_bar(open=open, high=high, low=low, close=close)
+
+    assert bar.open == open
+
+
+def test_bar_serialization_is_json_compatible_stable_and_round_trips(
+    bar_factory: Callable[..., OHLCVBar],
+) -> None:
+    bar = bar_factory()
+
+    payload = bar.to_dict()
+
+    assert list(payload) == [
+        "instrument",
+        "start",
+        "end",
+        "open",
+        "high",
+        "low",
+        "close",
+        "volume",
+    ]
+    assert json.loads(json.dumps(payload, allow_nan=False)) == payload
+    assert OHLCVBar.from_dict(payload) == bar
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda payload: payload.pop("volume"),
+        lambda payload: payload.update(extra=True),
+        lambda payload: payload.update(open=1),
+        lambda payload: payload.update(instrument=None),
+        lambda payload: payload.update(start="2026-02-28T23:59:00"),
+    ],
+)
+def test_bar_rejects_invalid_serialized_data(
+    mutation: Callable[[dict[str, object]], object],
+) -> None:
+    payload = make_ohlcv_bar().to_dict()
+    mutation(payload)
+
+    with pytest.raises((TypeError, ValueError)):
+        OHLCVBar.from_dict(payload)

--- a/tests/domain/test_public_api.py
+++ b/tests/domain/test_public_api.py
@@ -1,0 +1,18 @@
+import importlib
+from collections.abc import Callable
+
+from tracequant.domain import InstrumentId, OHLCVBar, TimeRange
+
+
+def test_domain_models_have_one_minimal_public_import_path() -> None:
+    domain = importlib.import_module("tracequant.domain")
+
+    assert domain.InstrumentId is InstrumentId
+    assert domain.TimeRange is TimeRange
+    assert domain.OHLCVBar is OHLCVBar
+
+
+def test_shared_factory_is_function_scoped(
+    bar_factory: Callable[..., OHLCVBar],
+) -> None:
+    assert bar_factory() is not bar_factory()

--- a/tests/domain/test_time_range.py
+++ b/tests/domain/test_time_range.py
@@ -1,0 +1,78 @@
+from datetime import UTC, datetime, timedelta, timezone
+
+import pytest
+
+from tests.fixtures.domain import DEFAULT_START, make_time_range
+from tracequant.domain import TimeRange
+
+
+def test_time_range_has_half_open_semantics_and_duration() -> None:
+    interval = make_time_range()
+
+    assert interval.duration == timedelta(minutes=1)
+    assert interval.contains(interval.start)
+    assert interval.contains(interval.end - timedelta(microseconds=1))
+    assert not interval.contains(interval.end)
+
+
+def test_time_range_handles_leap_day_and_month_boundary() -> None:
+    start = datetime(2028, 2, 29, 23, 59, tzinfo=UTC)
+    interval = make_time_range(start=start)
+
+    assert interval.start == start
+    assert interval.end == datetime(2028, 3, 1, 0, 0, tzinfo=UTC)
+
+
+@pytest.mark.parametrize(
+    ("start", "end"),
+    [
+        (datetime(2026, 1, 1), datetime(2026, 1, 2, tzinfo=UTC)),
+        (
+            datetime(2026, 1, 1, tzinfo=timezone(timedelta(hours=8))),
+            datetime(2026, 1, 2, tzinfo=UTC),
+        ),
+        (DEFAULT_START, DEFAULT_START),
+        (DEFAULT_START + timedelta(minutes=1), DEFAULT_START),
+    ],
+)
+def test_time_range_rejects_non_utc_and_invalid_intervals(
+    start: datetime, end: datetime
+) -> None:
+    with pytest.raises(ValueError):
+        TimeRange(start, end)
+
+
+def test_time_range_serialization_is_stable_and_round_trips() -> None:
+    interval = make_time_range()
+
+    payload = interval.to_dict()
+
+    assert payload == {
+        "start": "2026-02-28T23:59:00Z",
+        "end": "2026-03-01T00:00:00Z",
+    }
+    assert TimeRange.from_dict(payload) == interval
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"start": "2026-01-01T00:00:00Z"},
+        {
+            "start": "2026-01-01T00:00:00Z",
+            "end": "2026-01-02T00:00:00Z",
+            "extra": True,
+        },
+        {"start": "2026-01-01T00:00:00", "end": "2026-01-02T00:00:00Z"},
+        {
+            "start": "2026-01-01T08:00:00+08:00",
+            "end": "2026-01-02T00:00:00Z",
+        },
+        {"start": 1, "end": "2026-01-02T00:00:00Z"},
+    ],
+)
+def test_time_range_rejects_invalid_serialized_data(
+    payload: dict[str, object],
+) -> None:
+    with pytest.raises((TypeError, ValueError)):
+        TimeRange.from_dict(payload)

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,0 +1,1 @@
+"""Deterministic shared test factories."""

--- a/tests/fixtures/domain.py
+++ b/tests/fixtures/domain.py
@@ -1,0 +1,52 @@
+"""Factories for explicit, deterministic domain test values."""
+
+from datetime import UTC, datetime, timedelta
+
+from tracequant.domain import InstrumentId, OHLCVBar, TimeRange
+
+DEFAULT_START = datetime(2026, 2, 28, 23, 59, tzinfo=UTC)
+
+
+def make_instrument(value: str = "BTCUSDT") -> InstrumentId:
+    return InstrumentId(value)
+
+
+def make_time_range(
+    *,
+    start: datetime = DEFAULT_START,
+    end: datetime | None = None,
+) -> TimeRange:
+    return TimeRange(start=start, end=end or start + timedelta(minutes=1))
+
+
+def make_ohlcv_bar(
+    *,
+    instrument: InstrumentId | None = None,
+    start: datetime = DEFAULT_START,
+    end: datetime | None = None,
+    open: float = 100.0,
+    high: float = 105.0,
+    low: float = 95.0,
+    close: float = 102.0,
+    volume: float = 12.5,
+) -> OHLCVBar:
+    return OHLCVBar(
+        instrument=instrument or make_instrument(),
+        start=start,
+        end=end or start + timedelta(minutes=1),
+        open=open,
+        high=high,
+        low=low,
+        close=close,
+        volume=volume,
+    )
+
+
+def invalid_ohlcv_numeric_values() -> tuple[tuple[str, float], ...]:
+    return (
+        ("open", float("nan")),
+        ("high", float("inf")),
+        ("low", float("-inf")),
+        ("close", float("nan")),
+        ("volume", -1.0),
+    )


### PR DESCRIPTION
Closes #65

## Summary

- add immutable `InstrumentId`, `TimeRange`, and `OHLCVBar` models at the minimal public import path `tracequant.domain`
- enforce symbol, strict UTC interval, finite numeric, volume, and OHLC relationship validation
- add deterministic JSON-compatible serialization and strict deserialization round trips
- establish reusable function-scoped fixtures and explicit deterministic domain factories
- document Research MVP model and fixture boundaries

## Validation

- `tools/agent_workflow/wsl2_validation_runner.py targeted` — pass
- `uv run --frozen pytest tests/domain` — 42 passed
- scoped Ruff lint and format checks — pass
- scoped strict mypy — pass
- `tools/agent_workflow/wsl2_validation_runner.py workflow-delivery --base-sha df1d9eb147950640f032d959312d9045cb9d2466` — pass
- `git diff --check` — pass

## Risks and limitations

- this is the initial internal Research MVP protocol; no external schema-version compatibility promise is introduced
- identifiers intentionally contain no venue, market type, or base/quote parsing
- finite zero and negative prices remain accepted by design; volume must be non-negative
- no order, account, exchange, persistence, strategy, or backtest abstractions are added
