### PR TITLE
[Task] 为 Independent Review 实现 bounded verified fact handoff

### DIFF
--- a/.agents/skills/task-pr-review-runner/SKILL.md
+++ b/.agents/skills/task-pr-review-runner/SKILL.md
@@ -74,6 +74,37 @@ The initial snapshot defines the reviewed identity. `workflow-review` is the
 independent CI-equivalent validation for the locked head. `recheck` verifies
 stability before verdict.
 
+## Optional bounded Review Fact Handoff
+
+The formal baseline remains fresh top-level Review root plus full mechanical
+fact reacquisition. A maintainer may explicitly provide a bounded JSON handoff
+to the Review entry:
+
+```text
+tools/agent_workflow/wsl2_github_evidence_runner.py review \
+  --task <TASK> --pr <PR> \
+  --expected-base-sha <LOCKED_BASE_SHA> \
+  --expected-head-sha <LOCKED_HEAD_SHA> \
+  --handoff-path .agents/evidence.local/review-handoffs/<FILE>.json \
+  --skill-path .agents/skills/task-pr-review-runner/SKILL.md
+```
+
+With `--handoff-path`, the Runner accepts only the exact bounded mechanical
+fields from `docs/development/pr-review.md` §11.4. Unknown or prohibited
+semantic fields, malformed input, missing source identity, incompatible schema,
+or any Task/PR/spec/base/head/diff/changed-file/check drift fail closed. The
+Runner reports `FRESH_ROOT_BOUNDED_HANDOFF` only after it revalidates the
+current object; the handoff never replaces `workflow-review`, current checks,
+the stability `recheck`, or semantic Review judgment. The handoff also carries
+an explicit freshness contract covering all eight drift types and must not
+contain Delivery conclusions or an old Review verdict.
+
+No `--handoff-path` preserves the existing `FULL_REACQUISITION` path and its
+semantics. A valid handoff is a candidate mechanical input only: the Reviewer
+still independently reads the complete effective diff, maps every applicable
+Acceptance Criterion, judges correctness/safety/risk, and forms findings and
+the verdict in a fresh semantic context.
+
 For `partial`, `unknown`, `fail`, truncation, schema mismatch, or drift, inspect
 only the named facts or failed commands. Semantic review may read any code or
 context needed to judge correctness.

--- a/.claude/skills/task-pr-review-runner/SKILL.md
+++ b/.claude/skills/task-pr-review-runner/SKILL.md
@@ -75,6 +75,37 @@ The initial snapshot defines the reviewed identity. `workflow-review` is the
 independent CI-equivalent validation for the locked head. `recheck` verifies
 stability before verdict.
 
+## Optional bounded Review Fact Handoff
+
+The formal baseline remains fresh top-level Review root plus full mechanical
+fact reacquisition. A maintainer may explicitly provide a bounded JSON handoff
+to the Review entry:
+
+```text
+tools/agent_workflow/wsl2_github_evidence_runner.py review \
+  --task <TASK> --pr <PR> \
+  --expected-base-sha <LOCKED_BASE_SHA> \
+  --expected-head-sha <LOCKED_HEAD_SHA> \
+  --handoff-path .agents/evidence.local/review-handoffs/<FILE>.json \
+  --skill-path .claude/skills/task-pr-review-runner/SKILL.md
+```
+
+With `--handoff-path`, the Runner accepts only the exact bounded mechanical
+fields from `docs/development/pr-review.md` §11.4. Unknown or prohibited
+semantic fields, malformed input, missing source identity, incompatible schema,
+or any Task/PR/spec/base/head/diff/changed-file/check drift fail closed. The
+Runner reports `FRESH_ROOT_BOUNDED_HANDOFF` only after it revalidates the
+current object; the handoff never replaces `workflow-review`, current checks,
+the stability `recheck`, or semantic Review judgment. The handoff also carries
+an explicit freshness contract covering all eight drift types and must not
+contain Delivery conclusions or an old Review verdict.
+
+No `--handoff-path` preserves the existing `FULL_REACQUISITION` path and its
+semantics. A valid handoff is a candidate mechanical input only: the Reviewer
+still independently reads the complete effective diff, maps every applicable
+Acceptance Criterion, judges correctness/safety/risk, and forms findings and
+the verdict in a fresh semantic context.
+
 For `partial`, `unknown`, `fail`, truncation, schema mismatch, or drift, inspect
 only the named facts or failed commands. Semantic review may read any code or
 context needed to judge correctness.

--- a/docs/development/pr-review.md
+++ b/docs/development/pr-review.md
@@ -230,6 +230,12 @@ freshness_contract
 - 是否把 handoff 实现为 durable artifact 不由本文件预先决定；#91 可以
   实验 artifact 形式，但不能改变字段边界和重新校验要求。
 
+当前 runtime 允许 Review 入口通过显式的
+`.agents/evidence.local/review-handoffs/<file>.json` 输入路径消费该契约。
+未提供路径时继续使用 fresh top-level session + full reacquisition baseline；
+提供路径时必须先完成当前对象的机械 revalidation，失败即 fail closed，不得
+把旧 handoff 当作当前事实继续使用。
+
 Handoff **不得**包含或派生出以下字段：
 
 ```text

--- a/docs/development/pr-review.md
+++ b/docs/development/pr-review.md
@@ -222,7 +222,7 @@ freshness_contract
 - `task_id` / `pr_id` 必须绑定同一 repository；`task_spec_hash`、base、
   head、diff、manifest 和 AC identifiers 共同定义一个 reviewed object。
 - `raw_check_facts` 与 `validation_facts` 只记录可重查的原始状态、profile、
-  result locator 和 digest，不把它们改写成质量或合并结论。
+  validated base identity、result locator 和 digest，不把它们改写成质量或合并结论。
 - `source_identity` 必须能说明来源对象、查询或 profile identity；
   `freshness_contract` 必须说明哪些当前条件不再满足时 handoff 失效。
 - `created_at` 记录产生时间，但不得单独作为 freshness 证明；本契约不

--- a/tests/tools/test_review_fact_handoff.py
+++ b/tests/tools/test_review_fact_handoff.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any, cast
 
@@ -253,7 +254,7 @@ def test_unverifiable_source_identity_fails_closed() -> None:
 
 
 def test_nested_allowlists_reject_unknown_fields() -> None:
-    cases = (
+    cases: tuple[tuple[Callable[[dict[str, Any]], None], str], ...] = (
         (lambda value: value.update({"unknown": True}), "top-level"),
         (
             lambda value: value["workflow_identity"]["runner"].update(

--- a/tests/tools/test_review_fact_handoff.py
+++ b/tests/tools/test_review_fact_handoff.py
@@ -43,6 +43,36 @@ def _workflow_identity() -> dict[str, Any]:
             "path": ".agents/skills/task-pr-review-runner/SKILL.md",
             "sha256": SHA256,
         },
+        "control_plane": {
+            "evidence_runner": {
+                "path": "tools/agent_workflow/wsl2_github_evidence_runner.py",
+                "content_sha256": SHA256,
+            },
+            "profile_spec": {
+                "path": "tools/agent_workflow/wsl2_github_evidence_profiles.json",
+                "content_sha256": SHA256,
+            },
+            "evidence_rules": {
+                "path": ".codex/rules/tracequant-wsl-evidence.rules",
+                "content_sha256": SHA256,
+            },
+            "workflow_common": {
+                "path": "tools/agent_workflow/workflow_common.py",
+                "content_sha256": SHA256,
+            },
+            "command_execution_policy": {
+                "path": ".agents/policies/command-execution.md",
+                "content_sha256": SHA256,
+            },
+            "workflow_evidence_policy": {
+                "path": ".agents/policies/workflow-evidence.md",
+                "content_sha256": SHA256,
+            },
+            "review_semantics": {
+                "path": "docs/development/pr-review.md",
+                "content_sha256": SHA256,
+            },
+        },
     }
 
 
@@ -335,6 +365,87 @@ def test_validation_head_mismatch_remains_fail_closed(tmp_path: Path) -> None:
     assert any("head identity mismatch" in error for error in errors)
 
 
+def test_all_required_drift_classes_fail_closed() -> None:
+    cases: list[tuple[str, Callable[[dict[str, Any], dict[str, Any]], None]]] = [
+        (
+            "TASK_SPEC_DRIFT",
+            lambda snapshot, current: snapshot["observed"]["issue"].update(
+                {"spec_sha256": "e" * 64}
+            ),
+        ),
+        (
+            "BASE_DRIFT",
+            lambda snapshot, current: snapshot["observed"]["pr"].update(
+                {"base_sha": "e" * 40}
+            ),
+        ),
+        (
+            "HEAD_DRIFT",
+            lambda snapshot, current: snapshot["observed"]["pr"].update(
+                {"head_sha": "e" * 40}
+            ),
+        ),
+        (
+            "EFFECTIVE_DIFF_DRIFT",
+            lambda snapshot, current: snapshot["observed"]["effective_diff"].update(
+                {"sha256": "e" * 64}
+            ),
+        ),
+        (
+            "CHECKS_DRIFT",
+            lambda snapshot, current: snapshot["observed"]["pr"]["checks"]["items"][
+                0
+            ].update({"state": "FAILURE"}),
+        ),
+        (
+            "VALIDATION_DRIFT",
+            lambda snapshot, current: current["validation"].update(
+                {"result_sha256": "e" * 64}
+            ),
+        ),
+        (
+            "WORKFLOW_RULE_DRIFT",
+            lambda snapshot, current: current["workflow"]["control_plane"][
+                "evidence_runner"
+            ].update({"content_sha256": "e" * 64}),
+        ),
+        (
+            "HANDOFF_SCHEMA_DRIFT",
+            lambda snapshot, current: current["source"].update(
+                {"source_digest": "e" * 64}
+            ),
+        ),
+    ]
+
+    for drift, mutate in cases:
+        snapshot = _snapshot()
+        current = {
+            "validation": _validation_facts(),
+            "workflow": _workflow_identity(),
+            "source": source_identity_for_snapshot(snapshot),
+        }
+        mutate(snapshot, current)
+        if drift not in {
+            "HANDOFF_SCHEMA_DRIFT",
+            "WORKFLOW_RULE_DRIFT",
+            "VALIDATION_DRIFT",
+        }:
+            current["source"] = source_identity_for_snapshot(snapshot)
+        result = validate_against_snapshot(
+            _handoff(),
+            snapshot,
+            current_acceptance_criteria_ids=["AC-1", "AC-2"],
+            current_validation_facts=current["validation"],
+            current_workflow_identity=current["workflow"],
+            current_source_identity=current["source"],
+        )
+        assert result["status"] == "fail", drift
+        assert any(item.startswith(drift) for item in result["invalidated"]), (
+            drift,
+            result["invalidated"],
+        )
+
+
 def test_stale_or_mismatched_validation_facts_fail_closed() -> None:
     current = _validation_facts()
     current["result_sha256"] = "e" * 64
@@ -359,15 +470,28 @@ def test_unverifiable_validation_facts_fail_closed() -> None:
     assert any(item.startswith("VALIDATION_DRIFT") for item in result["invalidated"])
 
 
-def test_workflow_runner_skill_and_schema_drift_fail_closed() -> None:
-    for drift in ("runner", "skill", "schema"):
+def test_workflow_runner_skill_schema_and_control_plane_drift_fail_closed() -> None:
+    for drift in (
+        "runner",
+        "skill",
+        "schema",
+        "evidence_runner",
+        "profile_spec",
+        "evidence_rules",
+        "workflow_common",
+        "command_execution_policy",
+        "workflow_evidence_policy",
+        "review_semantics",
+    ):
         current = _workflow_identity()
         if drift == "runner":
             current["runner"]["content_sha256"] = "e" * 64
         elif drift == "skill":
             current["skill"]["sha256"] = "e" * 64
-        else:
+        elif drift == "schema":
             current["schema_version"] = 2
+        else:
+            current["control_plane"][drift]["content_sha256"] = "e" * 64
         result = validate_against_snapshot(
             _handoff(),
             _snapshot(),
@@ -435,6 +559,12 @@ def test_nested_allowlists_reject_unknown_fields() -> None:
             ),
             "workflow",
         ),
+        (
+            lambda value: value["workflow_identity"]["control_plane"][
+                "evidence_runner"
+            ].update({"unknown": True}),
+            "workflow-control-plane",
+        ),
         (lambda value: value["source_identity"].update({"unknown": True}), "source"),
         (
             lambda value: value["validation_facts"]["runner_identity"].update(
@@ -472,5 +602,21 @@ def test_defined_nested_fields_remain_compatible() -> None:
 
 def test_default_freshness_contract_covers_all_required_drift() -> None:
     contract = default_freshness_contract()
-    assert set(contract["invalidate_on"]) == set(DRIFT_TYPES)
+    assert contract["invalidate_on"] == list(DRIFT_TYPES)
     assert contract["requires_new_semantic_context_on_object_drift"] is True
+
+
+def test_freshness_contract_is_closed_world() -> None:
+    mutators: tuple[Callable[[dict[str, Any]], Any], ...] = (
+        lambda value: value["freshness_contract"]["invalidate_on"].append(
+            "UNKNOWN_DRIFT"
+        ),
+        lambda value: value["freshness_contract"]["revalidate_current_facts"].pop(),
+    )
+    for mutate in mutators:
+        handoff = _handoff()
+        mutate(handoff)
+        violations = validate_handoff_structure(
+            handoff, expected_repository="owner/repo"
+        )
+        assert violations

--- a/tests/tools/test_review_fact_handoff.py
+++ b/tests/tools/test_review_fact_handoff.py
@@ -119,17 +119,21 @@ def _snapshot() -> dict[str, Any]:
                 "base_sha": SHA40,
                 "head_sha": HEAD40,
                 "checks": {
-                    "items": [
-                        {
-                            "name": "quality",
-                            "state": "SUCCESS",
-                            "category": "success",
-                            "run_id": "run-1",
-                            "started_at": "2026-08-20T00:00:00Z",
-                            "completed_at": "2026-08-20T00:01:00Z",
-                            "source_url": "https://example.invalid/run-1",
-                        }
-                    ]
+                    "items": {
+                        "items": [
+                            {
+                                "name": "quality",
+                                "state": "SUCCESS",
+                                "category": "success",
+                                "run_id": "run-1",
+                                "started_at": "2026-08-20T00:00:00Z",
+                                "completed_at": "2026-08-20T00:01:00Z",
+                                "source_url": "https://example.invalid/run-1",
+                            }
+                        ],
+                        "count": 1,
+                        "truncated": False,
+                    }
                 },
             },
             "effective_diff": {
@@ -394,8 +398,8 @@ def test_all_required_drift_classes_fail_closed() -> None:
         (
             "CHECKS_DRIFT",
             lambda snapshot, current: snapshot["observed"]["pr"]["checks"]["items"][
-                0
-            ].update({"state": "FAILURE"}),
+                "items"
+            ][0].update({"state": "FAILURE"}),
         ),
         (
             "VALIDATION_DRIFT",
@@ -598,6 +602,35 @@ def test_defined_nested_fields_remain_compatible() -> None:
     }
     handoff["raw_check_facts"]["observed"][0]["source_url"] = None
     assert validate_handoff_structure(handoff, expected_repository="owner/repo") == []
+
+
+def test_current_required_check_facts_fail_closed_when_incomplete() -> None:
+    cases = []
+
+    truncated_contexts = json.loads(json.dumps(_snapshot()))
+    truncated_contexts["observed"]["required_checks"]["contexts"]["truncated"] = True
+    cases.append(truncated_contexts)
+
+    unknown_configuration = json.loads(json.dumps(_snapshot()))
+    unknown_configuration["observed"]["required_checks"]["configuration"] = "unknown"
+    cases.append(unknown_configuration)
+
+    truncated_checks = json.loads(json.dumps(_snapshot()))
+    truncated_checks["observed"]["pr"]["checks"]["items"]["truncated"] = True
+    cases.append(truncated_checks)
+
+    for snapshot in cases:
+        result = validate_against_snapshot(
+            _handoff(),
+            snapshot,
+            current_acceptance_criteria_ids=["AC-1", "AC-2"],
+            current_validation_facts=_validation_facts(),
+            current_workflow_identity=_workflow_identity(),
+        )
+        assert result["status"] == "fail"
+        assert result["trusted"] is False
+        assert result["strategy"] == "FAIL_CLOSED"
+        assert any(item.startswith("CHECKS_DRIFT") for item in result["invalidated"])
 
 
 def test_default_freshness_contract_covers_all_required_drift() -> None:

--- a/tests/tools/test_review_fact_handoff.py
+++ b/tests/tools/test_review_fact_handoff.py
@@ -21,20 +21,57 @@ SHA256 = "c" * 64
 DIFF_SHA256 = "d" * 64
 
 
+def _workflow_identity() -> dict[str, Any]:
+    return {
+        "profile": "delivery-readiness",
+        "schema_version": 1,
+        "runner": {
+            "path": "tools/agent_workflow/workflow_evidence.py",
+            "source_sha": SHA40,
+            "content_sha256": SHA256,
+            "handoff_schema": {
+                "path": "tools/agent_workflow/review_fact_handoff.py",
+                "content_sha256": SHA256,
+            },
+        },
+        "skill": {
+            "path": ".agents/skills/task-pr-review-runner/SKILL.md",
+            "sha256": SHA256,
+        },
+    }
+
+
+def _validation_facts() -> dict[str, Any]:
+    return {
+        "profile": "workflow-delivery",
+        "schema_version": 1,
+        "runner_identity": {
+            "path": "tools/agent_workflow/wsl2_validation_runner.py",
+            "sha256": SHA256,
+            "profile_spec_path": "tools/agent_workflow/wsl2_validation_profiles.json",
+            "profile_spec_sha256": SHA256,
+            "rules_path": ".codex/rules/tracequant-wsl-validation.rules",
+            "rules_sha256": SHA256,
+            "workflow_validation_path": "tools/agent_workflow/workflow_validation.py",
+            "workflow_validation_sha256": SHA256,
+            "skill": {
+                "path": ".agents/skills/task-delivery-runner/SKILL.md",
+                "sha256": SHA256,
+            },
+        },
+        "exit_code": 0,
+        "result_locator": ".agents/validation.local/wsl2-runs/run/result.json",
+        "result_sha256": SHA256,
+    }
+
+
 def _snapshot() -> dict[str, Any]:
     return {
         "schema_version": 1,
         "snapshot_id": "ev-1234567890abcdef",
         "repository": "owner/repo",
         "operation": "delivery-readiness",
-        "execution_context": {
-            "workflow_identity": {
-                "profile": "delivery-readiness",
-                "schema_version": 1,
-                "runner": {"path": "runner", "content_sha256": SHA256},
-                "skill": {"path": "skill", "sha256": SHA256},
-            }
-        },
+        "execution_context": {"workflow_identity": _workflow_identity()},
         "observed": {
             "issue": {
                 "number": 70,
@@ -45,13 +82,28 @@ def _snapshot() -> dict[str, Any]:
                 "number": 71,
                 "base_sha": SHA40,
                 "head_sha": HEAD40,
-                "checks": {"items": [{"name": "quality", "state": "SUCCESS"}]},
+                "checks": {
+                    "items": [
+                        {
+                            "name": "quality",
+                            "state": "SUCCESS",
+                            "category": "success",
+                            "run_id": "run-1",
+                            "started_at": "2026-08-20T00:00:00Z",
+                            "completed_at": "2026-08-20T00:01:00Z",
+                            "source_url": "https://example.invalid/run-1",
+                        }
+                    ]
+                },
             },
             "effective_diff": {
                 "sha256": DIFF_SHA256,
                 "changed_files": {"items": ["src/app.py"], "truncated": False},
             },
-            "required_checks": {"configuration": "available", "contexts": ["quality"]},
+            "required_checks": {
+                "configuration": "available",
+                "contexts": {"items": ["quality"], "count": 1, "truncated": False},
+            },
         },
     }
 
@@ -62,25 +114,8 @@ def _handoff() -> dict[str, Any]:
         build_handoff_from_snapshot(
             _snapshot(),
             acceptance_criteria_ids=["AC-1", "AC-2"],
-            validation_facts={
-                "profile": "workflow-delivery",
-                "schema_version": 1,
-                "runner_identity": {"path": "validation", "sha256": SHA256},
-                "exit_code": 0,
-                "result_locator": ".agents/validation.local/run.json",
-                "result_sha256": SHA256,
-            },
-            workflow_identity={
-                "profile": "delivery-readiness",
-                "schema_version": 1,
-                "runner": {"path": "runner", "content_sha256": SHA256},
-                "skill": {"path": "skill", "sha256": SHA256},
-            },
-            source_identity={
-                "repository": "owner/repo",
-                "source_locator": ".agents/evidence.local/snapshot.json",
-                "source_digest": SHA256,
-            },
+            validation_facts=_validation_facts(),
+            workflow_identity=_workflow_identity(),
             created_at="2026-08-20T00:00:00+00:00",
         ),
     )
@@ -108,10 +143,157 @@ def test_current_object_drift_invalidates_handoff() -> None:
         snapshot,
         handoff_digest=SHA256,
         current_acceptance_criteria_ids=["AC-1", "AC-2"],
+        current_validation_facts=_validation_facts(),
     )
     assert result["status"] == "fail"
     assert result["trusted"] is False
     assert any(item.startswith("HEAD_DRIFT") for item in result["invalidated"])
+
+
+def test_current_validation_facts_match_handoff() -> None:
+    result = validate_against_snapshot(
+        _handoff(),
+        _snapshot(),
+        current_acceptance_criteria_ids=["AC-1", "AC-2"],
+        current_validation_facts=_validation_facts(),
+    )
+    assert result["status"] == "pass"
+    assert result["trusted"] is True
+
+
+def test_stale_or_mismatched_validation_facts_fail_closed() -> None:
+    current = _validation_facts()
+    current["result_sha256"] = "e" * 64
+    result = validate_against_snapshot(
+        _handoff(),
+        _snapshot(),
+        current_acceptance_criteria_ids=["AC-1", "AC-2"],
+        current_validation_facts=current,
+    )
+    assert result["status"] == "fail"
+    assert any(item.startswith("VALIDATION_DRIFT") for item in result["invalidated"])
+
+
+def test_unverifiable_validation_facts_fail_closed() -> None:
+    result = validate_against_snapshot(
+        _handoff(),
+        _snapshot(),
+        current_acceptance_criteria_ids=["AC-1", "AC-2"],
+        current_validation_facts=None,
+    )
+    assert result["status"] == "fail"
+    assert any(item.startswith("VALIDATION_DRIFT") for item in result["invalidated"])
+
+
+def test_workflow_runner_skill_and_schema_drift_fail_closed() -> None:
+    for drift in ("runner", "skill", "schema"):
+        current = _workflow_identity()
+        if drift == "runner":
+            current["runner"]["content_sha256"] = "e" * 64
+        elif drift == "skill":
+            current["skill"]["sha256"] = "e" * 64
+        else:
+            current["schema_version"] = 2
+        result = validate_against_snapshot(
+            _handoff(),
+            _snapshot(),
+            current_acceptance_criteria_ids=["AC-1", "AC-2"],
+            current_validation_facts=_validation_facts(),
+            current_workflow_identity=current,
+        )
+        assert result["status"] == "fail", drift
+        assert any(
+            item.startswith("WORKFLOW_RULE_DRIFT") for item in result["invalidated"]
+        ), drift
+
+
+def test_unverifiable_workflow_identity_fails_closed() -> None:
+    result = validate_against_snapshot(
+        _handoff(),
+        _snapshot(),
+        current_acceptance_criteria_ids=["AC-1", "AC-2"],
+        current_validation_facts=_validation_facts(),
+        current_workflow_identity={},
+    )
+    assert result["status"] == "fail"
+    assert any(item.startswith("WORKFLOW_RULE_DRIFT") for item in result["invalidated"])
+
+
+def test_source_digest_mismatch_fails_closed() -> None:
+    current = {
+        "repository": "owner/repo",
+        "source_locator": _handoff()["source_identity"]["source_locator"],
+        "source_digest": "e" * 64,
+    }
+    result = validate_against_snapshot(
+        _handoff(),
+        _snapshot(),
+        current_acceptance_criteria_ids=["AC-1", "AC-2"],
+        current_validation_facts=_validation_facts(),
+        current_source_identity=current,
+    )
+    assert result["status"] == "fail"
+    assert any(
+        item.startswith("HANDOFF_SCHEMA_DRIFT") for item in result["invalidated"]
+    )
+
+
+def test_unverifiable_source_identity_fails_closed() -> None:
+    result = validate_against_snapshot(
+        _handoff(),
+        _snapshot(),
+        current_acceptance_criteria_ids=["AC-1", "AC-2"],
+        current_validation_facts=_validation_facts(),
+        current_source_identity={},
+    )
+    assert result["status"] == "fail"
+    assert any(
+        item.startswith("HANDOFF_SCHEMA_DRIFT") for item in result["invalidated"]
+    )
+
+
+def test_nested_allowlists_reject_unknown_fields() -> None:
+    cases = (
+        (lambda value: value.update({"unknown": True}), "top-level"),
+        (
+            lambda value: value["workflow_identity"]["runner"].update(
+                {"unknown": True}
+            ),
+            "workflow",
+        ),
+        (lambda value: value["source_identity"].update({"unknown": True}), "source"),
+        (
+            lambda value: value["validation_facts"]["runner_identity"].update(
+                {"unknown": True}
+            ),
+            "validation",
+        ),
+        (
+            lambda value: value["workflow_identity"]["skill"].update(
+                {"semantic_claim": "all acceptance criteria pass"}
+            ),
+            "semantic-looking",
+        ),
+    )
+    for mutate, label in cases:
+        handoff = _handoff()
+        mutate(handoff)
+        violations = validate_handoff_structure(
+            handoff, expected_repository="owner/repo"
+        )
+        assert violations, label
+
+
+def test_defined_nested_fields_remain_compatible() -> None:
+    handoff = _handoff()
+    handoff["raw_check_facts"]["required"]["failure"] = {
+        "category": "unknown",
+        "reason": "required-checks-query-failed",
+        "http_status": None,
+        "command_id": "gh-required-checks-main",
+    }
+    handoff["raw_check_facts"]["observed"][0]["source_url"] = None
+    assert validate_handoff_structure(handoff, expected_repository="owner/repo") == []
 
 
 def test_default_freshness_contract_covers_all_required_drift() -> None:

--- a/tests/tools/test_review_fact_handoff.py
+++ b/tests/tools/test_review_fact_handoff.py
@@ -14,6 +14,7 @@ from review_fact_handoff import (  # type: ignore[import-not-found]  # noqa: E40
     acquire_current_validation_facts,
     build_handoff_from_snapshot,
     default_freshness_contract,
+    source_identity_for_snapshot,
     validate_against_snapshot,
     validate_handoff_structure,
 )
@@ -264,6 +265,28 @@ def test_current_validation_facts_match_handoff() -> None:
     )
     assert result["status"] == "pass"
     assert result["trusted"] is True
+
+
+def test_review_phase_operation_does_not_change_stable_source_identity() -> None:
+    initial = _snapshot()
+    recheck = _snapshot()
+    recheck["operation"] = "pr-review-recheck"
+    recheck["snapshot_id"] = "ev-fedcba9876543210"
+
+    assert source_identity_for_snapshot(initial) == source_identity_for_snapshot(
+        recheck
+    )
+    result = validate_against_snapshot(
+        _handoff(),
+        recheck,
+        current_acceptance_criteria_ids=["AC-1", "AC-2"],
+        current_validation_facts=_validation_facts(),
+    )
+    assert result["status"] == "pass"
+    assert result["trusted"] is True
+    assert not any(
+        item.startswith("HANDOFF_SCHEMA_DRIFT") for item in result["invalidated"]
+    )
 
 
 def test_validation_base_and_head_match_reviewed_object(tmp_path: Path) -> None:

--- a/tests/tools/test_review_fact_handoff.py
+++ b/tests/tools/test_review_fact_handoff.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 sys.path.insert(0, str(Path(__file__).parents[2] / "tools/agent_workflow"))
 
-from review_fact_handoff import (  # noqa: E402, I001
+from review_fact_handoff import (  # type: ignore[import-not-found]  # noqa: E402, I001
     DRIFT_TYPES,
     build_handoff_from_snapshot,
     default_freshness_contract,
@@ -45,9 +45,7 @@ def _snapshot() -> dict[str, Any]:
                 "number": 71,
                 "base_sha": SHA40,
                 "head_sha": HEAD40,
-                "checks": {
-                    "items": [{"name": "quality", "state": "SUCCESS"}]
-                },
+                "checks": {"items": [{"name": "quality", "state": "SUCCESS"}]},
             },
             "effective_diff": {
                 "sha256": DIFF_SHA256,
@@ -59,29 +57,32 @@ def _snapshot() -> dict[str, Any]:
 
 
 def _handoff() -> dict[str, Any]:
-    return build_handoff_from_snapshot(
-        _snapshot(),
-        acceptance_criteria_ids=["AC-1", "AC-2"],
-        validation_facts={
-            "profile": "workflow-delivery",
-            "schema_version": 1,
-            "runner_identity": {"path": "validation", "sha256": SHA256},
-            "exit_code": 0,
-            "result_locator": ".agents/validation.local/run.json",
-            "result_sha256": SHA256,
-        },
-        workflow_identity={
-            "profile": "delivery-readiness",
-            "schema_version": 1,
-            "runner": {"path": "runner", "content_sha256": SHA256},
-            "skill": {"path": "skill", "sha256": SHA256},
-        },
-        source_identity={
-            "repository": "owner/repo",
-            "source_locator": ".agents/evidence.local/snapshot.json",
-            "source_digest": SHA256,
-        },
-        created_at="2026-08-20T00:00:00+00:00",
+    return cast(
+        dict[str, Any],
+        build_handoff_from_snapshot(
+            _snapshot(),
+            acceptance_criteria_ids=["AC-1", "AC-2"],
+            validation_facts={
+                "profile": "workflow-delivery",
+                "schema_version": 1,
+                "runner_identity": {"path": "validation", "sha256": SHA256},
+                "exit_code": 0,
+                "result_locator": ".agents/validation.local/run.json",
+                "result_sha256": SHA256,
+            },
+            workflow_identity={
+                "profile": "delivery-readiness",
+                "schema_version": 1,
+                "runner": {"path": "runner", "content_sha256": SHA256},
+                "skill": {"path": "skill", "sha256": SHA256},
+            },
+            source_identity={
+                "repository": "owner/repo",
+                "source_locator": ".agents/evidence.local/snapshot.json",
+                "source_digest": SHA256,
+            },
+            created_at="2026-08-20T00:00:00+00:00",
+        ),
     )
 
 

--- a/tests/tools/test_review_fact_handoff.py
+++ b/tests/tools/test_review_fact_handoff.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).parents[2] / "tools/agent_workflow"))
+
+from review_fact_handoff import (  # noqa: E402, I001
+    DRIFT_TYPES,
+    build_handoff_from_snapshot,
+    default_freshness_contract,
+    validate_against_snapshot,
+    validate_handoff_structure,
+)
+
+
+SHA40 = "a" * 40
+HEAD40 = "b" * 40
+SHA256 = "c" * 64
+DIFF_SHA256 = "d" * 64
+
+
+def _snapshot() -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "snapshot_id": "ev-1234567890abcdef",
+        "repository": "owner/repo",
+        "operation": "delivery-readiness",
+        "execution_context": {
+            "workflow_identity": {
+                "profile": "delivery-readiness",
+                "schema_version": 1,
+                "runner": {"path": "runner", "content_sha256": SHA256},
+                "skill": {"path": "skill", "sha256": SHA256},
+            }
+        },
+        "observed": {
+            "issue": {
+                "number": 70,
+                "spec_sha256": SHA256,
+                "acceptance_criteria_ids": ["AC-1", "AC-2"],
+            },
+            "pr": {
+                "number": 71,
+                "base_sha": SHA40,
+                "head_sha": HEAD40,
+                "checks": {
+                    "items": [{"name": "quality", "state": "SUCCESS"}]
+                },
+            },
+            "effective_diff": {
+                "sha256": DIFF_SHA256,
+                "changed_files": {"items": ["src/app.py"], "truncated": False},
+            },
+            "required_checks": {"configuration": "available", "contexts": ["quality"]},
+        },
+    }
+
+
+def _handoff() -> dict[str, Any]:
+    return build_handoff_from_snapshot(
+        _snapshot(),
+        acceptance_criteria_ids=["AC-1", "AC-2"],
+        validation_facts={
+            "profile": "workflow-delivery",
+            "schema_version": 1,
+            "runner_identity": {"path": "validation", "sha256": SHA256},
+            "exit_code": 0,
+            "result_locator": ".agents/validation.local/run.json",
+            "result_sha256": SHA256,
+        },
+        workflow_identity={
+            "profile": "delivery-readiness",
+            "schema_version": 1,
+            "runner": {"path": "runner", "content_sha256": SHA256},
+            "skill": {"path": "skill", "sha256": SHA256},
+        },
+        source_identity={
+            "repository": "owner/repo",
+            "source_locator": ".agents/evidence.local/snapshot.json",
+            "source_digest": SHA256,
+        },
+        created_at="2026-08-20T00:00:00+00:00",
+    )
+
+
+def test_valid_handoff_has_exact_bounded_contract() -> None:
+    handoff = _handoff()
+    assert validate_handoff_structure(handoff, expected_repository="owner/repo") == []
+    assert handoff["freshness_contract"]["invalidate_on"] == list(DRIFT_TYPES)
+
+
+def test_prohibited_semantic_field_fails_closed_even_when_nested() -> None:
+    handoff = _handoff()
+    handoff["raw_check_facts"]["review_conclusion"] = "pass"
+    violations = validate_handoff_structure(handoff, expected_repository="owner/repo")
+    assert any("prohibited semantic fields" in item for item in violations)
+
+
+def test_current_object_drift_invalidates_handoff() -> None:
+    handoff = _handoff()
+    snapshot = _snapshot()
+    snapshot["observed"]["pr"]["head_sha"] = "e" * 40
+    result = validate_against_snapshot(
+        handoff,
+        snapshot,
+        handoff_digest=SHA256,
+        current_acceptance_criteria_ids=["AC-1", "AC-2"],
+    )
+    assert result["status"] == "fail"
+    assert result["trusted"] is False
+    assert any(item.startswith("HEAD_DRIFT") for item in result["invalidated"])
+
+
+def test_default_freshness_contract_covers_all_required_drift() -> None:
+    contract = default_freshness_contract()
+    assert set(contract["invalidate_on"]) == set(DRIFT_TYPES)
+    assert contract["requires_new_semantic_context_on_object_drift"] is True

--- a/tests/tools/test_review_fact_handoff.py
+++ b/tests/tools/test_review_fact_handoff.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import hashlib
+import json
 import sys
 from collections.abc import Callable
 from pathlib import Path
@@ -9,6 +11,7 @@ sys.path.insert(0, str(Path(__file__).parents[2] / "tools/agent_workflow"))
 
 from review_fact_handoff import (  # type: ignore[import-not-found]  # noqa: E402, I001
     DRIFT_TYPES,
+    acquire_current_validation_facts,
     build_handoff_from_snapshot,
     default_freshness_contract,
     validate_against_snapshot,
@@ -44,6 +47,7 @@ def _workflow_identity() -> dict[str, Any]:
 
 def _validation_facts() -> dict[str, Any]:
     return {
+        "base_sha": SHA40,
         "profile": "workflow-delivery",
         "schema_version": 1,
         "runner_identity": {
@@ -109,15 +113,115 @@ def _snapshot() -> dict[str, Any]:
     }
 
 
-def _handoff() -> dict[str, Any]:
+def _handoff(validation_facts: dict[str, Any] | None = None) -> dict[str, Any]:
     return cast(
         dict[str, Any],
         build_handoff_from_snapshot(
             _snapshot(),
             acceptance_criteria_ids=["AC-1", "AC-2"],
-            validation_facts=_validation_facts(),
+            validation_facts=validation_facts or _validation_facts(),
             workflow_identity=_workflow_identity(),
             created_at="2026-08-20T00:00:00+00:00",
+        ),
+    )
+
+
+def _write_validation_result(
+    repo: Path,
+    *,
+    base_sha: Any = SHA40,
+    head_sha: Any = HEAD40,
+    clean: bool = True,
+    include_base: bool = True,
+) -> dict[str, Any]:
+    identity_paths = {
+        "path": "tools/agent_workflow/wsl2_validation_runner.py",
+        "profile_spec_path": "tools/agent_workflow/wsl2_validation_profiles.json",
+        "rules_path": ".codex/rules/tracequant-wsl-validation.rules",
+        "workflow_validation_path": "tools/agent_workflow/workflow_validation.py",
+        "skill_path": ".agents/skills/task-delivery-runner/SKILL.md",
+    }
+    digests: dict[str, str] = {}
+    for key, relative in identity_paths.items():
+        target = repo / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(b"validation identity")
+        digests[key] = hashlib.sha256(target.read_bytes()).hexdigest()
+    identity = {
+        "path": identity_paths["path"],
+        "sha256": digests["path"],
+        "profile_spec_path": identity_paths["profile_spec_path"],
+        "profile_spec_sha256": digests["profile_spec_path"],
+        "rules_path": identity_paths["rules_path"],
+        "rules_sha256": digests["rules_path"],
+        "workflow_validation_path": identity_paths["workflow_validation_path"],
+        "workflow_validation_sha256": digests["workflow_validation_path"],
+        "skill": {
+            "path": identity_paths["skill_path"],
+            "sha256": digests["skill_path"],
+        },
+    }
+    locator = ".agents/validation.local/wsl2-runs/run/result.json"
+    document: dict[str, Any] = {
+        "schema_version": 1,
+        "profile": "workflow-delivery",
+        "status": "pass",
+        "repository": {"state": {"head_sha": head_sha, "clean": clean}},
+        "artifacts": {"result_json": locator},
+        "integrity": {
+            "verification": "current-worktree-content",
+            "repository_head_sha": head_sha,
+            "repository_clean": clean,
+            "runner_path": identity["path"],
+            "runner_sha256": identity["sha256"],
+            "profile_spec_path": identity["profile_spec_path"],
+            "profile_spec_sha256": identity["profile_spec_sha256"],
+            "rules_path": identity["rules_path"],
+            "rules_sha256": identity["rules_sha256"],
+            "workflow_validation_path": identity["workflow_validation_path"],
+            "workflow_validation_sha256": identity["workflow_validation_sha256"],
+            "skill": identity["skill"],
+        },
+    }
+    if include_base:
+        document["base_sha"] = base_sha
+    payload = (json.dumps(document, sort_keys=True) + "\n").encode()
+    result_path = repo / locator
+    result_path.parent.mkdir(parents=True, exist_ok=True)
+    result_path.write_bytes(payload)
+    return {
+        "base_sha": base_sha,
+        "profile": document["profile"],
+        "schema_version": document["schema_version"],
+        "runner_identity": identity,
+        "exit_code": 0,
+        "result_locator": locator,
+        "result_sha256": hashlib.sha256(payload).hexdigest(),
+    }
+
+
+def _acquire_validation(
+    tmp_path: Path,
+    *,
+    base_sha: Any = SHA40,
+    head_sha: Any = HEAD40,
+    clean: bool = True,
+    include_base: bool = True,
+) -> tuple[dict[str, Any] | None, list[str]]:
+    facts = _write_validation_result(
+        tmp_path,
+        base_sha=base_sha,
+        head_sha=head_sha,
+        clean=clean,
+        include_base=include_base,
+    )
+    return cast(
+        tuple[dict[str, Any] | None, list[str]],
+        acquire_current_validation_facts(
+            tmp_path,
+            facts,
+            expected_base_sha=SHA40,
+            expected_head_sha=HEAD40,
         ),
     )
 
@@ -160,6 +264,52 @@ def test_current_validation_facts_match_handoff() -> None:
     )
     assert result["status"] == "pass"
     assert result["trusted"] is True
+
+
+def test_validation_base_and_head_match_reviewed_object(tmp_path: Path) -> None:
+    current, errors = _acquire_validation(tmp_path)
+    assert errors == []
+    assert current is not None
+    result = validate_against_snapshot(
+        _handoff(current),
+        _snapshot(),
+        current_acceptance_criteria_ids=["AC-1", "AC-2"],
+        current_validation_facts=current,
+    )
+    assert result["status"] == "pass"
+    assert result["trusted"] is True
+
+
+def test_validation_base_mismatch_fails_even_when_head_matches(tmp_path: Path) -> None:
+    current, errors = _acquire_validation(tmp_path, base_sha=HEAD40)
+    assert current is None
+    assert any("base identity mismatch" in error for error in errors)
+
+
+def test_validation_base_missing_fails_closed(tmp_path: Path) -> None:
+    current, errors = _acquire_validation(tmp_path, include_base=False)
+    assert current is None
+    assert any("base identity is unavailable" in error for error in errors)
+
+
+def test_validation_base_unknown_fails_closed(tmp_path: Path) -> None:
+    current, errors = _acquire_validation(tmp_path, base_sha="UNKNOWN")
+    assert current is None
+    assert any("base identity is unavailable" in error for error in errors)
+
+
+def test_validation_base_and_head_match_but_clean_fails_closed(
+    tmp_path: Path,
+) -> None:
+    current, errors = _acquire_validation(tmp_path, clean=False)
+    assert current is None
+    assert any("repository was not clean" in error for error in errors)
+
+
+def test_validation_head_mismatch_remains_fail_closed(tmp_path: Path) -> None:
+    current, errors = _acquire_validation(tmp_path, head_sha="e" * 40)
+    assert current is None
+    assert any("head identity mismatch" in error for error in errors)
 
 
 def test_stale_or_mismatched_validation_facts_fail_closed() -> None:

--- a/tests/tools/test_workflow_evidence.py
+++ b/tests/tools/test_workflow_evidence.py
@@ -285,7 +285,7 @@ def _write_repo(
     repo = tmp_path / "repo"
     repo.mkdir()
     (repo / ".gitignore").write_text(
-        ".agents/evidence.local/\n.agents/validation.local/\n",
+        ".agents/evidence.local/\n.agents/validation.local/\n__pycache__/\n",
         encoding="utf-8",
     )
     state_path = tmp_path / "state.json"

--- a/tests/tools/test_workflow_evidence.py
+++ b/tests/tools/test_workflow_evidence.py
@@ -317,6 +317,7 @@ def test_help_for_all_commands() -> None:
     commands = (
         "delivery-preflight",
         "delivery-readiness",
+        "delivery-readiness-recheck",
         "pr-review-snapshot",
         "pr-review-recheck",
         "closeout-plan",
@@ -432,6 +433,68 @@ def test_review_recheck_detects_head_and_diff_drift(tmp_path: Path) -> None:
     assert "head_sha" in value["stability"]["changed_fields"]["items"]
     assert "effective_diff_sha256" in value["stability"]["changed_fields"]["items"]
     assert value["gates"]["snapshot_stability"]["status"] == "fail"
+
+
+def test_delivery_readiness_recheck_is_stable_when_object_is_unchanged(
+    tmp_path: Path,
+) -> None:
+    state = _base_state()
+    state["issues"]["70"]["projectItems"] = [{"status": {"name": "Review"}}]
+    repo, _, env = _write_repo(tmp_path, state)
+    first = _run(repo, env, "delivery-readiness", "--task", "70", "--pr", "71")
+    assert first.returncode == 0, first.stderr
+    initial = json.loads(first.stdout)
+
+    second = _run(
+        repo,
+        env,
+        "delivery-readiness-recheck",
+        "--snapshot-id",
+        initial["snapshot_id"],
+    )
+    assert second.returncode == 0, second.stderr
+    recheck = json.loads(second.stdout)
+    assert initial["operation"] == "delivery-readiness"
+    assert recheck["operation"] == "delivery-readiness-recheck"
+    assert (
+        initial["execution_context"]["workflow_identity"]["profile"]
+        == "delivery-readiness"
+    )
+    assert (
+        recheck["execution_context"]["workflow_identity"]["profile"]
+        == "delivery-readiness"
+    )
+    assert recheck["stability"]["stable"] is True
+    assert recheck["stability"]["changed_fields"]["items"] == []
+    assert recheck["gates"]["snapshot_stability"]["status"] == "pass"
+
+
+def test_delivery_readiness_recheck_detects_head_and_diff_drift(
+    tmp_path: Path,
+) -> None:
+    state = _base_state()
+    state["issues"]["70"]["projectItems"] = [{"status": {"name": "Review"}}]
+    repo, state_path, env = _write_repo(tmp_path, state)
+    first = _run(repo, env, "delivery-readiness", "--task", "70", "--pr", "71")
+    assert first.returncode == 0, first.stderr
+    snapshot_id = json.loads(first.stdout)["snapshot_id"]
+
+    state["pr"]["headRefOid"] = "5" * 40
+    state["diff"] = "diff --git a/file.py b/file.py\n+changed\n"
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    second = _run(
+        repo,
+        env,
+        "delivery-readiness-recheck",
+        "--snapshot-id",
+        snapshot_id,
+    )
+    assert second.returncode == 0, second.stderr
+    recheck = json.loads(second.stdout)
+    assert recheck["stability"]["stable"] is False
+    assert "head_sha" in recheck["stability"]["changed_fields"]["items"]
+    assert "effective_diff_sha256" in recheck["stability"]["changed_fields"]["items"]
+    assert recheck["gates"]["snapshot_stability"]["status"] == "fail"
 
 
 def test_read_only_mode_skips_fetch_and_reports_local_main(tmp_path: Path) -> None:

--- a/tests/tools/test_workflow_skills.py
+++ b/tests/tools/test_workflow_skills.py
@@ -94,6 +94,24 @@ def test_review_runner_is_read_only_and_emits_bounded_remediation_handoff() -> N
     assert "task-delivery-runner 修复" in text
 
 
+def test_review_runner_exposes_explicit_bounded_fact_handoff_mode() -> None:
+    for relative in (
+        ".agents/skills/task-pr-review-runner/SKILL.md",
+        ".claude/skills/task-pr-review-runner/SKILL.md",
+    ):
+        text = (ROOT / relative).read_text(encoding="utf-8")
+        for phrase in (
+            "FRESH_ROOT_BOUNDED_HANDOFF",
+            "--handoff-path",
+            "FULL_REACQUISITION",
+            "all eight drift types",
+            "fail closed",
+            "Delivery conclusions",
+            "fresh semantic context",
+        ):
+            assert phrase in text, (relative, phrase)
+
+
 def test_closeout_and_feature_audit_keep_manual_gates() -> None:
     closeout = ACTIVE_SKILLS["task-closeout"].read_text(encoding="utf-8")
     audit = ACTIVE_SKILLS["feature-completion-audit"].read_text(encoding="utf-8")

--- a/tests/tools/test_wsl2_github_evidence_runner.py
+++ b/tests/tools/test_wsl2_github_evidence_runner.py
@@ -26,6 +26,9 @@ IDENTITY_FILES = (
     Path("tools/agent_workflow/workflow_evidence.py"),
     Path("tools/agent_workflow/workflow_common.py"),
     Path("tools/agent_workflow/review_fact_handoff.py"),
+    Path(".agents/policies/command-execution.md"),
+    Path(".agents/policies/workflow-evidence.md"),
+    Path("docs/development/pr-review.md"),
 )
 VALIDATION_IDENTITY_FILES = (
     Path("tools/agent_workflow/wsl2_validation_runner.py"),
@@ -577,6 +580,68 @@ def test_review_profile_consumes_verified_handoff_and_recheck_invalidates_drift(
     assert recheck.returncode == 4
     recheck_digest = json.loads(recheck.stdout)
     assert recheck_digest["status"] == "fail"
+
+
+def test_review_handoff_fails_closed_when_control_plane_drifts(tmp_path: Path) -> None:
+    repo, state_path, env, main_sha, head_sha = _prepare_repo(tmp_path)
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["issue"]["body"] = "## Acceptance Criteria\n- [ ] first\n- [ ] second\n"
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    first = _run(repo, env, *_review_args(main_sha, head_sha))
+    assert first.returncode == 0, first.stderr
+    first_digest = json.loads(first.stdout)
+    snapshot = json.loads(
+        (
+            repo
+            / ".agents/evidence.local/snapshots"
+            / f"{first_digest['snapshot_id']}.json"
+        ).read_text(encoding="utf-8")
+    )
+    handoff = build_handoff_from_snapshot(
+        snapshot,
+        acceptance_criteria_ids=["AC-1", "AC-2"],
+        validation_facts=_validation_facts(repo, main_sha, head_sha),
+        workflow_identity=snapshot["execution_context"]["workflow_identity"],
+    )
+    write_handoff(repo, handoff, filename="task-84-control-plane.json")
+    handoff_run = _run(
+        repo,
+        env,
+        *_review_args(main_sha, head_sha),
+        "--handoff-path",
+        ".agents/evidence.local/review-handoffs/task-84-control-plane.json",
+    )
+    assert handoff_run.returncode == 0, handoff_run.stderr
+    handoff_digest = json.loads(handoff_run.stdout)
+
+    for relative in (Path("tools/agent_workflow/wsl2_github_evidence_runner.py"),):
+        target = repo / relative
+        original = target.read_bytes()
+        target.write_bytes(original + b"\n")
+        try:
+            recheck = _run(
+                repo,
+                env,
+                "recheck",
+                "--snapshot-id",
+                handoff_digest["snapshot_id"],
+            )
+            assert recheck.returncode == 4, (relative, recheck.stderr)
+            recheck_result = _result(repo, recheck.stdout)
+            current_snapshot = json.loads(
+                (repo / recheck_result["evidence"]["source_details_path"]).read_text(
+                    encoding="utf-8"
+                )
+            )
+            invalidated = current_snapshot["observed"]["review_fact_handoff"][
+                "invalidated"
+            ]
+            assert any(
+                item.startswith("WORKFLOW_RULE_DRIFT") for item in invalidated
+            ), (relative, invalidated)
+        finally:
+            target.write_bytes(original)
 
 
 def test_delivery_readiness_recheck_is_stable_through_runner(tmp_path: Path) -> None:

--- a/tests/tools/test_wsl2_github_evidence_runner.py
+++ b/tests/tools/test_wsl2_github_evidence_runner.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import shutil
@@ -25,6 +26,13 @@ IDENTITY_FILES = (
     Path("tools/agent_workflow/workflow_evidence.py"),
     Path("tools/agent_workflow/workflow_common.py"),
     Path("tools/agent_workflow/review_fact_handoff.py"),
+)
+VALIDATION_IDENTITY_FILES = (
+    Path("tools/agent_workflow/wsl2_validation_runner.py"),
+    Path("tools/agent_workflow/wsl2_validation_profiles.json"),
+    Path(".codex/rules/tracequant-wsl-validation.rules"),
+    Path("tools/agent_workflow/workflow_validation.py"),
+    Path(".agents/skills/task-delivery-runner/SKILL.md"),
 )
 REAL_GIT_OPTIONAL = shutil.which("git")
 assert REAL_GIT_OPTIONAL is not None
@@ -248,6 +256,10 @@ def _prepare_repo(
         target = repo / relative
         target.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(ROOT / relative, target)
+    for relative in VALIDATION_IDENTITY_FILES:
+        target = repo / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(ROOT / relative, target)
     for skill_dir in (".agents", ".claude"):
         for skill in (
             "task-delivery-runner",
@@ -386,6 +398,60 @@ def _result(repo: Path, stdout: str) -> dict[str, Any]:
     return result
 
 
+def _validation_facts(repo: Path, head_sha: str) -> dict[str, Any]:
+    def digest(relative: Path) -> str:
+        return hashlib.sha256((repo / relative).read_bytes()).hexdigest()
+
+    locator = ".agents/validation.local/wsl2-runs/run/result.json"
+    identity = {
+        "path": "tools/agent_workflow/wsl2_validation_runner.py",
+        "sha256": digest(VALIDATION_IDENTITY_FILES[0]),
+        "profile_spec_path": "tools/agent_workflow/wsl2_validation_profiles.json",
+        "profile_spec_sha256": digest(VALIDATION_IDENTITY_FILES[1]),
+        "rules_path": ".codex/rules/tracequant-wsl-validation.rules",
+        "rules_sha256": digest(VALIDATION_IDENTITY_FILES[2]),
+        "workflow_validation_path": "tools/agent_workflow/workflow_validation.py",
+        "workflow_validation_sha256": digest(VALIDATION_IDENTITY_FILES[3]),
+        "skill": {
+            "path": ".agents/skills/task-delivery-runner/SKILL.md",
+            "sha256": digest(VALIDATION_IDENTITY_FILES[4]),
+        },
+    }
+    document = {
+        "schema_version": 1,
+        "profile": "workflow-delivery",
+        "status": "pass",
+        "repository": {"state": {"head_sha": head_sha, "clean": True}},
+        "artifacts": {"result_json": locator},
+        "integrity": {
+            "verification": "current-worktree-content",
+            "repository_head_sha": head_sha,
+            "repository_clean": True,
+            "runner_path": identity["path"],
+            "runner_sha256": identity["sha256"],
+            "profile_spec_path": identity["profile_spec_path"],
+            "profile_spec_sha256": identity["profile_spec_sha256"],
+            "rules_path": identity["rules_path"],
+            "rules_sha256": identity["rules_sha256"],
+            "workflow_validation_path": identity["workflow_validation_path"],
+            "workflow_validation_sha256": identity["workflow_validation_sha256"],
+            "skill": identity["skill"],
+        },
+    }
+    payload = (json.dumps(document, sort_keys=True) + "\n").encode()
+    result_path = repo / locator
+    result_path.parent.mkdir(parents=True, exist_ok=True)
+    result_path.write_bytes(payload)
+    return {
+        "profile": document["profile"],
+        "schema_version": document["schema_version"],
+        "runner_identity": identity,
+        "exit_code": 0,
+        "result_locator": locator,
+        "result_sha256": hashlib.sha256(payload).hexdigest(),
+    }
+
+
 def test_review_profile_returns_required_schema_and_compact_digest(
     tmp_path: Path,
 ) -> None:
@@ -447,20 +513,8 @@ def test_review_profile_consumes_verified_handoff_and_recheck_invalidates_drift(
     handoff = build_handoff_from_snapshot(
         snapshot,
         acceptance_criteria_ids=["AC-1", "AC-2"],
-        validation_facts={
-            "profile": "workflow-delivery",
-            "schema_version": 1,
-            "runner_identity": {"path": "validation", "sha256": "c" * 64},
-            "exit_code": 0,
-            "result_locator": ".agents/validation.local/result.json",
-            "result_sha256": "d" * 64,
-        },
+        validation_facts=_validation_facts(repo, head_sha),
         workflow_identity=snapshot["execution_context"]["workflow_identity"],
-        source_identity={
-            "repository": "PhoenixSss/tracequant",
-            "source_locator": ".agents/evidence.local/snapshot.json",
-            "source_digest": "e" * 64,
-        },
     )
     write_handoff(
         repo,

--- a/tests/tools/test_wsl2_github_evidence_runner.py
+++ b/tests/tools/test_wsl2_github_evidence_runner.py
@@ -12,7 +12,7 @@ import pytest
 
 ROOT = Path(__file__).parents[2]
 sys.path.insert(0, str(ROOT / "tools/agent_workflow"))
-from review_fact_handoff import (  # noqa: E402, I001
+from review_fact_handoff import (  # type: ignore[import-not-found]  # noqa: E402, I001
     build_handoff_from_snapshot,
     write_handoff,
 )

--- a/tests/tools/test_wsl2_github_evidence_runner.py
+++ b/tests/tools/test_wsl2_github_evidence_runner.py
@@ -545,6 +545,30 @@ def test_review_profile_consumes_verified_handoff_and_recheck_invalidates_drift(
         == "FRESH_ROOT_BOUNDED_HANDOFF"
     )
 
+    stable_recheck = _run(
+        repo,
+        env,
+        "recheck",
+        "--snapshot-id",
+        handoff_digest["snapshot_id"],
+    )
+    assert stable_recheck.returncode == 0, stable_recheck.stderr
+    stable_value = _result(repo, stable_recheck.stdout)
+    assert stable_value["stability"]["stable"] is True
+    assert stable_value["stability"]["changed_fields"]["items"] == []
+    assert stable_value["evidence"]["source_operation"] == "pr-review-recheck"
+    stable_snapshot = json.loads(
+        (repo / stable_value["evidence"]["source_details_path"]).read_text(
+            encoding="utf-8"
+        )
+    )
+    assert stable_snapshot["operation"] == "pr-review-recheck"
+    assert stable_snapshot["observed"]["review_fact_handoff"]["status"] == "pass"
+    assert not any(
+        item.startswith("HANDOFF_SCHEMA_DRIFT")
+        for item in stable_snapshot["observed"]["review_fact_handoff"]["invalidated"]
+    )
+
     handoff["head_sha"] = "f" * 40
     (repo / ".agents/evidence.local/review-handoffs/task-84-review.json").write_text(
         json.dumps(handoff), encoding="utf-8"
@@ -1390,6 +1414,7 @@ def test_recheck_preserves_skill_identity(
     assert second.returncode == 0, second.stderr
     value = _result(repo, second.stdout)
     assert value["integrity"]["skill"]["path"] == claude_skill
+    assert value["stability"]["stable"] is True
 
 
 def test_skill_path_hash_mismatch_detected(

--- a/tests/tools/test_wsl2_github_evidence_runner.py
+++ b/tests/tools/test_wsl2_github_evidence_runner.py
@@ -579,6 +579,47 @@ def test_review_profile_consumes_verified_handoff_and_recheck_invalidates_drift(
     assert recheck_digest["status"] == "fail"
 
 
+def test_delivery_readiness_recheck_is_stable_through_runner(tmp_path: Path) -> None:
+    repo, _, env, main_sha, head_sha = _prepare_repo(tmp_path)
+    first = _run(repo, env, *_review_args(main_sha, head_sha, "delivery-readiness"))
+    assert first.returncode == 0, first.stderr
+    first_digest = json.loads(first.stdout)
+    first_result = _result(repo, first.stdout)
+    first_snapshot = json.loads(
+        (repo / first_result["evidence"]["source_details_path"]).read_text(
+            encoding="utf-8"
+        )
+    )
+
+    second = _run(
+        repo,
+        env,
+        "recheck",
+        "--snapshot-id",
+        first_digest["snapshot_id"],
+    )
+    assert second.returncode == 0, second.stderr
+    second_result = _result(repo, second.stdout)
+    second_snapshot = json.loads(
+        (repo / second_result["evidence"]["source_details_path"]).read_text(
+            encoding="utf-8"
+        )
+    )
+    assert first_snapshot["operation"] == "delivery-readiness"
+    assert second_snapshot["operation"] == "delivery-readiness-recheck"
+    assert (
+        first_snapshot["execution_context"]["workflow_identity"]["profile"]
+        == "delivery-readiness"
+    )
+    assert (
+        second_snapshot["execution_context"]["workflow_identity"]["profile"]
+        == "delivery-readiness"
+    )
+    assert second_result["status"] == "pass"
+    assert second_result["stability"]["stable"] is True
+    assert second_result["stability"]["changed_fields"]["items"] == []
+
+
 @pytest.mark.parametrize("profile", ["delivery-readiness", "review", "pre-merge"])
 def test_task_pr_profiles_are_fixed_and_pass(tmp_path: Path, profile: str) -> None:
     repo, _, env, main_sha, head_sha = _prepare_repo(tmp_path)

--- a/tests/tools/test_wsl2_github_evidence_runner.py
+++ b/tests/tools/test_wsl2_github_evidence_runner.py
@@ -11,6 +11,12 @@ from typing import Any
 import pytest
 
 ROOT = Path(__file__).parents[2]
+sys.path.insert(0, str(ROOT / "tools/agent_workflow"))
+from review_fact_handoff import (  # noqa: E402, I001
+    build_handoff_from_snapshot,
+    write_handoff,
+)
+
 RUNNER_REL = Path("tools/agent_workflow/wsl2_github_evidence_runner.py")
 IDENTITY_FILES = (
     RUNNER_REL,
@@ -18,6 +24,7 @@ IDENTITY_FILES = (
     Path(".codex/rules/tracequant-wsl-evidence.rules"),
     Path("tools/agent_workflow/workflow_evidence.py"),
     Path("tools/agent_workflow/workflow_common.py"),
+    Path("tools/agent_workflow/review_fact_handoff.py"),
 )
 REAL_GIT_OPTIONAL = shutil.which("git")
 assert REAL_GIT_OPTIONAL is not None
@@ -253,7 +260,7 @@ def _prepare_repo(
                 target.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copy2(source, target)
     (repo / ".gitignore").write_text(
-        ".agents/evidence.local/\n.agents/validation.local/\n",
+        ".agents/evidence.local/\n.agents/validation.local/\n__pycache__/\n",
         encoding="utf-8",
         newline="\n",
     )
@@ -419,6 +426,77 @@ def test_review_profile_returns_required_schema_and_compact_digest(
     assert set(value["integrity"]["files"]) == {
         path.as_posix() for path in IDENTITY_FILES
     }
+
+
+def test_review_profile_consumes_verified_handoff_and_recheck_invalidates_drift(
+    tmp_path: Path,
+) -> None:
+    repo, state_path, env, main_sha, head_sha = _prepare_repo(tmp_path)
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["issue"]["body"] = "## Acceptance Criteria\n- [ ] first\n- [ ] second\n"
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    first = _run(repo, env, *_review_args(main_sha, head_sha))
+    assert first.returncode == 0, first.stderr
+    first_digest = json.loads(first.stdout)
+    snapshot_path = (
+        repo
+        / ".agents/evidence.local/snapshots"
+        / f"{first_digest['snapshot_id']}.json"
+    )
+    snapshot = json.loads(snapshot_path.read_text(encoding="utf-8"))
+    handoff = build_handoff_from_snapshot(
+        snapshot,
+        acceptance_criteria_ids=["AC-1", "AC-2"],
+        validation_facts={
+            "profile": "workflow-delivery",
+            "schema_version": 1,
+            "runner_identity": {"path": "validation", "sha256": "c" * 64},
+            "exit_code": 0,
+            "result_locator": ".agents/validation.local/result.json",
+            "result_sha256": "d" * 64,
+        },
+        workflow_identity=snapshot["execution_context"]["workflow_identity"],
+        source_identity={
+            "repository": "PhoenixSss/tracequant",
+            "source_locator": ".agents/evidence.local/snapshot.json",
+            "source_digest": "e" * 64,
+        },
+    )
+    write_handoff(
+        repo,
+        handoff,
+        filename="task-84-review.json",
+    )
+    handoff_run = _run(
+        repo,
+        env,
+        *_review_args(main_sha, head_sha),
+        "--handoff-path",
+        ".agents/evidence.local/review-handoffs/task-84-review.json",
+    )
+    assert handoff_run.returncode == 0, handoff_run.stderr
+    handoff_digest = json.loads(handoff_run.stdout)
+    handoff_snapshot = json.loads(
+        (
+            repo
+            / ".agents/evidence.local/snapshots"
+            / f"{handoff_digest['snapshot_id']}.json"
+        ).read_text(encoding="utf-8")
+    )
+    assert handoff_snapshot["gates"]["review_fact_handoff"]["status"] == "pass"
+    assert (
+        handoff_snapshot["observed"]["review_fact_handoff"]["strategy"]
+        == "FRESH_ROOT_BOUNDED_HANDOFF"
+    )
+
+    handoff["head_sha"] = "f" * 40
+    (repo / ".agents/evidence.local/review-handoffs/task-84-review.json").write_text(
+        json.dumps(handoff), encoding="utf-8"
+    )
+    recheck = _run(repo, env, "recheck", "--snapshot-id", handoff_digest["snapshot_id"])
+    assert recheck.returncode == 4
+    recheck_digest = json.loads(recheck.stdout)
+    assert recheck_digest["status"] == "fail"
 
 
 @pytest.mark.parametrize("profile", ["delivery-readiness", "review", "pre-merge"])

--- a/tests/tools/test_wsl2_github_evidence_runner.py
+++ b/tests/tools/test_wsl2_github_evidence_runner.py
@@ -582,6 +582,106 @@ def test_review_profile_consumes_verified_handoff_and_recheck_invalidates_drift(
     assert recheck_digest["status"] == "fail"
 
 
+def test_review_handoff_fails_closed_when_pr_metadata_is_unavailable(
+    tmp_path: Path,
+) -> None:
+    repo, state_path, env, main_sha, head_sha = _prepare_repo(tmp_path)
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["issue"]["body"] = "## Acceptance Criteria\n- [ ] first\n- [ ] second\n"
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    first = _run(repo, env, *_review_args(main_sha, head_sha))
+    assert first.returncode == 0, first.stderr
+    first_digest = json.loads(first.stdout)
+    snapshot = json.loads(
+        (
+            repo
+            / ".agents/evidence.local/snapshots"
+            / f"{first_digest['snapshot_id']}.json"
+        ).read_text(encoding="utf-8")
+    )
+    handoff = build_handoff_from_snapshot(
+        snapshot,
+        acceptance_criteria_ids=["AC-1", "AC-2"],
+        validation_facts=_validation_facts(repo, main_sha, head_sha),
+        workflow_identity=snapshot["execution_context"]["workflow_identity"],
+    )
+    write_handoff(repo, handoff, filename="task-84-pr-unavailable.json")
+
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["pr"] = None
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    failed = _run(
+        repo,
+        env,
+        *_review_args(main_sha, head_sha),
+        "--handoff-path",
+        ".agents/evidence.local/review-handoffs/task-84-pr-unavailable.json",
+    )
+    assert "Traceback" not in failed.stderr
+    digest = json.loads(failed.stdout)
+    assert digest["status"] == "fail"
+    result = _result(repo, failed.stdout)
+    failed_snapshot = json.loads(
+        (repo / result["evidence"]["source_details_path"]).read_text(encoding="utf-8")
+    )
+    handoff_status = failed_snapshot["observed"]["review_fact_handoff"]
+    assert handoff_status["status"] == "fail"
+    assert handoff_status["trusted"] is False
+    assert handoff_status["strategy"] == "FAIL_CLOSED"
+
+
+def test_review_handoff_fails_closed_when_required_checks_are_unknown(
+    tmp_path: Path,
+) -> None:
+    repo, state_path, env, main_sha, head_sha = _prepare_repo(tmp_path)
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["issue"]["body"] = "## Acceptance Criteria\n- [ ] first\n- [ ] second\n"
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    first = _run(repo, env, *_review_args(main_sha, head_sha))
+    assert first.returncode == 0, first.stderr
+    first_digest = json.loads(first.stdout)
+    snapshot = json.loads(
+        (
+            repo
+            / ".agents/evidence.local/snapshots"
+            / f"{first_digest['snapshot_id']}.json"
+        ).read_text(encoding="utf-8")
+    )
+    handoff = build_handoff_from_snapshot(
+        snapshot,
+        acceptance_criteria_ids=["AC-1", "AC-2"],
+        validation_facts=_validation_facts(repo, main_sha, head_sha),
+        workflow_identity=snapshot["execution_context"]["workflow_identity"],
+    )
+    write_handoff(repo, handoff, filename="task-84-checks-unknown.json")
+
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["required_checks_mode"] = "rate-limit"
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    failed = _run(
+        repo,
+        env,
+        *_review_args(main_sha, head_sha),
+        "--handoff-path",
+        ".agents/evidence.local/review-handoffs/task-84-checks-unknown.json",
+    )
+    digest = json.loads(failed.stdout)
+    assert digest["status"] == "fail"
+    result = _result(repo, failed.stdout)
+    failed_snapshot = json.loads(
+        (repo / result["evidence"]["source_details_path"]).read_text(encoding="utf-8")
+    )
+    handoff_status = failed_snapshot["observed"]["review_fact_handoff"]
+    assert handoff_status["status"] == "fail"
+    assert handoff_status["trusted"] is False
+    assert handoff_status["strategy"] == "FAIL_CLOSED"
+    assert any(
+        item.startswith("CHECKS_DRIFT") for item in handoff_status["invalidated"]
+    )
+
+
 def test_review_handoff_fails_closed_when_control_plane_drifts(tmp_path: Path) -> None:
     repo, state_path, env, main_sha, head_sha = _prepare_repo(tmp_path)
     state = json.loads(state_path.read_text(encoding="utf-8"))

--- a/tests/tools/test_wsl2_github_evidence_runner.py
+++ b/tests/tools/test_wsl2_github_evidence_runner.py
@@ -398,7 +398,7 @@ def _result(repo: Path, stdout: str) -> dict[str, Any]:
     return result
 
 
-def _validation_facts(repo: Path, head_sha: str) -> dict[str, Any]:
+def _validation_facts(repo: Path, base_sha: str, head_sha: str) -> dict[str, Any]:
     def digest(relative: Path) -> str:
         return hashlib.sha256((repo / relative).read_bytes()).hexdigest()
 
@@ -420,6 +420,7 @@ def _validation_facts(repo: Path, head_sha: str) -> dict[str, Any]:
     document = {
         "schema_version": 1,
         "profile": "workflow-delivery",
+        "base_sha": base_sha,
         "status": "pass",
         "repository": {"state": {"head_sha": head_sha, "clean": True}},
         "artifacts": {"result_json": locator},
@@ -443,6 +444,7 @@ def _validation_facts(repo: Path, head_sha: str) -> dict[str, Any]:
     result_path.parent.mkdir(parents=True, exist_ok=True)
     result_path.write_bytes(payload)
     return {
+        "base_sha": document["base_sha"],
         "profile": document["profile"],
         "schema_version": document["schema_version"],
         "runner_identity": identity,
@@ -513,7 +515,7 @@ def test_review_profile_consumes_verified_handoff_and_recheck_invalidates_drift(
     handoff = build_handoff_from_snapshot(
         snapshot,
         acceptance_criteria_ids=["AC-1", "AC-2"],
-        validation_facts=_validation_facts(repo, head_sha),
+        validation_facts=_validation_facts(repo, main_sha, head_sha),
         workflow_identity=snapshot["execution_context"]["workflow_identity"],
     )
     write_handoff(

--- a/tests/tools/test_wsl2_validation_runner.py
+++ b/tests/tools/test_wsl2_validation_runner.py
@@ -575,6 +575,7 @@ def test_workflow_profiles_require_base_sha_and_run_one_bounded_command(
         stored = json.loads((repo / digest["result_path"]).read_text())
         assert stored["commands"][0]["id"] == "workflow-validation"
         assert stored["commands"][0]["exit_code"] == 0
+        assert stored["base_sha"] == base_sha
 
 
 def test_workflow_closeout_requires_clean_synchronized_main(tmp_path: Path) -> None:

--- a/tools/agent_workflow/review_fact_handoff.py
+++ b/tools/agent_workflow/review_fact_handoff.py
@@ -110,6 +110,15 @@ WORKFLOW_RUNNER_FIELDS: Final = frozenset(
 WORKFLOW_SCHEMA_FIELDS: Final = frozenset({"path", "content_sha256"})
 WORKFLOW_SKILL_FIELDS: Final = frozenset({"path", "sha256"})
 SOURCE_FIELDS: Final = frozenset({"repository", "source_locator", "source_digest"})
+SOURCE_STABLE_FIELDS: Final = (
+    "schema_version",
+    "repository",
+    "subject",
+    "execution_context",
+    "observed",
+    "gates",
+    "limitations",
+)
 FRESHNESS_FIELDS: Final = frozenset(
     {
         "invalidate_on",
@@ -342,20 +351,21 @@ def _validate_source_identity(
     return source
 
 
+def _stable_source_projection(snapshot: Mapping[str, Any]) -> dict[str, Any]:
+    """Select canonical source facts, excluding operation-phase metadata."""
+    return {field: snapshot.get(field) for field in SOURCE_STABLE_FIELDS}
+
+
 def source_identity_for_snapshot(snapshot: Mapping[str, Any]) -> dict[str, str]:
-    """Return the only source identity this handoff schema can independently verify."""
+    """Return the source identity that remains stable across review phases."""
     repository = snapshot.get("repository")
-    snapshot_id = snapshot.get("snapshot_id")
     if not isinstance(repository, str) or not repository:
         raise ReviewFactHandoffError("current source repository is unavailable")
-    if not isinstance(snapshot_id, str) or not _SOURCE_LOCATOR.fullmatch(
-        f"snapshot:{snapshot_id}"
-    ):
-        raise ReviewFactHandoffError("current source snapshot identity is unavailable")
+    stable_digest = sha256_json(_stable_source_projection(snapshot))
     return {
         "repository": repository,
-        "source_locator": f"snapshot:{snapshot_id}",
-        "source_digest": sha256_json(snapshot),
+        "source_locator": f"snapshot:ev-{stable_digest[:16]}",
+        "source_digest": stable_digest,
     }
 
 

--- a/tools/agent_workflow/review_fact_handoff.py
+++ b/tools/agent_workflow/review_fact_handoff.py
@@ -81,6 +81,7 @@ REQUIRED_FAILURE_FIELDS: Final = frozenset(
 )
 VALIDATION_FIELDS: Final = frozenset(
     {
+        "base_sha",
         "profile",
         "schema_version",
         "runner_identity",
@@ -505,6 +506,12 @@ def validate_handoff_structure(
         violations,
     )
     if validation_mapping is not None:
+        _require_sha_length(
+            validation_mapping.get("base_sha"),
+            "validation_facts.base_sha",
+            40,
+            violations,
+        )
         profile = validation_mapping.get("profile")
         _require_string(
             profile,
@@ -753,12 +760,13 @@ def acquire_current_validation_facts(
     repo_root: Path,
     validation_facts: Mapping[str, Any],
     *,
+    expected_base_sha: str | None,
     expected_head_sha: str | None,
 ) -> tuple[dict[str, Any] | None, list[str]]:
     """Read and normalize the canonical validation Runner result for a handoff.
 
     The handoff contains only a locator and digest.  The current result file is
-    the canonical mechanical source; its repository/head, profile, schema, and
+    the canonical mechanical source; its repository/base/head, profile, schema, and
     Runner/Skill identities must all be present and internally verified before
     the facts can be compared with the handoff.
     """
@@ -792,6 +800,7 @@ def acquire_current_validation_facts(
 
     schema_version = document.get("schema_version")
     profile = document.get("profile")
+    base_sha = document.get("base_sha")
     status = document.get("status")
     artifacts = document.get("artifacts")
     integrity = document.get("integrity")
@@ -807,6 +816,12 @@ def acquire_current_validation_facts(
         errors.append("validation result profile is not canonical")
     if status != "pass":
         errors.append("validation result is not a passing current fact")
+    if not is_sha(base_sha):
+        errors.append("validation result base identity is unavailable")
+    elif not is_sha(expected_base_sha):
+        errors.append("expected validation base identity is unavailable")
+    elif base_sha != expected_base_sha:
+        errors.append("validation result base identity mismatch")
     if not isinstance(artifacts, Mapping) or artifacts.get("result_json") != locator:
         errors.append("validation result locator identity mismatch")
     if not isinstance(repository_state, Mapping):
@@ -910,6 +925,7 @@ def acquire_current_validation_facts(
         and identity is not None
     ):
         canonical = {
+            "base_sha": base_sha,
             "profile": profile,
             "schema_version": schema_version,
             "runner_identity": identity,
@@ -1038,10 +1054,19 @@ def validate_against_snapshot(
     validation = handoff.get("validation_facts")
     if current_validation_facts is None:
         errors.append("VALIDATION_DRIFT: current validation facts unavailable")
-    elif not isinstance(validation, Mapping) or dict(validation) != dict(
-        current_validation_facts
-    ):
-        errors.append("VALIDATION_DRIFT: validation_facts")
+    else:
+        if not isinstance(validation, Mapping) or dict(validation) != dict(
+            current_validation_facts
+        ):
+            errors.append("VALIDATION_DRIFT: validation_facts")
+        validation_base = current_validation_facts.get("base_sha")
+        expected_base = pr.get("base_sha")
+        if not is_sha(validation_base):
+            errors.append("VALIDATION_DRIFT: validation base identity unavailable")
+        elif not is_sha(expected_base):
+            errors.append("VALIDATION_DRIFT: reviewed base identity unavailable")
+        elif validation_base != expected_base:
+            errors.append("VALIDATION_DRIFT: validation base identity mismatch")
 
     if current_workflow_identity is None:
         execution_context = snapshot.get("execution_context")

--- a/tools/agent_workflow/review_fact_handoff.py
+++ b/tools/agent_workflow/review_fact_handoff.py
@@ -769,27 +769,67 @@ def _current_changed_files(
     return sorted(set(items)), None
 
 
+def _bounded_string_list_complete(value: Any) -> bool:
+    if not isinstance(value, Mapping) or value.get("truncated") is not False:
+        return False
+    items = value.get("items")
+    count = value.get("count")
+    return (
+        isinstance(items, list)
+        and all(isinstance(item, str) for item in items)
+        and isinstance(count, int)
+        and not isinstance(count, bool)
+        and count == len(items)
+    )
+
+
+def _bounded_check_items(value: Any) -> list[Any] | None:
+    if not isinstance(value, Mapping) or value.get("truncated") is not False:
+        return None
+    items = value.get("items")
+    count = value.get("count")
+    if (
+        not isinstance(items, list)
+        or not isinstance(count, int)
+        or isinstance(count, bool)
+        or count != len(items)
+    ):
+        return None
+    return items
+
+
 def _current_raw_check_facts(snapshot: Mapping[str, Any]) -> dict[str, Any] | None:
     observed = snapshot.get("observed")
     observed = observed if isinstance(observed, Mapping) else {}
     pr = observed.get("pr")
-    pr = pr if isinstance(pr, Mapping) else {}
+    if not isinstance(pr, Mapping):
+        return None
     checks = pr.get("checks")
-    checks = checks if isinstance(checks, Mapping) else {}
+    if not isinstance(checks, Mapping):
+        return None
     required = observed.get("required_checks")
-    required = required if isinstance(required, Mapping) else {}
-    bounded_items = checks.get("items")
-    if isinstance(bounded_items, Mapping):
-        if bounded_items.get("truncated") is True:
-            return None
-        items = bounded_items.get("items")
-    else:
-        items = bounded_items
-    if not isinstance(items, list):
+    if not isinstance(required, Mapping):
+        return None
+
+    configuration = required.get("configuration")
+    if configuration not in {"available", "configured-empty", "not-configured"}:
+        return None
+    contexts = required.get("contexts")
+    if not _bounded_string_list_complete(contexts):
+        return None
+    if required.get("failure") is not None:
+        return None
+
+    items = _bounded_check_items(checks.get("items"))
+    if items is None:
         return None
     raw_items: list[dict[str, Any]] = []
     for item in items:
         if not isinstance(item, Mapping):
+            return None
+        if not all(
+            isinstance(item.get(field), str) for field in ("name", "state", "category")
+        ):
             return None
         raw_items.append(
             {

--- a/tools/agent_workflow/review_fact_handoff.py
+++ b/tools/agent_workflow/review_fact_handoff.py
@@ -68,6 +68,68 @@ DRIFT_TYPES: Final = (
 )
 _AC_ID = re.compile(r"^AC-[0-9]+$")
 _RELATIVE_PATH = re.compile(r"^[^/].*$")
+_SOURCE_LOCATOR = re.compile(r"^snapshot:ev-[0-9a-f]{16}$")
+
+RAW_CHECK_FIELDS: Final = frozenset({"observed", "required"})
+CHECK_ITEM_FIELDS: Final = frozenset(
+    {"name", "state", "category", "run_id", "started_at", "completed_at", "source_url"}
+)
+BOUNDED_LIST_FIELDS: Final = frozenset({"items", "count", "truncated"})
+REQUIRED_CHECK_FIELDS: Final = frozenset({"configuration", "contexts", "failure"})
+REQUIRED_FAILURE_FIELDS: Final = frozenset(
+    {"category", "reason", "http_status", "command_id"}
+)
+VALIDATION_FIELDS: Final = frozenset(
+    {
+        "profile",
+        "schema_version",
+        "runner_identity",
+        "exit_code",
+        "result_locator",
+        "result_sha256",
+    }
+)
+VALIDATION_RUNNER_FIELDS: Final = frozenset(
+    {
+        "path",
+        "sha256",
+        "profile_spec_path",
+        "profile_spec_sha256",
+        "rules_path",
+        "rules_sha256",
+        "workflow_validation_path",
+        "workflow_validation_sha256",
+        "skill",
+    }
+)
+WORKFLOW_FIELDS: Final = frozenset({"profile", "schema_version", "runner", "skill"})
+WORKFLOW_RUNNER_FIELDS: Final = frozenset(
+    {"path", "source_sha", "content_sha256", "handoff_schema"}
+)
+WORKFLOW_SCHEMA_FIELDS: Final = frozenset({"path", "content_sha256"})
+WORKFLOW_SKILL_FIELDS: Final = frozenset({"path", "sha256"})
+SOURCE_FIELDS: Final = frozenset({"repository", "source_locator", "source_digest"})
+FRESHNESS_FIELDS: Final = frozenset(
+    {
+        "invalidate_on",
+        "revalidate_current_facts",
+        "requires_new_semantic_context_on_object_drift",
+    }
+)
+VALIDATION_PROFILES: Final = frozenset(
+    {"workflow-delivery", "workflow-review", "workflow-closeout"}
+)
+VALIDATION_IDENTITY_PATHS: Final = {
+    "path": "tools/agent_workflow/wsl2_validation_runner.py",
+    "profile_spec_path": "tools/agent_workflow/wsl2_validation_profiles.json",
+    "rules_path": ".codex/rules/tracequant-wsl-validation.rules",
+    "workflow_validation_path": "tools/agent_workflow/workflow_validation.py",
+}
+VALIDATION_SKILL_NAMES: Final = {
+    "workflow-delivery": "task-delivery-runner",
+    "workflow-review": "task-pr-review-runner",
+    "workflow-closeout": "task-closeout",
+}
 
 
 class ReviewFactHandoffError(WorkflowToolError):
@@ -85,7 +147,9 @@ def default_freshness_contract() -> dict[str, Any]:
             "task_spec_and_acceptance_criteria",
             "checks_and_required_configuration",
             "validation_result_freshness",
+            "validation_facts",
             "workflow_identity",
+            "source_identity",
         ],
         "requires_new_semantic_context_on_object_drift": True,
     }
@@ -126,6 +190,172 @@ def _require_sha(value: Any, field: str, violations: list[str]) -> None:
 def _require_mapping(value: Any, field: str, violations: list[str]) -> None:
     if not isinstance(value, Mapping):
         violations.append(f"{field} must be an object")
+
+
+def _exact_fields(
+    value: Any,
+    field: str,
+    allowed: frozenset[str],
+    required: frozenset[str],
+    violations: list[str],
+) -> Mapping[str, Any] | None:
+    """Validate one bounded object and reject every unspecified field."""
+    if not isinstance(value, Mapping):
+        violations.append(f"{field} must be an object")
+        return None
+    extra = sorted(set(value) - allowed)
+    missing = sorted(required - set(value))
+    if extra:
+        violations.append(f"{field} has unknown fields: {extra}")
+    if missing:
+        violations.extend(f"{field} missing field: {item}" for item in missing)
+    return value
+
+
+def _require_string(
+    value: Any, field: str, violations: list[str], *, non_empty: bool = True
+) -> None:
+    if not isinstance(value, str) or (non_empty and not value):
+        violations.append(f"{field} must be a string")
+
+
+def _require_sha_length(
+    value: Any, field: str, length: int, violations: list[str]
+) -> None:
+    if not isinstance(value, str) or not is_sha(value) or len(value) != length:
+        violations.append(f"{field} must be a {length}-character SHA")
+
+
+def _validate_bounded_list(
+    value: Any, field: str, violations: list[str], *, item_type: type = str
+) -> None:
+    bounded = _exact_fields(
+        value,
+        field,
+        BOUNDED_LIST_FIELDS,
+        frozenset(BOUNDED_LIST_FIELDS),
+        violations,
+    )
+    if bounded is None:
+        return
+    items = bounded.get("items")
+    if not isinstance(items, list) or any(
+        not isinstance(item, item_type) for item in items
+    ):
+        violations.append(f"{field}.items must be a list of {item_type.__name__}")
+    if not isinstance(bounded.get("truncated"), bool):
+        violations.append(f"{field}.truncated must be a boolean")
+    if type(bounded.get("count")) is not int or bounded["count"] < 0:
+        violations.append(f"{field}.count must be a non-negative integer")
+
+
+def _validate_workflow_identity(
+    value: Any, field: str, violations: list[str]
+) -> Mapping[str, Any] | None:
+    workflow = _exact_fields(
+        value, field, WORKFLOW_FIELDS, frozenset(WORKFLOW_FIELDS), violations
+    )
+    if workflow is None:
+        return None
+    if not isinstance(workflow.get("profile"), str) or not workflow["profile"]:
+        violations.append(f"{field}.profile must be a non-empty string")
+    if workflow.get("schema_version") != SCHEMA_VERSION:
+        violations.append(f"{field}.schema_version must be {SCHEMA_VERSION}")
+
+    runner = _exact_fields(
+        workflow.get("runner"),
+        f"{field}.runner",
+        WORKFLOW_RUNNER_FIELDS,
+        frozenset(WORKFLOW_RUNNER_FIELDS),
+        violations,
+    )
+    if runner is not None:
+        _require_string(runner.get("path"), f"{field}.runner.path", violations)
+        _require_sha_length(
+            runner.get("source_sha"), f"{field}.runner.source_sha", 40, violations
+        )
+        _require_sha_length(
+            runner.get("content_sha256"),
+            f"{field}.runner.content_sha256",
+            64,
+            violations,
+        )
+        schema = _exact_fields(
+            runner.get("handoff_schema"),
+            f"{field}.runner.handoff_schema",
+            WORKFLOW_SCHEMA_FIELDS,
+            frozenset(WORKFLOW_SCHEMA_FIELDS),
+            violations,
+        )
+        if schema is not None:
+            _require_string(
+                schema.get("path"),
+                f"{field}.runner.handoff_schema.path",
+                violations,
+            )
+            _require_sha_length(
+                schema.get("content_sha256"),
+                f"{field}.runner.handoff_schema.content_sha256",
+                64,
+                violations,
+            )
+
+    skill = _exact_fields(
+        workflow.get("skill"),
+        f"{field}.skill",
+        WORKFLOW_SKILL_FIELDS,
+        frozenset(WORKFLOW_SKILL_FIELDS),
+        violations,
+    )
+    if skill is not None:
+        _require_string(skill.get("path"), f"{field}.skill.path", violations)
+        _require_sha_length(
+            skill.get("sha256"), f"{field}.skill.sha256", 64, violations
+        )
+    return workflow
+
+
+def _validate_source_identity(
+    value: Any,
+    field: str,
+    violations: list[str],
+    *,
+    expected_repository: str | None = None,
+) -> Mapping[str, Any] | None:
+    source = _exact_fields(
+        value, field, SOURCE_FIELDS, frozenset(SOURCE_FIELDS), violations
+    )
+    if source is None:
+        return None
+    _require_string(source.get("repository"), f"{field}.repository", violations)
+    locator = source.get("source_locator")
+    if not isinstance(locator, str) or not _SOURCE_LOCATOR.fullmatch(locator):
+        violations.append(
+            f"{field}.source_locator must identify a canonical evidence snapshot"
+        )
+    _require_sha_length(
+        source.get("source_digest"), f"{field}.source_digest", 64, violations
+    )
+    if expected_repository and source.get("repository") != expected_repository:
+        violations.append(f"{field}.repository does not match repository")
+    return source
+
+
+def source_identity_for_snapshot(snapshot: Mapping[str, Any]) -> dict[str, str]:
+    """Return the only source identity this handoff schema can independently verify."""
+    repository = snapshot.get("repository")
+    snapshot_id = snapshot.get("snapshot_id")
+    if not isinstance(repository, str) or not repository:
+        raise ReviewFactHandoffError("current source repository is unavailable")
+    if not isinstance(snapshot_id, str) or not _SOURCE_LOCATOR.fullmatch(
+        f"snapshot:{snapshot_id}"
+    ):
+        raise ReviewFactHandoffError("current source snapshot identity is unavailable")
+    return {
+        "repository": repository,
+        "source_locator": f"snapshot:{snapshot_id}",
+        "source_digest": sha256_json(snapshot),
+    }
 
 
 def validate_handoff_structure(
@@ -192,139 +422,230 @@ def validate_handoff_structure(
         violations.append("acceptance_criteria_ids must be ordered and unique")
 
     raw_checks = handoff.get("raw_check_facts")
-    _require_mapping(raw_checks, "raw_check_facts", violations)
-    if isinstance(raw_checks, Mapping):
-        extra_check_fields = sorted(set(raw_checks) - {"observed", "required"})
-        if extra_check_fields:
-            violations.append(
-                f"raw_check_facts has non-mechanical fields: {extra_check_fields}"
-            )
-        if not isinstance(raw_checks.get("observed"), list):
+    raw_checks_mapping = _exact_fields(
+        raw_checks,
+        "raw_check_facts",
+        RAW_CHECK_FIELDS,
+        frozenset(RAW_CHECK_FIELDS),
+        violations,
+    )
+    if raw_checks_mapping is not None:
+        observed_checks = raw_checks_mapping.get("observed")
+        if not isinstance(observed_checks, list):
             violations.append("raw_check_facts.observed must be a list")
         else:
-            allowed_check_fields = {
-                "name",
-                "state",
-                "run_id",
-                "started_at",
-                "completed_at",
-                "source_url",
-            }
-            for index, item in enumerate(raw_checks["observed"]):
-                if not isinstance(item, Mapping):
-                    violations.append(
-                        f"raw_check_facts.observed[{index}] must be an object"
-                    )
-                else:
-                    extra = sorted(set(item) - allowed_check_fields)
-                    if extra:
-                        violations.append(
-                            f"raw_check_facts.observed[{index}] has non-mechanical fields: {extra}"
-                        )
-        _require_mapping(
-            raw_checks.get("required"), "raw_check_facts.required", violations
-        )
-        required = raw_checks.get("required")
-        if isinstance(required, Mapping):
-            extra = sorted(set(required) - {"configuration", "contexts", "failure"})
-            if extra:
-                violations.append(
-                    f"raw_check_facts.required has non-mechanical fields: {extra}"
+            for index, item in enumerate(observed_checks):
+                check = _exact_fields(
+                    item,
+                    f"raw_check_facts.observed[{index}]",
+                    CHECK_ITEM_FIELDS,
+                    frozenset(CHECK_ITEM_FIELDS),
+                    violations,
                 )
+                if check is not None:
+                    for field in ("name", "state", "category"):
+                        _require_string(
+                            check.get(field),
+                            f"raw_check_facts.observed[{index}].{field}",
+                            violations,
+                        )
+                    for field in ("run_id", "started_at", "completed_at", "source_url"):
+                        value = check.get(field)
+                        if value is not None and not isinstance(value, str):
+                            violations.append(
+                                f"raw_check_facts.observed[{index}].{field} must be a string or null"
+                            )
+
+        required = _exact_fields(
+            raw_checks_mapping.get("required"),
+            "raw_check_facts.required",
+            REQUIRED_CHECK_FIELDS,
+            frozenset({"configuration", "contexts"}),
+            violations,
+        )
+        if required is not None:
+            _require_string(
+                required.get("configuration"),
+                "raw_check_facts.required.configuration",
+                violations,
+            )
+            _validate_bounded_list(
+                required.get("contexts"),
+                "raw_check_facts.required.contexts",
+                violations,
+            )
+            if "failure" in required:
+                failure = _exact_fields(
+                    required.get("failure"),
+                    "raw_check_facts.required.failure",
+                    REQUIRED_FAILURE_FIELDS,
+                    frozenset(REQUIRED_FAILURE_FIELDS),
+                    violations,
+                )
+                if failure is not None:
+                    for field in ("category", "reason", "command_id"):
+                        _require_string(
+                            failure.get(field),
+                            f"raw_check_facts.required.failure.{field}",
+                            violations,
+                        )
+                    if failure.get("http_status") is not None and not isinstance(
+                        failure.get("http_status"), int
+                    ):
+                        violations.append(
+                            "raw_check_facts.required.failure.http_status must be an integer or null"
+                        )
 
     validation = handoff.get("validation_facts")
-    _require_mapping(validation, "validation_facts", violations)
-    if isinstance(validation, Mapping):
-        extra = sorted(
-            set(validation)
-            - {
-                "profile",
-                "schema_version",
-                "runner_identity",
-                "exit_code",
-                "result_locator",
-                "result_sha256",
-            }
+    validation_mapping = _exact_fields(
+        validation,
+        "validation_facts",
+        VALIDATION_FIELDS,
+        frozenset(VALIDATION_FIELDS),
+        violations,
+    )
+    if validation_mapping is not None:
+        profile = validation_mapping.get("profile")
+        _require_string(
+            profile,
+            "validation_facts.profile",
+            violations,
         )
-        if extra:
-            violations.append(f"validation_facts has non-mechanical fields: {extra}")
-        for field in (
-            "profile",
-            "schema_version",
-            "runner_identity",
-            "exit_code",
-            "result_locator",
-            "result_sha256",
-        ):
-            if field not in validation:
-                violations.append(f"validation_facts missing field: {field}")
-        if not isinstance(validation.get("profile"), str):
-            violations.append("validation_facts.profile must be a string")
-        if not isinstance(validation.get("runner_identity"), Mapping):
-            violations.append("validation_facts.runner_identity must be an object")
-        if not isinstance(validation.get("exit_code"), int):
-            violations.append("validation_facts.exit_code must be an integer")
-        if not _is_relative_repo_path(validation.get("result_locator")):
+        if profile not in VALIDATION_PROFILES:
             violations.append(
-                "validation_facts.result_locator must be repository-relative"
+                "validation_facts.profile is not a canonical workflow profile"
             )
-        result_sha = validation.get("result_sha256")
-        if (
-            not isinstance(result_sha, str)
-            or not is_sha(result_sha)
-            or len(result_sha) != 64
+        if validation_mapping.get("schema_version") != SCHEMA_VERSION:
+            violations.append(
+                f"validation_facts.schema_version must be {SCHEMA_VERSION}"
+            )
+        identity = _exact_fields(
+            validation_mapping.get("runner_identity"),
+            "validation_facts.runner_identity",
+            VALIDATION_RUNNER_FIELDS,
+            frozenset(VALIDATION_RUNNER_FIELDS),
+            violations,
+        )
+        if identity is not None:
+            _require_string(
+                identity.get("path"),
+                "validation_facts.runner_identity.path",
+                violations,
+            )
+            for field in (
+                "sha256",
+                "profile_spec_sha256",
+                "rules_sha256",
+                "workflow_validation_sha256",
+            ):
+                _require_sha_length(
+                    identity.get(field),
+                    f"validation_facts.runner_identity.{field}",
+                    64,
+                    violations,
+                )
+            for field in (
+                "profile_spec_path",
+                "rules_path",
+                "workflow_validation_path",
+            ):
+                if not _is_relative_repo_path(identity.get(field)):
+                    violations.append(
+                        f"validation_facts.runner_identity.{field} must be repository-relative"
+                    )
+            skill = _exact_fields(
+                identity.get("skill"),
+                "validation_facts.runner_identity.skill",
+                WORKFLOW_SKILL_FIELDS,
+                frozenset(WORKFLOW_SKILL_FIELDS),
+                violations,
+            )
+            if skill is not None:
+                _require_string(
+                    skill.get("path"),
+                    "validation_facts.runner_identity.skill.path",
+                    violations,
+                )
+                _require_sha_length(
+                    skill.get("sha256"),
+                    "validation_facts.runner_identity.skill.sha256",
+                    64,
+                    violations,
+                )
+            if profile in VALIDATION_PROFILES:
+                for field, expected in VALIDATION_IDENTITY_PATHS.items():
+                    if identity.get(field) != expected:
+                        violations.append(
+                            f"validation_facts.runner_identity.{field} is not canonical"
+                        )
+                skill_path = skill.get("path") if isinstance(skill, Mapping) else None
+                expected_skill_suffix = f"/{VALIDATION_SKILL_NAMES[profile]}/SKILL.md"
+                if (
+                    not isinstance(skill_path, str)
+                    or not (
+                        skill_path.startswith(".agents/skills/")
+                        or skill_path.startswith(".claude/skills/")
+                    )
+                    or not skill_path.endswith(expected_skill_suffix)
+                ):
+                    violations.append(
+                        "validation_facts.runner_identity.skill.path is not canonical"
+                    )
+        exit_code = validation_mapping.get("exit_code")
+        if type(exit_code) is not int or exit_code != 0:
+            violations.append("validation_facts.exit_code must be 0")
+        locator = validation_mapping.get("result_locator")
+        if not _is_relative_repo_path(locator) or not (
+            isinstance(locator, str) and locator.startswith(".agents/validation.local/")
         ):
             violations.append(
-                "validation_facts.result_sha256 must be a 64-character SHA-256"
+                "validation_facts.result_locator must be under .agents/validation.local/"
             )
+        _require_sha_length(
+            validation_mapping.get("result_sha256"),
+            "validation_facts.result_sha256",
+            64,
+            violations,
+        )
 
     workflow = handoff.get("workflow_identity")
-    _require_mapping(workflow, "workflow_identity", violations)
-    if isinstance(workflow, Mapping):
-        for field in ("profile", "schema_version", "runner", "skill"):
-            if field not in workflow:
-                violations.append(f"workflow_identity missing field: {field}")
-        if not isinstance(workflow.get("profile"), str):
-            violations.append("workflow_identity.profile must be a string")
-        if not isinstance(workflow.get("runner"), Mapping):
-            violations.append("workflow_identity.runner must be an object")
-        if not isinstance(workflow.get("skill"), Mapping):
-            violations.append("workflow_identity.skill must be an object")
+    _validate_workflow_identity(workflow, "workflow_identity", violations)
 
     source = handoff.get("source_identity")
-    _require_mapping(source, "source_identity", violations)
-    if isinstance(source, Mapping):
-        if not isinstance(source.get("repository"), str):
-            violations.append("source_identity.repository must be a string")
-        if not isinstance(source.get("source_locator"), str):
-            violations.append("source_identity.source_locator must be a string")
-        source_digest = source.get("source_digest")
-        if (
-            not isinstance(source_digest, str)
-            or not is_sha(source_digest)
-            or len(source_digest) != 64
-        ):
-            violations.append(
-                "source_identity.source_digest must be a 64-character SHA-256"
-            )
-        if expected_repository and source.get("repository") != expected_repository:
-            violations.append("source_identity.repository does not match repository")
+    _validate_source_identity(
+        source,
+        "source_identity",
+        violations,
+        expected_repository=expected_repository,
+    )
 
     freshness = handoff.get("freshness_contract")
-    _require_mapping(freshness, "freshness_contract", violations)
-    if isinstance(freshness, Mapping):
-        invalidations = freshness.get("invalidate_on")
+    freshness_mapping = _exact_fields(
+        freshness,
+        "freshness_contract",
+        FRESHNESS_FIELDS,
+        frozenset(FRESHNESS_FIELDS),
+        violations,
+    )
+    if freshness_mapping is not None:
+        invalidations = freshness_mapping.get("invalidate_on")
         if not isinstance(invalidations, list) or set(invalidations) != set(
             DRIFT_TYPES
         ):
             violations.append(
                 "freshness_contract.invalidate_on must list all supported drift types"
             )
-        if not isinstance(freshness.get("revalidate_current_facts"), list):
+        current_facts = freshness_mapping.get("revalidate_current_facts")
+        if not isinstance(current_facts, list) or any(
+            not isinstance(item, str) for item in current_facts
+        ):
             violations.append(
                 "freshness_contract.revalidate_current_facts must be a list"
             )
-        if freshness.get("requires_new_semantic_context_on_object_drift") is not True:
+        if (
+            freshness_mapping.get("requires_new_semantic_context_on_object_drift")
+            is not True
+        ):
             violations.append(
                 "freshness_contract must require a new semantic context on object drift"
             )
@@ -418,6 +739,7 @@ def _current_raw_check_facts(snapshot: Mapping[str, Any]) -> dict[str, Any] | No
             {
                 "name": item.get("name"),
                 "state": item.get("state"),
+                "category": item.get("category"),
                 "run_id": item.get("run_id"),
                 "started_at": item.get("started_at"),
                 "completed_at": item.get("completed_at"),
@@ -427,15 +749,249 @@ def _current_raw_check_facts(snapshot: Mapping[str, Any]) -> dict[str, Any] | No
     return {"observed": raw_items, "required": dict(required)}
 
 
+def acquire_current_validation_facts(
+    repo_root: Path,
+    validation_facts: Mapping[str, Any],
+    *,
+    expected_head_sha: str | None,
+) -> tuple[dict[str, Any] | None, list[str]]:
+    """Read and normalize the canonical validation Runner result for a handoff.
+
+    The handoff contains only a locator and digest.  The current result file is
+    the canonical mechanical source; its repository/head, profile, schema, and
+    Runner/Skill identities must all be present and internally verified before
+    the facts can be compared with the handoff.
+    """
+    errors: list[str] = []
+    if not isinstance(validation_facts, Mapping):
+        return None, ["validation facts unavailable"]
+    locator = validation_facts.get("result_locator")
+    if not isinstance(locator, str) or not _is_relative_repo_path(locator):
+        return None, ["validation result locator is unavailable"]
+    root = (repo_root / ".agents/validation.local").resolve()
+    path = (repo_root / locator).resolve()
+    if not locator.startswith(".agents/validation.local/") or root not in path.parents:
+        return None, [
+            "validation result locator is outside canonical validation artifacts"
+        ]
+    if path.is_symlink():
+        return None, ["validation result must not be a symlink"]
+    try:
+        raw = path.read_bytes()
+    except (FileNotFoundError, OSError):
+        return None, ["validation result is unavailable"]
+    result_digest = sha256_bytes(raw)
+    if result_digest != validation_facts.get("result_sha256"):
+        errors.append("validation result digest mismatch")
+    try:
+        document = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None, ["validation result is not valid JSON"]
+    if not isinstance(document, Mapping):
+        return None, ["validation result is not an object"]
+
+    schema_version = document.get("schema_version")
+    profile = document.get("profile")
+    status = document.get("status")
+    artifacts = document.get("artifacts")
+    integrity = document.get("integrity")
+    repository = document.get("repository")
+    repository_state = (
+        repository.get("state") if isinstance(repository, Mapping) else None
+    )
+    if type(schema_version) is not int:
+        errors.append("validation result schema identity is unavailable")
+    if not isinstance(profile, str) or not profile:
+        errors.append("validation result profile is unavailable")
+    elif profile not in VALIDATION_PROFILES:
+        errors.append("validation result profile is not canonical")
+    if status != "pass":
+        errors.append("validation result is not a passing current fact")
+    if not isinstance(artifacts, Mapping) or artifacts.get("result_json") != locator:
+        errors.append("validation result locator identity mismatch")
+    if not isinstance(repository_state, Mapping):
+        errors.append("validation result repository state is unavailable")
+    if not isinstance(integrity, Mapping):
+        errors.append("validation result integrity is unavailable")
+
+    if isinstance(repository_state, Mapping):
+        if repository_state.get("clean") is not True:
+            errors.append("validation result repository was not clean")
+        if (
+            expected_head_sha is None
+            or repository_state.get("head_sha") != expected_head_sha
+        ):
+            errors.append("validation result head identity mismatch")
+    if isinstance(integrity, Mapping):
+        if integrity.get("verification") != "current-worktree-content":
+            errors.append("validation result integrity verification is unavailable")
+        if integrity.get("repository_clean") is not True:
+            errors.append(
+                "validation result integrity does not prove a clean repository"
+            )
+        if (
+            expected_head_sha is None
+            or integrity.get("repository_head_sha") != expected_head_sha
+        ):
+            errors.append("validation result integrity head identity mismatch")
+
+    identity: dict[str, Any] | None = None
+    if isinstance(integrity, Mapping):
+        skill = integrity.get("skill")
+        identity = {
+            "path": integrity.get("runner_path"),
+            "sha256": integrity.get("runner_sha256"),
+            "profile_spec_path": integrity.get("profile_spec_path"),
+            "profile_spec_sha256": integrity.get("profile_spec_sha256"),
+            "rules_path": integrity.get("rules_path"),
+            "rules_sha256": integrity.get("rules_sha256"),
+            "workflow_validation_path": integrity.get("workflow_validation_path"),
+            "workflow_validation_sha256": integrity.get("workflow_validation_sha256"),
+            "skill": dict(skill) if isinstance(skill, Mapping) else skill,
+        }
+        identity_violations: list[str] = []
+        _validate_validation_runner_identity(identity, identity_violations)
+        errors.extend(identity_violations)
+        if (
+            isinstance(profile, str)
+            and profile in VALIDATION_PROFILES
+            and identity is not None
+        ):
+            for field, expected in VALIDATION_IDENTITY_PATHS.items():
+                if identity.get(field) != expected:
+                    errors.append(
+                        f"validation result identity is not canonical: {field}"
+                    )
+            skill = identity.get("skill")
+            skill_path = skill.get("path") if isinstance(skill, Mapping) else None
+            expected_skill_suffix = f"/{VALIDATION_SKILL_NAMES[profile]}/SKILL.md"
+            if (
+                not isinstance(skill_path, str)
+                or not (
+                    skill_path.startswith(".agents/skills/")
+                    or skill_path.startswith(".claude/skills/")
+                )
+                or not skill_path.endswith(expected_skill_suffix)
+            ):
+                errors.append("validation result Skill identity is not canonical")
+        if not identity_violations:
+            identity_files = (
+                ("path", "sha256"),
+                ("profile_spec_path", "profile_spec_sha256"),
+                ("rules_path", "rules_sha256"),
+                ("workflow_validation_path", "workflow_validation_sha256"),
+            )
+            for path_field, digest_field in identity_files:
+                relative = identity.get(path_field)
+                target = repo_root / relative if isinstance(relative, str) else None
+                if target is None or target.is_symlink() or not target.is_file():
+                    errors.append(f"validation identity file unavailable: {path_field}")
+                elif sha256_bytes(target.read_bytes()) != identity.get(digest_field):
+                    errors.append(f"validation identity digest drift: {path_field}")
+            skill = identity.get("skill")
+            skill_path = skill.get("path") if isinstance(skill, Mapping) else None
+            skill_digest = skill.get("sha256") if isinstance(skill, Mapping) else None
+            skill_target = (
+                repo_root / skill_path if isinstance(skill_path, str) else None
+            )
+            if (
+                skill_target is None
+                or skill_target.is_symlink()
+                or not skill_target.is_file()
+            ):
+                errors.append("validation identity file unavailable: skill")
+            elif sha256_bytes(skill_target.read_bytes()) != skill_digest:
+                errors.append("validation identity digest drift: skill")
+
+    canonical: dict[str, Any] | None = None
+    if (
+        type(schema_version) is int
+        and isinstance(profile, str)
+        and identity is not None
+    ):
+        canonical = {
+            "profile": profile,
+            "schema_version": schema_version,
+            "runner_identity": identity,
+            "exit_code": 0 if status == "pass" else 1,
+            "result_locator": locator,
+            "result_sha256": result_digest,
+        }
+        if canonical != dict(validation_facts):
+            errors.append("validation facts do not match current canonical result")
+    if errors:
+        return None, list(dict.fromkeys(errors))
+    return canonical, []
+
+
+def _validate_validation_runner_identity(
+    value: Any, violations: list[str]
+) -> Mapping[str, Any] | None:
+    identity = _exact_fields(
+        value,
+        "validation_facts.runner_identity",
+        VALIDATION_RUNNER_FIELDS,
+        frozenset(VALIDATION_RUNNER_FIELDS),
+        violations,
+    )
+    if identity is None:
+        return None
+    _require_string(
+        identity.get("path"), "validation_facts.runner_identity.path", violations
+    )
+    for field in (
+        "sha256",
+        "profile_spec_sha256",
+        "rules_sha256",
+        "workflow_validation_sha256",
+    ):
+        _require_sha_length(
+            identity.get(field),
+            f"validation_facts.runner_identity.{field}",
+            64,
+            violations,
+        )
+    for field in ("profile_spec_path", "rules_path", "workflow_validation_path"):
+        if not _is_relative_repo_path(identity.get(field)):
+            violations.append(
+                f"validation_facts.runner_identity.{field} must be repository-relative"
+            )
+    skill = _exact_fields(
+        identity.get("skill"),
+        "validation_facts.runner_identity.skill",
+        WORKFLOW_SKILL_FIELDS,
+        frozenset(WORKFLOW_SKILL_FIELDS),
+        violations,
+    )
+    if skill is not None:
+        _require_string(
+            skill.get("path"), "validation_facts.runner_identity.skill.path", violations
+        )
+        _require_sha_length(
+            skill.get("sha256"),
+            "validation_facts.runner_identity.skill.sha256",
+            64,
+            violations,
+        )
+    return identity
+
+
 def validate_against_snapshot(
     handoff: Mapping[str, Any],
     snapshot: Mapping[str, Any],
     *,
     handoff_digest: str | None = None,
     current_acceptance_criteria_ids: Sequence[str] | None = None,
+    current_validation_facts: Mapping[str, Any] | None = None,
+    current_workflow_identity: Mapping[str, Any] | None = None,
+    current_source_identity: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Compare trusted handoff candidates with freshly collected current facts."""
-    errors = validate_handoff_structure(handoff)
+    repository = snapshot.get("repository")
+    errors = validate_handoff_structure(
+        handoff,
+        expected_repository=repository if isinstance(repository, str) else None,
+    )
     observed = snapshot.get("observed")
     observed = observed if isinstance(observed, Mapping) else {}
     issue = observed.get("issue")
@@ -444,7 +1000,6 @@ def validate_against_snapshot(
     pr = pr if isinstance(pr, Mapping) else {}
     diff = observed.get("effective_diff")
     diff = diff if isinstance(diff, Mapping) else {}
-    repository = snapshot.get("repository")
     source = handoff.get("source_identity")
     source_repository = (
         source.get("repository") if isinstance(source, Mapping) else None
@@ -480,6 +1035,43 @@ def validate_against_snapshot(
     if current_checks is None or current_checks != handoff.get("raw_check_facts"):
         errors.append("CHECKS_DRIFT: raw_check_facts")
 
+    validation = handoff.get("validation_facts")
+    if current_validation_facts is None:
+        errors.append("VALIDATION_DRIFT: current validation facts unavailable")
+    elif not isinstance(validation, Mapping) or dict(validation) != dict(
+        current_validation_facts
+    ):
+        errors.append("VALIDATION_DRIFT: validation_facts")
+
+    if current_workflow_identity is None:
+        execution_context = snapshot.get("execution_context")
+        execution_context = (
+            execution_context if isinstance(execution_context, Mapping) else {}
+        )
+        candidate = execution_context.get("workflow_identity")
+        current_workflow_identity = (
+            candidate if isinstance(candidate, Mapping) else None
+        )
+    workflow = handoff.get("workflow_identity")
+    if current_workflow_identity is None:
+        errors.append("WORKFLOW_RULE_DRIFT: current workflow identity unavailable")
+    elif not isinstance(workflow, Mapping) or dict(workflow) != dict(
+        current_workflow_identity
+    ):
+        errors.append("WORKFLOW_RULE_DRIFT: workflow_identity")
+
+    if current_source_identity is None:
+        try:
+            current_source_identity = source_identity_for_snapshot(snapshot)
+        except ReviewFactHandoffError:
+            current_source_identity = None
+    if current_source_identity is None:
+        errors.append("HANDOFF_SCHEMA_DRIFT: current source identity unavailable")
+    elif not isinstance(source, Mapping) or dict(source) != dict(
+        current_source_identity
+    ):
+        errors.append("HANDOFF_SCHEMA_DRIFT: source_identity")
+
     unique_errors = list(dict.fromkeys(errors))
     status = "pass" if not unique_errors else "fail"
     return {
@@ -497,6 +1089,7 @@ def validate_against_snapshot(
             "checks_and_required_configuration",
             "validation_result_freshness",
             "workflow_identity",
+            "source_identity",
         ],
     }
 
@@ -533,12 +1126,7 @@ def build_handoff_from_snapshot(
     repository = snapshot.get("repository")
     if not isinstance(repository, str):
         raise ReviewFactHandoffError("snapshot repository is unavailable")
-    source = dict(source_identity or {})
-    source.setdefault("repository", repository)
-    source.setdefault(
-        "source_locator", f"snapshot:{snapshot.get('snapshot_id', 'unknown')}"
-    )
-    source.setdefault("source_digest", sha256_json(snapshot))
+    source = dict(source_identity or source_identity_for_snapshot(snapshot))
     handoff = {
         "schema_version": SCHEMA_VERSION,
         "task_id": issue.get("number"),

--- a/tools/agent_workflow/review_fact_handoff.py
+++ b/tools/agent_workflow/review_fact_handoff.py
@@ -66,6 +66,17 @@ DRIFT_TYPES: Final = (
     "WORKFLOW_RULE_DRIFT",
     "HANDOFF_SCHEMA_DRIFT",
 )
+REVALIDATE_CURRENT_FACTS: Final = (
+    "task_pr_identity",
+    "base_head_merge_base",
+    "effective_diff_and_changed_files",
+    "task_spec_and_acceptance_criteria",
+    "checks_and_required_configuration",
+    "validation_result_freshness",
+    "validation_facts",
+    "workflow_identity",
+    "source_identity",
+)
 _AC_ID = re.compile(r"^AC-[0-9]+$")
 _RELATIVE_PATH = re.compile(r"^[^/].*$")
 _SOURCE_LOCATOR = re.compile(r"^snapshot:ev-[0-9a-f]{16}$")
@@ -103,12 +114,25 @@ VALIDATION_RUNNER_FIELDS: Final = frozenset(
         "skill",
     }
 )
-WORKFLOW_FIELDS: Final = frozenset({"profile", "schema_version", "runner", "skill"})
+WORKFLOW_FIELDS: Final = frozenset(
+    {"profile", "schema_version", "runner", "skill", "control_plane"}
+)
 WORKFLOW_RUNNER_FIELDS: Final = frozenset(
     {"path", "source_sha", "content_sha256", "handoff_schema"}
 )
 WORKFLOW_SCHEMA_FIELDS: Final = frozenset({"path", "content_sha256"})
 WORKFLOW_SKILL_FIELDS: Final = frozenset({"path", "sha256"})
+WORKFLOW_CONTROL_ITEM_FIELDS: Final = frozenset({"path", "content_sha256"})
+WORKFLOW_CONTROL_PATHS: Final = {
+    "evidence_runner": "tools/agent_workflow/wsl2_github_evidence_runner.py",
+    "profile_spec": "tools/agent_workflow/wsl2_github_evidence_profiles.json",
+    "evidence_rules": ".codex/rules/tracequant-wsl-evidence.rules",
+    "workflow_common": "tools/agent_workflow/workflow_common.py",
+    "command_execution_policy": ".agents/policies/command-execution.md",
+    "workflow_evidence_policy": ".agents/policies/workflow-evidence.md",
+    "review_semantics": "docs/development/pr-review.md",
+}
+WORKFLOW_CONTROL_FIELDS: Final = frozenset(WORKFLOW_CONTROL_PATHS)
 SOURCE_FIELDS: Final = frozenset({"repository", "source_locator", "source_digest"})
 SOURCE_STABLE_FIELDS: Final = (
     "schema_version",
@@ -150,17 +174,7 @@ def default_freshness_contract() -> dict[str, Any]:
     """Return the explicit invalidation contract required by the schema."""
     return {
         "invalidate_on": list(DRIFT_TYPES),
-        "revalidate_current_facts": [
-            "task_pr_identity",
-            "base_head_merge_base",
-            "effective_diff_and_changed_files",
-            "task_spec_and_acceptance_criteria",
-            "checks_and_required_configuration",
-            "validation_result_freshness",
-            "validation_facts",
-            "workflow_identity",
-            "source_identity",
-        ],
+        "revalidate_current_facts": list(REVALIDATE_CURRENT_FACTS),
         "requires_new_semantic_context_on_object_drift": True,
     }
 
@@ -322,6 +336,33 @@ def _validate_workflow_identity(
         _require_sha_length(
             skill.get("sha256"), f"{field}.skill.sha256", 64, violations
         )
+
+    control_plane = _exact_fields(
+        workflow.get("control_plane"),
+        f"{field}.control_plane",
+        WORKFLOW_CONTROL_FIELDS,
+        frozenset(WORKFLOW_CONTROL_FIELDS),
+        violations,
+    )
+    if control_plane is not None:
+        for name, expected_path in WORKFLOW_CONTROL_PATHS.items():
+            item = _exact_fields(
+                control_plane.get(name),
+                f"{field}.control_plane.{name}",
+                WORKFLOW_CONTROL_ITEM_FIELDS,
+                frozenset(WORKFLOW_CONTROL_ITEM_FIELDS),
+                violations,
+            )
+            if item is None:
+                continue
+            if item.get("path") != expected_path:
+                violations.append(f"{field}.control_plane.{name}.path is not canonical")
+            _require_sha_length(
+                item.get("content_sha256"),
+                f"{field}.control_plane.{name}.content_sha256",
+                64,
+                violations,
+            )
     return workflow
 
 
@@ -646,18 +687,16 @@ def validate_handoff_structure(
     )
     if freshness_mapping is not None:
         invalidations = freshness_mapping.get("invalidate_on")
-        if not isinstance(invalidations, list) or set(invalidations) != set(
-            DRIFT_TYPES
-        ):
+        if invalidations != list(DRIFT_TYPES):
             violations.append(
-                "freshness_contract.invalidate_on must list all supported drift types"
+                "freshness_contract.invalidate_on must exactly match the supported "
+                "drift types"
             )
         current_facts = freshness_mapping.get("revalidate_current_facts")
-        if not isinstance(current_facts, list) or any(
-            not isinstance(item, str) for item in current_facts
-        ):
+        if current_facts != list(REVALIDATE_CURRENT_FACTS):
             violations.append(
-                "freshness_contract.revalidate_current_facts must be a list"
+                "freshness_contract.revalidate_current_facts must exactly match the "
+                "required current facts"
             )
         if (
             freshness_mapping.get("requires_new_semantic_context_on_object_drift")

--- a/tools/agent_workflow/review_fact_handoff.py
+++ b/tools/agent_workflow/review_fact_handoff.py
@@ -1,0 +1,538 @@
+#!/usr/bin/env python3
+"""Bounded mechanical facts that a fresh Independent Review may revalidate.
+
+This module deliberately contains no semantic review result.  A handoff is a
+candidate input for a fresh Review root, never a verdict or an acceptance
+summary.  The current Task/PR/effective diff must still be collected and
+compared before the facts can be trusted.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Final
+
+if __name__ != "__main__" or not any(p.endswith("agent_workflow") for p in sys.path):
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from workflow_common import (  # noqa: E402
+    WorkflowToolError,
+    atomic_write_json,
+    is_sha,
+    sha256_bytes,
+    sha256_json,
+)
+
+SCHEMA_VERSION: Final = 1
+HANDOFF_ROOT: Final = ".agents/evidence.local/review-handoffs"
+HANDOFF_FIELDS: Final = (
+    "schema_version",
+    "task_id",
+    "pr_id",
+    "task_spec_hash",
+    "base_sha",
+    "head_sha",
+    "effective_diff_sha256",
+    "changed_files_manifest",
+    "acceptance_criteria_ids",
+    "raw_check_facts",
+    "validation_facts",
+    "workflow_identity",
+    "created_at",
+    "source_identity",
+    "freshness_contract",
+)
+PROHIBITED_FIELDS: Final = frozenset(
+    {
+        "delivery_correctness_verdict",
+        "delivery_risk_verdict",
+        "delivery_ac_satisfaction_verdict",
+        "review_conclusion",
+        "recommended_review_outcome",
+    }
+)
+DRIFT_TYPES: Final = (
+    "TASK_SPEC_DRIFT",
+    "BASE_DRIFT",
+    "HEAD_DRIFT",
+    "EFFECTIVE_DIFF_DRIFT",
+    "CHECKS_DRIFT",
+    "VALIDATION_DRIFT",
+    "WORKFLOW_RULE_DRIFT",
+    "HANDOFF_SCHEMA_DRIFT",
+)
+_AC_ID = re.compile(r"^AC-[0-9]+$")
+_RELATIVE_PATH = re.compile(r"^[^/].*$")
+
+
+class ReviewFactHandoffError(WorkflowToolError):
+    """Expected fail-closed error for a malformed or stale handoff."""
+
+
+def default_freshness_contract() -> dict[str, Any]:
+    """Return the explicit invalidation contract required by the schema."""
+    return {
+        "invalidate_on": list(DRIFT_TYPES),
+        "revalidate_current_facts": [
+            "task_pr_identity",
+            "base_head_merge_base",
+            "effective_diff_and_changed_files",
+            "task_spec_and_acceptance_criteria",
+            "checks_and_required_configuration",
+            "validation_result_freshness",
+            "workflow_identity",
+        ],
+        "requires_new_semantic_context_on_object_drift": True,
+    }
+
+
+def _walk_keys(value: Any, prefix: str = "") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, Mapping):
+        for key, nested in value.items():
+            if isinstance(key, str):
+                path = f"{prefix}.{key}" if prefix else key
+                if key in PROHIBITED_FIELDS:
+                    found.append(path)
+                found.extend(_walk_keys(nested, path))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            found.extend(_walk_keys(nested, f"{prefix}[{index}]"))
+    return found
+
+
+def _is_relative_repo_path(value: Any) -> bool:
+    if not isinstance(value, str) or not _RELATIVE_PATH.fullmatch(value):
+        return False
+    path = Path(value)
+    return (
+        not path.is_absolute()
+        and ".." not in path.parts
+        and "" not in path.parts
+        and "\\" not in value
+    )
+
+
+def _require_sha(value: Any, field: str, violations: list[str]) -> None:
+    if not is_sha(value) or not isinstance(value, str) or len(value) not in {40, 64}:
+        violations.append(f"{field} must be a 40- or 64-character SHA")
+
+
+def _require_mapping(value: Any, field: str, violations: list[str]) -> None:
+    if not isinstance(value, Mapping):
+        violations.append(f"{field} must be an object")
+
+
+def validate_handoff_structure(
+    handoff: Mapping[str, Any], *, expected_repository: str | None = None
+) -> list[str]:
+    """Return structural violations; an empty list means trusted shape only.
+
+    Identity, freshness, and source checks are intentionally separate so the
+    Review entry can report malformed input distinctly from current-object
+    drift.  Unknown top-level fields are rejected to prevent semantic claims
+    from being smuggled into an otherwise valid mechanical package.
+    """
+    violations: list[str] = []
+    if not isinstance(handoff, Mapping):
+        return ["handoff must be an object"]
+
+    missing = [field for field in HANDOFF_FIELDS if field not in handoff]
+    extra = sorted(set(handoff) - set(HANDOFF_FIELDS))
+    if missing:
+        violations.extend(f"missing field: {field}" for field in missing)
+    if extra:
+        violations.append(f"unknown top-level fields: {extra}")
+    prohibited = _walk_keys(handoff)
+    if prohibited:
+        violations.append(f"prohibited semantic fields: {sorted(prohibited)}")
+
+    if handoff.get("schema_version") != SCHEMA_VERSION:
+        violations.append(f"schema_version must be {SCHEMA_VERSION}")
+    for field in ("task_id", "pr_id"):
+        value = handoff.get(field)
+        if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+            violations.append(f"{field} must be a positive integer")
+    task_spec_hash = handoff.get("task_spec_hash")
+    if not isinstance(task_spec_hash, str) or not is_sha(task_spec_hash) or len(task_spec_hash) != 64:
+        violations.append("task_spec_hash must be a 64-character SHA-256")
+    for field in ("base_sha", "head_sha"):
+        value = handoff.get(field)
+        if not isinstance(value, str) or not is_sha(value) or len(value) != 40:
+            violations.append(f"{field} must be a 40-character Git SHA")
+    _require_sha(handoff.get("effective_diff_sha256"), "effective_diff_sha256", violations)
+
+    files = handoff.get("changed_files_manifest")
+    if not isinstance(files, list) or not files:
+        violations.append("changed_files_manifest must be a non-empty list")
+    elif any(not _is_relative_repo_path(item) for item in files):
+        violations.append("changed_files_manifest contains an invalid repository path")
+    elif files != sorted(set(files)):
+        violations.append("changed_files_manifest must be sorted and unique")
+
+    ac_ids = handoff.get("acceptance_criteria_ids")
+    if not isinstance(ac_ids, list) or not ac_ids:
+        violations.append("acceptance_criteria_ids must be a non-empty list")
+    elif any(not isinstance(item, str) or not _AC_ID.fullmatch(item) for item in ac_ids):
+        violations.append("acceptance_criteria_ids must contain only AC-N identifiers")
+    elif ac_ids != sorted(set(ac_ids), key=lambda item: int(item[3:])):
+        violations.append("acceptance_criteria_ids must be ordered and unique")
+
+    raw_checks = handoff.get("raw_check_facts")
+    _require_mapping(raw_checks, "raw_check_facts", violations)
+    if isinstance(raw_checks, Mapping):
+        extra_check_fields = sorted(set(raw_checks) - {"observed", "required"})
+        if extra_check_fields:
+            violations.append(
+                f"raw_check_facts has non-mechanical fields: {extra_check_fields}"
+            )
+        if not isinstance(raw_checks.get("observed"), list):
+            violations.append("raw_check_facts.observed must be a list")
+        else:
+            allowed_check_fields = {
+                "name",
+                "state",
+                "run_id",
+                "started_at",
+                "completed_at",
+                "source_url",
+            }
+            for index, item in enumerate(raw_checks["observed"]):
+                if not isinstance(item, Mapping):
+                    violations.append(f"raw_check_facts.observed[{index}] must be an object")
+                else:
+                    extra = sorted(set(item) - allowed_check_fields)
+                    if extra:
+                        violations.append(
+                            f"raw_check_facts.observed[{index}] has non-mechanical fields: {extra}"
+                        )
+        _require_mapping(raw_checks.get("required"), "raw_check_facts.required", violations)
+        required = raw_checks.get("required")
+        if isinstance(required, Mapping):
+            extra = sorted(set(required) - {"configuration", "contexts", "failure"})
+            if extra:
+                violations.append(
+                    f"raw_check_facts.required has non-mechanical fields: {extra}"
+                )
+
+    validation = handoff.get("validation_facts")
+    _require_mapping(validation, "validation_facts", violations)
+    if isinstance(validation, Mapping):
+        extra = sorted(
+            set(validation)
+            - {
+                "profile",
+                "schema_version",
+                "runner_identity",
+                "exit_code",
+                "result_locator",
+                "result_sha256",
+            }
+        )
+        if extra:
+            violations.append(
+                f"validation_facts has non-mechanical fields: {extra}"
+            )
+        for field in (
+            "profile",
+            "schema_version",
+            "runner_identity",
+            "exit_code",
+            "result_locator",
+            "result_sha256",
+        ):
+            if field not in validation:
+                violations.append(f"validation_facts missing field: {field}")
+        if not isinstance(validation.get("profile"), str):
+            violations.append("validation_facts.profile must be a string")
+        if not isinstance(validation.get("runner_identity"), Mapping):
+            violations.append("validation_facts.runner_identity must be an object")
+        if not isinstance(validation.get("exit_code"), int):
+            violations.append("validation_facts.exit_code must be an integer")
+        if not _is_relative_repo_path(validation.get("result_locator")):
+            violations.append("validation_facts.result_locator must be repository-relative")
+        result_sha = validation.get("result_sha256")
+        if not isinstance(result_sha, str) or not is_sha(result_sha) or len(result_sha) != 64:
+            violations.append("validation_facts.result_sha256 must be a 64-character SHA-256")
+
+    workflow = handoff.get("workflow_identity")
+    _require_mapping(workflow, "workflow_identity", violations)
+    if isinstance(workflow, Mapping):
+        for field in ("profile", "schema_version", "runner", "skill"):
+            if field not in workflow:
+                violations.append(f"workflow_identity missing field: {field}")
+        if not isinstance(workflow.get("profile"), str):
+            violations.append("workflow_identity.profile must be a string")
+        if not isinstance(workflow.get("runner"), Mapping):
+            violations.append("workflow_identity.runner must be an object")
+        if not isinstance(workflow.get("skill"), Mapping):
+            violations.append("workflow_identity.skill must be an object")
+
+    source = handoff.get("source_identity")
+    _require_mapping(source, "source_identity", violations)
+    if isinstance(source, Mapping):
+        if not isinstance(source.get("repository"), str):
+            violations.append("source_identity.repository must be a string")
+        if not isinstance(source.get("source_locator"), str):
+            violations.append("source_identity.source_locator must be a string")
+        source_digest = source.get("source_digest")
+        if not isinstance(source_digest, str) or not is_sha(source_digest) or len(source_digest) != 64:
+            violations.append("source_identity.source_digest must be a 64-character SHA-256")
+        if expected_repository and source.get("repository") != expected_repository:
+            violations.append("source_identity.repository does not match repository")
+
+    freshness = handoff.get("freshness_contract")
+    _require_mapping(freshness, "freshness_contract", violations)
+    if isinstance(freshness, Mapping):
+        invalidations = freshness.get("invalidate_on")
+        if not isinstance(invalidations, list) or set(invalidations) != set(DRIFT_TYPES):
+            violations.append("freshness_contract.invalidate_on must list all supported drift types")
+        if not isinstance(freshness.get("revalidate_current_facts"), list):
+            violations.append("freshness_contract.revalidate_current_facts must be a list")
+        if freshness.get("requires_new_semantic_context_on_object_drift") is not True:
+            violations.append(
+                "freshness_contract must require a new semantic context on object drift"
+            )
+
+    created_at = handoff.get("created_at")
+    if not isinstance(created_at, str):
+        violations.append("created_at must be an ISO-8601 string")
+    else:
+        try:
+            datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+        except ValueError:
+            violations.append("created_at must be an ISO-8601 string")
+    return violations
+
+
+def load_handoff(path: Path, *, expected_repository: str | None = None) -> tuple[dict[str, Any], str]:
+    """Load and structurally validate one handoff, returning value and digest."""
+    if path.is_symlink():
+        raise ReviewFactHandoffError("handoff path must not be a symlink")
+    try:
+        raw = path.read_bytes()
+    except FileNotFoundError as exc:
+        raise ReviewFactHandoffError(f"handoff file is missing: {path}") from exc
+    try:
+        value = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ReviewFactHandoffError(f"handoff is not valid JSON: {path}") from exc
+    if not isinstance(value, dict):
+        raise ReviewFactHandoffError("handoff must be a JSON object")
+    violations = validate_handoff_structure(value, expected_repository=expected_repository)
+    if violations:
+        raise ReviewFactHandoffError("; ".join(violations))
+    return value, sha256_bytes(raw)
+
+
+def resolve_handoff_path(repo_root: Path, value: str) -> Path:
+    """Resolve a read-only, repository-relative handoff under ignored evidence."""
+    candidate = Path(value)
+    if candidate.is_absolute() or ".." in candidate.parts or "\\" in value:
+        raise ReviewFactHandoffError("handoff path must be repository-relative")
+    root = (repo_root / HANDOFF_ROOT).resolve()
+    path = (repo_root / candidate).resolve()
+    if path == root or root not in path.parents:
+        raise ReviewFactHandoffError(
+            f"handoff path must be under {HANDOFF_ROOT}/"
+        )
+    return path
+
+
+def _current_changed_files(snapshot: Mapping[str, Any]) -> tuple[list[str] | None, str | None]:
+    observed = snapshot.get("observed")
+    observed = observed if isinstance(observed, Mapping) else {}
+    diff = observed.get("effective_diff")
+    diff = diff if isinstance(diff, Mapping) else {}
+    files = diff.get("changed_files")
+    if not isinstance(files, Mapping) or files.get("truncated") is True:
+        return None, "current effective diff manifest is unavailable or truncated"
+    items = files.get("items")
+    if not isinstance(items, list) or any(not isinstance(item, str) for item in items):
+        return None, "current effective diff manifest is unavailable"
+    return sorted(set(items)), None
+
+
+def _current_raw_check_facts(snapshot: Mapping[str, Any]) -> dict[str, Any] | None:
+    observed = snapshot.get("observed")
+    observed = observed if isinstance(observed, Mapping) else {}
+    pr = observed.get("pr")
+    pr = pr if isinstance(pr, Mapping) else {}
+    checks = pr.get("checks")
+    checks = checks if isinstance(checks, Mapping) else {}
+    required = observed.get("required_checks")
+    required = required if isinstance(required, Mapping) else {}
+    bounded_items = checks.get("items")
+    if isinstance(bounded_items, Mapping):
+        if bounded_items.get("truncated") is True:
+            return None
+        items = bounded_items.get("items")
+    else:
+        items = bounded_items
+    if not isinstance(items, list):
+        return None
+    raw_items: list[dict[str, Any]] = []
+    for item in items:
+        if not isinstance(item, Mapping):
+            return None
+        raw_items.append(
+            {
+                "name": item.get("name"),
+                "state": item.get("state"),
+                "run_id": item.get("run_id"),
+                "started_at": item.get("started_at"),
+                "completed_at": item.get("completed_at"),
+                "source_url": item.get("source_url"),
+            }
+        )
+    return {"observed": raw_items, "required": dict(required)}
+
+
+def validate_against_snapshot(
+    handoff: Mapping[str, Any],
+    snapshot: Mapping[str, Any],
+    *,
+    handoff_digest: str | None = None,
+    current_acceptance_criteria_ids: Sequence[str] | None = None,
+) -> dict[str, Any]:
+    """Compare trusted handoff candidates with freshly collected current facts."""
+    errors = validate_handoff_structure(handoff)
+    observed = snapshot.get("observed")
+    observed = observed if isinstance(observed, Mapping) else {}
+    issue = observed.get("issue")
+    issue = issue if isinstance(issue, Mapping) else {}
+    pr = observed.get("pr")
+    pr = pr if isinstance(pr, Mapping) else {}
+    diff = observed.get("effective_diff")
+    diff = diff if isinstance(diff, Mapping) else {}
+    repository = snapshot.get("repository")
+    source = handoff.get("source_identity")
+    source_repository = source.get("repository") if isinstance(source, Mapping) else None
+    if isinstance(repository, str) and source_repository != repository:
+        errors.append("TASK_PR_IDENTITY_DRIFT: repository")
+    comparisons = (
+        ("task_id", issue.get("number"), "TASK_PR_IDENTITY_DRIFT"),
+        ("pr_id", pr.get("number"), "TASK_PR_IDENTITY_DRIFT"),
+        ("task_spec_hash", issue.get("spec_sha256"), "TASK_SPEC_DRIFT"),
+        ("base_sha", pr.get("base_sha"), "BASE_DRIFT"),
+        ("head_sha", pr.get("head_sha"), "HEAD_DRIFT"),
+        ("effective_diff_sha256", diff.get("sha256"), "EFFECTIVE_DIFF_DRIFT"),
+    )
+    for field, current, drift in comparisons:
+        if field in handoff and handoff.get(field) != current:
+            errors.append(f"{drift}: {field}")
+
+    files, file_error = _current_changed_files(snapshot)
+    if file_error:
+        errors.append(f"EFFECTIVE_DIFF_DRIFT: {file_error}")
+    elif files != handoff.get("changed_files_manifest"):
+        errors.append("EFFECTIVE_DIFF_DRIFT: changed_files_manifest")
+
+    if current_acceptance_criteria_ids is None:
+        errors.append("TASK_SPEC_DRIFT: current acceptance_criteria_ids unavailable")
+    elif list(current_acceptance_criteria_ids) != handoff.get("acceptance_criteria_ids"):
+        errors.append("TASK_SPEC_DRIFT: acceptance_criteria_ids")
+
+    current_checks = _current_raw_check_facts(snapshot)
+    if current_checks is None or current_checks != handoff.get("raw_check_facts"):
+        errors.append("CHECKS_DRIFT: raw_check_facts")
+
+    unique_errors = list(dict.fromkeys(errors))
+    status = "pass" if not unique_errors else "fail"
+    return {
+        "available": True,
+        "status": status,
+        "trusted": status == "pass",
+        "strategy": "FRESH_ROOT_BOUNDED_HANDOFF" if status == "pass" else "FAIL_CLOSED",
+        "handoff_sha256": handoff_digest,
+        "invalidated": unique_errors,
+        "revalidation_required": [
+            "task_pr_identity",
+            "base_head_merge_base",
+            "effective_diff_and_changed_files",
+            "task_spec_and_acceptance_criteria",
+            "checks_and_required_configuration",
+            "validation_result_freshness",
+            "workflow_identity",
+        ],
+    }
+
+
+def build_handoff_from_snapshot(
+    snapshot: Mapping[str, Any],
+    *,
+    acceptance_criteria_ids: Sequence[str],
+    validation_facts: Mapping[str, Any],
+    workflow_identity: Mapping[str, Any],
+    source_identity: Mapping[str, Any] | None = None,
+    created_at: str | None = None,
+) -> dict[str, Any]:
+    """Build the exact bounded field set from an evidence snapshot.
+
+    The caller supplies validation facts and AC identifiers because those facts
+    come from the separate validation run and semantic Review context.  This
+    function only copies mechanical values from the snapshot.
+    """
+    observed = snapshot.get("observed")
+    observed = observed if isinstance(observed, Mapping) else {}
+    issue = observed.get("issue")
+    issue = issue if isinstance(issue, Mapping) else {}
+    pr = observed.get("pr")
+    pr = pr if isinstance(pr, Mapping) else {}
+    diff = observed.get("effective_diff")
+    diff = diff if isinstance(diff, Mapping) else {}
+    files, file_error = _current_changed_files(snapshot)
+    if file_error or files is None:
+        raise ReviewFactHandoffError(file_error or "changed file manifest unavailable")
+    raw_checks = _current_raw_check_facts(snapshot)
+    if raw_checks is None:
+        raise ReviewFactHandoffError("raw check facts unavailable")
+    repository = snapshot.get("repository")
+    if not isinstance(repository, str):
+        raise ReviewFactHandoffError("snapshot repository is unavailable")
+    source = dict(source_identity or {})
+    source.setdefault("repository", repository)
+    source.setdefault(
+        "source_locator", f"snapshot:{snapshot.get('snapshot_id', 'unknown')}"
+    )
+    source.setdefault("source_digest", sha256_json(snapshot))
+    handoff = {
+        "schema_version": SCHEMA_VERSION,
+        "task_id": issue.get("number"),
+        "pr_id": pr.get("number"),
+        "task_spec_hash": issue.get("spec_sha256"),
+        "base_sha": pr.get("base_sha"),
+        "head_sha": pr.get("head_sha"),
+        "effective_diff_sha256": diff.get("sha256"),
+        "changed_files_manifest": files,
+        "acceptance_criteria_ids": list(acceptance_criteria_ids),
+        "raw_check_facts": raw_checks,
+        "validation_facts": dict(validation_facts),
+        "workflow_identity": dict(workflow_identity),
+        "created_at": created_at or datetime.now(UTC).isoformat(),
+        "source_identity": source,
+        "freshness_contract": default_freshness_contract(),
+    }
+    violations = validate_handoff_structure(handoff, expected_repository=repository)
+    if violations:
+        raise ReviewFactHandoffError("; ".join(violations))
+    return handoff
+
+
+def write_handoff(repo_root: Path, handoff: Mapping[str, Any], *, filename: str) -> Path:
+    """Write a validated handoff to the exact ignored evidence root."""
+    violations = validate_handoff_structure(handoff)
+    if violations:
+        raise ReviewFactHandoffError("; ".join(violations))
+    if not filename or Path(filename).name != filename or not filename.endswith(".json"):
+        raise ReviewFactHandoffError("handoff filename must be a simple .json filename")
+    root = repo_root / HANDOFF_ROOT
+    root.mkdir(parents=True, exist_ok=True)
+    path = root / filename
+    atomic_write_json(path, dict(handoff))
+    return path

--- a/tools/agent_workflow/review_fact_handoff.py
+++ b/tools/agent_workflow/review_fact_handoff.py
@@ -159,13 +159,19 @@ def validate_handoff_structure(
         if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
             violations.append(f"{field} must be a positive integer")
     task_spec_hash = handoff.get("task_spec_hash")
-    if not isinstance(task_spec_hash, str) or not is_sha(task_spec_hash) or len(task_spec_hash) != 64:
+    if (
+        not isinstance(task_spec_hash, str)
+        or not is_sha(task_spec_hash)
+        or len(task_spec_hash) != 64
+    ):
         violations.append("task_spec_hash must be a 64-character SHA-256")
     for field in ("base_sha", "head_sha"):
         value = handoff.get(field)
         if not isinstance(value, str) or not is_sha(value) or len(value) != 40:
             violations.append(f"{field} must be a 40-character Git SHA")
-    _require_sha(handoff.get("effective_diff_sha256"), "effective_diff_sha256", violations)
+    _require_sha(
+        handoff.get("effective_diff_sha256"), "effective_diff_sha256", violations
+    )
 
     files = handoff.get("changed_files_manifest")
     if not isinstance(files, list) or not files:
@@ -178,7 +184,9 @@ def validate_handoff_structure(
     ac_ids = handoff.get("acceptance_criteria_ids")
     if not isinstance(ac_ids, list) or not ac_ids:
         violations.append("acceptance_criteria_ids must be a non-empty list")
-    elif any(not isinstance(item, str) or not _AC_ID.fullmatch(item) for item in ac_ids):
+    elif any(
+        not isinstance(item, str) or not _AC_ID.fullmatch(item) for item in ac_ids
+    ):
         violations.append("acceptance_criteria_ids must contain only AC-N identifiers")
     elif ac_ids != sorted(set(ac_ids), key=lambda item: int(item[3:])):
         violations.append("acceptance_criteria_ids must be ordered and unique")
@@ -204,14 +212,18 @@ def validate_handoff_structure(
             }
             for index, item in enumerate(raw_checks["observed"]):
                 if not isinstance(item, Mapping):
-                    violations.append(f"raw_check_facts.observed[{index}] must be an object")
+                    violations.append(
+                        f"raw_check_facts.observed[{index}] must be an object"
+                    )
                 else:
                     extra = sorted(set(item) - allowed_check_fields)
                     if extra:
                         violations.append(
                             f"raw_check_facts.observed[{index}] has non-mechanical fields: {extra}"
                         )
-        _require_mapping(raw_checks.get("required"), "raw_check_facts.required", violations)
+        _require_mapping(
+            raw_checks.get("required"), "raw_check_facts.required", violations
+        )
         required = raw_checks.get("required")
         if isinstance(required, Mapping):
             extra = sorted(set(required) - {"configuration", "contexts", "failure"})
@@ -235,9 +247,7 @@ def validate_handoff_structure(
             }
         )
         if extra:
-            violations.append(
-                f"validation_facts has non-mechanical fields: {extra}"
-            )
+            violations.append(f"validation_facts has non-mechanical fields: {extra}")
         for field in (
             "profile",
             "schema_version",
@@ -255,10 +265,18 @@ def validate_handoff_structure(
         if not isinstance(validation.get("exit_code"), int):
             violations.append("validation_facts.exit_code must be an integer")
         if not _is_relative_repo_path(validation.get("result_locator")):
-            violations.append("validation_facts.result_locator must be repository-relative")
+            violations.append(
+                "validation_facts.result_locator must be repository-relative"
+            )
         result_sha = validation.get("result_sha256")
-        if not isinstance(result_sha, str) or not is_sha(result_sha) or len(result_sha) != 64:
-            violations.append("validation_facts.result_sha256 must be a 64-character SHA-256")
+        if (
+            not isinstance(result_sha, str)
+            or not is_sha(result_sha)
+            or len(result_sha) != 64
+        ):
+            violations.append(
+                "validation_facts.result_sha256 must be a 64-character SHA-256"
+            )
 
     workflow = handoff.get("workflow_identity")
     _require_mapping(workflow, "workflow_identity", violations)
@@ -281,8 +299,14 @@ def validate_handoff_structure(
         if not isinstance(source.get("source_locator"), str):
             violations.append("source_identity.source_locator must be a string")
         source_digest = source.get("source_digest")
-        if not isinstance(source_digest, str) or not is_sha(source_digest) or len(source_digest) != 64:
-            violations.append("source_identity.source_digest must be a 64-character SHA-256")
+        if (
+            not isinstance(source_digest, str)
+            or not is_sha(source_digest)
+            or len(source_digest) != 64
+        ):
+            violations.append(
+                "source_identity.source_digest must be a 64-character SHA-256"
+            )
         if expected_repository and source.get("repository") != expected_repository:
             violations.append("source_identity.repository does not match repository")
 
@@ -290,10 +314,16 @@ def validate_handoff_structure(
     _require_mapping(freshness, "freshness_contract", violations)
     if isinstance(freshness, Mapping):
         invalidations = freshness.get("invalidate_on")
-        if not isinstance(invalidations, list) or set(invalidations) != set(DRIFT_TYPES):
-            violations.append("freshness_contract.invalidate_on must list all supported drift types")
+        if not isinstance(invalidations, list) or set(invalidations) != set(
+            DRIFT_TYPES
+        ):
+            violations.append(
+                "freshness_contract.invalidate_on must list all supported drift types"
+            )
         if not isinstance(freshness.get("revalidate_current_facts"), list):
-            violations.append("freshness_contract.revalidate_current_facts must be a list")
+            violations.append(
+                "freshness_contract.revalidate_current_facts must be a list"
+            )
         if freshness.get("requires_new_semantic_context_on_object_drift") is not True:
             violations.append(
                 "freshness_contract must require a new semantic context on object drift"
@@ -310,7 +340,9 @@ def validate_handoff_structure(
     return violations
 
 
-def load_handoff(path: Path, *, expected_repository: str | None = None) -> tuple[dict[str, Any], str]:
+def load_handoff(
+    path: Path, *, expected_repository: str | None = None
+) -> tuple[dict[str, Any], str]:
     """Load and structurally validate one handoff, returning value and digest."""
     if path.is_symlink():
         raise ReviewFactHandoffError("handoff path must not be a symlink")
@@ -324,7 +356,9 @@ def load_handoff(path: Path, *, expected_repository: str | None = None) -> tuple
         raise ReviewFactHandoffError(f"handoff is not valid JSON: {path}") from exc
     if not isinstance(value, dict):
         raise ReviewFactHandoffError("handoff must be a JSON object")
-    violations = validate_handoff_structure(value, expected_repository=expected_repository)
+    violations = validate_handoff_structure(
+        value, expected_repository=expected_repository
+    )
     if violations:
         raise ReviewFactHandoffError("; ".join(violations))
     return value, sha256_bytes(raw)
@@ -338,13 +372,13 @@ def resolve_handoff_path(repo_root: Path, value: str) -> Path:
     root = (repo_root / HANDOFF_ROOT).resolve()
     path = (repo_root / candidate).resolve()
     if path == root or root not in path.parents:
-        raise ReviewFactHandoffError(
-            f"handoff path must be under {HANDOFF_ROOT}/"
-        )
+        raise ReviewFactHandoffError(f"handoff path must be under {HANDOFF_ROOT}/")
     return path
 
 
-def _current_changed_files(snapshot: Mapping[str, Any]) -> tuple[list[str] | None, str | None]:
+def _current_changed_files(
+    snapshot: Mapping[str, Any],
+) -> tuple[list[str] | None, str | None]:
     observed = snapshot.get("observed")
     observed = observed if isinstance(observed, Mapping) else {}
     diff = observed.get("effective_diff")
@@ -412,7 +446,9 @@ def validate_against_snapshot(
     diff = diff if isinstance(diff, Mapping) else {}
     repository = snapshot.get("repository")
     source = handoff.get("source_identity")
-    source_repository = source.get("repository") if isinstance(source, Mapping) else None
+    source_repository = (
+        source.get("repository") if isinstance(source, Mapping) else None
+    )
     if isinstance(repository, str) and source_repository != repository:
         errors.append("TASK_PR_IDENTITY_DRIFT: repository")
     comparisons = (
@@ -435,7 +471,9 @@ def validate_against_snapshot(
 
     if current_acceptance_criteria_ids is None:
         errors.append("TASK_SPEC_DRIFT: current acceptance_criteria_ids unavailable")
-    elif list(current_acceptance_criteria_ids) != handoff.get("acceptance_criteria_ids"):
+    elif list(current_acceptance_criteria_ids) != handoff.get(
+        "acceptance_criteria_ids"
+    ):
         errors.append("TASK_SPEC_DRIFT: acceptance_criteria_ids")
 
     current_checks = _current_raw_check_facts(snapshot)
@@ -524,12 +562,18 @@ def build_handoff_from_snapshot(
     return handoff
 
 
-def write_handoff(repo_root: Path, handoff: Mapping[str, Any], *, filename: str) -> Path:
+def write_handoff(
+    repo_root: Path, handoff: Mapping[str, Any], *, filename: str
+) -> Path:
     """Write a validated handoff to the exact ignored evidence root."""
     violations = validate_handoff_structure(handoff)
     if violations:
         raise ReviewFactHandoffError("; ".join(violations))
-    if not filename or Path(filename).name != filename or not filename.endswith(".json"):
+    if (
+        not filename
+        or Path(filename).name != filename
+        or not filename.endswith(".json")
+    ):
         raise ReviewFactHandoffError("handoff filename must be a simple .json filename")
     root = repo_root / HANDOFF_ROOT
     root.mkdir(parents=True, exist_ok=True)

--- a/tools/agent_workflow/workflow_evidence.py
+++ b/tools/agent_workflow/workflow_evidence.py
@@ -3320,9 +3320,7 @@ def _stability_projection(snapshot: Mapping[str, Any]) -> dict[str, Any]:
     handoff = observed.get("review_fact_handoff")
     handoff = handoff if isinstance(handoff, dict) else {}
     execution_context = snapshot.get("execution_context")
-    execution_context = (
-        execution_context if isinstance(execution_context, dict) else {}
-    )
+    execution_context = execution_context if isinstance(execution_context, dict) else {}
     return {
         "repository": snapshot.get("repository"),
         "subject": snapshot.get("subject"),

--- a/tools/agent_workflow/workflow_evidence.py
+++ b/tools/agent_workflow/workflow_evidence.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any, Final
 
 from review_fact_handoff import (
+    WORKFLOW_CONTROL_PATHS,
     ReviewFactHandoffError,
     acquire_current_validation_facts,
     load_handoff,
@@ -2035,6 +2036,23 @@ def _runner_source(
     }
 
 
+def _workflow_control_plane_identity() -> dict[str, dict[str, str]]:
+    """Hash the stable control plane that defines Review evidence semantics."""
+    repo_root = Path(__file__).resolve().parents[2]
+    identity: dict[str, dict[str, str]] = {}
+    for name, relative in WORKFLOW_CONTROL_PATHS.items():
+        target = repo_root / relative
+        if target.is_symlink() or not target.is_file():
+            raise WorkflowToolError(
+                f"workflow control-plane file is unavailable: {relative}"
+            )
+        identity[name] = {
+            "path": relative,
+            "content_sha256": sha256_bytes(target.read_bytes()),
+        }
+    return identity
+
+
 def _skill_identity(
     repo_root: Path,
     value: str | None,
@@ -2791,6 +2809,7 @@ def _task_pr_snapshot(
         "skill": _skill_identity(
             repo_root, getattr(args, "skill_path", None), default=skill_default
         ),
+        "control_plane": _workflow_control_plane_identity(),
     }
     execution_context = {
         "object_base_sha": object_base_sha,

--- a/tools/agent_workflow/workflow_evidence.py
+++ b/tools/agent_workflow/workflow_evidence.py
@@ -44,6 +44,12 @@ from workflow_common import (
 )
 
 SCHEMA_VERSION: Final = 1
+WORKFLOW_PROFILES: Final = {
+    "delivery-readiness": "delivery-readiness",
+    "delivery-readiness-recheck": "delivery-readiness",
+    "pr-review-snapshot": "review",
+    "pr-review-recheck": "review",
+}
 EVIDENCE_ROOT: Final = ".agents/evidence.local"
 SNAPSHOT_SUBDIR: Final = "snapshots"
 MAX_CHILDREN: Final = 50
@@ -2779,7 +2785,7 @@ def _task_pr_snapshot(
         else ".agents/skills/task-delivery-runner/SKILL.md"
     )
     workflow_identity = {
-        "profile": "review" if is_review else operation,
+        "profile": WORKFLOW_PROFILES[operation],
         "schema_version": SCHEMA_VERSION,
         "runner": _runner_source(runner, warnings),
         "skill": _skill_identity(
@@ -3575,6 +3581,10 @@ def _build_parser() -> argparse.ArgumentParser:
     feature.add_argument("--expected-main-sha")
 
     for name, help_text in (
+        (
+            "delivery-readiness-recheck",
+            "recollect and compare a Delivery readiness snapshot",
+        ),
         ("pr-review-recheck", "recollect and compare a PR review snapshot"),
         ("closeout-final", "recollect and compare a closeout plan"),
         ("feature-audit-recheck", "recollect and compare a Feature audit snapshot"),

--- a/tools/agent_workflow/workflow_evidence.py
+++ b/tools/agent_workflow/workflow_evidence.py
@@ -2846,13 +2846,14 @@ def _task_pr_snapshot(
                 handoff, handoff_digest = load_handoff(
                     path, expected_repository=repository
                 )
+                pr_base_sha = pr.get("base_sha") if isinstance(pr, Mapping) else None
                 pr_head_sha = pr.get("head_sha") if isinstance(pr, Mapping) else None
                 current_validation_facts, validation_errors = (
                     acquire_current_validation_facts(
                         repo_root,
                         handoff["validation_facts"],
-                        expected_base_sha=pr.get("base_sha")
-                        if isinstance(pr.get("base_sha"), str)
+                        expected_base_sha=pr_base_sha
+                        if isinstance(pr_base_sha, str)
                         else None,
                         expected_head_sha=pr_head_sha
                         if isinstance(pr_head_sha, str)

--- a/tools/agent_workflow/workflow_evidence.py
+++ b/tools/agent_workflow/workflow_evidence.py
@@ -10,12 +10,19 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 import sys
 import unicodedata
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any, Final
 
+from review_fact_handoff import (
+    ReviewFactHandoffError,
+    load_handoff,
+    resolve_handoff_path,
+    validate_against_snapshot,
+)
 from workflow_common import (
     CommandResult,
     CommandRunner,
@@ -190,6 +197,28 @@ query($owner:String!, $name:String!, $number:Int!) {
 def _normalize_title(value: str) -> str:
     normalized = unicodedata.normalize("NFKC", value)
     return " ".join(normalized.split()).casefold()
+
+
+def _acceptance_criteria_ids(body: str | None) -> list[str] | None:
+    """Extract deterministic AC identifiers from the current Task body."""
+    if not isinstance(body, str):
+        return None
+    in_section = False
+    identifiers: list[str] = []
+    for line in body.splitlines():
+        heading = re.match(r"^\s*#{1,6}\s+(.+?)\s*$", line)
+        if heading:
+            title = _normalize_title(heading.group(1)).rstrip(":：")
+            in_section = title in {
+                "acceptance criteria",
+                "acceptance criterion",
+                "验收标准",
+                "验收条件",
+            }
+            continue
+        if in_section and re.match(r"^\s*[-*]\s+\[[ xX]\]\s+", line):
+            identifiers.append(f"AC-{len(identifiers) + 1}")
+    return identifiers if in_section or identifiers else None
 
 
 def _gate(status: str, detail: str | None = None) -> dict[str, Any]:
@@ -460,6 +489,8 @@ def _issue_view(
         "number": value.get("number"),
         "title": safe_text(value.get("title")),
         "content_sha256": sha256_json(content_facts),
+        "spec_sha256": sha256_bytes(body.encode("utf-8")) if body is not None else None,
+        "acceptance_criteria_ids": _acceptance_criteria_ids(body),
         "body_characters": len(body) if body is not None else None,
         "comment_count": len(comment_facts),
         "state": safe_text(value.get("state")),
@@ -990,6 +1021,14 @@ def _normalize_checks(value: Any) -> dict[str, Any]:
                 "name": safe_text(name, limit=160),
                 "state": safe_text(normalized_state, limit=64),
                 "category": category,
+                "run_id": safe_text(
+                    item.get("databaseId") or item.get("id"), limit=160
+                ),
+                "started_at": safe_text(item.get("startedAt")),
+                "completed_at": safe_text(item.get("completedAt")),
+                "source_url": safe_text(
+                    item.get("detailsUrl") or item.get("url"), limit=512
+                ),
             }
         )
     count = len(items)
@@ -1941,11 +1980,20 @@ def _diff_digest(
         warnings.append(command_warning(result))
         return {"available": False, "sha256": None, "bytes": None, "lines": None}
     raw = result.stdout.encode("utf-8")
+    changed_files: list[str] = []
+    for line in result.stdout.splitlines():
+        if not line.startswith("diff --git a/"):
+            continue
+        marker = line[len("diff --git a/") :]
+        separator = marker.find(" b/")
+        if separator > 0:
+            changed_files.append(marker[separator + 3 :])
     return {
         "available": True,
         "sha256": sha256_bytes(raw),
         "bytes": len(raw),
         "lines": result.stdout.count("\n"),
+        "changed_files": bounded_list(sorted(set(changed_files)), item_limit=MAX_FILES),
     }
 
 
@@ -1954,6 +2002,7 @@ def _runner_source(
     warnings: list[dict[str, Any]],
 ) -> dict[str, Any]:
     script = Path(__file__).resolve()
+    handoff_script = script.with_name("review_fact_handoff.py")
     digest = sha256_bytes(script.read_bytes())
     commit = _git_value(
         runner,
@@ -1971,7 +2020,35 @@ def _runner_source(
         "path": "tools/agent_workflow/workflow_evidence.py",
         "source_sha": commit if is_sha(commit) else None,
         "content_sha256": digest,
+        "handoff_schema": {
+            "path": "tools/agent_workflow/review_fact_handoff.py",
+            "content_sha256": sha256_bytes(handoff_script.read_bytes()),
+        },
     }
+
+
+def _skill_identity(
+    repo_root: Path,
+    value: str | None,
+    *,
+    default: str = ".agents/skills/task-pr-review-runner/SKILL.md",
+) -> dict[str, Any]:
+    relative = value or default
+    normalized = relative.replace("\\", "/")
+    if (
+        normalized.startswith("/")
+        or ".." in normalized
+        or not normalized.endswith("/SKILL.md")
+        or not normalized.startswith((".agents/skills/", ".claude/skills/"))
+    ):
+        raise WorkflowToolError("workflow Skill path is invalid")
+    path = repo_root / normalized
+    if path.is_symlink() or not path.is_file():
+        # The outer WSL2 Runner verifies the caller Skill before collection.
+        # Keep the lower-level evidence tool usable in isolated test fixtures
+        # that intentionally contain only the workflow identity files.
+        return {"path": normalized, "sha256": None}
+    return {"path": normalized, "sha256": sha256_bytes(path.read_bytes())}
 
 
 def _issue_gates(
@@ -2691,11 +2768,68 @@ def _task_pr_snapshot(
             gates["project_status_review"] = _gate(
                 "pass" if project == "Review" else "unknown", str(project)
             )
+        if operation in {"pr-review-snapshot", "pr-review-recheck"}:
+            handoff_path = getattr(args, "handoff_path", None)
+            if isinstance(handoff_path, str):
+                try:
+                    path = resolve_handoff_path(repo_root, handoff_path)
+                    handoff, handoff_digest = load_handoff(
+                        path, expected_repository=repository
+                    )
+                    handoff_status = validate_against_snapshot(
+                        handoff,
+                        {"repository": repository, "observed": observed},
+                        handoff_digest=handoff_digest,
+                        current_acceptance_criteria_ids=(
+                            issue.get("acceptance_criteria_ids")
+                            if isinstance(issue, dict)
+                            and isinstance(issue.get("acceptance_criteria_ids"), list)
+                            else None
+                        ),
+                    )
+                    handoff_status["path"] = handoff_path
+                    observed["review_fact_handoff"] = handoff_status
+                    gates["review_fact_handoff"] = _gate(
+                        handoff_status["status"],
+                        "; ".join(handoff_status["invalidated"]),
+                    )
+                except ReviewFactHandoffError as exc:
+                    observed["review_fact_handoff"] = {
+                        "available": False,
+                        "status": "fail",
+                        "trusted": False,
+                        "strategy": "FAIL_CLOSED",
+                        "path": handoff_path,
+                        "invalidated": [str(exc)],
+                    }
+                    gates["review_fact_handoff"] = _gate("fail", str(exc))
+            else:
+                observed["review_fact_handoff"] = {
+                    "available": False,
+                    "status": "not-selected",
+                    "trusted": False,
+                    "strategy": "FULL_REACQUISITION",
+                }
     pr = observed.get("pr")
     object_base_sha = pr.get("base_sha") if isinstance(pr, dict) else None
+    is_review = operation in {"pr-review-snapshot", "pr-review-recheck"}
+    skill_default = (
+        ".agents/skills/task-pr-review-runner/SKILL.md"
+        if is_review
+        else ".agents/skills/task-delivery-runner/SKILL.md"
+    )
+    workflow_identity = {
+        "profile": "review" if is_review else operation,
+        "schema_version": SCHEMA_VERSION,
+        "runner": _runner_source(runner, warnings),
+        "skill": _skill_identity(
+            repo_root, getattr(args, "skill_path", None), default=skill_default
+        ),
+    }
     execution_context = {
         "object_base_sha": object_base_sha,
-        "runner": _runner_source(runner, warnings),
+        "runner": workflow_identity["runner"],
+        "workflow_identity": workflow_identity,
     }
     return _base_snapshot(
         operation=operation,
@@ -3087,7 +3221,7 @@ def _snapshot_path(repo_root: Path, snapshot_id: str) -> Path:
 
 
 def _collect_for_recheck(
-    previous: Mapping[str, Any], repo_root: Path
+    previous: Mapping[str, Any], repo_root: Path, skill_path: str | None
 ) -> dict[str, Any]:
     operation = previous.get("operation")
     subject = previous.get("subject")
@@ -3102,13 +3236,43 @@ def _collect_for_recheck(
         expected_head_sha=None,
         expected_main_sha=None,
         expected_merge_sha=None,
+        handoff_path=None,
+        skill_path=skill_path,
     )
+    previous_observed = previous.get("observed")
+    previous_observed = (
+        previous_observed if isinstance(previous_observed, Mapping) else {}
+    )
+    previous_handoff = previous_observed.get("review_fact_handoff")
+    if isinstance(previous_handoff, Mapping) and isinstance(
+        previous_handoff.get("path"), str
+    ):
+        namespace.handoff_path = previous_handoff["path"]
+    if namespace.skill_path is None:
+        previous_context = previous.get("execution_context")
+        previous_context = (
+            previous_context if isinstance(previous_context, Mapping) else {}
+        )
+        previous_identity = previous_context.get("workflow_identity")
+        previous_identity = (
+            previous_identity if isinstance(previous_identity, Mapping) else {}
+        )
+        previous_skill = previous_identity.get("skill")
+        if isinstance(previous_skill, Mapping) and isinstance(
+            previous_skill.get("path"), str
+        ):
+            namespace.skill_path = previous_skill["path"]
     if operation in {"delivery-readiness", "pr-review-snapshot"}:
         namespace.task = subject.get("task_number")
         namespace.pr = subject.get("pr_number")
         if not isinstance(namespace.task, int) or not isinstance(namespace.pr, int):
             raise WorkflowToolError("snapshot Task/PR identity is invalid")
-        current = _task_pr_snapshot(namespace, repo_root, "pr-review-recheck")
+        current_operation = (
+            "pr-review-recheck"
+            if operation == "pr-review-snapshot"
+            else "delivery-readiness-recheck"
+        )
+        current = _task_pr_snapshot(namespace, repo_root, current_operation)
     elif operation == "closeout-plan":
         namespace.task = subject.get("task_number")
         namespace.pr = subject.get("pr_number")
@@ -3153,6 +3317,12 @@ def _stability_projection(snapshot: Mapping[str, Any]) -> dict[str, Any]:
     git: dict[str, Any] = raw_git if isinstance(raw_git, dict) else {}
     raw_threads = observed.get("review_threads")
     threads: dict[str, Any] = raw_threads if isinstance(raw_threads, dict) else {}
+    handoff = observed.get("review_fact_handoff")
+    handoff = handoff if isinstance(handoff, dict) else {}
+    execution_context = snapshot.get("execution_context")
+    execution_context = (
+        execution_context if isinstance(execution_context, dict) else {}
+    )
     return {
         "repository": snapshot.get("repository"),
         "subject": snapshot.get("subject"),
@@ -3199,6 +3369,8 @@ def _stability_projection(snapshot: Mapping[str, Any]) -> dict[str, Any]:
         "direct_child_set_digest": observed.get("direct_child_set_digest"),
         "direct_child_evidence_digest": observed.get("direct_child_evidence_digest"),
         "relationships_digest": observed.get("relationships_digest"),
+        "review_fact_handoff": handoff,
+        "workflow_identity": execution_context.get("workflow_identity"),
     }
 
 
@@ -3207,7 +3379,7 @@ def _recheck(args: argparse.Namespace, repo_root: Path) -> dict[str, Any]:
     previous = read_json_file(path)
     if not isinstance(previous, dict):
         raise WorkflowToolError("snapshot is not an object")
-    current = _collect_for_recheck(previous, repo_root)
+    current = _collect_for_recheck(previous, repo_root, args.skill_path)
     before = _stability_projection(previous)
     after = _stability_projection(current)
     changed = sorted(
@@ -3294,6 +3466,8 @@ def _pr_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--pr", type=int, required=True)
     parser.add_argument("--expected-base-sha")
     parser.add_argument("--expected-head-sha")
+    parser.add_argument("--handoff-path")
+    parser.add_argument("--skill-path")
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -3360,6 +3534,7 @@ def _build_parser() -> argparse.ArgumentParser:
         recheck = sub.add_parser(name, help=help_text)
         _common(recheck)
         recheck.add_argument("--snapshot-id", required=True)
+        recheck.add_argument("--skill-path")
     return parser
 
 

--- a/tools/agent_workflow/workflow_evidence.py
+++ b/tools/agent_workflow/workflow_evidence.py
@@ -19,8 +19,10 @@ from typing import Any, Final
 
 from review_fact_handoff import (
     ReviewFactHandoffError,
+    acquire_current_validation_facts,
     load_handoff,
     resolve_handoff_path,
+    source_identity_for_snapshot,
     validate_against_snapshot,
 )
 from workflow_common import (
@@ -2768,48 +2770,6 @@ def _task_pr_snapshot(
             gates["project_status_review"] = _gate(
                 "pass" if project == "Review" else "unknown", str(project)
             )
-        if operation in {"pr-review-snapshot", "pr-review-recheck"}:
-            handoff_path = getattr(args, "handoff_path", None)
-            if isinstance(handoff_path, str):
-                try:
-                    path = resolve_handoff_path(repo_root, handoff_path)
-                    handoff, handoff_digest = load_handoff(
-                        path, expected_repository=repository
-                    )
-                    handoff_status = validate_against_snapshot(
-                        handoff,
-                        {"repository": repository, "observed": observed},
-                        handoff_digest=handoff_digest,
-                        current_acceptance_criteria_ids=(
-                            issue.get("acceptance_criteria_ids")
-                            if isinstance(issue, dict)
-                            and isinstance(issue.get("acceptance_criteria_ids"), list)
-                            else None
-                        ),
-                    )
-                    handoff_status["path"] = handoff_path
-                    observed["review_fact_handoff"] = handoff_status
-                    gates["review_fact_handoff"] = _gate(
-                        handoff_status["status"],
-                        "; ".join(handoff_status["invalidated"]),
-                    )
-                except ReviewFactHandoffError as exc:
-                    observed["review_fact_handoff"] = {
-                        "available": False,
-                        "status": "fail",
-                        "trusted": False,
-                        "strategy": "FAIL_CLOSED",
-                        "path": handoff_path,
-                        "invalidated": [str(exc)],
-                    }
-                    gates["review_fact_handoff"] = _gate("fail", str(exc))
-            else:
-                observed["review_fact_handoff"] = {
-                    "available": False,
-                    "status": "not-selected",
-                    "trusted": False,
-                    "strategy": "FULL_REACQUISITION",
-                }
     pr = observed.get("pr")
     object_base_sha = pr.get("base_sha") if isinstance(pr, dict) else None
     is_review = operation in {"pr-review-snapshot", "pr-review-recheck"}
@@ -2831,6 +2791,93 @@ def _task_pr_snapshot(
         "runner": workflow_identity["runner"],
         "workflow_identity": workflow_identity,
     }
+    if is_review:
+        handoff_path = getattr(args, "handoff_path", None)
+        source_observed = dict(observed)
+        source_observed["review_fact_handoff"] = {
+            "available": False,
+            "status": "not-selected",
+            "trusted": False,
+            "strategy": "FULL_REACQUISITION",
+        }
+        source_snapshot = _base_snapshot(
+            operation=operation,
+            subject={
+                "kind": "task-pr",
+                "task_number": args.task,
+                "pr_number": args.pr,
+            },
+            repository=repository,
+            observed=source_observed,
+            execution_context=execution_context,
+            gates=gates,
+            warnings=warnings,
+            limitations=limitations,
+            operations=runner.counters(),
+        )
+        if isinstance(handoff_path, str):
+            try:
+                path = resolve_handoff_path(repo_root, handoff_path)
+                handoff, handoff_digest = load_handoff(
+                    path, expected_repository=repository
+                )
+                pr_head_sha = pr.get("head_sha") if isinstance(pr, Mapping) else None
+                current_validation_facts, validation_errors = (
+                    acquire_current_validation_facts(
+                        repo_root,
+                        handoff["validation_facts"],
+                        expected_head_sha=pr_head_sha
+                        if isinstance(pr_head_sha, str)
+                        else None,
+                    )
+                )
+                handoff_status = validate_against_snapshot(
+                    handoff,
+                    source_snapshot,
+                    handoff_digest=handoff_digest,
+                    current_acceptance_criteria_ids=(
+                        issue.get("acceptance_criteria_ids")
+                        if isinstance(issue, dict)
+                        and isinstance(issue.get("acceptance_criteria_ids"), list)
+                        else None
+                    ),
+                    current_validation_facts=current_validation_facts,
+                    current_workflow_identity=workflow_identity,
+                    current_source_identity=source_identity_for_snapshot(
+                        source_snapshot
+                    ),
+                )
+                if validation_errors:
+                    handoff_status["invalidated"] = list(
+                        dict.fromkeys(
+                            handoff_status["invalidated"]
+                            + [
+                                f"VALIDATION_DRIFT: {item}"
+                                for item in validation_errors
+                            ]
+                        )
+                    )
+                    handoff_status["status"] = "fail"
+                    handoff_status["trusted"] = False
+                    handoff_status["strategy"] = "FAIL_CLOSED"
+                handoff_status["path"] = handoff_path
+                observed["review_fact_handoff"] = handoff_status
+                gates["review_fact_handoff"] = _gate(
+                    handoff_status["status"],
+                    "; ".join(handoff_status["invalidated"]),
+                )
+            except ReviewFactHandoffError as exc:
+                observed["review_fact_handoff"] = {
+                    "available": False,
+                    "status": "fail",
+                    "trusted": False,
+                    "strategy": "FAIL_CLOSED",
+                    "path": handoff_path,
+                    "invalidated": [str(exc)],
+                }
+                gates["review_fact_handoff"] = _gate("fail", str(exc))
+        else:
+            observed["review_fact_handoff"] = source_observed["review_fact_handoff"]
     return _base_snapshot(
         operation=operation,
         subject={"kind": "task-pr", "task_number": args.task, "pr_number": args.pr},

--- a/tools/agent_workflow/workflow_evidence.py
+++ b/tools/agent_workflow/workflow_evidence.py
@@ -2826,6 +2826,9 @@ def _task_pr_snapshot(
                     acquire_current_validation_facts(
                         repo_root,
                         handoff["validation_facts"],
+                        expected_base_sha=pr.get("base_sha")
+                        if isinstance(pr.get("base_sha"), str)
+                        else None,
                         expected_head_sha=pr_head_sha
                         if isinstance(pr_head_sha, str)
                         else None,

--- a/tools/agent_workflow/wsl2_github_evidence_runner.py
+++ b/tools/agent_workflow/wsl2_github_evidence_runner.py
@@ -151,7 +151,7 @@ CANONICAL_PROFILES: Final[dict[str, tuple[str, tuple[str, ...]]]] = {
     "recheck": ("recheck", ("snapshot_id",)),
 }
 RECHECK_COMMANDS: Final = {
-    "delivery-readiness": "pr-review-recheck",
+    "delivery-readiness": "delivery-readiness-recheck",
     "pr-review-snapshot": "pr-review-recheck",
     "closeout-plan": "closeout-final",
 }

--- a/tools/agent_workflow/wsl2_github_evidence_runner.py
+++ b/tools/agent_workflow/wsl2_github_evidence_runner.py
@@ -17,6 +17,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Final
 
+from review_fact_handoff import ReviewFactHandoffError, resolve_handoff_path
+
 SCHEMA_VERSION: Final = 1
 RUNNER_VERSION: Final = "1.3.0"
 REPOSITORY: Final = "PhoenixSss/tracequant"
@@ -26,6 +28,7 @@ SPEC_PATH: Final = "tools/agent_workflow/wsl2_github_evidence_profiles.json"
 RULES_PATH: Final = ".codex/rules/tracequant-wsl-evidence.rules"
 EVIDENCE_TOOL_PATH: Final = "tools/agent_workflow/workflow_evidence.py"
 COMMON_TOOL_PATH: Final = "tools/agent_workflow/workflow_common.py"
+HANDOFF_TOOL_PATH: Final = "tools/agent_workflow/review_fact_handoff.py"
 STDIO_LIMIT_BYTES: Final = 8192
 SHA_PATTERN: Final = re.compile(r"^[0-9a-f]{40}$")
 SNAPSHOT_ID_PATTERN: Final = re.compile(r"^ev-[0-9a-f]{16}$")
@@ -95,6 +98,7 @@ IDENTITY_PATHS: Final = (
     RULES_PATH,
     EVIDENCE_TOOL_PATH,
     COMMON_TOOL_PATH,
+    HANDOFF_TOOL_PATH,
 )
 ALLOWED_ENV: Final = (
     "PATH",
@@ -478,6 +482,13 @@ def _build_parser() -> argparse.ArgumentParser:
             default=None,
             help="repo-relative path to the calling Skill's SKILL.md",
         )
+        if name == "review":
+            subp.add_argument(
+                "--handoff-path",
+                type=str,
+                default=None,
+                help="repo-relative bounded Review Fact Handoff JSON path",
+            )
 
     closeout = sub.add_parser("closeout-readonly")
     closeout.add_argument("--task", type=_positive_int, required=True)
@@ -557,7 +568,7 @@ def _evidence_argv(args: argparse.Namespace, repo_root: Path) -> list[str]:
             raise RunnerError(
                 "snapshot operation does not support this recheck profile"
             )
-        return [
+        command = [
             *base,
             recheck_command,
             "--snapshot-id",
@@ -567,6 +578,9 @@ def _evidence_argv(args: argparse.Namespace, repo_root: Path) -> list[str]:
             "--repository",
             REPOSITORY,
         ]
+        if args.skill_path is not None:
+            command.extend(["--skill-path", args.skill_path])
+        return command
 
     result = [
         *base,
@@ -608,6 +622,10 @@ def _evidence_argv(args: argparse.Namespace, repo_root: Path) -> list[str]:
                 args.expected_head_sha,
             ]
         )
+        if args.skill_path is not None:
+            result.extend(["--skill-path", args.skill_path])
+        if profile == "review" and args.handoff_path is not None:
+            result.extend(["--handoff-path", args.handoff_path])
     elif profile == "closeout-readonly":
         result.extend(
             [
@@ -768,6 +786,8 @@ def _compact_result(
             "labels": issue.get("labels"),
             "project_status": issue.get("project_status"),
             "content_sha256": issue.get("content_sha256"),
+            "spec_sha256": issue.get("spec_sha256"),
+            "acceptance_criteria_ids": issue.get("acceptance_criteria_ids"),
             "closure": {
                 "status": issue_closure.get("status"),
                 "reason": issue_closure.get("reason"),
@@ -854,6 +874,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         repo_root = _find_repo_root(Path(__file__))
         _, content_hashes = _load_inputs(repo_root)
         _require_output_root_ignored(repo_root)
+        if args.profile == "review" and args.handoff_path is not None:
+            try:
+                resolve_handoff_path(repo_root, args.handoff_path)
+            except ReviewFactHandoffError as exc:
+                raise RunnerError(str(exc)) from exc
         # Validate --skill-path early (before any GitHub queries)
         _resolve_skill_identity(repo_root, args.profile, args.skill_path)
         command = _evidence_argv(args, repo_root)

--- a/tools/agent_workflow/wsl2_github_evidence_runner.py
+++ b/tools/agent_workflow/wsl2_github_evidence_runner.py
@@ -17,18 +17,29 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Final
 
-from review_fact_handoff import ReviewFactHandoffError, resolve_handoff_path
+from review_fact_handoff import (
+    WORKFLOW_CONTROL_PATHS,
+    ReviewFactHandoffError,
+    resolve_handoff_path,
+)
 
 SCHEMA_VERSION: Final = 1
 RUNNER_VERSION: Final = "1.3.0"
 REPOSITORY: Final = "PhoenixSss/tracequant"
 OUTPUT_ROOT: Final = ".agents/evidence.local/wsl2-github-runs"
-RUNNER_PATH: Final = "tools/agent_workflow/wsl2_github_evidence_runner.py"
-SPEC_PATH: Final = "tools/agent_workflow/wsl2_github_evidence_profiles.json"
-RULES_PATH: Final = ".codex/rules/tracequant-wsl-evidence.rules"
+RUNNER_PATH: Final = WORKFLOW_CONTROL_PATHS["evidence_runner"]
+SPEC_PATH: Final = WORKFLOW_CONTROL_PATHS["profile_spec"]
+RULES_PATH: Final = WORKFLOW_CONTROL_PATHS["evidence_rules"]
 EVIDENCE_TOOL_PATH: Final = "tools/agent_workflow/workflow_evidence.py"
-COMMON_TOOL_PATH: Final = "tools/agent_workflow/workflow_common.py"
+COMMON_TOOL_PATH: Final = WORKFLOW_CONTROL_PATHS["workflow_common"]
 HANDOFF_TOOL_PATH: Final = "tools/agent_workflow/review_fact_handoff.py"
+COMMAND_EXECUTION_POLICY_PATH: Final = WORKFLOW_CONTROL_PATHS[
+    "command_execution_policy"
+]
+WORKFLOW_EVIDENCE_POLICY_PATH: Final = WORKFLOW_CONTROL_PATHS[
+    "workflow_evidence_policy"
+]
+REVIEW_SEMANTICS_PATH: Final = WORKFLOW_CONTROL_PATHS["review_semantics"]
 STDIO_LIMIT_BYTES: Final = 8192
 SHA_PATTERN: Final = re.compile(r"^[0-9a-f]{40}$")
 SNAPSHOT_ID_PATTERN: Final = re.compile(r"^ev-[0-9a-f]{16}$")
@@ -99,6 +110,9 @@ IDENTITY_PATHS: Final = (
     EVIDENCE_TOOL_PATH,
     COMMON_TOOL_PATH,
     HANDOFF_TOOL_PATH,
+    COMMAND_EXECUTION_POLICY_PATH,
+    WORKFLOW_EVIDENCE_POLICY_PATH,
+    REVIEW_SEMANTICS_PATH,
 )
 ALLOWED_ENV: Final = (
     "PATH",

--- a/tools/agent_workflow/wsl2_validation_runner.py
+++ b/tools/agent_workflow/wsl2_validation_runner.py
@@ -690,6 +690,7 @@ def _run_profile(
         "schema_version": SCHEMA_VERSION,
         "runner_version": RUNNER_VERSION,
         "profile": profile_name,
+        "base_sha": base_sha,
         "profile_kind": profile.get("kind"),
         "status": status,
         "started_at": started_at.isoformat(),


### PR DESCRIPTION
Closes #153

## Summary

- Add a bounded Review Fact Handoff schema with strict recursive mechanical-field allowlists and prohibited-semantic-field rejection.
- Bind inherited validation facts to the current canonical validation result, including the existing validated base_sha, reviewed base SHA, clean reviewed head, result digest, canonical Runner/spec/rules/workflow-validation/Skill identities, and fail closed on stale or unverifiable facts.
- Preserve the fresh top-level Review root, full-reacquisition path, independent semantic Review, and existing Task/PR/spec/base/head/effective-diff/check revalidation.
- Separate stable source identity from snapshot operation metadata so the normal pr-review-snapshot to pr-review-recheck phase transition does not produce handoff identity drift, while canonical source/object/workflow/validation fact drift remains fail closed.

## Validation

- review_fact_handoff and WSL2 evidence runner targeted tests: 68 passed, 1 skipped
- workflow_evidence and workflow skill contract tests: 101 passed
- targeted:tools-tests: pass
- targeted:workflow-tests: pass
- workflow-delivery at base 4fcf4b869e92abf49b3effe7afb608ff94b87225: 470 passed, 1 skipped; lock, Ruff check/format, mypy, diff check, and all workflow Skill validators passed
- PR quality check: pass
- Regression: valid bounded handoff now passes pr-review-snapshot to pr-review-recheck with unchanged stable facts and no HANDOFF_SCHEMA_DRIFT

## Risks and limitations

The handoff remains an optional mechanical candidate input. Validation base and head, worktree cleanliness, workflow identity, source identity, current object facts, independent semantic Review, and final stability recheck remain fail-closed. No Review, merge, Issue close, or post-merge action was performed.