### PR TITLE
maintenance: restore initial Task branch bootstrap

### DIFF
--- a/.agents/skills/task-delivery-runner/SKILL.md
+++ b/.agents/skills/task-delivery-runner/SKILL.md
@@ -68,7 +68,7 @@ tools/agent_workflow/wsl2_github_evidence_runner.py delivery-readiness \
 | Entry point | Invoked at | Params beyond `--task`, `--expected-main-sha` |
 |---|---|---|
 | `delivery-start` | Phase 1 before any write | — |
-| `implementation` | Phase 2 before branch/implementation writes | `--branch --expected-base-sha` |
+| `implementation` | Phase 2 before branch/implementation writes | `--branch --expected-base-sha` (`--bootstrap-verify` after creation) |
 | `final-validation` | Phase 3 before commit + `workflow-delivery` | `--branch --expected-base-sha --expected-head-sha` |
 | `pr-readiness` | Phase 4 before PR creation/push | `--branch --expected-base-sha --expected-head-sha` |
 | `review-remediation` | Remediation before any repair edit | `--pr --expected-base-sha --expected-head-sha` |
@@ -193,9 +193,30 @@ re-read lifecycle transitions only after readiness passes.
 
 Start from clean `main` unless facts prove a valid recovery point. Create or
 reuse one exact Task branch after verifying identity, history, scope, and
-ownership. Implement the smallest correct change — follow scoped rules,
-preserve safety, add required tests/docs, inspect tracked and untracked scope.
-Do not weaken tests to obtain a pass.
+ownership. The implementation preflight classifies the branch state:
+
+- existing branch with proven Task identity, ownership, and locked base:
+  reuse it;
+- absent branch with a clean locked `main`, no local/remote/worktree conflict,
+  and the canonical `task/<Issue number>-<slug>` name: `branch_bootstrap = pass`
+  is deterministic authorization for the Skill to create it;
+- ambiguous identity, ownership, or base: fail closed and require Human Gate.
+
+For the authorized new-branch path, the Skill creates directly from the locked
+base and never uses a noncanonical name such as `task-<Issue number>`:
+
+```text
+git switch -c task/<Issue number>-<slug> <LOCKED_MAIN_SHA>
+```
+
+Immediately rerun the implementation Evidence Runner with
+`--bootstrap-verify`. Continue only when it proves the actual branch name,
+HEAD and branch tip equal the locked base, branch base identity is correct, the
+worktree is clean, and no remote or other drift appeared. Existing numeric
+branch forms may be reused only when the Runner proves their Task ownership;
+they are never new-branch creation targets. Implement the smallest correct
+change — follow scoped rules, preserve safety, add required tests/docs, inspect
+tracked and untracked scope. Do not weaken tests to obtain a pass.
 
 ## Phase 3: commit, final validation, and push
 

--- a/.agents/skills/task-delivery-runner/SKILL.md
+++ b/.agents/skills/task-delivery-runner/SKILL.md
@@ -195,8 +195,8 @@ Start from clean `main` unless facts prove a valid recovery point. Create or
 reuse one exact Task branch after verifying identity, history, scope, and
 ownership. The implementation preflight classifies the branch state:
 
-- existing branch with proven Task identity, ownership, and locked base:
-  reuse it;
+- existing branch with proven Task identity, ownership, locked base, and a
+  clean worktree: reuse it;
 - absent branch with a clean locked `main`, no local/remote/worktree conflict,
   and the canonical `task/<Issue number>-<slug>` name: `branch_bootstrap = pass`
   is deterministic authorization for the Skill to create it;

--- a/.claude/skills/task-delivery-runner/SKILL.md
+++ b/.claude/skills/task-delivery-runner/SKILL.md
@@ -256,8 +256,8 @@ point. Create or reuse one exact Task branch after verifying its identity,
 history, scope, and ownership. The implementation preflight classifies the
 branch state:
 
-- existing branch with proven Task identity, ownership, and locked base:
-  reuse it;
+- existing branch with proven Task identity, ownership, locked base, and a
+  clean worktree: reuse it;
 - absent branch with a clean locked `main`, no local/remote/worktree conflict,
   and the canonical `task/<Issue number>-<slug>` name: `branch_bootstrap = pass`
   is deterministic authorization for the Skill to create it;

--- a/.claude/skills/task-delivery-runner/SKILL.md
+++ b/.claude/skills/task-delivery-runner/SKILL.md
@@ -74,7 +74,7 @@ tools/agent_workflow/wsl2_github_evidence_runner.py delivery-readiness \
 | Entry point | Invoked at | Params beyond `--task`, `--expected-main-sha` |
 |---|---|---|
 | `delivery-start` | Phase 1 before any write | — |
-| `implementation` | Phase 2 before branch/implementation writes | `--branch --expected-base-sha` |
+| `implementation` | Phase 2 before branch/implementation writes | `--branch --expected-base-sha` (`--bootstrap-verify` after creation) |
 | `final-validation` | Phase 3 before commit/`workflow-delivery` | `--branch --expected-base-sha --expected-head-sha` |
 | `pr-readiness` | Phase 4 before PR creation/push verification | `--branch --expected-base-sha --expected-head-sha` |
 | `review-remediation` | Review remediation before any repair edit | `--pr --expected-base-sha --expected-head-sha` |
@@ -253,7 +253,30 @@ transitions only after readiness passes.
 
 Start from clean synchronized `main` unless current facts prove a valid recovery
 point. Create or reuse one exact Task branch after verifying its identity,
-history, scope, and ownership.
+history, scope, and ownership. The implementation preflight classifies the
+branch state:
+
+- existing branch with proven Task identity, ownership, and locked base:
+  reuse it;
+- absent branch with a clean locked `main`, no local/remote/worktree conflict,
+  and the canonical `task/<Issue number>-<slug>` name: `branch_bootstrap = pass`
+  is deterministic authorization for the Skill to create it;
+- ambiguous identity, ownership, or base: fail closed and require Human Gate.
+
+For the authorized new-branch path, the Skill creates directly from the locked
+base and never uses a noncanonical name such as `task-<Issue number>`:
+
+```text
+git switch -c task/<Issue number>-<slug> <LOCKED_MAIN_SHA>
+```
+
+Immediately rerun the implementation Evidence Runner with
+`--bootstrap-verify`. Continue only when it proves the actual branch name,
+HEAD and branch tip equal the locked base, branch base identity is correct, the
+worktree is clean, and no remote or other drift appeared. Existing numeric
+branch forms may be reused only when the Runner proves their Task ownership;
+they are never new-branch creation targets. The Runner supplies facts and
+classification; the Skill owns branch creation/reuse orchestration.
 
 Implement the smallest correct change. Follow scoped rules, preserve safety, add
 required tests/docs, inspect tracked and untracked scope, and do not weaken tests

--- a/docs/development/issue-workflow.md
+++ b/docs/development/issue-workflow.md
@@ -117,6 +117,21 @@ intent 无法可靠解析时：**不要猜**。回退到 explicit Skill-name fal
   targeted validation → commit → push → PR → CI checks → delivery readiness →
   handoff for Independent Review。
 - 一个 Task 通常产生一个 PR（base = `main`）。
+- Initial Task branch bootstrap is a shared workflow contract: Delivery locks
+  the trusted `main`/base first, then the implementation preflight classifies
+  the target branch. An existing branch is reusable only when Task identity,
+  ownership, and base are mechanically proven. A missing branch is creatable
+  only when the worktree is clean, the current/local/remote `main` identities
+  equal the locked base, no local/remote/worktree conflict exists, and the
+  target uses canonical `task/<Issue number>-<slug>` naming. The Runner returns
+  the deterministic creation authorization; the Delivery Skill performs the
+  branch creation from that exact base and reruns mechanical verification
+  before implementation continues.
+- Noncanonical names such as `task-<Issue number>` are never new-branch
+  creation targets. Historical numeric forms may be reused only for an
+  existing branch whose ownership is proven. Ambiguous branch identity,
+  ownership, base, dirty bootstrap state, or post-creation drift fails closed
+  and enters Human Gate.
 - 实现只处理当前 leaf Task；不进行无关重构。
 - 提交前必须完成 target validation；PR 创建前必须完成 delivery readiness
   验证（Runner 快照）。

--- a/docs/development/issue-workflow.md
+++ b/docs/development/issue-workflow.md
@@ -120,7 +120,8 @@ intent 无法可靠解析时：**不要猜**。回退到 explicit Skill-name fal
 - Initial Task branch bootstrap is a shared workflow contract: Delivery locks
   the trusted `main`/base first, then the implementation preflight classifies
   the target branch. An existing branch is reusable only when Task identity,
-  ownership, and base are mechanically proven. A missing branch is creatable
+  ownership, base, and a clean worktree are mechanically proven. A missing
+  branch is creatable
   only when the worktree is clean, the current/local/remote `main` identities
   equal the locked base, no local/remote/worktree conflict exists, and the
   target uses canonical `task/<Issue number>-<slug>` naming. The Runner returns

--- a/tests/tools/test_workflow_evidence.py
+++ b/tests/tools/test_workflow_evidence.py
@@ -5,7 +5,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -1398,7 +1398,7 @@ def _run_implementation_preflight(
         args.append("--bootstrap-verify")
     result = _run(repo, env, *args)
     assert result.returncode == 0, result.stderr
-    return json.loads(result.stdout)
+    return cast(dict[str, Any], json.loads(result.stdout))
 
 
 def _safe_bootstrap_state() -> dict[str, Any]:

--- a/tests/tools/test_workflow_evidence.py
+++ b/tests/tools/test_workflow_evidence.py
@@ -7,6 +7,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 SCRIPT = Path(__file__).parents[2] / "tools" / "agent_workflow" / "workflow_evidence.py"
 PYTHON = os.environ.get("WORKFLOW_TEST_PYTHON", sys.executable)
 
@@ -57,9 +59,12 @@ elif args[:3] == ['worktree','list','--porcelain']:
     out('\\n'.join(lines))
 elif args[:3] == ['log','-1','--format=%H']: out(state.get('runner_source_sha','c'*40))
 elif args[:2] == ['ls-remote','--heads']:
-    if state.get('remote_branch_exists',True): out(state.get('pr',{{}}).get('headRefOid','d'*40)+'\\trefs/heads/'+args[-1])
+    if state.get('remote_branch_exists',True):
+        out(state.get('remote_branch_tips',{{}}).get(args[-1], state.get('pr',{{}}).get('headRefOid','d'*40))+'\\trefs/heads/'+args[-1])
 elif args[:3] == ['show-ref','--verify','--quiet']:
     sys.exit(0 if state.get('local_branch_exists',True) else 1)
+elif args[:1] == ['merge-base']:
+    out(state.get('branch_base', state.get('origin_main','b'*40)))
 elif args[:2] == ['merge-base','--is-ancestor']:
     sys.exit(0 if state.get('merge_on_main', True) else 1)
 elif args[:2] == ['diff','--quiet']:
@@ -1366,6 +1371,235 @@ def test_fetch_failure_is_explicit_unknown_gate(tmp_path: Path) -> None:
 # --- Delivery Preflight tests (new) ---
 
 SHA40 = "2" * 40
+
+
+def _run_implementation_preflight(
+    repo: Path,
+    env: dict[str, str],
+    *,
+    branch: str = "task/70-bootstrap",
+    expected_base: str = SHA40,
+    bootstrap_verify: bool = False,
+) -> dict[str, Any]:
+    args = [
+        "delivery-preflight",
+        "--task",
+        "70",
+        "--expected-main-sha",
+        SHA40,
+        "--entry-point",
+        "implementation",
+        "--branch",
+        branch,
+        "--expected-base-sha",
+        expected_base,
+    ]
+    if bootstrap_verify:
+        args.append("--bootstrap-verify")
+    result = _run(repo, env, *args)
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+def _safe_bootstrap_state() -> dict[str, Any]:
+    state = _base_state()
+    state.update(
+        branch="main",
+        git_head=SHA40,
+        local_main=SHA40,
+        origin_main=SHA40,
+        local_branch_exists=False,
+        remote_branch_exists=False,
+        status=[],
+        extra_worktree_branches=[],
+    )
+    return state
+
+
+def test_implementation_missing_canonical_branch_authorizes_bootstrap(
+    tmp_path: Path,
+) -> None:
+    repo, _, env = _write_repo(tmp_path, _safe_bootstrap_state())
+    value = _run_implementation_preflight(repo, env)
+    assert value["gates"]["branch_exists"]["status"] == "pass"
+    assert value["gates"]["branch_identity"]["status"] == "pass"
+    assert value["gates"]["branch_remote"]["status"] == "pass"
+    assert value["gates"]["branch_base"]["status"] == "pass"
+    assert value["gates"]["branch_bootstrap"]["status"] == "pass"
+    assert "creation authorized" in value["gates"]["branch_bootstrap"]["detail"]
+    assert value["disposition"]["write_actions_allowed"] is True
+
+
+def test_implementation_existing_valid_branch_is_reuse_authorized(
+    tmp_path: Path,
+) -> None:
+    state = _safe_bootstrap_state()
+    state.update(
+        local_branch_exists=True,
+        remote_branch_exists=True,
+        local_branch_tips={"task/70-bootstrap": "4" * 40},
+        remote_branch_tips={"task/70-bootstrap": "4" * 40},
+        branch_base=SHA40,
+    )
+    repo, _, env = _write_repo(tmp_path, state)
+    value = _run_implementation_preflight(repo, env)
+    assert value["gates"]["branch_state"]["status"] == "pass"
+    assert "reuse authorized" in value["gates"]["branch_state"]["detail"]
+    assert value["gates"]["branch_bootstrap"]["status"] == "pass"
+    assert value["gates"]["branch_base"]["status"] == "pass"
+    assert value["disposition"]["status"] == "pass"
+
+
+def test_implementation_existing_numeric_branch_can_only_be_reused(
+    tmp_path: Path,
+) -> None:
+    state = _safe_bootstrap_state()
+    state.update(
+        local_branch_exists=True,
+        remote_branch_exists=True,
+        local_branch_tips={"task-70": "4" * 40},
+        remote_branch_tips={"task-70": "4" * 40},
+        branch_base=SHA40,
+    )
+    repo, _, env = _write_repo(tmp_path, state)
+    value = _run_implementation_preflight(repo, env, branch="task-70")
+    assert value["gates"]["branch_identity"]["status"] == "pass"
+    assert value["gates"]["branch_bootstrap"]["status"] == "pass"
+
+
+@pytest.mark.parametrize("branch", ["task-70", "task/70", "foreign/branch"])
+def test_implementation_missing_noncanonical_or_unproven_branch_fails_closed(
+    tmp_path: Path, branch: str
+) -> None:
+    repo, _, env = _write_repo(tmp_path, _safe_bootstrap_state())
+    value = _run_implementation_preflight(repo, env, branch=branch)
+    assert value["disposition"]["write_actions_allowed"] is False
+    assert value["gates"]["branch_state"]["status"] == "fail"
+    assert value["gates"]["branch_bootstrap"]["status"] == "fail"
+    if branch == "foreign/branch":
+        assert value["gates"]["branch_identity"]["status"] == "fail"
+    else:
+        assert "canonical" in value["gates"]["branch_bootstrap"]["detail"]
+
+
+def test_implementation_existing_wrong_base_fails_closed(tmp_path: Path) -> None:
+    state = _safe_bootstrap_state()
+    state.update(
+        local_branch_exists=True,
+        remote_branch_exists=True,
+        local_branch_tips={"task/70-bootstrap": "4" * 40},
+        remote_branch_tips={"task/70-bootstrap": "4" * 40},
+        branch_base="9" * 40,
+    )
+    repo, _, env = _write_repo(tmp_path, state)
+    value = _run_implementation_preflight(repo, env)
+    assert value["gates"]["branch_base"]["status"] == "fail"
+    assert value["disposition"]["write_actions_allowed"] is False
+
+
+def test_implementation_dirty_missing_branch_fails_closed(tmp_path: Path) -> None:
+    state = _safe_bootstrap_state()
+    state["status"] = [" M unrelated.py"]
+    repo, _, env = _write_repo(tmp_path, state)
+    value = _run_implementation_preflight(repo, env)
+    assert value["gates"]["branch_bootstrap"]["status"] == "fail"
+    assert "clean worktree" in value["gates"]["branch_bootstrap"]["detail"]
+    assert value["disposition"]["write_actions_allowed"] is False
+
+
+def test_implementation_remote_conflict_on_missing_branch_fails_closed(
+    tmp_path: Path,
+) -> None:
+    state = _safe_bootstrap_state()
+    state["remote_branch_exists"] = True
+    repo, _, env = _write_repo(tmp_path, state)
+    value = _run_implementation_preflight(repo, env)
+    assert value["gates"]["branch_bootstrap"]["status"] == "fail"
+    assert "ownership is ambiguous" in value["gates"]["branch_bootstrap"]["detail"]
+
+
+def test_implementation_worktree_ownership_conflict_fails_closed(
+    tmp_path: Path,
+) -> None:
+    state = _safe_bootstrap_state()
+    state["extra_worktree_branches"] = ["task/70-bootstrap"]
+    repo, _, env = _write_repo(tmp_path, state)
+    value = _run_implementation_preflight(repo, env)
+    assert value["gates"]["branch_bootstrap"]["status"] == "fail"
+    assert "another worktree" in value["gates"]["branch_bootstrap"]["detail"]
+    assert value["disposition"]["write_actions_allowed"] is False
+
+
+def test_implementation_existing_remote_tip_drift_fails_closed(tmp_path: Path) -> None:
+    state = _safe_bootstrap_state()
+    state.update(
+        local_branch_exists=True,
+        remote_branch_exists=True,
+        local_branch_tips={"task/70-bootstrap": "4" * 40},
+        remote_branch_tips={"task/70-bootstrap": "5" * 40},
+        branch_base=SHA40,
+    )
+    repo, _, env = _write_repo(tmp_path, state)
+    value = _run_implementation_preflight(repo, env)
+    assert value["gates"]["branch_bootstrap"]["status"] == "fail"
+    assert "tips differ" in value["gates"]["branch_bootstrap"]["detail"]
+    assert value["disposition"]["write_actions_allowed"] is False
+
+
+def test_bootstrap_then_reenter_implementation_verifies_and_continues(
+    tmp_path: Path,
+) -> None:
+    state = _safe_bootstrap_state()
+    repo, state_path, env = _write_repo(tmp_path, state)
+    initial = _run_implementation_preflight(repo, env)
+    assert initial["gates"]["branch_bootstrap"]["status"] == "pass"
+
+    state.update(
+        branch="task/70-bootstrap",
+        git_head=SHA40,
+        local_branch_exists=True,
+        local_branch_tips={"task/70-bootstrap": SHA40},
+        branch_base=SHA40,
+    )
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    verified = _run_implementation_preflight(repo, env, bootstrap_verify=True)
+    assert verified["gates"]["branch_bootstrap"]["status"] == "pass"
+    assert verified["gates"]["bootstrap_head"]["status"] == "pass"
+    assert verified["gates"]["worktree_state_compatible"]["status"] == "pass"
+    assert verified["disposition"]["workflow_may_continue"] is True
+
+
+def test_bootstrap_verification_requires_clean_worktree(tmp_path: Path) -> None:
+    state = _safe_bootstrap_state()
+    state.update(
+        branch="task/70-bootstrap",
+        git_head=SHA40,
+        local_branch_exists=True,
+        local_branch_tips={"task/70-bootstrap": SHA40},
+        branch_base=SHA40,
+        status=[" M drift.py"],
+    )
+    repo, _, env = _write_repo(tmp_path, state)
+    value = _run_implementation_preflight(repo, env, bootstrap_verify=True)
+    assert value["gates"]["worktree_state_compatible"]["status"] == "fail"
+    assert value["gates"]["branch_bootstrap"]["status"] == "fail"
+    assert value["disposition"]["write_actions_allowed"] is False
+
+
+def test_bootstrap_verification_detects_unexpected_drift(tmp_path: Path) -> None:
+    state = _safe_bootstrap_state()
+    state.update(
+        branch="task/70-bootstrap",
+        git_head="4" * 40,
+        local_branch_exists=True,
+        local_branch_tips={"task/70-bootstrap": "4" * 40},
+        branch_base=SHA40,
+    )
+    repo, _, env = _write_repo(tmp_path, state)
+    value = _run_implementation_preflight(repo, env, bootstrap_verify=True)
+    assert value["gates"]["bootstrap_head"]["status"] == "fail"
+    assert value["gates"]["branch_bootstrap"]["status"] == "fail"
+    assert value["disposition"]["write_actions_allowed"] is False
 
 
 def test_delivery_preflight_delivery_start_passes_with_ready_status(

--- a/tests/tools/test_workflow_evidence.py
+++ b/tests/tools/test_workflow_evidence.py
@@ -1450,6 +1450,23 @@ def test_implementation_existing_valid_branch_is_reuse_authorized(
     assert value["disposition"]["status"] == "pass"
 
 
+def test_implementation_existing_dirty_branch_fails_closed(tmp_path: Path) -> None:
+    state = _safe_bootstrap_state()
+    state.update(
+        local_branch_exists=True,
+        remote_branch_exists=True,
+        local_branch_tips={"task/70-bootstrap": "4" * 40},
+        remote_branch_tips={"task/70-bootstrap": "4" * 40},
+        branch_base=SHA40,
+        status=[" M unrelated.py"],
+    )
+    repo, _, env = _write_repo(tmp_path, state)
+    value = _run_implementation_preflight(repo, env)
+    assert value["gates"]["branch_bootstrap"]["status"] == "fail"
+    assert "clean worktree" in value["gates"]["branch_bootstrap"]["detail"]
+    assert value["disposition"]["write_actions_allowed"] is False
+
+
 def test_implementation_existing_numeric_branch_can_only_be_reused(
     tmp_path: Path,
 ) -> None:

--- a/tests/tools/test_workflow_skills.py
+++ b/tests/tools/test_workflow_skills.py
@@ -65,13 +65,14 @@ def test_delivery_branch_bootstrap_contract_is_shared_by_both_skills() -> None:
         ".agents/skills/task-delivery-runner/SKILL.md",
         ".claude/skills/task-delivery-runner/SKILL.md",
     ):
-        text = (ROOT / relative).read_text(encoding="utf-8")
+        text = (ROOT / relative).read_text(encoding="utf-8").casefold()
         for phrase in (
             "branch_bootstrap = pass",
-            "task/<Issue number>-<slug>",
+            "task/<issue number>-<slug>",
             "--bootstrap-verify",
             "fail closed",
-            "existing numeric branch forms",
+            "existing numeric",
+            "branch forms may be reused",
         ):
             assert phrase in text, (relative, phrase)
 

--- a/tests/tools/test_workflow_skills.py
+++ b/tests/tools/test_workflow_skills.py
@@ -71,6 +71,7 @@ def test_delivery_branch_bootstrap_contract_is_shared_by_both_skills() -> None:
             "task/<issue number>-<slug>",
             "--bootstrap-verify",
             "fail closed",
+            "clean worktree",
             "existing numeric",
             "branch forms may be reused",
         ):

--- a/tests/tools/test_workflow_skills.py
+++ b/tests/tools/test_workflow_skills.py
@@ -56,6 +56,24 @@ def test_delivery_runner_has_current_profiles_and_remediation_loop() -> None:
     assert "lifecycle conflict" in text.casefold()
     assert "`review-remediation` requires the bounded handoff" in text
     assert "stop before Runner or repair writes" in text
+    assert "branch_bootstrap" in text
+    assert "--bootstrap-verify" in text
+
+
+def test_delivery_branch_bootstrap_contract_is_shared_by_both_skills() -> None:
+    for relative in (
+        ".agents/skills/task-delivery-runner/SKILL.md",
+        ".claude/skills/task-delivery-runner/SKILL.md",
+    ):
+        text = (ROOT / relative).read_text(encoding="utf-8")
+        for phrase in (
+            "branch_bootstrap = pass",
+            "task/<Issue number>-<slug>",
+            "--bootstrap-verify",
+            "fail closed",
+            "existing numeric branch forms",
+        ):
+            assert phrase in text, (relative, phrase)
 
 
 def test_review_runner_is_read_only_and_emits_bounded_remediation_handoff() -> None:
@@ -97,7 +115,6 @@ def test_active_skills_have_bounded_failure_contract_without_evolution_traces() 
         "trusted-base",
         "trusted control",
         "predecessor",
-        "bootstrap",
         "old chain",
         "old path",
         "legacy path",

--- a/tests/tools/test_wsl2_github_evidence_runner.py
+++ b/tests/tools/test_wsl2_github_evidence_runner.py
@@ -937,6 +937,44 @@ def test_delivery_entry_point_in_compact_digest(
     assert digest["entry_point"] == "delivery-start"
 
 
+def test_delivery_implementation_accepts_bootstrap_verification_mode(
+    tmp_path: Path,
+) -> None:
+    repo, state_path, env, main_sha, _ = _prepare_repo(tmp_path)
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["issue"]["projectItems"] = [{"status": {"name": "Ready"}}]
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    _git(repo, "switch", "-q", "main")
+    _git(repo, "switch", "-q", "-c", "task/84-bootstrap")
+    completed = _run(
+        repo,
+        env,
+        "delivery",
+        "--task",
+        "84",
+        "--expected-main-sha",
+        main_sha,
+        "--entry-point",
+        "implementation",
+        "--branch",
+        "task/84-bootstrap",
+        "--expected-base-sha",
+        main_sha,
+        "--bootstrap-verify",
+    )
+    assert completed.returncode == 0, completed.stderr
+    result = _result(repo, completed.stdout)
+    assert result["status"] == "pass"
+    digest = json.loads(completed.stdout)
+    snapshot = json.loads(
+        (repo / digest["result_path"])
+        .with_name("workflow-evidence.stdout.json")
+        .read_text(encoding="utf-8")
+    )
+    assert snapshot["gates"]["branch_bootstrap"]["status"] == "pass"
+    assert snapshot["gates"]["bootstrap_head"]["status"] == "pass"
+
+
 def test_delivery_lifecycle_conflict_ready_and_needs_spec_returns_fail(
     tmp_path: Path,
 ) -> None:

--- a/tools/agent_workflow/skill_path_audit.py
+++ b/tools/agent_workflow/skill_path_audit.py
@@ -84,7 +84,6 @@ EVOLUTION_TRACES: Final = (
     "trusted-base",
     "trusted control",
     "predecessor",
-    "bootstrap",
     "old chain",
     "old path",
     "legacy path",

--- a/tools/agent_workflow/workflow_evidence.py
+++ b/tools/agent_workflow/workflow_evidence.py
@@ -1252,6 +1252,8 @@ def _branch_bootstrap_gate(
         reasons.append("worktree branch inventory is truncated")
     if branch in worktree_items and git.get("branch") != branch:
         reasons.append("target branch is occupied by another worktree")
+    if branch_exists and git.get("clean") is not True:
+        return _gate("fail", "existing branch reuse requires a clean worktree")
 
     if not branch_exists:
         if bootstrap_verify:

--- a/tools/agent_workflow/workflow_evidence.py
+++ b/tools/agent_workflow/workflow_evidence.py
@@ -111,6 +111,9 @@ DELIVERY_ENTRY_PARAMS: Final = {
         {"task", "expected_main_sha", "pr", "expected_base_sha", "expected_head_sha"}
     ),
 }
+DELIVERY_OPTIONAL_PARAMS: Final = {
+    "implementation": frozenset({"bootstrap_verify"}),
+}
 DELIVERY_PARAM_SPACE: Final = frozenset(
     {
         "task",
@@ -119,6 +122,7 @@ DELIVERY_PARAM_SPACE: Final = frozenset(
         "pr",
         "expected_base_sha",
         "expected_head_sha",
+        "bootstrap_verify",
     }
 )
 BRANCH_NAME_ALLOWED: Final = frozenset(
@@ -1151,11 +1155,12 @@ def _parent_state_gate(relationships: Mapping[str, Any]) -> dict[str, Any]:
 def _validate_delivery_entry_args(args: argparse.Namespace) -> None:
     entry_point = args.entry_point
     allowed = DELIVERY_ENTRY_PARAMS[entry_point]
+    optional = DELIVERY_OPTIONAL_PARAMS.get(entry_point, frozenset())
     supplied = {
         name for name in DELIVERY_PARAM_SPACE if getattr(args, name, None) is not None
     }
     missing = sorted(allowed - supplied)
-    extra = sorted(supplied - allowed)
+    extra = sorted(supplied - allowed - optional)
     if missing or extra:
         raise WorkflowToolError(
             f"delivery entry-point {entry_point} parameter contract violation: "
@@ -1178,6 +1183,140 @@ def _validate_delivery_entry_args(args: argparse.Namespace) -> None:
             raise WorkflowToolError(f"invalid branch name: {value!r}")
 
 
+def _task_branch_identity_gate(branch: Any, task: int) -> dict[str, Any]:
+    """Prove that a supplied branch name identifies the current Task.
+
+    Canonical ``task/<number>-<slug>`` names are required for creation.  The
+    older numeric forms remain valid only for an existing branch that is
+    independently proven safe to reuse.
+    """
+    if not isinstance(branch, str) or not branch:
+        return _gate("unknown", "Task branch name unavailable")
+    if (
+        branch == f"task/{task}"
+        or branch.startswith(f"task/{task}-")
+        or branch.startswith(f"{task}-")
+        or branch == f"task-{task}"
+        or branch.startswith(f"task-{task}-")
+    ):
+        return _gate("pass", f"branch carries Task #{task} identity")
+    return _gate("fail", f"branch {branch!r} does not identify Task #{task}")
+
+
+def _is_canonical_new_task_branch(branch: str, task: int) -> bool:
+    prefix = f"task/{task}-"
+    suffix = branch[len(prefix) :] if branch.startswith(prefix) else ""
+    return bool(suffix) and "/" not in suffix
+
+
+def _worktree_branch_items(git: Mapping[str, Any]) -> tuple[list[str], bool]:
+    raw = git.get("worktree_branches")
+    if not isinstance(raw, Mapping):
+        return [], False
+    items = raw.get("items")
+    return (
+        [item for item in items if isinstance(item, str)]
+        if isinstance(items, list)
+        else [],
+        raw.get("truncated") is True,
+    )
+
+
+def _branch_bootstrap_gate(
+    *,
+    git: Mapping[str, Any],
+    branch: str | None,
+    task: int,
+    expected_main_sha: str | None,
+    expected_base_sha: str | None,
+    branch_exists: bool | None,
+    local_tip: str | None,
+    remote_tip: str | None,
+    remote_available: bool,
+    bootstrap_verify: bool,
+) -> dict[str, Any]:
+    """Classify safe Task branch creation, reuse, or fail-closed state.
+
+    This function is deterministic and read-only.  The Delivery Skill owns the
+    branch creation/reuse procedure after the returned authorization.
+    """
+    identity = _task_branch_identity_gate(branch, task)
+    if identity.get("status") != "pass":
+        return identity
+    if not isinstance(branch, str) or branch_exists is None:
+        return _gate("unknown", "Task branch existence could not be established")
+
+    worktree_items, worktree_truncated = _worktree_branch_items(git)
+    reasons: list[str] = []
+    if worktree_truncated:
+        reasons.append("worktree branch inventory is truncated")
+    if branch in worktree_items and git.get("branch") != branch:
+        reasons.append("target branch is occupied by another worktree")
+
+    if not branch_exists:
+        if bootstrap_verify:
+            return _gate("fail", "bootstrap verification requires the branch to exist")
+        if not _is_canonical_new_task_branch(branch, task):
+            return _gate(
+                "fail",
+                "new Task branches must use canonical task/<issue>-<slug> naming",
+            )
+        if not remote_available:
+            reasons.append("remote branch existence unavailable")
+        elif remote_tip is not None:
+            reasons.append("remote branch already exists; ownership is ambiguous")
+        if git.get("clean") is not True:
+            reasons.append("new branch bootstrap requires a clean worktree")
+        if git.get("branch") != "main":
+            reasons.append("bootstrap requires current branch main")
+        if git.get("head_sha") != expected_main_sha:
+            reasons.append("current HEAD does not equal expected main SHA")
+        if git.get("local_main_sha") != expected_main_sha:
+            reasons.append("local main does not equal expected main SHA")
+        if git.get("origin_main_sha") != expected_main_sha:
+            reasons.append("origin/main does not equal expected main SHA")
+        if expected_base_sha != expected_main_sha:
+            reasons.append("expected Task base is not the locked main SHA")
+        if reasons:
+            return _gate("fail", "; ".join(reasons))
+        return _gate(
+            "pass",
+            f"branch {branch!r} absent; branch creation authorized from locked base",
+        )
+
+    if not remote_available:
+        return _gate("unknown", "existing branch remote state unavailable")
+    if local_tip is None:
+        return _gate("unknown", "existing branch tip unavailable")
+    if remote_tip is not None and remote_tip != local_tip:
+        reasons.append("local and remote Task branch tips differ")
+    if bootstrap_verify:
+        if git.get("branch") != branch:
+            reasons.append(
+                "post-bootstrap current branch does not match expected branch"
+            )
+        if git.get("head_sha") != expected_base_sha:
+            reasons.append("post-bootstrap HEAD does not equal locked base SHA")
+        if local_tip != expected_base_sha:
+            reasons.append("post-bootstrap branch tip does not equal locked base SHA")
+        if git.get("local_main_sha") != expected_main_sha:
+            reasons.append("post-bootstrap local main does not equal locked main SHA")
+        if git.get("origin_main_sha") != expected_main_sha:
+            reasons.append("post-bootstrap origin/main does not equal locked main SHA")
+        if remote_tip is not None:
+            reasons.append("post-bootstrap remote branch unexpectedly exists")
+        if git.get("clean") is not True:
+            reasons.append("post-bootstrap worktree is not clean")
+    if reasons:
+        return _gate("fail", "; ".join(reasons))
+    if bootstrap_verify:
+        return _gate(
+            "pass",
+            f"post-bootstrap branch {branch!r}, HEAD, base, and clean state verified",
+        )
+    return _gate("pass", f"existing branch {branch!r} is eligible for idempotent reuse")
+
+
 def _entry_point_gates(
     args: argparse.Namespace,
     runner: CommandRunner,
@@ -1192,18 +1331,92 @@ def _entry_point_gates(
 
     if entry_point in {"implementation", "final-validation", "pr-readiness"}:
         branch = args.branch
+        bootstrap_verify = bool(getattr(args, "bootstrap_verify", False))
         branch_exists = runner.run(
             ["git", "show-ref", "--verify", "--quiet", f"refs/heads/{branch}"],
             command_id="git-branch-exists",
         )
+        branch_is_present: bool | None
         if branch_exists.returncode == 0:
+            branch_is_present = True
             gates["branch_exists"] = _gate("pass")
         elif branch_exists.returncode == 1:
-            gates["branch_exists"] = _gate("fail", f"branch {branch!r} does not exist")
+            branch_is_present = False
+            if entry_point == "implementation":
+                gates["branch_exists"] = _gate(
+                    "pass",
+                    f"branch {branch!r} absent; bootstrap classification required",
+                )
+            else:
+                gates["branch_exists"] = _gate(
+                    "fail", f"branch {branch!r} does not exist"
+                )
         else:
+            branch_is_present = None
             gates["branch_exists"] = _gate("unknown")
 
-        if args.expected_base_sha and repository:
+        local_branch_tip: str | None = None
+        remote_tip: str | None = None
+        remote_available = True
+        if entry_point == "implementation" and repository:
+            if branch_is_present:
+                local_tip_result = runner.run(
+                    ["git", "rev-parse", f"refs/heads/{branch}"],
+                    command_id="git-implementation-branch-tip",
+                )
+                if local_tip_result.returncode == 0:
+                    local_branch_tip = local_tip_result.stdout.strip()
+                else:
+                    warnings.append(command_warning(local_tip_result))
+            remote_result = runner.run(
+                ["git", "ls-remote", "--heads", "origin", str(branch)],
+                command_id="git-implementation-remote-branch",
+            )
+            if remote_result.returncode == 0:
+                remote_tip = _remote_branch_tip(remote_result.stdout)
+                gates["branch_remote"] = _gate(
+                    "pass",
+                    "remote branch absent"
+                    if remote_tip is None
+                    else f"remote branch tip {remote_tip}",
+                )
+            else:
+                remote_available = False
+                warnings.append(command_warning(remote_result))
+                gates["branch_remote"] = _gate("unknown")
+
+            gates["branch_identity"] = _task_branch_identity_gate(branch, args.task)
+            gates["branch_bootstrap"] = _branch_bootstrap_gate(
+                git=git,
+                branch=branch,
+                task=args.task,
+                expected_main_sha=args.expected_main_sha,
+                expected_base_sha=args.expected_base_sha,
+                branch_exists=branch_is_present,
+                local_tip=local_branch_tip,
+                remote_tip=remote_tip,
+                remote_available=remote_available,
+                bootstrap_verify=bootstrap_verify,
+            )
+            bootstrap_gate = gates["branch_bootstrap"]
+            if branch_is_present:
+                if bootstrap_gate.get("status") == "pass":
+                    gates["branch_state"] = _gate(
+                        "pass",
+                        "post-bootstrap verification requested"
+                        if bootstrap_verify
+                        else "existing branch reuse authorized",
+                    )
+                else:
+                    gates["branch_state"] = bootstrap_gate
+            elif branch_is_present is False:
+                gates["branch_state"] = bootstrap_gate
+            else:
+                gates["branch_state"] = _gate(
+                    "unknown", "branch state classification unavailable"
+                )
+
+        if args.expected_base_sha and repository and branch_is_present:
             merge_base = runner.run(
                 [
                     "git",
@@ -1229,6 +1442,30 @@ def _entry_point_gates(
             else:
                 warnings.append(command_warning(merge_base))
                 gates["branch_base"] = _gate("unknown")
+        elif (
+            args.expected_base_sha
+            and repository
+            and entry_point == "implementation"
+            and branch_is_present is False
+        ):
+            gates["branch_base"] = _gate(
+                "pass" if args.expected_base_sha == args.expected_main_sha else "fail",
+                "locked base is the source for safe branch bootstrap"
+                if args.expected_base_sha == args.expected_main_sha
+                else "expected Task base is not the locked main SHA",
+            )
+
+        if bootstrap_verify and branch_is_present:
+            gates["bootstrap_head"] = _gate(
+                "pass"
+                if git.get("head_sha") == args.expected_base_sha
+                and local_branch_tip == args.expected_base_sha
+                else "fail",
+                "post-bootstrap HEAD and branch tip equal locked base SHA"
+                if git.get("head_sha") == args.expected_base_sha
+                and local_branch_tip == args.expected_base_sha
+                else "post-bootstrap HEAD or branch tip drifted from locked base SHA",
+            )
 
     if entry_point in {"final-validation", "pr-readiness"}:
         branch = args.branch
@@ -2129,7 +2366,7 @@ def _collect_task_pr(
 
 
 def _worktree_state_compatible_gate(
-    git: Mapping[str, Any], *, entry_point: str
+    git: Mapping[str, Any], *, entry_point: str, bootstrap_verify: bool = False
 ) -> dict[str, Any]:
     """Gate worktree cleanliness per entry point.
 
@@ -2145,7 +2382,9 @@ def _worktree_state_compatible_gate(
     changed_items = changed.get("items") if isinstance(changed, dict) else []
     status_entries = git.get("status_entries")
 
-    dirty_allowed = entry_point in {"delivery-start", "implementation"}
+    dirty_allowed = entry_point in {"delivery-start", "implementation"} and not (
+        entry_point == "implementation" and bootstrap_verify
+    )
     blocked: list[dict[str, Any]] = []
 
     if clean:
@@ -2361,7 +2600,9 @@ def _delivery_preflight(args: argparse.Namespace, repo_root: Path) -> dict[str, 
             git.get("origin_main_sha"), args.expected_main_sha, "origin/main SHA"
         )
         gates["worktree_state_compatible"] = _worktree_state_compatible_gate(
-            git, entry_point=args.entry_point
+            git,
+            entry_point=args.entry_point,
+            bootstrap_verify=bool(getattr(args, "bootstrap_verify", False)),
         )
         if issue is not None:
             labels = set(issue.get("labels", {}).get("items", []))
@@ -3075,6 +3316,12 @@ def _build_parser() -> argparse.ArgumentParser:
     delivery.add_argument("--expected-base-sha", help="expected branch base SHA")
     delivery.add_argument("--expected-head-sha", help="expected branch head SHA")
     delivery.add_argument("--pr", type=int, help="expected PR number")
+    delivery.add_argument(
+        "--bootstrap-verify",
+        action="store_true",
+        default=None,
+        help="verify a newly created Task branch before implementation writes",
+    )
 
     readiness = sub.add_parser("delivery-readiness", help="Task PR readiness snapshot")
     _common(readiness)

--- a/tools/agent_workflow/wsl2_github_evidence_runner.py
+++ b/tools/agent_workflow/wsl2_github_evidence_runner.py
@@ -64,6 +64,9 @@ DELIVERY_ENTRY_PARAMS: Final = {
         {"task", "expected_main_sha", "pr", "expected_base_sha", "expected_head_sha"}
     ),
 }
+DELIVERY_OPTIONAL_PARAMS: Final = {
+    "implementation": frozenset({"bootstrap_verify"}),
+}
 DELIVERY_PARAM_SPACE: Final = frozenset(
     {
         "task",
@@ -72,6 +75,7 @@ DELIVERY_PARAM_SPACE: Final = frozenset(
         "pr",
         "expected_base_sha",
         "expected_head_sha",
+        "bootstrap_verify",
     }
 )
 REPOSITORY_PATTERN: Final = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
@@ -423,11 +427,12 @@ def _branch_name(value: str) -> str:
 
 def _validate_delivery_contract(args: argparse.Namespace) -> None:
     allowed = DELIVERY_ENTRY_PARAMS[args.entry_point]
+    optional = DELIVERY_OPTIONAL_PARAMS.get(args.entry_point, frozenset())
     supplied = {
         name for name in DELIVERY_PARAM_SPACE if getattr(args, name, None) is not None
     }
     missing = sorted(allowed - supplied)
-    extra = sorted(supplied - allowed)
+    extra = sorted(supplied - allowed - optional)
     if missing or extra:
         raise RunnerError(
             f"delivery entry-point {args.entry_point} parameter contract violation: "
@@ -454,6 +459,12 @@ def _build_parser() -> argparse.ArgumentParser:
     delivery.add_argument("--expected-base-sha", type=_sha)
     delivery.add_argument("--expected-head-sha", type=_sha)
     delivery.add_argument("--pr", type=_positive_int)
+    delivery.add_argument(
+        "--bootstrap-verify",
+        action="store_true",
+        default=None,
+        help="verify a newly created Task branch before implementation writes",
+    )
 
     for name in ("delivery-readiness", "review", "pre-merge"):
         subp = sub.add_parser(name)
@@ -584,6 +595,8 @@ def _evidence_argv(args: argparse.Namespace, repo_root: Path) -> list[str]:
             result.extend(["--expected-head-sha", args.expected_head_sha])
         if args.pr is not None:
             result.extend(["--pr", str(args.pr)])
+        if args.bootstrap_verify is not None:
+            result.append("--bootstrap-verify")
     elif profile in {"delivery-readiness", "review", "pre-merge"}:
         result.extend(
             [


### PR DESCRIPTION
Closes #149 

## Summary

- Restore the minimal initial Task branch bootstrap contract in the current Agent / Skill / Runner architecture.
- Classify existing branch reuse versus safe canonical branch creation, and fail closed on ambiguous identity, ownership, base, worktree, or drift.
- Add post-bootstrap mechanical verification through the implementation Evidence Runner.

## Validation

- `targeted:workflow-tests` — pass
- `workflow-delivery --base-sha 32f48d0d6a164c09552ecaca26efd9ba5bce370d` — pass
- Final workflow validation: 447 passed, 1 skipped; Ruff, mypy, lock, diff, and Skill validators passed.

## Scope and limitations

This is a workflow control-plane maintenance repair. It does not modify Issue #89 implementation, Independent Review strategy, approval/sandbox policy, validation profiles, command batching, Context Compiler, Closeout, Recovery, or unrelated test cleanup. Independent Review has not been started; merge remains a maintainer action.
