### PR TITLE
[Task] 定义初始公共领域模型与共享测试 Fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,21 @@ Pull requests targeting `main` and pushes to `main` automatically run CI. The wo
 
 Internal datetimes must be timezone-aware and use UTC as the standard timezone. Naive datetimes are explicitly rejected. Time utilities are provided by `tracequant.core.time`.
 
+## Initial domain models
+
+The Research MVP exposes three immutable, validated models from
+`tracequant.domain`: `InstrumentId`, `TimeRange`, and `OHLCVBar`. They provide
+strict JSON-compatible `to_dict` / `from_dict` representations and reuse the
+project UTC utilities. `TimeRange` and bars use half-open `[start, end)` UTC
+intervals. Bar prices are finite Python floats and may currently be zero or
+negative for research data; volume must be finite and non-negative.
+
+Shared test fixtures use function scope in `tests/conftest.py`. Deterministic,
+field-overridable factories live in `tests/fixtures/domain.py`; they use fixed
+UTC timestamps and never read the clock, random state, environment, network, or
+filesystem. Test-specific data should remain in its test module, and shared
+fixtures should be added only after at least two modules need them.
+
 ## Configuration
 
 Application configuration is loaded explicitly with `tracequant.config.load_settings`.

--- a/packages/domain/README.md
+++ b/packages/domain/README.md
@@ -3,3 +3,7 @@
 Core quantitative-trading domain models, invariants, and risk-independent business rules belong here as they are introduced.
 
 Domain code must not depend on exchange/network clients, UI code, or deployment implementations.
+
+The Research MVP's initial Python domain boundary is exposed as
+`tracequant.domain` from the current bootstrap package. Moving it into a
+separately built package requires a dedicated compatibility-preserving Task.

--- a/src/tracequant/domain/__init__.py
+++ b/src/tracequant/domain/__init__.py
@@ -1,0 +1,5 @@
+"""Initial public domain models for the Research MVP."""
+
+from tracequant.domain.models import InstrumentId, OHLCVBar, TimeRange
+
+__all__ = ["InstrumentId", "OHLCVBar", "TimeRange"]

--- a/src/tracequant/domain/models.py
+++ b/src/tracequant/domain/models.py
@@ -1,0 +1,198 @@
+"""Immutable, validated domain values shared by research modules."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from math import isfinite
+from typing import ClassVar, Self
+
+from tracequant.core.time import format_utc, is_utc, parse_utc, to_utc
+
+
+def _require_exact_fields(
+    value: Mapping[str, object], expected: frozenset[str], model_name: str
+) -> None:
+    actual = frozenset(value)
+    if actual != expected:
+        missing = sorted(expected - actual)
+        extra = sorted(actual - expected)
+        raise ValueError(
+            f"invalid {model_name} fields: missing={missing}, extra={extra}"
+        )
+
+
+def _require_string(value: object, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{field_name} must be a string")
+    return value
+
+
+def _require_datetime(value: object, field_name: str) -> datetime:
+    if not isinstance(value, datetime):
+        raise TypeError(f"{field_name} must be a datetime")
+    return value
+
+
+def _require_float(value: object, field_name: str) -> float:
+    if type(value) is not float:
+        raise TypeError(f"{field_name} must be a float")
+    if not isfinite(value):
+        raise ValueError(f"{field_name} must be finite")
+    return value
+
+
+@dataclass(frozen=True, slots=True, order=True)
+class InstrumentId:
+    """A normalized instrument identifier without exchange metadata."""
+
+    value: str
+
+    MAX_LENGTH: ClassVar[int] = 32
+
+    def __post_init__(self) -> None:
+        value = _require_string(self.value, "instrument").strip().upper()
+        if not value:
+            raise ValueError("instrument must not be empty")
+        if len(value) > self.MAX_LENGTH:
+            raise ValueError(f"instrument must not exceed {self.MAX_LENGTH} characters")
+        if not value.isascii() or not value.isalnum():
+            raise ValueError(
+                "instrument must contain only ASCII uppercase letters and digits"
+            )
+        object.__setattr__(self, "value", value)
+
+    def __str__(self) -> str:
+        return self.value
+
+    def to_dict(self) -> str:
+        """Return the JSON-compatible string representation."""
+        return self.value
+
+    @classmethod
+    def from_dict(cls, value: object) -> Self:
+        """Build an identifier from its JSON-compatible representation."""
+        return cls(_require_string(value, "instrument"))
+
+
+@dataclass(frozen=True, slots=True, order=True)
+class TimeRange:
+    """A non-empty, half-open UTC interval: ``[start, end)``."""
+
+    start: datetime
+    end: datetime
+
+    _SERIALIZED_FIELDS: ClassVar[frozenset[str]] = frozenset({"start", "end"})
+
+    def __post_init__(self) -> None:
+        start = _require_datetime(self.start, "start")
+        end = _require_datetime(self.end, "end")
+        if not is_utc(start) or not is_utc(end):
+            raise ValueError("start and end must be timezone-aware UTC datetimes")
+        start = to_utc(start)
+        end = to_utc(end)
+        if start >= end:
+            raise ValueError("start must be earlier than end")
+        object.__setattr__(self, "start", start)
+        object.__setattr__(self, "end", end)
+
+    @property
+    def duration(self) -> timedelta:
+        """Return the interval duration."""
+        return self.end - self.start
+
+    def contains(self, value: datetime) -> bool:
+        """Return whether an aware UTC datetime is in ``[start, end)``."""
+        value = _require_datetime(value, "value")
+        if not is_utc(value):
+            raise ValueError("value must be a timezone-aware UTC datetime")
+        return self.start <= to_utc(value) < self.end
+
+    def to_dict(self) -> dict[str, str]:
+        """Return a stable JSON-compatible representation."""
+        return {"start": format_utc(self.start), "end": format_utc(self.end)}
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, object]) -> Self:
+        """Build a range from a strict JSON-compatible representation."""
+        _require_exact_fields(value, cls._SERIALIZED_FIELDS, "TimeRange")
+        start = parse_utc(_require_string(value["start"], "start"))
+        end = parse_utc(_require_string(value["end"], "end"))
+        return cls(start=start, end=end)
+
+
+@dataclass(frozen=True, slots=True, order=True)
+class OHLCVBar:
+    """An immutable OHLCV bar for one instrument and UTC time range.
+
+    Prices are floats and may be zero or negative for research datasets. Volume
+    must be non-negative. All numeric values must be finite.
+    """
+
+    instrument: InstrumentId
+    start: datetime
+    end: datetime
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float
+
+    _SERIALIZED_FIELDS: ClassVar[frozenset[str]] = frozenset(
+        {"instrument", "start", "end", "open", "high", "low", "close", "volume"}
+    )
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.instrument, InstrumentId):
+            raise TypeError("instrument must be an InstrumentId")
+
+        interval = TimeRange(start=self.start, end=self.end)
+        object.__setattr__(self, "start", interval.start)
+        object.__setattr__(self, "end", interval.end)
+
+        numeric_values = {
+            "open": _require_float(self.open, "open"),
+            "high": _require_float(self.high, "high"),
+            "low": _require_float(self.low, "low"),
+            "close": _require_float(self.close, "close"),
+            "volume": _require_float(self.volume, "volume"),
+        }
+        if numeric_values["volume"] < 0.0:
+            raise ValueError("volume must be non-negative")
+        if numeric_values["high"] < max(
+            numeric_values["open"], numeric_values["low"], numeric_values["close"]
+        ):
+            raise ValueError("high must be at least open, low, and close")
+        if numeric_values["low"] > min(
+            numeric_values["open"], numeric_values["high"], numeric_values["close"]
+        ):
+            raise ValueError("low must be at most open, high, and close")
+
+    def to_dict(self) -> dict[str, str | float]:
+        """Return a stable JSON-compatible representation."""
+        return {
+            "instrument": self.instrument.to_dict(),
+            "start": format_utc(self.start),
+            "end": format_utc(self.end),
+            "open": self.open,
+            "high": self.high,
+            "low": self.low,
+            "close": self.close,
+            "volume": self.volume,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, object]) -> Self:
+        """Build a bar from a strict JSON-compatible representation."""
+        _require_exact_fields(value, cls._SERIALIZED_FIELDS, "OHLCVBar")
+        return cls(
+            instrument=InstrumentId.from_dict(value["instrument"]),
+            start=parse_utc(_require_string(value["start"], "start")),
+            end=parse_utc(_require_string(value["end"], "end")),
+            open=_require_float(value["open"], "open"),
+            high=_require_float(value["high"], "high"),
+            low=_require_float(value["low"], "low"),
+            close=_require_float(value["close"], "close"),
+            volume=_require_float(value["volume"], "volume"),
+        )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""TraceQuant test package."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+"""Shared pytest fixtures used by multiple test modules."""
+
+import pytest
+
+from tests.fixtures.domain import make_bar
+from tracequant.domain import OHLCVBar
+
+
+@pytest.fixture
+def sample_bar() -> OHLCVBar:
+    """Return a fresh deterministic bar for each requesting test."""
+    return make_bar()

--- a/tests/domain/test_models.py
+++ b/tests/domain/test_models.py
@@ -1,0 +1,159 @@
+from dataclasses import FrozenInstanceError
+from datetime import UTC, datetime, timedelta, timezone
+
+import pytest
+
+from tests.fixtures.domain import make_bar, make_time_range
+from tracequant.domain import InstrumentId, OHLCVBar, TimeRange
+
+
+@pytest.mark.parametrize(
+    ("raw", "normalized"),
+    [
+        (" btcusdt ", "BTCUSDT"),
+        ("ETHUSDC", "ETHUSDC"),
+        ("ABC123", "ABC123"),
+        ("A" * 32, "A" * 32),
+    ],
+)
+def test_instrument_normalizes_valid_values(raw: str, normalized: str) -> None:
+    instrument = InstrumentId(raw)
+
+    assert instrument.value == normalized
+    assert str(instrument) == normalized
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["", "   ", "BTC-USDT", "BTC/USDT", "BTC_USDT", "比特币", "A" * 33],
+)
+def test_instrument_rejects_invalid_values(value: str) -> None:
+    with pytest.raises(ValueError):
+        InstrumentId(value)
+
+
+def test_instrument_is_immutable_comparable_and_hashable() -> None:
+    instrument = InstrumentId("btcusdt")
+
+    assert instrument == InstrumentId("BTCUSDT")
+    assert {instrument, InstrumentId("BTCUSDT")} == {instrument}
+    with pytest.raises(FrozenInstanceError):
+        instrument.value = "ETHUSDT"  # type: ignore[misc]
+
+
+def test_time_range_is_half_open_and_reports_duration() -> None:
+    interval = make_time_range()
+
+    assert interval.duration == timedelta(minutes=15)
+    assert interval.contains(interval.start)
+    assert interval.contains(interval.end - timedelta(microseconds=1))
+    assert not interval.contains(interval.end)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        datetime(2026, 2, 28, 23, 50),
+        datetime(2026, 3, 1, 7, 50, tzinfo=timezone(timedelta(hours=8))),
+    ],
+)
+def test_time_range_contains_rejects_non_utc_values(value: datetime) -> None:
+    with pytest.raises(ValueError, match="timezone-aware UTC"):
+        make_time_range().contains(value)
+
+
+@pytest.mark.parametrize(
+    ("start", "end"),
+    [
+        (datetime(2026, 2, 28, 23, 45), datetime(2026, 3, 1, 0, 0, tzinfo=UTC)),
+        (
+            datetime(2026, 2, 28, 23, 45, tzinfo=timezone(timedelta(hours=8))),
+            datetime(2026, 3, 1, 0, 0, tzinfo=UTC),
+        ),
+        (
+            datetime(2026, 3, 1, 0, 0, tzinfo=UTC),
+            datetime(2026, 3, 1, 0, 0, tzinfo=UTC),
+        ),
+        (
+            datetime(2026, 3, 1, 0, 1, tzinfo=UTC),
+            datetime(2026, 3, 1, 0, 0, tzinfo=UTC),
+        ),
+    ],
+)
+def test_time_range_rejects_non_utc_and_invalid_intervals(
+    start: datetime, end: datetime
+) -> None:
+    with pytest.raises(ValueError):
+        TimeRange(start=start, end=end)
+
+
+def test_time_range_handles_leap_day_and_is_immutable() -> None:
+    interval = TimeRange(
+        start=datetime(2024, 2, 29, 23, 45, tzinfo=UTC),
+        end=datetime(2024, 3, 1, 0, 0, tzinfo=UTC),
+    )
+
+    assert interval.duration == timedelta(minutes=15)
+    with pytest.raises(FrozenInstanceError):
+        interval.start = interval.end  # type: ignore[misc]
+
+
+def test_shared_sample_bar_is_explicit_and_valid(sample_bar: OHLCVBar) -> None:
+    assert sample_bar.instrument == InstrumentId("BTCUSDT")
+    assert sample_bar.open == 100.0
+    assert sample_bar.high == 110.0
+    assert sample_bar.low == 90.0
+    assert sample_bar.close == 105.0
+    assert sample_bar.volume == 42.5
+
+
+@pytest.mark.parametrize("field", ["open", "high", "low", "close", "volume"])
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_bar_rejects_non_finite_numbers(field: str, value: float) -> None:
+    with pytest.raises(ValueError, match=f"^{field} must be finite$"):
+        make_bar(**{field: value})  # type: ignore[arg-type]
+
+
+def test_bar_rejects_negative_volume() -> None:
+    with pytest.raises(ValueError, match="^volume must be non-negative$"):
+        make_bar(volume=-0.1)
+
+
+@pytest.mark.parametrize("field", ["open", "high", "low", "close", "volume"])
+@pytest.mark.parametrize("value", [1, True])
+def test_bar_requires_python_float_values(field: str, value: object) -> None:
+    with pytest.raises(TypeError, match=f"^{field} must be a float$"):
+        make_bar(**{field: value})  # type: ignore[arg-type]
+
+
+def test_bar_requires_instrument_id() -> None:
+    with pytest.raises(TypeError, match="^instrument must be an InstrumentId$"):
+        make_bar(instrument="BTCUSDT")  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [{"high": 99.0}, {"low": 101.0}, {"high": 104.0, "close": 105.0}],
+)
+def test_bar_rejects_invalid_ohlc_relationships(overrides: dict[str, float]) -> None:
+    with pytest.raises(ValueError):
+        make_bar(**overrides)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("open", "high", "low", "close"),
+    [(0.0, 0.0, 0.0, 0.0), (-5.0, -1.0, -10.0, -3.0)],
+)
+def test_bar_allows_zero_and_negative_prices(
+    open: float, high: float, low: float, close: float
+) -> None:
+    bar = make_bar(open=open, high=high, low=low, close=close)
+
+    assert (bar.open, bar.high, bar.low, bar.close) == (open, high, low, close)
+
+
+def test_bar_is_immutable_comparable_and_hashable(sample_bar: OHLCVBar) -> None:
+    assert sample_bar == make_bar()
+    assert {sample_bar, make_bar()} == {sample_bar}
+    with pytest.raises(FrozenInstanceError):
+        sample_bar.close = 99.0  # type: ignore[misc]

--- a/tests/domain/test_serialization.py
+++ b/tests/domain/test_serialization.py
@@ -1,0 +1,110 @@
+import json
+
+import pytest
+
+from tests.fixtures.domain import invalid_bar_payload, make_bar
+from tracequant.domain import InstrumentId, OHLCVBar, TimeRange
+
+
+def test_public_domain_import_path_exposes_only_initial_models() -> None:
+    from tracequant import domain
+
+    assert domain.__all__ == ["InstrumentId", "OHLCVBar", "TimeRange"]
+
+
+def test_instrument_string_serialization_round_trip() -> None:
+    instrument = InstrumentId(" btcusdt ")
+
+    assert instrument.to_dict() == "BTCUSDT"
+    assert InstrumentId.from_dict(instrument.to_dict()) == instrument
+
+
+def test_instrument_rejects_non_string_serialized_data() -> None:
+    with pytest.raises(TypeError, match="^instrument must be a string$"):
+        InstrumentId.from_dict(123)
+
+
+def test_time_range_serialization_is_stable_and_round_trips() -> None:
+    interval = TimeRange.from_dict(
+        {
+            "start": "2026-03-01T07:45:00+08:00",
+            "end": "2026-03-01T08:00:00+08:00",
+        }
+    )
+
+    assert interval.to_dict() == {
+        "start": "2026-02-28T23:45:00Z",
+        "end": "2026-03-01T00:00:00Z",
+    }
+    assert TimeRange.from_dict(interval.to_dict()) == interval
+
+
+def test_shared_sample_bar_is_json_compatible_and_round_trips(
+    sample_bar: OHLCVBar,
+) -> None:
+    payload = sample_bar.to_dict()
+
+    encoded = json.dumps(payload, allow_nan=False, sort_keys=True)
+
+    assert json.loads(encoded) == payload
+    assert OHLCVBar.from_dict(json.loads(encoded)) == sample_bar
+    assert list(payload) == [
+        "instrument",
+        "start",
+        "end",
+        "open",
+        "high",
+        "low",
+        "close",
+        "volume",
+    ]
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"start": "2026-01-01T00:00:00Z"},
+        {
+            "start": "2026-01-01T00:00:00Z",
+            "end": "2026-01-01T00:01:00Z",
+            "extra": "value",
+        },
+        {"start": "2026-01-01T00:00:00", "end": "2026-01-01T00:01:00Z"},
+        {"start": 1, "end": "2026-01-01T00:01:00Z"},
+    ],
+)
+def test_time_range_rejects_invalid_serialized_data(
+    payload: dict[str, object],
+) -> None:
+    with pytest.raises((TypeError, ValueError)):
+        TimeRange.from_dict(payload)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        invalid_bar_payload(volume=-1.0),
+        invalid_bar_payload(high=float("nan")),
+        invalid_bar_payload(start="2026-02-28T23:45:00"),
+        invalid_bar_payload(open=100),
+        {key: value for key, value in invalid_bar_payload().items() if key != "close"},
+        {**invalid_bar_payload(), "extra": "value"},
+    ],
+)
+def test_bar_rejects_invalid_serialized_data(payload: dict[str, object]) -> None:
+    with pytest.raises((TypeError, ValueError)):
+        OHLCVBar.from_dict(payload)
+
+
+def test_factory_calls_and_serialized_payloads_are_isolated() -> None:
+    first = make_bar()
+    second = make_bar()
+    first_payload = first.to_dict()
+    second_payload = second.to_dict()
+
+    first_payload["instrument"] = "ETHUSDT"
+
+    assert first is not second
+    assert first.instrument is not second.instrument
+    assert second_payload["instrument"] == "BTCUSDT"
+    assert second.instrument == InstrumentId("BTCUSDT")

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,0 +1,1 @@
+"""Shared deterministic test-data factories."""

--- a/tests/fixtures/domain.py
+++ b/tests/fixtures/domain.py
@@ -1,0 +1,60 @@
+"""Factories for explicit, deterministic domain test data."""
+
+from datetime import UTC, datetime
+
+from tracequant.domain import InstrumentId, OHLCVBar, TimeRange
+
+DEFAULT_START = datetime(2026, 2, 28, 23, 45, tzinfo=UTC)
+DEFAULT_END = datetime(2026, 3, 1, 0, 0, tzinfo=UTC)
+
+
+def make_instrument(value: str = "BTCUSDT") -> InstrumentId:
+    """Build an instrument with an explicitly overridable identifier."""
+    return InstrumentId(value)
+
+
+def make_time_range(
+    *, start: datetime = DEFAULT_START, end: datetime = DEFAULT_END
+) -> TimeRange:
+    """Build a fixed UTC time range with explicitly overridable fields."""
+    return TimeRange(start=start, end=end)
+
+
+def make_bar(
+    *,
+    instrument: InstrumentId | None = None,
+    start: datetime = DEFAULT_START,
+    end: datetime = DEFAULT_END,
+    open: float = 100.0,
+    high: float = 110.0,
+    low: float = 90.0,
+    close: float = 105.0,
+    volume: float = 42.5,
+) -> OHLCVBar:
+    """Build a fixed OHLCV bar while allowing every field to be overridden."""
+    return OHLCVBar(
+        instrument=instrument if instrument is not None else make_instrument(),
+        start=start,
+        end=end,
+        open=open,
+        high=high,
+        low=low,
+        close=close,
+        volume=volume,
+    )
+
+
+def invalid_bar_payload(**overrides: object) -> dict[str, object]:
+    """Build an explicit invalid-input payload for deserialization tests."""
+    payload: dict[str, object] = {
+        "instrument": "BTCUSDT",
+        "start": "2026-02-28T23:45:00Z",
+        "end": "2026-03-01T00:00:00Z",
+        "open": 100.0,
+        "high": 110.0,
+        "low": 90.0,
+        "close": 105.0,
+        "volume": 42.5,
+    }
+    payload.update(overrides)
+    return payload


### PR DESCRIPTION
Closes #65

## Summary

- add immutable `InstrumentId`, `TimeRange`, and `OHLCVBar` public models under `tracequant.domain`
- enforce normalized instrument IDs, aware UTC intervals, finite Python float values, non-negative volume, and OHLC relationships
- add deterministic JSON-compatible serialization, reusable function-scoped fixtures/factories, boundary tests, and usage documentation

## Validation

- `tools/agent_workflow/wsl2_validation_runner.py workflow-delivery --base-sha 3975e2edf28dd55560b402e9b6f755e74ad2697d` — passed
- domain-focused pytest — 70 passed
- changed-path Ruff lint and format checks — passed
- changed-path strict mypy — passed
- `git diff --cached --check` — passed before commit

## Risks and limitations

- these are initial internal public Research MVP models, not an externally versioned wire protocol
- zero and negative prices remain valid at this research-data boundary by design
- exchange metadata, precision rules, timeframes, orders, storage, and future domain objects remain out of scope
