### PR TITLE
[Task] 建立 LCK Core 与 Live State Resolution

### DIFF
--- a/docs/workflows/LCK-v1-Design-Charter.md
+++ b/docs/workflows/LCK-v1-Design-Charter.md
@@ -1,0 +1,1293 @@
+# LCK v1 Design Charter
+
+> **Status:** Draft Design Baseline
+> **Architecture name:** Local Control Kernel Workflow v1
+> **Short name:** LCK v1
+> **Purpose:** Define the target control architecture, lifecycle responsibilities, design constraints, and migration guardrails for the next-generation local Codex / Claude Agentic SDLC workflow.
+
+---
+
+## 1. Charter Purpose
+
+This document freezes the design baseline for **LCK v1 (Local Control Kernel Workflow v1)**.
+
+LCK v1 is not a new agent platform and not a parallel workflow runtime. It is the target evolution of the repository's existing Runner-based workflow architecture.
+
+Its purpose is to move deterministic lifecycle control out of Skills and semantic agents, while preserving the current interactive Codex / Claude workflow.
+
+The target architecture is:
+
+> **Human keeps intent and merge authority.
+> Codex / Claude keep semantic work.
+> Skills become semantic procedures and entry instructions.
+> LCK owns deterministic lifecycle control.
+> Git and GitHub remain the authoritative current-state systems.**
+
+LCK v1 MUST evolve from the current Runner infrastructure. It MUST NOT introduce a second long-lived workflow platform beside the existing system.
+
+---
+
+## 2. Core Architectural Decision
+
+The primary architectural change is:
+
+> **Lifecycle control moves out of Skill interpretation and into a deterministic local control layer.**
+
+The current workflow already contains strong deterministic infrastructure through Evidence Runner, Validation Runner, Git/GitHub helpers, and related workflow utilities.
+
+LCK v1 treats these components as the technical foundation of the future control plane.
+
+The intended evolution is conceptually:
+
+```text
+Current
+
+Human
+  ↓
+Codex / Claude
+  ↓
+Skill                       ← lifecycle controller
+  ├─ calls Runner
+  ├─ interprets Runner facts
+  ├─ decides phase actions
+  ├─ performs Git/GitHub writes
+  └─ advances lifecycle
+       ↓
+Runner                      ← deterministic assistant
+```
+
+Target:
+
+```text
+Human
+  ↓
+Codex / Claude
+  ↓
+Skill                       ← semantic procedure / entry instructions
+  ↓
+LCK                         ← lifecycle controller
+  ├─ resolves live facts
+  ├─ evaluates deterministic gates
+  ├─ runs formal validation
+  ├─ executes bounded Git/GitHub effects
+  ├─ resolves lifecycle state
+  └─ returns deterministic results
+       ↓
+Git / GitHub                ← authoritative current state
+```
+
+The implementation MUST prefer restructuring and reusing current Runner code over creating a new parallel framework.
+
+---
+
+## 3. LCK v1 Goals
+
+LCK v1 MUST achieve the following goals.
+
+### 3.1 Preserve interactive Codex / Claude usage
+
+Codex and Claude windows remain the primary human interaction surface.
+
+A normal Task may still begin with a simple instruction such as:
+
+```text
+请严格遵循 LCK v1 实现 Issue #123
+```
+
+The user MUST NOT be forced to replace interactive work with a black-box background workflow.
+
+### 3.2 Separate semantic work from deterministic mechanics
+
+Codex / Claude remain responsible for semantic work:
+
+```text
+Understand
+Design
+Implement
+Diagnose
+Review
+Explain
+```
+
+LCK becomes responsible for deterministic mechanics:
+
+```text
+repository identity
+branch identity
+workspace preparation
+HEAD / SHA resolution
+remote identity
+PR identity
+checks state
+phase eligibility
+formal validation
+commit execution
+push execution
+PR creation/reuse/update
+merge preflight
+closeout mechanics
+recovery classification
+cleanup
+```
+
+### 3.3 Remove lifecycle authority from Skills
+
+Skills remain useful, but their responsibility changes.
+
+A Skill MAY:
+
+- explain the semantic role of the current phase;
+- tell the Agent which LCK entrypoint to invoke;
+- define semantic expectations;
+- define output structure;
+- define what semantic work is allowed or prohibited.
+
+A Skill MUST NOT:
+
+- implement a Git/GitHub state machine;
+- determine actionable branch / SHA / PR identity;
+- decide whether direct Git/GitHub writes are permitted;
+- perform lifecycle state transitions through interpreted procedural logic;
+- act as the primary recovery engine.
+
+### 3.4 Make workflow correctness independent of conversation continuity
+
+Workflow correctness MUST NOT depend on:
+
+- the Agent remembering an earlier SHA;
+- a Codex session remaining open;
+- a Claude session remaining open;
+- an earlier conversation retaining phase facts;
+- the same model continuing the Task;
+- a handoff snapshot remaining fresh.
+
+A new invocation MUST be able to reconstruct the current workflow state from authoritative current facts.
+
+### 3.5 Reduce control-plane complexity
+
+LCK v1 is successful only if it improves correctness while reducing or containing control complexity.
+
+The final architecture MUST NOT become:
+
+```text
+Current Workflow
++ LCK
++ compatibility runtime
++ snapshot lineage
++ another state engine
+```
+
+The target is a net simplification.
+
+---
+
+## 4. Non-Goals
+
+LCK v1 MUST NOT become a general agent platform.
+
+The following are explicit non-goals unless future evidence justifies them through a separate architecture decision:
+
+- long-running workflow daemon;
+- background workflow server;
+- workflow database;
+- event-sourced lifecycle store;
+- durable provenance lineage system;
+- cross-phase authoritative snapshot cache;
+- a second bounded verified fact handoff system;
+- generic drift framework;
+- generic dynamic permission engine;
+- generic workflow DSL;
+- DAG compiler;
+- import graph;
+- workflow lockfile system;
+- local clone of GitHub Agentic Workflows Safe Outputs MCP Gateway;
+- plugin architecture for workflow control;
+- arbitrary shell execution API;
+- automatic Review → Remediation loop;
+- automatic merge;
+- background retry loop;
+- durable fact cache introduced only for token or latency optimization;
+- distributed control infrastructure built for hypothetical future needs.
+
+The default answer to such mechanisms in LCK v1 is **NO**.
+
+---
+
+## 5. Full Lifecycle Model
+
+LCK v1 uses the following full Task lifecycle:
+
+```text
+Task Contract
+      │
+      ▼
+Prepare
+      │
+      ▼
+Delivery
+      │
+      ▼
+HUMAN STOP
+      │
+      ▼
+Independent Review
+   │          │
+ FAIL        PASS
+   │          │
+   ▼          ▼
+HUMAN STOP   Merge Preflight
+   │          │
+explicit     ▼
+remediation HUMAN SQUASH MERGE
+   │          │
+   ▼          ▼
+Remediation Closeout
+   │
+   └────────────→ Independent Review again
+```
+
+Recovery is not a normal linear phase. It is a cross-cutting state resolution capability available at any invocation boundary.
+
+---
+
+## 6. Full-Lifecycle Responsibility Model
+
+The following responsibility model is the design baseline for LCK v1.
+
+| Lifecycle area | Human | Codex / Claude | Skill | LCK / Runner | Git / GitHub |
+|---|---|---|---|---|---|
+| **Task Contract** | Defines / approves business intent and resolves real ambiguity | May analyze Task, identify conflicts, propose clarification | Provides Task semantic rules | Validates contract requirements required by workflow | Stores Issue body and lifecycle metadata |
+| **Prepare** | Starts the Task | Reads Task and semantic context | Instructs Agent how to enter Delivery | **Resolves live facts, checks eligibility, prepares or resumes correct workspace** | Authoritative repository / Issue / PR state |
+| **Delivery** | Provides semantic steering when needed | **Understand / Design / Implement / Diagnose** | Provides Delivery semantic procedure | **Formal validation, lifecycle gates, commit, remote synchronization, PR resolution/creation/update, delivery result** | Stores commit / branch / PR / checks |
+| **Independent Review** | Starts a separate Review invocation | **Fresh semantic reviewer; Inspect / Reason / Judge / Report** | Provides Review semantic procedure | **Resolves current review target, prepares clean read-only context, runs deterministic validation, checks verdict applicability** | Authoritative PR head/base/checks/review state |
+| **Review FAIL** | **Decides remediation / redesign / abandon** | MUST NOT automatically continue into repair | MUST NOT automatically transition workflow | **Returns STOP_REQUIRED** | Stores findings / review state |
+| **Remediation** | Explicitly starts repair | **Understands findings, modifies implementation, diagnoses failures** | Provides remediation semantic procedure | **Re-resolves live state, validates, commits, synchronizes remote, updates existing PR** | Stores new PR head and checks |
+| **Review PASS** | Decides whether to merge | No merge authority | No merge authority | Performs deterministic merge preflight only | Authoritative mergeability and checks |
+| **Merge** | **Performs manual Squash Merge** | No authority | No authority | MUST NOT auto-merge in v1 | Executes and records merge |
+| **Closeout** | Usually no action; resolves true ambiguity if needed | Normally no semantic work | May provide minimal explanatory procedure if retained | **Reacquires merged state, determines Business Delivery status, synchronizes main, converges metadata, performs cleanup** | Authoritative merged / Issue / branch state |
+| **Recovery / State Resolution** | Resolves only genuine ambiguity | Used only when semantic judgment is genuinely required | MUST NOT own recovery state machine | **Reconstructs current state from live Git/GitHub facts and selects the unique safe deterministic action or STOP** | Authoritative current state |
+
+---
+
+## 7. Agent Roles
+
+LCK v1 distinguishes two semantic Agent roles.
+
+### 7.1 Implementation Agent
+
+Used in:
+
+```text
+Prepare
+Delivery
+Remediation
+```
+
+Primary responsibilities:
+
+```text
+Understand
+Design
+Implement
+Diagnose
+Explain
+```
+
+The Implementation Agent MAY:
+
+- read repository files;
+- inspect Git history and diffs;
+- modify permitted workspace files;
+- run local semantic/debugging tests;
+- explain implementation decisions;
+- respond to Human steering;
+- consume Review findings during explicitly started remediation.
+
+The Implementation Agent MUST NOT directly own:
+
+- branch identity;
+- remote identity;
+- actionable SHA;
+- PR identity;
+- push target;
+- lifecycle authorization;
+- phase transition;
+- merge;
+- closeout;
+- recovery classification.
+
+### 7.2 Independent Review Agent
+
+Used only in Independent Review.
+
+Responsibilities:
+
+```text
+Inspect
+Reason
+Judge
+Report
+```
+
+The Review Agent MUST:
+
+- operate from a fresh review context;
+- review the target resolved by LCK;
+- remain read-only with respect to implementation;
+- independently judge the Task and current PR;
+- report PASS / FAIL and findings.
+
+The Review Agent MUST NOT:
+
+- modify implementation;
+- inherit Delivery's semantic verdict as truth;
+- supply actionable target SHA as authority;
+- start remediation automatically;
+- merge.
+
+Implementation Agent and Review Agent are separate workflow roles even when both use Codex or both use Claude.
+
+---
+
+## 8. Skill Role
+
+Skills remain part of LCK v1, but only as Agent-side semantic guidance.
+
+Conceptually:
+
+```text
+Skill
+=
+semantic procedure
++ role instructions
++ allowed semantic behavior
++ LCK entrypoint guidance
+```
+
+Not:
+
+```text
+Skill
+=
+lifecycle state machine
++ Git/GitHub authorization engine
++ branch/PR/SHA resolver
++ recovery engine
+```
+
+A future Delivery Skill may state, for example:
+
+```text
+You are performing Task Delivery.
+
+Your responsibilities:
+- understand the Task;
+- design the implementation;
+- modify the workspace;
+- diagnose failures;
+- provide semantic delivery metadata.
+
+Use LCK for lifecycle operations.
+
+Do not directly:
+- create or select task branches;
+- commit;
+- push;
+- resolve or create PRs;
+- change lifecycle state;
+- merge.
+```
+
+---
+
+## 9. Invocation Model
+
+LCK v1 MUST use an **on-demand invocation model**.
+
+It MUST NOT require a resident daemon.
+
+Each LCK operation follows:
+
+```text
+start process
+→ reacquire current facts
+→ validate preconditions
+→ perform one bounded operation or phase action
+→ verify postconditions
+→ return structured result
+→ exit
+```
+
+Typical interaction:
+
+```text
+Human
+  ↓
+Codex / Claude session
+  ↓
+LCK invocation
+  ↓
+deterministic operation
+  ↓
+LCK exits
+  ↓
+Codex / Claude continues semantic work
+```
+
+Example conceptual entrypoints:
+
+```text
+lck delivery prepare <issue>
+lck delivery complete <issue>
+lck review prepare <issue-or-pr>
+lck remediation prepare <issue>
+lck remediation complete <issue>
+lck merge preflight <issue-or-pr>
+lck closeout <issue>
+lck status <issue>
+```
+
+Exact CLI design is not frozen by this Charter.
+
+The architectural requirement is only:
+
+> **LCK is invoked on demand and derives its state from current authority.**
+
+---
+
+## 10. Fact Authority Model
+
+### 10.1 Authoritative durable state
+
+The authoritative durable sources are:
+
+- Git commits and refs;
+- GitHub Issue state;
+- GitHub PR state;
+- GitHub current PR head/base;
+- GitHub checks;
+- GitHub review state;
+- GitHub merge state;
+- Task contract;
+- repository-controlled workflow definitions.
+
+### 10.2 Diagnostic durable state
+
+LCK MAY persist diagnostic evidence such as:
+
+- run ID;
+- timestamps;
+- Kernel / Runner version;
+- workflow source/version/hash;
+- validation results;
+- effect receipts;
+- historical observed SHA;
+- historical PR identity;
+- Human action;
+- review result;
+- audit artifacts.
+
+Diagnostic state answers:
+
+> **What happened at that time?**
+
+It MUST NOT answer:
+
+> **What is currently authorized?**
+
+### 10.3 Ephemeral operation state
+
+Within one bounded operation, LCK MAY retain short-lived facts such as:
+
+```text
+observed local HEAD = X
+observed remote OID = Y
+observed PR head = Z
+```
+
+These are valid only as precondition guards for that operation.
+
+They MUST NOT become cross-phase authority.
+
+### 10.4 Forbidden state category
+
+LCK v1 MUST NOT create:
+
+> **durable derived authoritative state**
+
+Examples include:
+
+- durable "expected head SHA" used by later phases as authority;
+- authoritative cross-phase fact handoff;
+- durable freshness contract;
+- snapshot lineage required for recovery;
+- generic workflow drift state.
+
+---
+
+## 11. Core State Principles
+
+The following principles are mandatory.
+
+### P1 — Evolve, do not replace
+
+LCK MUST evolve from existing Runner infrastructure.
+
+It MUST NOT introduce a parallel long-term workflow runtime.
+
+### P2 — Interactive Agent stays
+
+Codex / Claude windows remain the primary human interaction surface.
+
+### P3 — Semantic / Mechanic separation
+
+Semantic work belongs to the Agent.
+
+Deterministic lifecycle mechanics belong to LCK.
+
+### P4 — Skill is not controller
+
+Skills may guide semantic work and invoke LCK, but MUST NOT own lifecycle control.
+
+### P5 — On-demand, no daemon
+
+LCK v1 uses process-scoped invocations and MUST NOT require a resident service.
+
+### P6 — Live facts are authority
+
+Current Git / GitHub state is authoritative for mechanical identity and lifecycle state.
+
+### P7 — Reacquire across phases
+
+Delivery, Review, Remediation, Merge preflight, and Closeout MUST reacquire mechanical facts rather than trust prior phase snapshots.
+
+### P8 — Guard within an operation
+
+Short-lived operation-local identity guards are allowed to prevent TOCTOU races.
+
+### P9 — Audit is not authority
+
+Historical evidence may be durable but MUST NOT authorize future actions.
+
+### P10 — Static authority, dynamic eligibility
+
+A phase has statically declared capabilities.
+
+Whether a capability can execute now depends on current live preconditions.
+
+### P11 — Bounded Safe Effects
+
+LCK side effects MUST be narrow, typed, deterministic, auditable, and explicitly verified.
+
+### P12 — Runtime owns actionable identity
+
+Agent-provided branch, remote, SHA, PR number, push refspec, or equivalent actionable identity MUST NOT be trusted as execution authority.
+
+### P13 — Critical Outcome is a first-class Task contract requirement
+
+The target workflow MUST support a Task-level Critical Outcome that proves the real supported caller reaches the intended capability and produces an observable result.
+
+Implementing Critical Outcome requires synchronized changes to both:
+
+- the Task / Issue body contract or template;
+- deterministic validation / gate execution.
+
+LCK design MUST NOT forget the Task-side contract change.
+
+### P14 — Fail closed on ambiguity
+
+If the deterministic resolver cannot identify a single safe action, the workflow MUST STOP.
+
+### P15 — Review FAIL means STOP
+
+Review FAIL MUST NOT automatically start remediation.
+
+A new remediation invocation requires explicit Human intent.
+
+### P16 — Human merge remains
+
+LCK v1 retains manual Squash Merge.
+
+### P17 — Business Delivery is separate from Cleanup
+
+Successful merge may complete business delivery even when cleanup is still pending.
+
+### P18 — Recovery from reality
+
+Recovery derives current state from Git/GitHub authority, not old workflow lineage.
+
+### P19 — Provider-neutral control
+
+Codex and Claude use the same LCK lifecycle contract.
+
+Provider differences remain in the semantic Agent layer.
+
+### P20 — Complexity must decrease
+
+The final LCK migration MUST reduce or contain control-plane complexity.
+
+---
+
+## 12. Capability Model
+
+LCK v1 uses:
+
+> **Static authority; dynamic eligibility.**
+
+A phase declares what kinds of effects it may perform.
+
+Example conceptual model:
+
+| Phase | Agent authority | LCK effect capability |
+|---|---|---|
+| Prepare | read / semantic inspection | prepare or restore Task workspace |
+| Delivery | workspace write | formal validation; commit; ensure remote; ensure open PR |
+| Independent Review | read-only | resolve review target; validation; publish review result |
+| Remediation | workspace write | validation; commit; ensure remote; update existing PR |
+| Merge | none | merge preflight only |
+| Closeout | none normally | main sync; metadata convergence; cleanup |
+| Recovery | none by default | deterministic state resolution and bounded recovery effects |
+
+LCK MUST NOT use a generalized global Boolean such as:
+
+```text
+write_actions_allowed = true
+```
+
+as the primary authorization model.
+
+Instead:
+
+```text
+phase capability
++
+current operation preconditions
+=
+operation eligibility
+```
+
+---
+
+## 13. Safe Effect Model
+
+Every LCK write operation MUST follow:
+
+```text
+resolve current facts
+        ↓
+validate preconditions
+        ↓
+perform ONE bounded side effect
+        ↓
+re-read authoritative facts
+        ↓
+verify postcondition
+        ↓
+return structured receipt
+```
+
+Every Safe Effect MUST have:
+
+- a clear purpose;
+- a narrow input contract;
+- no Agent-controlled actionable identity;
+- explicit preconditions;
+- explicit postconditions;
+- deterministic error states;
+- audit evidence;
+- bounded retries only where safe;
+- fail-closed behavior on ambiguity;
+- idempotent behavior where practical.
+
+Candidate effects may include:
+
+```text
+commit_current_tree
+ensure_remote_branch
+ensure_open_pr
+publish_review
+cleanup_task_refs
+```
+
+The exact final effect set is not frozen by this Charter.
+
+LCK v1 MUST NOT expose:
+
+```text
+run_arbitrary_shell
+push_arbitrary_refspec
+write_arbitrary_github_object
+```
+
+or equivalent generic escape hatches.
+
+---
+
+## 14. Validation and Critical Outcome
+
+### 14.1 Validation boundary
+
+LCK MUST provide a deterministic validation/gate boundary that can execute repository and Task acceptance requirements.
+
+### 14.2 Critical Outcome
+
+The target workflow MUST add a formal **Critical Outcome** to the Task contract.
+
+Conceptually:
+
+```text
+real supported caller
+        ↓
+new or changed capability
+        ↓
+observable expected result
+```
+
+Critical Outcome is intended to prove:
+
+> The Task's claimed user-facing or supported capability is actually connected end-to-end.
+
+It MUST NOT be silently replaced by:
+
+- private helper unit tests;
+- module existence;
+- local function return values;
+- mocked-away integration boundaries;
+- passing static checks.
+
+### 14.3 Task contract synchronization
+
+Critical Outcome implementation requires a corresponding change to Task Issue bodies/templates.
+
+The workflow implementation MUST include:
+
+1. Task contract format / authoring rules;
+2. deterministic reading of the contract;
+3. formal execution or verification;
+4. evidence output;
+5. Delivery veto when Critical Outcome fails.
+
+Critical Outcome MUST NOT be implemented only in Runner code while leaving Task bodies unable to express the required contract.
+
+### 14.4 Acceptance hierarchy
+
+Conceptually:
+
+```text
+Task Contract Valid
+        ↓
+Critical Outcome PASS
+        ↓
+Task-specific Acceptance Criteria
+        ↓
+Regression / integration / unit tests
+        ↓
+Static validation
+        ↓
+Delivery mechanics
+```
+
+Cheap checks MAY execute earlier for fail-fast efficiency.
+
+But in acceptance semantics:
+
+> **Critical Outcome FAIL = Delivery MUST NOT complete.**
+
+---
+
+## 15. Delivery Contract
+
+A successful Delivery follows the following ownership pattern.
+
+### Human
+
+Starts Delivery and provides semantic steering only when required.
+
+### LCK Prepare
+
+LCK:
+
+- identifies repository and Task;
+- reacquires main / branch / PR facts;
+- validates lifecycle eligibility;
+- prepares or restores the correct Task workspace;
+- returns a deterministic Delivery context.
+
+### Implementation Agent
+
+Codex / Claude:
+
+- understands the Task;
+- designs the change;
+- modifies permitted files;
+- adds or updates tests;
+- diagnoses failures;
+- responds to Human semantic steering;
+- returns semantic completion metadata.
+
+The Agent does not directly commit, push, create PRs, or advance lifecycle state.
+
+### LCK Delivery Completion
+
+LCK:
+
+1. reacquires current facts;
+2. executes Critical Outcome;
+3. runs formal validation;
+4. verifies allowed scope / validated tree;
+5. commits the validated tree;
+6. resolves current commit identity;
+7. ensures the remote Task branch;
+8. ensures the current OPEN PR;
+9. reacquires final Git/GitHub state;
+10. verifies Delivery postconditions;
+11. emits a Delivery receipt;
+12. returns `READY_FOR_REVIEW`;
+13. stops.
+
+Delivery MUST end at a Human boundary before Independent Review.
+
+---
+
+## 16. Independent Review Contract
+
+Independent Review MUST be a separate invocation.
+
+LCK:
+
+1. resolves the current OPEN PR from live GitHub state;
+2. resolves current PR head and base;
+3. prepares a clean read-only review context;
+4. runs deterministic applicable validation;
+5. invokes or enables a fresh semantic Review Agent.
+
+The Review Agent:
+
+- independently inspects the effective change;
+- evaluates Task requirements;
+- evaluates Critical Outcome evidence and current applicability;
+- returns PASS / FAIL with findings.
+
+Before accepting the verdict, LCK MUST re-query applicability facts.
+
+Examples:
+
+```text
+PR head changed during review
+→ REVIEW_STALE_HEAD
+
+relevant base changed during review
+→ REVIEW_STALE_BASE
+```
+
+These are invocation-local stale conditions, not a generalized cross-phase drift system.
+
+### PASS
+
+Returns readiness for Human merge.
+
+### FAIL
+
+Returns `STOP_REQUIRED`.
+
+No automatic remediation occurs.
+
+---
+
+## 17. Remediation Contract
+
+Remediation starts only through explicit Human intent after Review FAIL.
+
+LCK reacquires:
+
+- Task;
+- current OPEN PR;
+- current PR head/base;
+- current workspace state;
+- current Review findings.
+
+The Implementation Agent:
+
+- understands the findings;
+- changes the implementation;
+- diagnoses issues;
+- completes semantic repair.
+
+LCK then:
+
+- reacquires current facts;
+- executes Critical Outcome;
+- runs formal validation;
+- commits the validated repair;
+- ensures the remote branch;
+- updates or reuses the current OPEN PR;
+- verifies postconditions;
+- stops at the next Independent Review boundary.
+
+Remediation MUST NOT automatically trigger Review.
+
+---
+
+## 18. Merge Contract
+
+LCK v1 retains:
+
+> **Manual Squash Merge**
+
+LCK MAY provide deterministic merge preflight:
+
+- correct PR;
+- current head;
+- current base;
+- required checks;
+- review verdict;
+- unresolved blocking conditions;
+- mergeability.
+
+LCK MUST NOT execute the merge automatically in v1.
+
+The Human performs the Squash Merge.
+
+---
+
+## 19. Closeout Contract
+
+Closeout MUST distinguish:
+
+```text
+Business Delivery
+```
+
+from:
+
+```text
+Cleanup
+```
+
+### Business Delivery
+
+If authoritative GitHub facts prove the intended PR has been successfully merged and the Task delivery contract is satisfied:
+
+```text
+Business Delivery = COMPLETE
+```
+
+### Cleanup
+
+Cleanup may independently be:
+
+```text
+COMPLETE
+PENDING
+```
+
+Cleanup includes items such as:
+
+- local branch cleanup;
+- worktree cleanup;
+- remote branch cleanup if applicable;
+- main synchronization;
+- metadata convergence.
+
+A cleanup failure MUST NOT retroactively convert a successfully merged business delivery into business failure.
+
+Cleanup operations SHOULD be idempotent and retryable.
+
+---
+
+## 20. Recovery / State Resolution Model
+
+Recovery is a cross-cutting deterministic resolver, not a semantic lifecycle phase.
+
+Each invocation starts by asking:
+
+> **What is true now?**
+
+Not:
+
+> **How does current state differ from an old workflow snapshot?**
+
+Examples:
+
+| Current live state | LCK behavior |
+|---|---|
+| local Task branch exists, remote absent | validate workspace and run `ensure_remote_branch` if the current phase permits |
+| remote branch exists, OPEN PR absent | `ensure_open_pr` |
+| historical CLOSED PR exists | ignore it for active PR resolution |
+| exactly one matching OPEN PR exists | use it |
+| multiple active matching PRs | STOP |
+| remote branch diverged | STOP |
+| PR already merged | Business Delivery becomes COMPLETE |
+| merge removed remote branch | treat missing remote branch as normal post-merge state |
+| cleanup incomplete | Cleanup = PENDING |
+| PR head changed during Review | invalidate that Review invocation |
+| facts do not produce one safe deterministic action | STOP and surface live facts to Human |
+
+Recovery MUST NOT depend on:
+
+- restoring a previous Kernel process;
+- snapshot lineage;
+- provenance chains;
+- generalized drift graphs.
+
+---
+
+## 21. Retry Policy
+
+Retries MUST be classified.
+
+| Failure type | Default LCK behavior |
+|---|---|
+| transient HTTP/network failure on idempotent operation | bounded automatic retry allowed |
+| state precondition changed | reacquire facts and re-resolve; no blind retry |
+| deterministic validation failure | return failure to semantic implementation/remediation flow |
+| Critical Outcome failure | Delivery blocked until semantic repair |
+| Review FAIL | zero automatic remediation |
+| identity ambiguity | zero Agent retry; STOP |
+| remote divergence | STOP |
+| merge conflict requiring semantic resolution | STOP / explicit remediation |
+| cleanup failure | bounded idempotent retry; Business Delivery remains COMPLETE if already merged |
+
+---
+
+## 22. Observability and Audit
+
+LCK MUST retain enough evidence to explain what happened without turning evidence into workflow authority.
+
+Audit records MAY include:
+
+- Task;
+- invocation;
+- phase;
+- LCK / Runner version;
+- workflow version/hash;
+- semantic engine identity/version;
+- start and end timestamps;
+- observed facts;
+- validation results;
+- Critical Outcome results;
+- Safe Effect requests and receipts;
+- review verdict;
+- Human boundary actions;
+- failure classification.
+
+Rule:
+
+> **Audit log is historical evidence, not recovery authority.**
+
+---
+
+## 23. Complexity Budget
+
+Complexity control is an acceptance criterion for LCK itself.
+
+### Hard v1 constraints
+
+LCK v1 target:
+
+```text
+0 new workflow databases
+0 daemons
+0 generic workflow DSLs
+0 generic dynamic permission engines
+0 cross-phase authoritative caches
+0 snapshot lineage systems
+0 automatic Review→Remediation loops
+0 automatic merges
+```
+
+### Design rule
+
+For every proposed control mechanism, first ask:
+
+> **Can this be solved by reacquiring current authoritative facts?**
+
+If yes, prefer reacquisition over new durable state.
+
+### Change discipline
+
+A small workflow bug fix SHOULD default to:
+
+```text
+0 new durable control-state fields
+0 new provenance concepts
+```
+
+New write capability SHOULD normally be introduced as one explicit bounded Safe Effect at a time.
+
+The migration SHOULD aim for net deletion or simplification of:
+
+- snapshot authority;
+- expected-SHA plumbing;
+- handoff freshness logic;
+- generic drift categories;
+- Skill-owned Git/GitHub mechanics;
+- direct Agent lifecycle writes;
+- duplicate lifecycle state logic.
+
+---
+
+## 24. Provider Neutrality
+
+LCK lifecycle correctness MUST be independent of whether semantic work is performed by Codex or Claude.
+
+The same lifecycle architecture MUST support:
+
+```text
+Codex implementation
+→ Claude remediation
+→ fresh Codex review
+```
+
+or any equivalent combination.
+
+Provider-specific differences may exist in:
+
+- prompt/Skill formatting;
+- sandbox configuration;
+- semantic tool availability;
+- output-schema integration.
+
+They MUST NOT determine:
+
+- current branch;
+- actionable SHA;
+- current PR;
+- phase eligibility;
+- push destination;
+- merge state;
+- recovery state.
+
+---
+
+## 25. Migration Principles
+
+LCK v1 migration MUST proceed by responsibility transfer, not by duplicating the whole workflow.
+
+Preferred pattern:
+
+```text
+existing Runner capability
+→ extract / normalize deterministic responsibility
+→ move lifecycle authority into LCK boundary
+→ simplify Skill
+→ delete obsolete snapshot / handoff / control logic
+```
+
+Not:
+
+```text
+build complete LCK platform
+→ keep old workflow
+→ maintain compatibility forever
+```
+
+The migration plan MUST identify existing mechanisms as one of:
+
+```text
+KEEP
+MOVE
+SIMPLIFY
+REMOVE
+```
+
+Examples of intended direction:
+
+| Existing mechanism | Direction |
+|---|---|
+| repository-local semantic Skills | KEEP + SIMPLIFY |
+| Validation Runner | KEEP + STRENGTHEN |
+| Evidence / Fact Runner | KEEP + REORGANIZE into live fact resolution |
+| Git/GitHub write mechanics in Skills | MOVE to LCK Safe Effects |
+| cross-phase trusted snapshot authority | REMOVE |
+| bounded verified fact handoff as workflow authority | REMOVE |
+| generic freshness / drift framework | REMOVE or sharply narrow to invocation-local stale conditions |
+| dynamic global write authorization | REPLACE with static phase capability + operation precondition |
+| automatic review/repair loop | REMOVE |
+| manual Squash Merge | KEEP |
+| monolithic closeout success state | REPLACE with Business Delivery + Cleanup |
+
+---
+
+## 26. Architecture Acceptance Criteria
+
+Before LCK v1 implementation is considered architecturally complete, the design and implementation MUST demonstrate all of the following:
+
+1. The user can still start work through a simple Codex / Claude window instruction.
+2. Codex and Claude can use the same lifecycle contract.
+3. Agent sessions may change without invalidating workflow correctness.
+4. Skills no longer implement lifecycle mechanics as interpreted state machines.
+5. LCK can reconstruct current workflow state from live Git/GitHub authority.
+6. Cross-phase authoritative snapshots are not required.
+7. Branch / SHA / PR actionable identity is resolved by LCK.
+8. Agent cannot directly own commit / push / PR mutation / lifecycle transition.
+9. Delivery ends at a Human boundary before Independent Review.
+10. Independent Review uses a fresh review role and live-resolved target.
+11. Review FAIL always stops.
+12. Remediation requires explicit Human intent.
+13. Human Squash Merge remains mandatory in v1.
+14. Closeout distinguishes Business Delivery from Cleanup.
+15. Recovery does not require an old Kernel process or snapshot lineage.
+16. Historical CLOSED PRs do not incorrectly block current active PR resolution.
+17. Normal lifecycle evolution is not generalized into "drift".
+18. Critical Outcome is part of the target Task contract and is enforced as a Delivery gate.
+19. Task Issue/template changes required for Critical Outcome are implemented together with the corresponding deterministic validation support.
+20. LCK does not require a workflow database or daemon.
+21. Control-plane complexity is demonstrably reduced or contained versus the current baseline.
+22. Current Runner infrastructure is reused rather than duplicated by a parallel runtime.
+
+---
+
+## 27. Design Freeze Summary
+
+The following decisions are considered the current LCK v1 design baseline.
+
+### Frozen
+
+- Name: **Local Control Kernel Workflow v1 (LCK v1)**.
+- Full-lifecycle responsibility model is the authoritative responsibility model.
+- Codex / Claude remain the interactive semantic engines.
+- Skills remain but cease to be lifecycle controllers.
+- LCK evolves from existing Runner infrastructure.
+- LCK uses on-demand invocations, not a daemon.
+- Git/GitHub live state is authoritative for mechanical facts.
+- Mechanical facts are reacquired across phases.
+- Operation-local ephemeral guards are allowed.
+- Audit evidence is not workflow authority.
+- Phase authority is static; operation eligibility is dynamic.
+- LCK uses bounded Safe Effects.
+- Review FAIL stops.
+- Remediation requires explicit Human intent.
+- Manual Squash Merge remains.
+- Business Delivery and Cleanup are separate.
+- Recovery derives state from current reality.
+- Critical Outcome is part of the target workflow and requires synchronized Task-contract changes.
+- LCK success requires correctness improvement and control-complexity reduction.
+
+### Not yet frozen
+
+The following remain implementation design questions:
+
+- exact CLI command names;
+- exact module/file layout;
+- exact structured output schemas;
+- exact Safe Effect inventory;
+- exact Task Critical Outcome syntax;
+- exact Task template migration strategy;
+- exact Runner refactor sequence;
+- exact lifecycle metadata naming;
+- exact audit artifact format.
+
+These MUST be decided later without violating the frozen architectural principles above.
+
+---
+
+## 28. Guiding Principle
+
+The design can be summarized as:
+
+> **Keep intelligence in the Agent.
+> Keep authority in deterministic control.
+> Keep truth in Git and GitHub.
+> Keep the Human at irreversible boundaries.
+> Keep the control plane small.**

--- a/docs/workflows/lck-v1-migration-matrix.md
+++ b/docs/workflows/lck-v1-migration-matrix.md
@@ -1,0 +1,64 @@
+# LCK v1 Current → Target Migration Matrix
+
+This matrix is the Task #159 implementation boundary. It normalizes the
+operation inventory from the Task #88 architecture audit against the LCK v1
+Design Charter. `KEEP` means the responsibility remains in its current layer,
+`MOVE` means deterministic lifecycle authority moves into LCK, `SIMPLIFY` means
+the semantic boundary remains while duplicate mechanics are removed, and
+`REMOVE` means the mechanism is not part of the target flow.
+
+Task #159 implements only the live-state, phase-eligibility, and Delivery
+Prepare rows marked `implemented here`. Commit, push, PR mutation, merge,
+closeout, and full Skill cutover remain bounded follow-up work owned by their
+respective Tasks.
+
+| ID | #88 operation | Current owner | LCK v1 target | Task #159 boundary |
+|---|---|---|---|---|
+| O01 | Resolve intent and exact Task | Agent + Skill routing | KEEP | KEEP |
+| O02 | Delivery admission / readiness | Evidence Runner + Skill | MOVE | Live facts reused; full admission remains follow-up |
+| O03 | Ready → In Progress | Skill / project helper | MOVE | Not moved in this Task |
+| O04 | Read leaf spec and Retrieval v2 context | Agent | KEEP | KEEP |
+| O05 | Triggered context expansion | Agent + Human Gate | KEEP | KEEP |
+| O06 | Scoped design and implementation | Agent | KEEP | KEEP |
+| O07 | Targeted validation | Skill + Validation Runner | KEEP | KEEP |
+| O08 | Commit-ready identity | Skill / Git | MOVE | No commit effect here |
+| O09 | CI-equivalent validation | Validation Runner | KEEP | KEEP |
+| O10 | Push validated head | Skill / Agent | MOVE | Out of scope |
+| O11 | PR resolve/create | PR helper + Skill | MOVE | Out of scope |
+| O12 | Check wait/read and interpretation | Skill + Runner | SIMPLIFY | Live facts are returned; polling remains follow-up |
+| O13 | Semantic self-review | Agent + helper | SIMPLIFY | Semantic judgement stays Agent-owned |
+| O14 | Delivery readiness snapshot | Evidence Runner + Skill | MOVE | Snapshot is diagnostic, not LCK authority |
+| O15 | Reviewed object identity lock | Review Skill + Runner | MOVE | Live resolver foundation only |
+| O16 | Complete effective-diff inspection | Review Agent | KEEP | KEEP |
+| O17 | Review correctness / AC / risk judgement | Review Agent | KEEP | KEEP |
+| O18 | Review CI-equivalent validation | Review Skill + Runner | KEEP | KEEP |
+| O19 | Review recheck and stability | Runner + Review Skill | SIMPLIFY | Invocation-local recheck only |
+| O20 | Review verdict and handoff | Review Agent + Skill | KEEP | KEEP |
+| O21 | Remediation admission | Delivery Skill + Runner | MOVE | Phase resolver exposes eligibility only |
+| O22 | Repair and new head | Agent + Delivery Skill | MOVE | Out of scope |
+| O23 | Manual Squash Merge checkpoint | Maintainer | KEEP | KEEP |
+| O24 | Closeout read-only plan | Closeout Skill + Runner | MOVE | Closeout phase eligibility only |
+| O25 | Main sync and post-merge validation | Skill + Runner | MOVE | Out of scope |
+| O26 | Lifecycle metadata convergence | Closeout Skill / GitHub | MOVE | Out of scope |
+| O27 | Exact Task branch cleanup | Closeout Skill | MOVE | Out of scope |
+| O28 | Recovery after valid gate / drift | Skill + Agent | MOVE | Reacquire live facts; no lineage |
+| O29 | Feature child-set / completion mechanics | Feature Audit Skill + Agent | MOVE | Separate Feature audit boundary |
+| O30 | Repeated fact re-query / reformat | Agent / Skill ad hoc | REMOVE | No snapshot authority |
+| O31 | Homogeneous Agent command grouping | Agent orchestration | SIMPLIFY | Optional; never hides failure boundaries |
+| O32 | Context Compiler beyond Retrieval v2 | No current owner | REMOVE | Not justified by the Charter |
+
+## Implemented LCK Core boundary
+
+`tools/agent_workflow/lck.py` provides three deterministic layers:
+
+1. `LiveStateResolver` reacquires repository, Task, Project, relationship,
+   local branch/HEAD, remote branch/OID, current OPEN PR, checks, merged, and
+   cleanup-relevant facts.
+2. `PhaseEligibilityResolver` applies static phase capabilities to those live
+   facts and stops on ambiguity, missing authority, or unresolved blockers.
+3. `DeliveryPreparer` creates, selects, or restores the uniquely resolved Task
+   workspace and verifies the postcondition by reacquiring live facts.
+
+The core does not accept `expected_sha` or `snapshot_id`, does not persist
+cross-phase authority, ignores CLOSED PRs when resolving the active PR, and
+does not expose commit, push, PR-create, merge, or arbitrary shell effects.

--- a/tests/tools/test_lck.py
+++ b/tests/tools/test_lck.py
@@ -12,9 +12,9 @@ AGENT_WORKFLOW = str(Path(__file__).parents[2] / "tools" / "agent_workflow")
 if AGENT_WORKFLOW not in sys.path:
     sys.path.insert(0, AGENT_WORKFLOW)
 
-import lck  # noqa: E402
-from pr_resolve import PrResolveError  # noqa: E402
-from workflow_common import CommandResult  # noqa: E402
+import lck  # type: ignore[import-not-found]  # noqa: E402
+from pr_resolve import PrResolveError  # type: ignore[import-not-found]  # noqa: E402
+from workflow_common import CommandResult  # type: ignore[import-not-found]  # noqa: E402
 
 
 SHA = "a" * 40

--- a/tests/tools/test_lck.py
+++ b/tests/tools/test_lck.py
@@ -296,6 +296,66 @@ def test_ambiguous_open_pr_stops_phase_resolution(
     assert any("multiple OPEN PRs" in reason for reason in decision.reasons)
 
 
+def test_multiple_merged_prs_stop_before_workspace_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = FakeRunner(branch="main")
+    _install_facts(
+        monkeypatch,
+        fake,
+        history=[
+            {"number": 200, "state": "MERGED"},
+            {"number": 201, "state": "MERGED"},
+        ],
+    )
+
+    with pytest.raises(lck.LckStopError, match="multiple merged PRs"):
+        lck.DeliveryPreparer(_resolver(fake)).prepare(159)
+
+    assert fake.branch == "main"
+    assert not any(command[:2] == ("git", "switch") for command in fake.commands)
+
+
+def test_open_pr_without_task_branch_stops_before_workspace_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    branch = "task/159-lck-core-live-state-resolution"
+    fake = FakeRunner(branch="main")
+    _install_facts(monkeypatch, fake, open_pr=_open_pr(branch))
+
+    with pytest.raises(
+        lck.LckStopError,
+        match="current OPEN PR has no local or remote Task branch",
+    ):
+        lck.DeliveryPreparer(_resolver(fake)).prepare(159)
+
+    assert fake.branch == "main"
+    assert not any(command[:2] == ("git", "switch") for command in fake.commands)
+
+
+def test_open_pr_head_mismatch_stops_before_workspace_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    branch = "task/159-lck-core-live-state-resolution"
+    fake = FakeRunner(
+        branch="main",
+        local_branches={branch},
+        remote_branches={branch: SHA},
+    )
+    open_pr = _open_pr(branch)
+    open_pr["headRefOid"] = "b" * 40
+    _install_facts(monkeypatch, fake, open_pr=open_pr)
+
+    with pytest.raises(
+        lck.LckStopError,
+        match="current OPEN PR head OID differs",
+    ):
+        lck.DeliveryPreparer(_resolver(fake)).prepare(159)
+
+    assert fake.branch == "main"
+    assert not any(command[:2] == ("git", "switch") for command in fake.commands)
+
+
 @pytest.mark.parametrize(
     ("blocked_by", "expected_detail"),
     [

--- a/tests/tools/test_lck.py
+++ b/tests/tools/test_lck.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 from typing import Any, cast
@@ -28,11 +29,19 @@ class FakeRunner:
         local_branches: set[str] | None = None,
         remote_branches: dict[str, str] | None = None,
         clean: bool = True,
+        head_sha: str = SHA,
+        local_main_sha: str = SHA,
+        origin_main_sha: str = SHA,
+        open_pr: dict[str, Any] | None = None,
     ) -> None:
         self.branch = branch
         self.local_branches = local_branches or set()
         self.remote_branches = remote_branches or {}
         self.clean = clean
+        self.head_sha = head_sha
+        self.local_main_sha = local_main_sha
+        self.origin_main_sha = origin_main_sha
+        self.open_pr = open_pr
         self.commands: list[tuple[str, ...]] = []
 
     def run(
@@ -55,13 +64,23 @@ class FakeRunner:
                 for branch, oid in sorted(self.remote_branches.items())
             )
         elif args[:2] == ["rev-parse", "refs/heads/main"]:
-            stdout = SHA
+            stdout = self.local_main_sha
         elif args[:1] == ["rev-parse"] and len(args) == 2:
             branch = args[1].removeprefix("refs/heads/")
             if branch not in self.local_branches:
                 returncode = 1
             else:
                 stdout = SHA
+        elif args[:3] == ["gh", "pr", "list"]:
+            if self.open_pr is not None:
+                stdout = json.dumps([self.open_pr])
+            else:
+                stdout = "[]"
+        elif args[:3] == ["gh", "pr", "view"]:
+            if self.open_pr is None:
+                returncode = 1
+            else:
+                stdout = json.dumps(self.open_pr)
         elif args[:2] == ["switch", "-c"]:
             branch = args[2]
             self.local_branches.add(branch)
@@ -107,9 +126,9 @@ def _relationships() -> dict[str, Any]:
 def _git_snapshot(fake: FakeRunner) -> dict[str, Any]:
     return {
         "branch": fake.branch,
-        "head_sha": SHA,
-        "local_main_sha": SHA,
-        "origin_main_sha": SHA,
+        "head_sha": fake.head_sha,
+        "local_main_sha": fake.local_main_sha,
+        "origin_main_sha": fake.origin_main_sha,
         "origin_fetch": "pass",
         "clean": fake.clean,
         "status_entries": 0 if fake.clean else 1,
@@ -184,6 +203,47 @@ def test_closed_pr_does_not_block_current_open_pr(
     assert state.merged_pr_numbers == ()
 
 
+def test_live_state_resolver_reads_non_empty_pr_checks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    branch = "task/159-lck-core-live-state-resolution"
+    open_pr = {
+        "number": 200,
+        "state": "OPEN",
+        "isDraft": False,
+        "baseRefName": "main",
+        "baseRefOid": SHA,
+        "headRefName": branch,
+        "headRefOid": SHA,
+        "url": "https://github.com/owner/repo/pull/200",
+        "statusCheckRollup": [
+            {"name": "quality", "conclusion": "SUCCESS"},
+        ],
+    }
+    fake = FakeRunner(
+        branch=branch,
+        local_branches={branch},
+        remote_branches={branch: SHA},
+        open_pr=open_pr,
+    )
+    monkeypatch.setattr(lck, "_repository_slug", lambda *_args: "owner/repo")
+    monkeypatch.setattr(lck, "_issue_view", lambda *_args: _issue())
+    monkeypatch.setattr(lck, "_relationship_snapshot", lambda *_args: _relationships())
+    monkeypatch.setattr(lck, "_git_snapshot", lambda *_args: _git_snapshot(fake))
+
+    state = _resolver(fake).resolve(159)
+
+    assert state.status is lck.ResolutionStatus.RESOLVED
+    assert state.checks["count"] == 1
+    assert state.checks["success"] == 1
+    view_commands = [
+        command for command in fake.commands if command[:3] == ("gh", "pr", "view")
+    ]
+    assert len(view_commands) == 1
+    fields = view_commands[0][view_commands[0].index("--json") + 1].split(",")
+    assert "statusCheckRollup" in fields
+
+
 def test_ambiguous_open_pr_stops_phase_resolution(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -242,6 +302,23 @@ def test_delivery_prepare_creates_then_reuses_workspace(
         or (command[:3] == ("gh", "pr", "create"))
         for command in fake.commands
     )
+
+
+def test_delivery_prepare_stops_on_divergent_main_without_branch_creation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = FakeRunner(
+        branch="main",
+        local_main_sha=SHA,
+        origin_main_sha="b" * 40,
+    )
+    _install_facts(monkeypatch, fake)
+
+    with pytest.raises(lck.LckStopError, match="HEAD == local main == origin/main"):
+        lck.DeliveryPreparer(_resolver(fake)).prepare(159)
+
+    assert fake.branch == "main"
+    assert not any(command[:3] == ("git", "switch", "-c") for command in fake.commands)
 
 
 def test_delivery_prepare_restores_remote_workspace(

--- a/tests/tools/test_lck.py
+++ b/tests/tools/test_lck.py
@@ -14,7 +14,10 @@ if AGENT_WORKFLOW not in sys.path:
     sys.path.insert(0, AGENT_WORKFLOW)
 
 import lck  # type: ignore[import-not-found]  # noqa: E402
-from pr_resolve import PrResolveError  # type: ignore[import-not-found]  # noqa: E402
+from pr_resolve import (  # type: ignore[import-not-found]
+    PrResolveError,
+    resolve_open_pr,
+)  # noqa: E402
 from workflow_common import CommandResult  # type: ignore[import-not-found]  # noqa: E402
 
 
@@ -116,10 +119,17 @@ def _issue() -> dict[str, Any]:
     }
 
 
-def _relationships() -> dict[str, Any]:
+def _relationships(
+    *,
+    blocked_by: dict[str, Any] | None = None,
+    issue_type: str | None = "Task",
+) -> dict[str, Any]:
     return {
         "available": True,
-        "blocked_by": {"items": [], "count": 0, "truncated": False},
+        "issue_type": issue_type,
+        "blocked_by": blocked_by
+        if blocked_by is not None
+        else {"items": [], "count": 0, "truncated": False},
     }
 
 
@@ -141,12 +151,17 @@ def _install_facts(
     fake: FakeRunner,
     *,
     issue: dict[str, Any] | None = None,
+    relationships: dict[str, Any] | None = None,
     open_pr: dict[str, Any] | None = None,
     history: list[dict[str, Any]] | None = None,
 ) -> None:
     monkeypatch.setattr(lck, "_repository_slug", lambda *_args: "owner/repo")
     monkeypatch.setattr(lck, "_issue_view", lambda *_args: issue or _issue())
-    monkeypatch.setattr(lck, "_relationship_snapshot", lambda *_args: _relationships())
+    monkeypatch.setattr(
+        lck,
+        "_relationship_snapshot",
+        lambda *_args: relationships if relationships is not None else _relationships(),
+    )
     monkeypatch.setattr(lck, "_git_snapshot", lambda *_args: _git_snapshot(fake))
     monkeypatch.setattr(lck, "resolve_open_pr", lambda *_args: open_pr)
     monkeypatch.setattr(
@@ -156,6 +171,24 @@ def _install_facts(
 
 def _resolver(fake: FakeRunner) -> lck.LiveStateResolver:
     return lck.LiveStateResolver(Path.cwd(), runner=cast(Any, fake))
+
+
+def _open_pr(
+    branch: str,
+    *,
+    is_draft: bool = False,
+) -> dict[str, Any]:
+    return {
+        "number": 200,
+        "state": "OPEN",
+        "isDraft": is_draft,
+        "baseRefName": "main",
+        "baseRefOid": SHA,
+        "headRefName": branch,
+        "headRefOid": SHA,
+        "url": "https://github.com/owner/repo/pull/200",
+        "statusCheckRollup": [],
+    }
 
 
 def test_canonical_branch_is_derived_from_current_issue_title() -> None:
@@ -261,6 +294,235 @@ def test_ambiguous_open_pr_stops_phase_resolution(
     assert state.status is lck.ResolutionStatus.STOP
     assert not decision.eligible
     assert any("multiple OPEN PRs" in reason for reason in decision.reasons)
+
+
+@pytest.mark.parametrize(
+    ("blocked_by", "expected_detail"),
+    [
+        (
+            {"items": [], "count": 0, "truncated": True},
+            "truncated",
+        ),
+        (
+            {"items": []},
+            "malformed",
+        ),
+        (
+            {"items": [], "count": 1, "truncated": False},
+            "count mismatch",
+        ),
+        (
+            {
+                "items": [{"number": 300, "state": "UNKNOWN"}],
+                "count": 1,
+                "truncated": False,
+            },
+            "unknown_state",
+        ),
+        (
+            {
+                "items": [{"number": 301, "state": "OPEN"}],
+                "count": 1,
+                "truncated": False,
+            },
+            "unresolved",
+        ),
+    ],
+)
+def test_formal_blocker_gate_stops_before_workspace_write(
+    monkeypatch: pytest.MonkeyPatch,
+    blocked_by: dict[str, Any],
+    expected_detail: str,
+) -> None:
+    fake = FakeRunner(branch="main")
+    _install_facts(
+        monkeypatch,
+        fake,
+        relationships=_relationships(blocked_by=blocked_by),
+    )
+
+    with pytest.raises(lck.LckStopError, match="formal blocker gate") as error:
+        lck.DeliveryPreparer(_resolver(fake)).prepare(159)
+
+    assert expected_detail in str(error.value)
+    assert fake.branch == "main"
+    assert not any(command[:2] == ("git", "switch") for command in fake.commands)
+
+
+@pytest.mark.parametrize(
+    ("phase", "project_status", "open_pr"),
+    [
+        (lck.Phase.DELIVERY_PREPARE, "Ready", None),
+        (lck.Phase.REVIEW_PREPARE, "Review", "review"),
+        (lck.Phase.REMEDIATION_PREPARE, "Review", "remediation"),
+    ],
+)
+def test_all_non_closeout_phases_require_task_type(
+    monkeypatch: pytest.MonkeyPatch,
+    phase: lck.Phase,
+    project_status: str,
+    open_pr: str | None,
+) -> None:
+    branch = "task/159-lck-core-live-state-resolution"
+    fake = FakeRunner(
+        branch=branch, local_branches={branch}, remote_branches={branch: SHA}
+    )
+    issue = _issue()
+    issue["project_status"] = project_status
+    issue["labels"] = {"items": ["type:feature", "codex:ready"]}
+    phase_pr = _open_pr(branch) if open_pr is not None else None
+    _install_facts(
+        monkeypatch,
+        fake,
+        issue=issue,
+        relationships=_relationships(issue_type="Feature"),
+        open_pr=phase_pr,
+    )
+
+    state = _resolver(fake).resolve(159)
+    decision = lck.PhaseEligibilityResolver().resolve(state, phase)
+
+    assert not decision.eligible
+    assert any("type:task" in reason for reason in decision.reasons)
+
+
+def test_non_task_delivery_prepare_stops_before_workspace_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = FakeRunner(branch="main")
+    issue = _issue()
+    issue["labels"] = {"items": ["type:feature", "codex:ready"]}
+    _install_facts(
+        monkeypatch,
+        fake,
+        issue=issue,
+        relationships=_relationships(issue_type="Feature"),
+    )
+
+    with pytest.raises(lck.LckStopError, match="type:task"):
+        lck.DeliveryPreparer(_resolver(fake)).prepare(159)
+
+    assert fake.branch == "main"
+    assert not any(command[:2] == ("git", "switch") for command in fake.commands)
+
+
+@pytest.mark.parametrize(
+    ("phase", "project_status", "open_pr"),
+    [
+        (lck.Phase.DELIVERY_PREPARE, "Ready", None),
+        (lck.Phase.REVIEW_PREPARE, "Review", "review"),
+        (lck.Phase.REMEDIATION_PREPARE, "Review", "remediation"),
+    ],
+)
+def test_all_non_closeout_phases_reject_lifecycle_label_conflict(
+    monkeypatch: pytest.MonkeyPatch,
+    phase: lck.Phase,
+    project_status: str,
+    open_pr: str | None,
+) -> None:
+    branch = "task/159-lck-core-live-state-resolution"
+    fake = FakeRunner(
+        branch=branch, local_branches={branch}, remote_branches={branch: SHA}
+    )
+    issue = _issue()
+    issue["project_status"] = project_status
+    issue["labels"] = {"items": ["type:task", "codex:ready", "codex:needs-spec"]}
+    phase_pr = _open_pr(branch) if open_pr is not None else None
+    _install_facts(
+        monkeypatch,
+        fake,
+        issue=issue,
+        open_pr=phase_pr,
+    )
+
+    state = _resolver(fake).resolve(159)
+    decision = lck.PhaseEligibilityResolver().resolve(state, phase)
+
+    assert not decision.eligible
+    assert any("lifecycle labels" in reason for reason in decision.reasons)
+
+
+def test_lifecycle_label_conflict_stops_before_workspace_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = FakeRunner(branch="main")
+    issue = _issue()
+    issue["labels"] = {"items": ["type:task", "codex:ready", "codex:needs-spec"]}
+    _install_facts(monkeypatch, fake, issue=issue)
+
+    with pytest.raises(lck.LckStopError, match="lifecycle labels"):
+        lck.DeliveryPreparer(_resolver(fake)).prepare(159)
+
+    assert fake.branch == "main"
+    assert not any(command[:2] == ("git", "switch") for command in fake.commands)
+
+
+def test_resolve_open_pr_observes_draft_pr() -> None:
+    branch = "task/159-lck-core-live-state-resolution"
+    draft_pr = _open_pr(branch, is_draft=True)
+    fake = FakeRunner(open_pr=draft_pr)
+
+    observed = resolve_open_pr(
+        cast(Any, fake),
+        "owner/repo",
+        branch,
+        "main",
+        [],
+    )
+
+    assert observed is not None
+    assert observed["isDraft"] is True
+
+
+def test_review_prepare_rejects_draft_open_pr(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    branch = "task/159-lck-core-live-state-resolution"
+    fake = FakeRunner(
+        branch=branch, local_branches={branch}, remote_branches={branch: SHA}
+    )
+    issue = _issue()
+    issue["project_status"] = "Review"
+    _install_facts(
+        monkeypatch,
+        fake,
+        issue=issue,
+        open_pr=_open_pr(branch, is_draft=True),
+    )
+
+    state = _resolver(fake).resolve(159)
+    decision = lck.PhaseEligibilityResolver().resolve(
+        state,
+        lck.Phase.REVIEW_PREPARE,
+    )
+
+    assert not decision.eligible
+    assert any("non-Draft" in reason for reason in decision.reasons)
+
+
+def test_remediation_prepare_keeps_draft_pr_observable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    branch = "task/159-lck-core-live-state-resolution"
+    fake = FakeRunner(
+        branch=branch, local_branches={branch}, remote_branches={branch: SHA}
+    )
+    issue = _issue()
+    issue["project_status"] = "Review"
+    _install_facts(
+        monkeypatch,
+        fake,
+        issue=issue,
+        open_pr=_open_pr(branch, is_draft=True),
+    )
+
+    state = _resolver(fake).resolve(159)
+    decision = lck.PhaseEligibilityResolver().resolve(
+        state,
+        lck.Phase.REMEDIATION_PREPARE,
+    )
+
+    assert decision.eligible
 
 
 def test_multiple_task_branches_stop_fail_closed(

--- a/tests/tools/test_lck.py
+++ b/tests/tools/test_lck.py
@@ -1,0 +1,294 @@
+# ruff: noqa: E402, I001
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+AGENT_WORKFLOW = str(Path(__file__).parents[2] / "tools" / "agent_workflow")
+if AGENT_WORKFLOW not in sys.path:
+    sys.path.insert(0, AGENT_WORKFLOW)
+
+import lck  # noqa: E402
+from pr_resolve import PrResolveError  # noqa: E402
+from workflow_common import CommandResult  # noqa: E402
+
+
+SHA = "a" * 40
+
+
+class FakeRunner:
+    def __init__(
+        self,
+        *,
+        branch: str = "main",
+        local_branches: set[str] | None = None,
+        remote_branches: dict[str, str] | None = None,
+        clean: bool = True,
+    ) -> None:
+        self.branch = branch
+        self.local_branches = local_branches or set()
+        self.remote_branches = remote_branches or {}
+        self.clean = clean
+        self.commands: list[tuple[str, ...]] = []
+
+    def run(
+        self,
+        argv: list[str] | tuple[str, ...],
+        *,
+        command_id: str,
+        **_: Any,
+    ) -> CommandResult:
+        command = tuple(str(item) for item in argv)
+        self.commands.append(command)
+        args = list(command[1:]) if command and command[0] == "git" else list(command)
+        stdout = ""
+        returncode = 0
+        if args[:2] == ["for-each-ref", "--format=%(refname:short)"]:
+            stdout = "\n".join(sorted(self.local_branches))
+        elif args[:3] == ["ls-remote", "--heads", "origin"]:
+            stdout = "\n".join(
+                f"{oid}\trefs/heads/{branch}"
+                for branch, oid in sorted(self.remote_branches.items())
+            )
+        elif args[:2] == ["rev-parse", "refs/heads/main"]:
+            stdout = SHA
+        elif args[:1] == ["rev-parse"] and len(args) == 2:
+            branch = args[1].removeprefix("refs/heads/")
+            if branch not in self.local_branches:
+                returncode = 1
+            else:
+                stdout = SHA
+        elif args[:2] == ["switch", "-c"]:
+            branch = args[2]
+            self.local_branches.add(branch)
+            self.branch = branch
+        elif args[:2] == ["switch", "--track"]:
+            branch = args[3]
+            self.local_branches.add(branch)
+            self.branch = branch
+        elif args[:1] == ["switch"]:
+            branch = args[1]
+            if branch not in self.local_branches:
+                returncode = 1
+            else:
+                self.branch = branch
+        else:
+            returncode = 1
+        return CommandResult(
+            command_id=command_id,
+            argv=command,
+            returncode=returncode,
+            stdout=f"{stdout}\n" if stdout else "",
+            stderr="" if returncode == 0 else "unsupported fake command",
+        )
+
+
+def _issue() -> dict[str, Any]:
+    return {
+        "number": 159,
+        "title": "[Task] 建立 LCK Core 与 Live State Resolution",
+        "state": "OPEN",
+        "labels": {"items": ["type:task", "codex:ready"]},
+        "project_status": "Ready",
+    }
+
+
+def _relationships() -> dict[str, Any]:
+    return {
+        "available": True,
+        "blocked_by": {"items": [], "count": 0, "truncated": False},
+    }
+
+
+def _git_snapshot(fake: FakeRunner) -> dict[str, Any]:
+    return {
+        "branch": fake.branch,
+        "head_sha": SHA,
+        "local_main_sha": SHA,
+        "origin_main_sha": SHA,
+        "origin_fetch": "pass",
+        "clean": fake.clean,
+        "status_entries": 0 if fake.clean else 1,
+        "worktree_branches": {"items": [fake.branch], "count": 1, "truncated": False},
+    }
+
+
+def _install_facts(
+    monkeypatch: pytest.MonkeyPatch,
+    fake: FakeRunner,
+    *,
+    issue: dict[str, Any] | None = None,
+    open_pr: dict[str, Any] | None = None,
+    history: list[dict[str, Any]] | None = None,
+) -> None:
+    monkeypatch.setattr(lck, "_repository_slug", lambda *_args: "owner/repo")
+    monkeypatch.setattr(lck, "_issue_view", lambda *_args: issue or _issue())
+    monkeypatch.setattr(lck, "_relationship_snapshot", lambda *_args: _relationships())
+    monkeypatch.setattr(lck, "_git_snapshot", lambda *_args: _git_snapshot(fake))
+    monkeypatch.setattr(lck, "resolve_open_pr", lambda *_args: open_pr)
+    monkeypatch.setattr(
+        lck, "list_matching_prs", lambda *_args, **_kwargs: history or []
+    )
+
+
+def _resolver(fake: FakeRunner) -> lck.LiveStateResolver:
+    return lck.LiveStateResolver(Path.cwd(), runner=cast(Any, fake))
+
+
+def test_canonical_branch_is_derived_from_current_issue_title() -> None:
+    assert (
+        lck.canonical_task_branch(159, "[Task] 建立 LCK Core 与 Live State Resolution")
+        == "task/159-lck-core-live-state-resolution"
+    )
+
+
+def test_closed_pr_does_not_block_current_open_pr(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    branch = "task/159-lck-core-live-state-resolution"
+    fake = FakeRunner(
+        branch=branch,
+        local_branches={branch},
+        remote_branches={branch: SHA},
+    )
+    open_pr = {
+        "number": 200,
+        "state": "OPEN",
+        "isDraft": False,
+        "baseRefName": "main",
+        "baseRefOid": SHA,
+        "headRefName": branch,
+        "headRefOid": SHA,
+        "url": "https://github.com/owner/repo/pull/200",
+        "statusCheckRollup": [],
+    }
+    _install_facts(
+        monkeypatch,
+        fake,
+        open_pr=open_pr,
+        history=[
+            {"number": 199, "state": "CLOSED"},
+            {"number": 200, "state": "OPEN"},
+        ],
+    )
+
+    state = _resolver(fake).resolve(159)
+
+    assert state.status is lck.ResolutionStatus.RESOLVED
+    assert state.open_pr is not None
+    assert state.open_pr["number"] == 200
+    assert state.merged_pr_numbers == ()
+
+
+def test_ambiguous_open_pr_stops_phase_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    branch = "task/159-lck-core-live-state-resolution"
+    fake = FakeRunner(branch=branch, local_branches={branch})
+    _install_facts(monkeypatch, fake)
+
+    def ambiguous(*_args: Any) -> dict[str, Any] | None:
+        raise PrResolveError("multiple OPEN PRs for the Task branch")
+
+    monkeypatch.setattr(lck, "resolve_open_pr", ambiguous)
+    state = _resolver(fake).resolve(159)
+    decision = lck.PhaseEligibilityResolver().resolve(state, lck.Phase.DELIVERY_PREPARE)
+
+    assert state.status is lck.ResolutionStatus.STOP
+    assert not decision.eligible
+    assert any("multiple OPEN PRs" in reason for reason in decision.reasons)
+
+
+def test_multiple_task_branches_stop_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = FakeRunner(
+        branch="main",
+        local_branches={
+            "task/159-lck-core-live-state-resolution",
+            "task-159",
+        },
+    )
+    _install_facts(monkeypatch, fake)
+
+    state = _resolver(fake).resolve(159)
+
+    assert state.status is lck.ResolutionStatus.STOP
+    assert any(
+        "multiple Task branch candidates" in reason for reason in state.stop_reasons
+    )
+
+
+def test_delivery_prepare_creates_then_reuses_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = FakeRunner(branch="main")
+    _install_facts(monkeypatch, fake)
+    preparer = lck.DeliveryPreparer(_resolver(fake))
+
+    created = preparer.prepare(159)
+    reused = preparer.prepare(159)
+
+    assert created.action == "created-from-main"
+    assert reused.action == "already-prepared"
+    assert fake.branch == "task/159-lck-core-live-state-resolution"
+    assert sum(command[:2] == ("git", "switch") for command in fake.commands) == 1
+    assert not any(
+        command[:2] in {("git", "commit"), ("git", "push")}
+        or (command[:3] == ("gh", "pr", "create"))
+        for command in fake.commands
+    )
+
+
+def test_delivery_prepare_restores_remote_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    branch = "task/159-lck-core-live-state-resolution"
+    fake = FakeRunner(branch="main", remote_branches={branch: SHA})
+    _install_facts(monkeypatch, fake)
+
+    context = lck.DeliveryPreparer(_resolver(fake)).prepare(159)
+
+    assert context.action == "restored-from-remote"
+    assert fake.branch == branch
+    assert branch in fake.local_branches
+
+
+def test_dirty_unrelated_worktree_is_not_switched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    branch = "task/159-lck-core-live-state-resolution"
+    fake = FakeRunner(
+        branch="main",
+        local_branches={branch},
+        clean=False,
+    )
+    _install_facts(monkeypatch, fake)
+
+    with pytest.raises(lck.LckStopError, match="dirty unrelated worktree"):
+        lck.DeliveryPreparer(_resolver(fake)).prepare(159)
+
+
+def test_closeout_eligibility_uses_merged_live_pr_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    branch = "task/159-lck-core-live-state-resolution"
+    fake = FakeRunner(branch=branch, local_branches={branch})
+    closed_issue = _issue()
+    closed_issue.update({"state": "CLOSED", "project_status": "Done"})
+    _install_facts(
+        monkeypatch,
+        fake,
+        issue=closed_issue,
+        history=[{"number": 200, "state": "MERGED"}],
+    )
+
+    state = _resolver(fake).resolve(159)
+    decision = lck.PhaseEligibilityResolver().resolve(state, lck.Phase.CLOSEOUT)
+
+    assert state.merged is True
+    assert decision.eligible

--- a/tests/tools/test_lck.py
+++ b/tests/tools/test_lck.py
@@ -356,6 +356,67 @@ def test_open_pr_head_mismatch_stops_before_workspace_write(
     assert not any(command[:2] == ("git", "switch") for command in fake.commands)
 
 
+def test_git_snapshot_warning_stops_before_workspace_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = FakeRunner(branch="main")
+    _install_facts(monkeypatch, fake)
+
+    def unavailable_git_snapshot(
+        _runner: Any,
+        warnings: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        warnings.append(
+            {
+                "command_id": "git-status",
+                "exit_code": 1,
+                "error": "git status unavailable",
+            }
+        )
+        return _git_snapshot(fake)
+
+    monkeypatch.setattr(lck, "_git_snapshot", unavailable_git_snapshot)
+
+    with pytest.raises(lck.LckStopError, match="local Git snapshot"):
+        lck.DeliveryPreparer(_resolver(fake)).prepare(159)
+
+    assert fake.branch == "main"
+    assert not any(command[:2] == ("git", "switch") for command in fake.commands)
+
+
+def test_task_branch_inventory_warning_stops_before_workspace_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = FakeRunner(branch="main")
+    _install_facts(monkeypatch, fake)
+
+    def unavailable_task_branches(
+        _resolver: Any,
+        _task_number: int,
+        warnings: list[dict[str, Any]],
+    ) -> tuple[set[str], dict[str, str], bool]:
+        warnings.append(
+            {
+                "command_id": "lck-local-task-branches",
+                "exit_code": 1,
+                "error": "local branch inventory unavailable",
+            }
+        )
+        return set(), {}, True
+
+    monkeypatch.setattr(
+        lck.LiveStateResolver,
+        "_task_branches",
+        unavailable_task_branches,
+    )
+
+    with pytest.raises(lck.LckStopError, match="Task branch inventory"):
+        lck.DeliveryPreparer(_resolver(fake)).prepare(159)
+
+    assert fake.branch == "main"
+    assert not any(command[:2] == ("git", "switch") for command in fake.commands)
+
+
 @pytest.mark.parametrize(
     ("blocked_by", "expected_detail"),
     [

--- a/tests/tools/test_lck.py
+++ b/tests/tools/test_lck.py
@@ -733,6 +733,24 @@ def test_dirty_unrelated_worktree_is_not_switched(
         lck.DeliveryPreparer(_resolver(fake)).prepare(159)
 
 
+def test_dirty_current_task_worktree_is_not_prepared(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    branch = "task/159-lck-core-live-state-resolution"
+    fake = FakeRunner(
+        branch=branch,
+        local_branches={branch},
+        clean=False,
+    )
+    _install_facts(monkeypatch, fake)
+
+    with pytest.raises(lck.LckStopError, match="clean worktree"):
+        lck.DeliveryPreparer(_resolver(fake)).prepare(159)
+
+    assert fake.branch == branch
+    assert not any(command[:2] == ("git", "switch") for command in fake.commands)
+
+
 def test_closeout_eligibility_uses_merged_live_pr_state(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tools/agent_workflow/lck.py
+++ b/tools/agent_workflow/lck.py
@@ -288,7 +288,10 @@ class LiveStateResolver:
         else:
             reasons.append("repository identity unavailable")
 
+        git_warning_count = len(warnings)
         git = _git_snapshot(self.runner, warnings)
+        if len(warnings) > git_warning_count:
+            reasons.append("local Git snapshot contains unavailable facts")
         if git.get("origin_fetch") != "pass":
             reasons.append("current origin/main facts are unavailable")
         if not is_sha(git.get("local_main_sha")) or not is_sha(
@@ -299,9 +302,12 @@ class LiveStateResolver:
             reasons.append("Task metadata unavailable")
         if relationships.get("available") is not True:
             reasons.append("Task relationship facts unavailable")
+        branch_warning_count = len(warnings)
         local_branches, remote_branches, remote_available = self._task_branches(
             task_number, warnings
         )
+        if len(warnings) > branch_warning_count:
+            reasons.append("Task branch inventory contains unavailable facts")
         if not remote_available:
             reasons.append("remote Task branch facts unavailable")
         title = issue.get("title") if isinstance(issue, Mapping) else None

--- a/tools/agent_workflow/lck.py
+++ b/tools/agent_workflow/lck.py
@@ -371,8 +371,7 @@ class LiveStateResolver:
             checks = _normalize_checks([])
         if len(merged_numbers) > 1:
             reasons.append(
-                "multiple merged PRs for the Task branch: "
-                f"{list(merged_numbers)}"
+                f"multiple merged PRs for the Task branch: {list(merged_numbers)}"
             )
         if open_pr is not None:
             pr_head_oid = open_pr.get("headRefOid")

--- a/tools/agent_workflow/lck.py
+++ b/tools/agent_workflow/lck.py
@@ -1,0 +1,668 @@
+#!/usr/bin/env python3
+# ruff: noqa: E402, I001
+"""Local Control Kernel v1 live-state resolution and Delivery Prepare.
+
+This module is intentionally limited to the first LCK migration boundary:
+resolving current mechanical facts, evaluating phase eligibility, and preparing
+the local Task workspace.  Commit, push, PR mutation, lifecycle writes, merge,
+and closeout effects remain outside this Task.
+
+The resolver delegates Issue, relationship, Git snapshot, and PR query details
+to the existing workflow helpers.  It does not use a snapshot, expected SHA,
+or session handoff as authority.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import unicodedata
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Any, Final, cast
+
+if __name__ != "__main__" or not any(p.endswith("agent_workflow") for p in sys.path):
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from pr_resolve import (
+    PrResolveError,
+    list_matching_prs,
+    resolve_open_pr,
+)
+from workflow_common import (
+    CommandRunner,
+    WorkflowToolError,
+    command_warning,
+    is_sha,
+    print_json,
+)
+from workflow_evidence import (
+    _git_snapshot,
+    _issue_view,
+    _normalize_checks,
+    _relationship_snapshot,
+    _repository_slug,
+)
+
+
+BASE_BRANCH: Final = "main"
+LCK_SCHEMA_VERSION: Final = 1
+TASK_BRANCH_PATTERN: Final = re.compile(
+    r"^(?:task/(?P<slash>\d+)(?:-.+)?|task-(?P<dash>\d+)(?:-.+)?|(?P<legacy>\d+)-.+)$"
+)
+
+
+class Phase(StrEnum):
+    """LCK phase capabilities exposed by the v1 core."""
+
+    DELIVERY_PREPARE = "Delivery Prepare"
+    REVIEW_PREPARE = "Review Prepare"
+    REMEDIATION_PREPARE = "Remediation Prepare"
+    CLOSEOUT = "Closeout"
+
+
+class ResolutionStatus(StrEnum):
+    RESOLVED = "resolved"
+    STOP = "stop"
+
+
+class LckStopError(WorkflowToolError):
+    """A deterministic LCK gate could not identify one safe action."""
+
+
+def canonical_task_branch(task_number: int, title: str) -> str:
+    """Derive the canonical Task branch from live Issue identity.
+
+    ASCII words in the title are retained after Unicode normalization.  This
+    keeps the branch stable for mixed-language titles without trusting a
+    branch name supplied by an Agent.
+    """
+    title_without_prefix = re.sub(r"^\s*\[[^]]+\]\s*", "", title)
+    normalized = unicodedata.normalize("NFKD", title_without_prefix)
+    ascii_title = normalized.encode("ascii", "ignore").decode("ascii")
+    words = re.findall(r"[a-zA-Z0-9]+", ascii_title.casefold())
+    slug = "-".join(words[:12]).strip("-")
+    if not slug:
+        slug = "task"
+    return f"task/{task_number}-{slug}"
+
+
+def _jsonable(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(key): _jsonable(nested) for key, nested in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(item) for item in value]
+    if isinstance(value, StrEnum):
+        return value.value
+    return value
+
+
+def _items(value: Any) -> list[Any]:
+    if isinstance(value, Mapping) and isinstance(value.get("items"), list):
+        return list(value["items"])
+    return []
+
+
+def _branch_matches_task(branch: str, task_number: int) -> bool:
+    match = TASK_BRANCH_PATTERN.fullmatch(branch)
+    if match is None:
+        return False
+    number = next(
+        (value for value in match.groups() if value is not None),
+        None,
+    )
+    return number == str(task_number)
+
+
+def _remote_refs(stdout: str) -> dict[str, str]:
+    refs: dict[str, str] = {}
+    for line in stdout.splitlines():
+        oid, separator, ref = line.partition("\t")
+        if not separator or not is_sha(oid) or not ref.startswith("refs/heads/"):
+            continue
+        refs[ref.removeprefix("refs/heads/")] = oid
+    return refs
+
+
+@dataclass(frozen=True)
+class LiveState:
+    """Current mechanical facts acquired from Git and GitHub."""
+
+    task_number: int
+    repository: str | None
+    issue: Mapping[str, Any] | None
+    relationships: Mapping[str, Any]
+    git: Mapping[str, Any]
+    target_branch: str
+    local_task_branch: str | None
+    local_task_head: str | None
+    remote_task_branch: str | None
+    remote_task_oid: str | None
+    open_pr: Mapping[str, Any] | None
+    merged_pr_numbers: tuple[int, ...]
+    merged: bool | None
+    checks: Mapping[str, Any]
+    cleanup: Mapping[str, Any]
+    status: ResolutionStatus = ResolutionStatus.RESOLVED
+    stop_reasons: tuple[str, ...] = ()
+    warnings: tuple[Mapping[str, Any], ...] = ()
+
+    @property
+    def project_status(self) -> str | None:
+        return (
+            self.issue.get("project_status")
+            if isinstance(self.issue, Mapping)
+            and isinstance(self.issue.get("project_status"), str)
+            else None
+        )
+
+    @property
+    def issue_state(self) -> str | None:
+        return (
+            self.issue.get("state")
+            if isinstance(self.issue, Mapping)
+            and isinstance(self.issue.get("state"), str)
+            else None
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return cast(
+            dict[str, Any],
+            _jsonable(
+                {
+                    "schema_version": LCK_SCHEMA_VERSION,
+                    "task_number": self.task_number,
+                    "repository": self.repository,
+                    "issue": self.issue,
+                    "relationships": self.relationships,
+                    "git": self.git,
+                    "target_branch": self.target_branch,
+                    "local_task_branch": self.local_task_branch,
+                    "local_task_head": self.local_task_head,
+                    "remote_task_branch": self.remote_task_branch,
+                    "remote_task_oid": self.remote_task_oid,
+                    "open_pr": self.open_pr,
+                    "merged_pr_numbers": self.merged_pr_numbers,
+                    "merged": self.merged,
+                    "checks": self.checks,
+                    "cleanup": self.cleanup,
+                    "status": self.status,
+                    "stop_reasons": self.stop_reasons,
+                    "warnings": self.warnings,
+                }
+            ),
+        )
+
+
+class LiveStateResolver:
+    """Resolve one Task from current local and GitHub authority."""
+
+    def __init__(
+        self,
+        repo_root: Path,
+        *,
+        runner: CommandRunner | None = None,
+        repository: str | None = None,
+    ) -> None:
+        self.repo_root = repo_root.resolve()
+        self.runner = runner or CommandRunner(self.repo_root)
+        self.repository = repository
+
+    def _git_lines(
+        self,
+        args: Sequence[str],
+        *,
+        command_id: str,
+        warnings: list[dict[str, Any]],
+    ) -> list[str]:
+        result = self.runner.run(["git", *args], command_id=command_id)
+        if result.returncode != 0:
+            warnings.append(command_warning(result))
+            return []
+        return [line for line in result.stdout.splitlines() if line]
+
+    def _task_branches(
+        self,
+        task_number: int,
+        warnings: list[dict[str, Any]],
+    ) -> tuple[set[str], dict[str, str], bool]:
+        local_lines = self._git_lines(
+            ["for-each-ref", "--format=%(refname:short)", "refs/heads"],
+            command_id="lck-local-task-branches",
+            warnings=warnings,
+        )
+        local = {
+            branch
+            for branch in local_lines
+            if _branch_matches_task(branch, task_number)
+        }
+        remote_result = self.runner.run(
+            ["git", "ls-remote", "--heads", "origin"],
+            command_id="lck-remote-task-branches",
+        )
+        if remote_result.returncode != 0:
+            warnings.append(command_warning(remote_result))
+            return local, {}, False
+        remote_all = _remote_refs(remote_result.stdout)
+        remote = {
+            branch: oid
+            for branch, oid in remote_all.items()
+            if _branch_matches_task(branch, task_number)
+        }
+        return local, remote, True
+
+    def resolve(self, task_number: int) -> LiveState:
+        if task_number <= 0:
+            raise LckStopError(f"Task number must be positive: {task_number}")
+
+        warnings: list[dict[str, Any]] = []
+        reasons: list[str] = []
+        repository = _repository_slug(self.runner, self.repository, warnings)
+        issue: Mapping[str, Any] | None = None
+        relationships: Mapping[str, Any] = {"available": False}
+        if repository is not None:
+            issue = _issue_view(self.runner, repository, task_number, warnings)
+            relationships = _relationship_snapshot(
+                self.runner, repository, task_number, warnings
+            )
+        else:
+            reasons.append("repository identity unavailable")
+
+        git = _git_snapshot(self.runner, warnings)
+        if git.get("origin_fetch") != "pass":
+            reasons.append("current origin/main facts are unavailable")
+        if not is_sha(git.get("local_main_sha")) or not is_sha(
+            git.get("origin_main_sha")
+        ):
+            reasons.append("current main identity is unavailable")
+        if issue is None:
+            reasons.append("Task metadata unavailable")
+        if relationships.get("available") is not True:
+            reasons.append("Task relationship facts unavailable")
+        local_branches, remote_branches, remote_available = self._task_branches(
+            task_number, warnings
+        )
+        if not remote_available:
+            reasons.append("remote Task branch facts unavailable")
+        title = issue.get("title") if isinstance(issue, Mapping) else None
+        title_text = title if isinstance(title, str) else f"Task {task_number}"
+        canonical = canonical_task_branch(task_number, title_text)
+        candidates = sorted(local_branches | set(remote_branches))
+        if len(candidates) > 1:
+            reasons.append(f"multiple Task branch candidates: {candidates}")
+        target_branch = candidates[0] if len(candidates) == 1 else canonical
+        local_branch = target_branch if target_branch in local_branches else None
+        remote_branch = target_branch if target_branch in remote_branches else None
+
+        local_head: str | None = None
+        if local_branch is not None:
+            result = self.runner.run(
+                ["git", "rev-parse", f"refs/heads/{local_branch}"],
+                command_id="lck-local-task-head",
+            )
+            if result.returncode == 0 and is_sha(result.stdout.strip()):
+                local_head = result.stdout.strip()
+            else:
+                warnings.append(command_warning(result))
+                reasons.append("local Task branch tip unavailable")
+        remote_oid = remote_branches.get(target_branch)
+        if (
+            local_head is not None
+            and remote_oid is not None
+            and local_head != remote_oid
+        ):
+            reasons.append("local and remote Task branch tips differ")
+
+        open_pr: Mapping[str, Any] | None = None
+        merged_numbers: tuple[int, ...] = ()
+        if repository is not None:
+            try:
+                open_pr = resolve_open_pr(
+                    self.runner,
+                    repository,
+                    target_branch,
+                    BASE_BRANCH,
+                    warnings,
+                )
+            except PrResolveError as exc:
+                reasons.append(str(exc))
+            try:
+                history = list_matching_prs(
+                    self.runner,
+                    repository,
+                    target_branch,
+                    BASE_BRANCH,
+                    warnings,
+                )
+                merged_numbers = tuple(
+                    sorted(
+                        int(item["number"])
+                        for item in history
+                        if str(item.get("state", "")).upper() == "MERGED"
+                        and isinstance(item.get("number"), int)
+                    )
+                )
+            except PrResolveError as exc:
+                reasons.append(str(exc))
+
+        if open_pr is not None:
+            checks = _normalize_checks(open_pr.get("statusCheckRollup"))
+        else:
+            checks = _normalize_checks([])
+        if open_pr is not None:
+            merged: bool | None = False
+        elif len(merged_numbers) == 1:
+            merged = True
+        elif len(merged_numbers) == 0:
+            merged = False
+        else:
+            merged = None
+
+        cleanup = {
+            "business_delivery": "complete" if merged is True else "pending",
+            "cleanup": "pending" if merged is True else "not-applicable",
+            "local_branch_present": local_branch is not None,
+            "remote_branch_present": remote_branch is not None,
+            "open_pr_number": (
+                open_pr.get("number") if isinstance(open_pr, Mapping) else None
+            ),
+            "merged_pr_numbers": merged_numbers,
+        }
+        status = ResolutionStatus.STOP if reasons else ResolutionStatus.RESOLVED
+        return LiveState(
+            task_number=task_number,
+            repository=repository,
+            issue=issue,
+            relationships=relationships,
+            git=git,
+            target_branch=target_branch,
+            local_task_branch=local_branch,
+            local_task_head=local_head,
+            remote_task_branch=remote_branch,
+            remote_task_oid=remote_oid,
+            open_pr=open_pr,
+            merged_pr_numbers=merged_numbers,
+            merged=merged,
+            checks=checks,
+            cleanup=cleanup,
+            status=status,
+            stop_reasons=tuple(reasons),
+            warnings=tuple(warnings),
+        )
+
+
+@dataclass(frozen=True)
+class PhaseDecision:
+    phase: Phase
+    eligible: bool
+    reasons: tuple[str, ...] = ()
+    capabilities: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "phase": self.phase.value,
+            "eligible": self.eligible,
+            "reasons": list(self.reasons),
+            "capabilities": list(self.capabilities),
+        }
+
+
+class PhaseEligibilityResolver:
+    """Apply static phase capabilities to current live preconditions."""
+
+    def resolve(self, state: LiveState, phase: Phase) -> PhaseDecision:
+        reasons = list(state.stop_reasons)
+        issue = state.issue
+        if state.status is not ResolutionStatus.RESOLVED:
+            reasons.append("live state resolution stopped")
+        if state.repository is None:
+            reasons.append("repository identity is unavailable")
+        if not isinstance(issue, Mapping):
+            reasons.append("Task metadata is unavailable")
+        else:
+            issue_state = str(issue.get("state", "")).upper()
+            if phase is not Phase.CLOSEOUT and issue_state != "OPEN":
+                reasons.append("Task is not OPEN")
+            if phase is not Phase.CLOSEOUT:
+                labels = set(_items(issue.get("labels")))
+                if "codex:ready" not in labels:
+                    reasons.append("Task is missing codex:ready")
+                if "codex:blocked" in labels:
+                    reasons.append("Task has codex:blocked")
+            project = issue.get("project_status")
+            allowed_projects = {
+                Phase.DELIVERY_PREPARE: {"Ready", "In Progress"},
+                Phase.REVIEW_PREPARE: {"Review", "In Progress"},
+                Phase.REMEDIATION_PREPARE: {"Review"},
+                Phase.CLOSEOUT: {"In Progress", "Review", "Done"},
+            }[phase]
+            if project not in allowed_projects:
+                reasons.append("Project Status is unavailable or unknown")
+
+        relationships = state.relationships
+        blocked_by = relationships.get("blocked_by")
+        if isinstance(blocked_by, Mapping):
+            open_blockers = [
+                item
+                for item in _items(blocked_by)
+                if isinstance(item, Mapping)
+                and str(item.get("state", "")).upper() == "OPEN"
+            ]
+            if open_blockers:
+                reasons.append(f"unresolved blocked-by Issues: {open_blockers}")
+        elif relationships.get("available") is not True:
+            reasons.append("relationship facts are unavailable")
+
+        if phase is Phase.DELIVERY_PREPARE:
+            if state.merged is True:
+                reasons.append("Task already has a merged PR")
+            if state.local_task_head and state.remote_task_oid:
+                if state.local_task_head != state.remote_task_oid:
+                    reasons.append("Task branch has divergent local and remote tips")
+            if not state.local_task_branch and not state.remote_task_branch:
+                current = state.git.get("branch")
+                if current != BASE_BRANCH:
+                    reasons.append("new workspace bootstrap requires current main")
+                if state.git.get("clean") is not True:
+                    reasons.append("new workspace bootstrap requires a clean worktree")
+            capabilities = ("prepare_task_workspace",)
+        elif phase is Phase.REVIEW_PREPARE:
+            if state.open_pr is None:
+                reasons.append("no current OPEN PR")
+            if state.project_status not in {"Review", "In Progress"}:
+                reasons.append("Task is not eligible for Review Prepare")
+            capabilities = ("prepare_read_only_review_context",)
+        elif phase is Phase.REMEDIATION_PREPARE:
+            if state.open_pr is None:
+                reasons.append("no current OPEN PR")
+            if state.project_status != "Review":
+                reasons.append("Remediation requires Project Status Review")
+            capabilities = ("prepare_task_workspace",)
+        else:
+            if state.merged is not True:
+                reasons.append("Closeout requires one current merged PR")
+            if state.open_pr is not None:
+                reasons.append("Closeout cannot proceed while an OPEN PR exists")
+            capabilities = ("resolve_cleanup_state",)
+        return PhaseDecision(
+            phase=phase,
+            eligible=not reasons,
+            reasons=tuple(dict.fromkeys(reasons)),
+            capabilities=capabilities,
+        )
+
+
+@dataclass(frozen=True)
+class DeliveryContext:
+    task_number: int
+    repository: str | None
+    branch: str
+    base_sha: str | None
+    action: str
+    state: LiveState
+    eligibility: PhaseDecision
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": LCK_SCHEMA_VERSION,
+            "operation": "delivery-prepare",
+            "task_number": self.task_number,
+            "repository": self.repository,
+            "branch": self.branch,
+            "base_sha": self.base_sha,
+            "action": self.action,
+            "state": self.state.to_dict(),
+            "eligibility": self.eligibility.to_dict(),
+        }
+
+
+class DeliveryPreparer:
+    """Prepare or restore one local Task workspace with bounded Git effects."""
+
+    def __init__(
+        self,
+        resolver: LiveStateResolver,
+        *,
+        eligibility: PhaseEligibilityResolver | None = None,
+    ) -> None:
+        self.resolver = resolver
+        self.eligibility = eligibility or PhaseEligibilityResolver()
+
+    def _run_git(self, args: Sequence[str], command_id: str) -> None:
+        result = self.resolver.runner.run(
+            ["git", *args],
+            command_id=command_id,
+        )
+        if result.returncode != 0:
+            raise LckStopError(
+                f"{command_id} failed with exit code {result.returncode}: "
+                f"{result.stderr.strip() or result.stdout.strip()}"
+            )
+
+    def prepare(self, task_number: int) -> DeliveryContext:
+        state = self.resolver.resolve(task_number)
+        decision = self.eligibility.resolve(state, Phase.DELIVERY_PREPARE)
+        if not decision.eligible:
+            raise LckStopError(
+                f"Delivery Prepare STOP for Task #{task_number}: "
+                + "; ".join(decision.reasons)
+            )
+
+        branch = state.target_branch
+        current_branch = state.git.get("branch")
+        clean = state.git.get("clean") is True
+        base_sha = state.git.get("local_main_sha")
+        action = "already-prepared"
+        local_exists = state.local_task_branch is not None
+
+        if local_exists:
+            if current_branch != branch:
+                if not clean:
+                    raise LckStopError(
+                        "cannot switch to Task branch with a dirty unrelated worktree"
+                    )
+                self._run_git(
+                    ["switch", branch],
+                    "lck-select-existing-task-branch",
+                )
+                action = "selected-existing"
+        elif state.remote_task_branch is not None:
+            if current_branch != BASE_BRANCH or not clean:
+                raise LckStopError(
+                    "restoring a remote Task branch requires a clean main worktree"
+                )
+            self._run_git(
+                ["switch", "--track", "-c", branch, f"origin/{branch}"],
+                "lck-restore-remote-task-branch",
+            )
+            action = "restored-from-remote"
+        else:
+            if (
+                current_branch != BASE_BRANCH
+                or not clean
+                or not isinstance(base_sha, str)
+                or not is_sha(base_sha)
+                or state.git.get("head_sha") != base_sha
+            ):
+                raise LckStopError(
+                    "new Task workspace requires clean main at current main SHA"
+                )
+            self._run_git(
+                ["switch", "-c", branch, base_sha],
+                "lck-create-task-branch",
+            )
+            action = "created-from-main"
+
+        final_state = self.resolver.resolve(task_number)
+        if (
+            final_state.status is not ResolutionStatus.RESOLVED
+            or final_state.git.get("branch") != branch
+        ):
+            raise LckStopError(
+                "workspace postcondition failed: current live branch is not the "
+                "resolved Task branch"
+            )
+        final_decision = self.eligibility.resolve(final_state, Phase.DELIVERY_PREPARE)
+        if not final_decision.eligible:
+            raise LckStopError(
+                "workspace postcondition is no longer eligible: "
+                + "; ".join(final_decision.reasons)
+            )
+        return DeliveryContext(
+            task_number=task_number,
+            repository=final_state.repository,
+            branch=branch,
+            base_sha=(
+                final_state.git.get("local_main_sha")
+                if isinstance(final_state.git.get("local_main_sha"), str)
+                else None
+            ),
+            action=action,
+            state=final_state,
+            eligibility=final_decision,
+        )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="LCK v1 live state operations")
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--repository")
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    status = commands.add_parser("status")
+    status.add_argument("task", type=int)
+
+    delivery = commands.add_parser("delivery")
+    delivery_commands = delivery.add_subparsers(dest="delivery_command", required=True)
+    prepare = delivery_commands.add_parser("prepare")
+    prepare.add_argument("task", type=int)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    resolver = LiveStateResolver(
+        args.repo_root,
+        repository=args.repository,
+    )
+    try:
+        if args.command == "status":
+            state = resolver.resolve(args.task)
+            print_json(state.to_dict(), pretty=True)
+            return 0 if state.status is ResolutionStatus.RESOLVED else 2
+        if args.delivery_command == "prepare":
+            context = DeliveryPreparer(resolver).prepare(args.task)
+            print_json(context.to_dict(), pretty=True)
+            return 0
+        raise LckStopError("unsupported LCK command")
+    except WorkflowToolError as exc:
+        print(json.dumps({"status": "stop", "error": str(exc)}, ensure_ascii=False))
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/agent_workflow/lck.py
+++ b/tools/agent_workflow/lck.py
@@ -118,6 +118,21 @@ def _branch_matches_task(branch: str, task_number: int) -> bool:
     return number == str(task_number)
 
 
+def _is_clean_current_main(git: Mapping[str, Any]) -> bool:
+    """Return whether a new Task branch can safely be based on current main."""
+    head_sha = git.get("head_sha")
+    local_main_sha = git.get("local_main_sha")
+    origin_main_sha = git.get("origin_main_sha")
+    return (
+        git.get("branch") == BASE_BRANCH
+        and git.get("clean") is True
+        and is_sha(head_sha)
+        and is_sha(local_main_sha)
+        and is_sha(origin_main_sha)
+        and head_sha == local_main_sha == origin_main_sha
+    )
+
+
 def _remote_refs(stdout: str) -> dict[str, str]:
     refs: dict[str, str] = {}
     for line in stdout.splitlines():
@@ -464,11 +479,11 @@ class PhaseEligibilityResolver:
                 if state.local_task_head != state.remote_task_oid:
                     reasons.append("Task branch has divergent local and remote tips")
             if not state.local_task_branch and not state.remote_task_branch:
-                current = state.git.get("branch")
-                if current != BASE_BRANCH:
-                    reasons.append("new workspace bootstrap requires current main")
-                if state.git.get("clean") is not True:
-                    reasons.append("new workspace bootstrap requires a clean worktree")
+                if not _is_clean_current_main(state.git):
+                    reasons.append(
+                        "new workspace bootstrap requires clean main with "
+                        "HEAD == local main == origin/main"
+                    )
             capabilities = ("prepare_task_workspace",)
         elif phase is Phase.REVIEW_PREPARE:
             if state.open_pr is None:
@@ -581,15 +596,10 @@ class DeliveryPreparer:
             )
             action = "restored-from-remote"
         else:
-            if (
-                current_branch != BASE_BRANCH
-                or not clean
-                or not isinstance(base_sha, str)
-                or not is_sha(base_sha)
-                or state.git.get("head_sha") != base_sha
-            ):
+            if not _is_clean_current_main(state.git):
                 raise LckStopError(
-                    "new Task workspace requires clean main at current main SHA"
+                    "new Task workspace requires clean main with "
+                    "HEAD == local main == origin/main"
                 )
             self._run_git(
                 ["switch", "-c", branch, base_sha],

--- a/tools/agent_workflow/lck.py
+++ b/tools/agent_workflow/lck.py
@@ -369,6 +369,26 @@ class LiveStateResolver:
             checks = _normalize_checks(open_pr.get("statusCheckRollup"))
         else:
             checks = _normalize_checks([])
+        if len(merged_numbers) > 1:
+            reasons.append(
+                "multiple merged PRs for the Task branch: "
+                f"{list(merged_numbers)}"
+            )
+        if open_pr is not None:
+            pr_head_oid = open_pr.get("headRefOid")
+            if not is_sha(pr_head_oid):
+                reasons.append("current OPEN PR head OID is unavailable")
+            elif local_branch is None and remote_branch is None:
+                reasons.append("current OPEN PR has no local or remote Task branch")
+            else:
+                if local_head is not None and local_head != pr_head_oid:
+                    reasons.append(
+                        "current OPEN PR head OID differs from local Task branch tip"
+                    )
+                if remote_oid is not None and remote_oid != pr_head_oid:
+                    reasons.append(
+                        "current OPEN PR head OID differs from remote Task branch tip"
+                    )
         if open_pr is not None:
             merged: bool | None = False
         elif len(merged_numbers) == 1:

--- a/tools/agent_workflow/lck.py
+++ b/tools/agent_workflow/lck.py
@@ -45,6 +45,7 @@ from workflow_evidence import (
     _issue_view,
     _normalize_checks,
     _relationship_snapshot,
+    _formal_blockers_gate,
     _repository_slug,
 )
 
@@ -432,6 +433,7 @@ class PhaseEligibilityResolver:
     def resolve(self, state: LiveState, phase: Phase) -> PhaseDecision:
         reasons = list(state.stop_reasons)
         issue = state.issue
+        relationships = state.relationships
         if state.status is not ResolutionStatus.RESOLVED:
             reasons.append("live state resolution stopped")
         if state.repository is None:
@@ -444,10 +446,22 @@ class PhaseEligibilityResolver:
                 reasons.append("Task is not OPEN")
             if phase is not Phase.CLOSEOUT:
                 labels = set(_items(issue.get("labels")))
-                if "codex:ready" not in labels:
-                    reasons.append("Task is missing codex:ready")
-                if "codex:blocked" in labels:
-                    reasons.append("Task has codex:blocked")
+                lifecycle_labels = labels & {
+                    "codex:needs-spec",
+                    "codex:ready",
+                    "codex:blocked",
+                }
+                if lifecycle_labels != {"codex:ready"}:
+                    reasons.append(
+                        "lifecycle labels must be exactly ['codex:ready']: "
+                        f"{sorted(lifecycle_labels) or 'none'}"
+                    )
+                issue_type = relationships.get("issue_type")
+                is_task = "type:task" in labels or (
+                    isinstance(issue_type, str) and issue_type.casefold() == "task"
+                )
+                if not is_task:
+                    reasons.append("target Issue is not a type:task")
             project = issue.get("project_status")
             allowed_projects = {
                 Phase.DELIVERY_PREPARE: {"Ready", "In Progress"},
@@ -458,19 +472,10 @@ class PhaseEligibilityResolver:
             if project not in allowed_projects:
                 reasons.append("Project Status is unavailable or unknown")
 
-        relationships = state.relationships
-        blocked_by = relationships.get("blocked_by")
-        if isinstance(blocked_by, Mapping):
-            open_blockers = [
-                item
-                for item in _items(blocked_by)
-                if isinstance(item, Mapping)
-                and str(item.get("state", "")).upper() == "OPEN"
-            ]
-            if open_blockers:
-                reasons.append(f"unresolved blocked-by Issues: {open_blockers}")
-        elif relationships.get("available") is not True:
-            reasons.append("relationship facts are unavailable")
+        blocker_gate = _formal_blockers_gate(relationships)
+        if blocker_gate.get("status") != "pass":
+            detail = blocker_gate.get("detail") or "formal blocker gate did not pass"
+            reasons.append(f"formal blocker gate: {detail}")
 
         if phase is Phase.DELIVERY_PREPARE:
             if state.merged is True:
@@ -488,6 +493,8 @@ class PhaseEligibilityResolver:
         elif phase is Phase.REVIEW_PREPARE:
             if state.open_pr is None:
                 reasons.append("no current OPEN PR")
+            elif state.open_pr.get("isDraft") is not False:
+                reasons.append("Review Prepare requires a non-Draft OPEN PR")
             if state.project_status not in {"Review", "In Progress"}:
                 reasons.append("Task is not eligible for Review Prepare")
             capabilities = ("prepare_read_only_review_context",)

--- a/tools/agent_workflow/lck.py
+++ b/tools/agent_workflow/lck.py
@@ -505,6 +505,11 @@ class PhaseEligibilityResolver:
         if phase is Phase.DELIVERY_PREPARE:
             if state.merged is True:
                 reasons.append("Task already has a merged PR")
+            if (
+                state.local_task_branch is not None
+                and state.git.get("clean") is not True
+            ):
+                reasons.append("existing Task branch reuse requires a clean worktree")
             if state.local_task_head and state.remote_task_oid:
                 if state.local_task_head != state.remote_task_oid:
                     reasons.append("Task branch has divergent local and remote tips")

--- a/tools/agent_workflow/lck.py
+++ b/tools/agent_workflow/lck.py
@@ -507,6 +507,7 @@ class PhaseEligibilityResolver:
                 reasons.append("Task already has a merged PR")
             if (
                 state.local_task_branch is not None
+                and state.git.get("branch") == state.local_task_branch
                 and state.git.get("clean") is not True
             ):
                 reasons.append("existing Task branch reuse requires a clean worktree")

--- a/tools/agent_workflow/pr_resolve.py
+++ b/tools/agent_workflow/pr_resolve.py
@@ -59,6 +59,7 @@ def _validate_pr_identity(
     expected_base: str,
     expected_head_sha: str | None,
     expected_base_sha: str | None,
+    require_non_draft: bool = True,
 ) -> None:
     """Verify a PR dict has all required identity fields and matches expectations."""
     missing = [f for f in _REQUIRED_PR_FIELDS if f not in pr]
@@ -84,7 +85,7 @@ def _validate_pr_identity(
         raise PrResolveError(f"PR state is not OPEN: {state}")
 
     is_draft = pr.get("isDraft")
-    if is_draft is not False:
+    if require_non_draft and is_draft is not False:
         raise PrResolveError(f"PR is Draft or draft status unknown: {is_draft!r}")
 
     head_branch = pr.get("headRefName")
@@ -116,6 +117,158 @@ def _validate_pr_identity(
                 f"PR head SHA mismatch: expected {expected_head_sha}, "
                 f"observed {head_sha!r}"
             )
+
+
+def list_matching_prs(
+    runner: CommandRunner,
+    repository: str,
+    current_branch: str,
+    base_branch: str,
+    warnings: list[dict[str, Any]],
+    *,
+    state: str = "all",
+    limit: int = 100,
+) -> list[dict[str, Any]]:
+    """Read matching PRs for live-state consumers without any side effect."""
+    if state not in {"open", "closed", "merged", "all"}:
+        raise PrResolveError(f"unsupported PR list state: {state!r}")
+    if limit < 1 or limit > 100:
+        raise PrResolveError(f"invalid PR list limit: {limit!r}")
+    result = runner.run(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--repo",
+            repository,
+            "--head",
+            current_branch,
+            "--base",
+            base_branch,
+            "--state",
+            state,
+            "--limit",
+            str(limit),
+            "--json",
+            _PR_LIST_FIELDS,
+        ],
+        command_id="gh-pr-list-live-state-history",
+    )
+    if result.returncode != 0:
+        warnings.append(command_warning(result))
+        raise PrResolveError(
+            f"gh pr list failed with exit code {result.returncode}: "
+            f"{result.stderr.strip() or result.stdout.strip()}"
+        )
+    if not result.stdout.strip():
+        raise PrResolveError("gh pr list returned empty stdout — cannot read PR state")
+    value = read_json_text(result.stdout, field="gh-pr-list-live-state-history")
+    if not isinstance(value, list):
+        raise PrResolveError("live PR history result is not a JSON array")
+    items: list[dict[str, Any]] = []
+    for item in value:
+        if not isinstance(item, Mapping):
+            raise PrResolveError("live PR history item is not a JSON object")
+        items.append(dict(item))
+    return items
+
+
+def resolve_open_pr(
+    runner: CommandRunner,
+    repository: str,
+    current_branch: str,
+    base_branch: str,
+    warnings: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    """Resolve the unique matching OPEN PR without creating or changing one.
+
+    This is the read-only counterpart used by live-state resolution.  It keeps
+    the PR query and identity checks in the shared resolver instead of creating
+    a second GitHub query stack in the Local Control Kernel.
+    """
+    list_result = runner.run(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--repo",
+            repository,
+            "--head",
+            current_branch,
+            "--base",
+            base_branch,
+            "--state",
+            "open",
+            "--limit",
+            "2",
+            "--json",
+            _PR_LIST_FIELDS,
+        ],
+        command_id="gh-pr-list-live-state",
+    )
+    if list_result.returncode != 0:
+        warnings.append(command_warning(list_result))
+        raise PrResolveError(
+            f"gh pr list failed with exit code {list_result.returncode}: "
+            f"{list_result.stderr.strip() or list_result.stdout.strip()}"
+        )
+    if not list_result.stdout.strip():
+        raise PrResolveError(
+            "gh pr list returned empty stdout — cannot resolve live PR state"
+        )
+    value = read_json_text(list_result.stdout, field="gh-pr-list-live-state")
+    if not isinstance(value, list):
+        raise PrResolveError("live PR list result is not a JSON array")
+    if not value:
+        return None
+    if len(value) > 1:
+        numbers = [
+            item.get("number") if isinstance(item, Mapping) else None for item in value
+        ]
+        raise PrResolveError(
+            f"multiple OPEN PRs for head={current_branch!r} "
+            f"base={base_branch!r}: {numbers}"
+        )
+
+    listed = value[0]
+    if not isinstance(listed, Mapping):
+        raise PrResolveError("live PR list item is not a JSON object")
+    pr_url = listed.get("url")
+    if not isinstance(pr_url, str) or not pr_url:
+        raise PrResolveError("live PR is missing URL")
+    view_result = runner.run(
+        [
+            "gh",
+            "pr",
+            "view",
+            pr_url,
+            "--repo",
+            repository,
+            "--json",
+            _PR_VIEW_FIELDS,
+        ],
+        command_id="gh-pr-view-live-state",
+    )
+    if view_result.returncode != 0:
+        warnings.append(command_warning(view_result))
+        raise PrResolveError(
+            f"gh pr view identity verification failed with exit code "
+            f"{view_result.returncode}: "
+            f"{view_result.stderr.strip() or view_result.stdout.strip()}"
+        )
+    viewed = read_json_text(view_result.stdout, field="gh-pr-view-live-state")
+    if not isinstance(viewed, Mapping):
+        raise PrResolveError("live PR view result is not a JSON object")
+    _validate_pr_identity(
+        viewed,
+        repository=repository,
+        expected_branch=current_branch,
+        expected_base=base_branch,
+        expected_head_sha=None,
+        expected_base_sha=None,
+        require_non_draft=False,
+    )
+    return dict(viewed)
 
 
 def resolve_or_create_pr(

--- a/tools/agent_workflow/pr_resolve.py
+++ b/tools/agent_workflow/pr_resolve.py
@@ -33,7 +33,8 @@ _PR_URL_PATTERN: Final = re.compile(
 )
 _PR_LIST_FIELDS: Final = "number,url,state,isDraft,baseRefName,headRefName,headRefOid"
 _PR_VIEW_FIELDS: Final = (
-    "number,url,state,isDraft,baseRefName,baseRefOid,headRefName,headRefOid"
+    "number,url,state,isDraft,baseRefName,baseRefOid,headRefName,headRefOid,"
+    "statusCheckRollup"
 )
 _REQUIRED_PR_FIELDS: Final = (
     "number",


### PR DESCRIPTION
Closes #159

## Summary

- Add the LCK v1 Design Charter and the complete Task #88 Current → Target migration matrix.
- Add live Git/GitHub state resolution for Task, branch, remote ref, OPEN PR, checks, merged state, and cleanup facts.
- Add phase eligibility and idempotent Delivery Prepare workspace create/select/restore effects.
- Fail closed when merged history is ambiguous, an OPEN PR cannot be bound to the live Task branch tip, required local Git/Task-branch facts are unavailable, or a current Task worktree is dirty.
- Reuse the existing workflow evidence and PR resolver query infrastructure; no snapshot or expected-SHA authority is introduced.

## Validation

- `workflow-delivery`: passed on clean committed head `51d757dde85dd422e22f66dfb27243d3e0602b18`.
- CI `quality`: passed.
- Repair commits: `b46453c` (`fix: reject dirty current LCK task worktree`) and `51d757d` (`fix: preserve unrelated dirty worktree stop reason`).
- Delivery readiness: passed for base `ed5b8ac9f6264f41bbf4bfe243ddbb4bfdc1f5d7` and head `51d757dde85dd422e22f66dfb27243d3e0602b18`.

## Risks / Limitations

- This Task does not move commit, push, PR mutation, lifecycle transition, merge, or closeout authority into LCK.
- Those effects remain bounded follow-up work for the subsequent LCK migration Tasks.
- This PR is ready for a new fresh independent review; the prior review verdict applies only to the superseded head.
