### PR TITLE
[Task] 将 Delivery lifecycle control 迁移至 LCK

### DIFF
--- a/.agents/skills/task-delivery-runner/SKILL.md
+++ b/.agents/skills/task-delivery-runner/SKILL.md
@@ -1,14 +1,18 @@
 ---
 name: task-delivery-runner
-description: Deliver one maintainer-specified existing GitHub Task from readiness through implementation, Runner validation, commit, push, PR creation, checks, and handoff for independent review; or repair an existing Task PR from an independent review handoff and return it for a new independent review. Do not choose Tasks, review independently, merge, close Issues, clean unrelated branches, or assess Feature completion.
+description: Deliver one maintainer-specified existing GitHub Task through LCK initial Delivery, or repair an existing Task PR from an independent review handoff. Initial Delivery uses LCK for workspace preparation, Critical Outcome, formal validation, commit, push, PR resolution/creation, checks, and Project Status. Independent review, merge, closeout, and Feature completion remain outside this Skill.
 ---
 
 # Task delivery runner
 
-Use this Skill for one existing Task explicitly named by the maintainer. It
-supports initial delivery and independent-review remediation. A successful run
-ends with one non-Draft PR ready for a new-session
-`task-pr-review-runner`.
+Use this Skill for one existing Task explicitly named by the maintainer.
+
+Initial Delivery is controlled by **LCK**. Codex / Claude owns semantic work;
+LCK owns deterministic lifecycle mechanics. A successful initial Delivery ends
+at `READY_FOR_REVIEW` and a Human boundary. It never starts Independent Review.
+
+Review remediation remains the separate procedure at the end of this Skill
+until its LCK cutover is implemented by the Review / Remediation migration Task.
 
 ## Standard invocation
 
@@ -32,321 +36,203 @@ Review remediation handoff:
 ```
 
 The Issue number is the primary key; the current Issue title is canonical.
-A request may limit execution to one named Phase. Verify prior Phase facts and
-stop at the requested boundary.
 
-## Policies and Runner interface
+## Policies and shared semantics
 
 Read applicable `AGENTS.md` and
 `.agents/policies/command-execution.md`, `.agents/policies/workflow-evidence.md`.
+Shared lifecycle semantics are owned by `docs/development/issue-workflow.md`.
+Read only the sections needed by the current invocation.
 
-Shared lifecycle semantics are owned by `docs/development/issue-workflow.md`
-(§3 lifecycle metadata, §4 readiness, §6 Delivery, §10 remediation). Read the
-minimal needed section for the current phase; do not duplicate lifecycle prose
-in this Skill.
+The current Task body is the business specification. Do not default to reading comments, complete Parent/Epic bodies, dependency bodies, templates, workflows, validation sources, or linked docs/ADRs. Expand only when the current Task explicitly references them, the specification is missing or ambiguous, a dependency affects implementation, a safety/architecture constraint applies, or verification requires it.
+Verifying these mechanical facts does not require reading the full text of any source into the model context. Read the minimum relevant source/section, evaluate sufficiency, and expand further only if still insufficient.
 
-Use the current repository Runner interfaces:
-
-```bash
-tools/agent_workflow/wsl2_github_evidence_runner.py delivery \
-  --entry-point <ENTRY_POINT> \
-  --task <TASK> \
-  --expected-main-sha <LOCKED_MAIN_SHA> \
-  [--branch <BRANCH> --expected-base-sha <BASE> \
-   [--expected-head-sha <HEAD>] | --pr <PR>]
-
-tools/agent_workflow/wsl2_validation_runner.py workflow-delivery \
-  --base-sha <LOCKED_TASK_BASE_SHA>
-
-tools/agent_workflow/wsl2_github_evidence_runner.py delivery-readiness \
-  --task <TASK> \
-  --pr <PR> \
-  --expected-base-sha <LOCKED_TASK_BASE_SHA> \
-  --expected-head-sha <CURRENT_HEAD_SHA>
-```
-
-| Entry point | Invoked at | Params beyond `--task`, `--expected-main-sha` |
-|---|---|---|
-| `delivery-start` | Phase 1 before any write | — |
-| `implementation` | Phase 2 before branch/implementation writes | `--branch --expected-base-sha` (`--bootstrap-verify` after creation) |
-| `final-validation` | Phase 3 before commit + `workflow-delivery` | `--branch --expected-base-sha --expected-head-sha` |
-| `pr-readiness` | Phase 4 before PR creation/push | `--branch --expected-base-sha --expected-head-sha` |
-| `review-remediation` | Remediation before any repair edit | `--pr --expected-base-sha --expected-head-sha` |
-
-During implementation, use a matching targeted Validation profile only when
-needed: `targeted`, `targeted:tools-tests`, or `targeted:workflow-tests`.
-
-`workflow-delivery` is the final CI-equivalent validation for the committed
-candidate head. The Evidence Runner is the source for workflow facts covered by
-its snapshot. For `partial`, `unknown`, `fail`, truncation, schema mismatch, or
-drift, inspect only the named facts or failed commands and preserve the original
-status.
-
-Evidence artifacts must record the Skill, Runner, profile/schema, target
-repository, base/head, and content hashes used in the run.
-
-## Permission boundary
-
-After its prerequisite gates pass, this Skill may: read Task, repository, Git,
-GitHub, Project, and Relationship facts; move the exact Task through `Ready`,
-`In Progress`, and `Review`; create or reuse the exact Task branch; edit only
-approved Task scope; run targeted and final Runner validation; stage explicit
-paths, create scoped commits, and push normally; create or reuse one matching
-non-Draft PR; repair confirmed in-scope independent review findings and update
-the existing Task PR; wait for and read checks; produce the independent-review
-handoff.
-
-It does not authorize: Task-scope changes, unrelated writes, force push,
-`--admin`, protection bypass, destructive Git cleanup, GitHub Review
-submission, merge, Issue close, post-merge work, branch deletion, or Feature
-completion assessment. Proposed Task-specification changes require separate
-maintainer authorization.
-
-## Lifecycle state
-
-The label / Project `Status` mapping and readiness conditions are defined in
-`docs/development/issue-workflow.md` §3–§4; do not re-derive the table here.
-Implementation requires an open Task, `Ready` or `In Progress`, `codex:ready`,
-no `codex:blocked`, and this invocation. Stop before a state write if actual
-Project options differ.
-
-`codex:ready` and `codex:needs-spec` are mutually exclusive lifecycle labels.
-Their coexistence is a lifecycle conflict that fails Preflight; do not proceed.
-
-## Preflight gate (terminal admission gate, required first step)
-
-Every invocation MUST run the `delivery` Preflight first, before any Git,
-GitHub, or code write. Preflight is a **terminal admission gate**, not a
-remediation phase — no recovery path through a non-pass result.
-
-Proceed only when ALL hold: `status = pass`, `disposition.workflow_may_continue
-= true`, `disposition.write_actions_allowed = true`, identity matches this
-Task/repository/entry-point/branch/base/head/PR.
-
-Any valid non-pass (`fail`, `partial`, `unknown`, `blocked`, lifecycle
-conflict, identity conflict, incompatible entry state,
-maintainer-decision-required) is a **final admission decision**: stop
-immediately, read only the compact digest and failing gate, report failure
-and required maintainer action, state no writes were performed. Do NOT modify
-code/config/GitHub state, auto-repair, enter implementation/validation/PR/
-readiness/review-remediation, route to a remediation loop, or re-invoke the
-same profile.
-
-Distinguish: **no valid result** (Runner crash, transport break, unparseable
-schema, no artifact) → one identical bounded retry. **Valid non-pass** →
-final; no auto-remediation or retry.
-
-### Worktree compatibility
-
-`worktree_state_compatible` is per-entry-point, not universal:
-
-| Entry point | Dirty worktree | Handling |
-|---|---|---|
-| `delivery-start` | Allowed | Full flow takes custody of existing changes |
-| `implementation` | Allowed | Phase continues development and commit |
-| `final-validation` | Forbidden | Must bind clean committed head |
-| `pr-readiness` | Forbidden | Local, remote, PR head must be stable |
-| `review-remediation` | Forbidden (fail-closed) | Must start from determinate reviewed head |
-
-When dirty allowed, Preflight records staged/unstaged/untracked files but
-never stages, commits, stashes, discards, resets, or edits. Dirty with
-unrelated, generated, secret-bearing, or prohibited files → fail.
-
-### Invocation lifecycle
-
-- First action: run Preflight with the appropriate entry point.
-- Full flow/phase-specific/new-session: execute Preflight once.
-- Same-invocation later phases: check local preconditions + drift.
-- Phase-specific calls stop at the requested boundary.
-- Initial Delivery with no handoff/artifact: generate one minimal read-only snapshot.
-- `review-remediation` requires the bounded handoff from the prior Independent
-  Review. Missing handoff, missing reviewed-head identity, or Task/PR/head mismatch
-  is a semantic admission failure: stop before Runner or repair writes. Do not use
-  the generic snapshot fallback to manufacture remediation authority.
-- Valid handoff/artifact (same Task/branch/base/head): reuse; regenerate only
-  when missing, expired, contradictory, or insufficient.
-
-## Phase 1: identity and readiness
-
-Generate the `delivery` snapshot. The snapshot provides deterministic
-identity facts: repository/origin, workspace, refs/worktrees, synchronized
-main identity, Task type/title/state, Parent identity,
-dependencies/Relationships metadata, labels, Project fields, blocker state,
-and PR head/base/checks when applicable. Verifying these mechanical facts
-does not require reading the full text of any source into the model context.
-
-The current Task body is the business specification: read it and confirm
-that goal, scope, acceptance criteria, exceptions, and out-of-scope work are
-implementable without guessing. Do not default to reading comments, complete
-Parent/Epic bodies, dependency bodies, templates, workflows, validation
-sources, or linked docs/ADRs. Expand those only when a trigger applies: the
-Task body explicitly references them, the specification is missing or
-ambiguous, a conflict must be located, a dependency's state/contract affects
-implementation, a safety/architecture constraint applies, or verification
-requires them. Read the minimum relevant source/section, evaluate
-sufficiency, and expand further only if still insufficient.
-
-The Issue title is canonical when a derived Project title lags. Apply and
-re-read lifecycle transitions only after readiness passes.
-
-## Phase 2: branch and implementation
-
-Start from clean `main` unless facts prove a valid recovery point. Create or
-reuse one exact Task branch after verifying identity, history, scope, and
-ownership. The implementation preflight classifies the branch state:
-
-- existing branch with proven Task identity, ownership, locked base, and a
-  clean worktree: reuse it;
-- absent branch with a clean locked `main`, no local/remote/worktree conflict,
-  and the canonical `task/<Issue number>-<slug>` name: `branch_bootstrap = pass`
-  is deterministic authorization for the Skill to create it;
-- ambiguous identity, ownership, or base: fail closed and require Human Gate.
-
-For the authorized new-branch path, the Skill creates directly from the locked
-base and never uses a noncanonical name such as `task-<Issue number>`:
+It must contain a valid `Critical Outcome` contract with:
 
 ```text
-git switch -c task/<Issue number>-<slug> <LOCKED_MAIN_SHA>
+Caller: ...
+Capability: ...
+Observable result: ...
+Verification test: tests/.../test_*.py::test_*
 ```
 
-Immediately rerun the implementation Evidence Runner with
-`--bootstrap-verify`. Continue only when it proves the actual branch name,
-HEAD and branch tip equal the locked base, branch base identity is correct, the
-worktree is clean, and no remote or other drift appeared. Existing numeric
-branch forms may be reused only when the Runner proves their Task ownership;
-they are never new-branch creation targets. Implement the smallest correct
-change — follow scoped rules, preserve safety, add required tests/docs, inspect
-tracked and untracked scope. Do not weaken tests to obtain a pass.
+The verification target is data, not an arbitrary command. LCK executes only
+the bounded pytest verifier defined by the repository runtime.
 
-## Phase 3: commit, final validation, and push
+## Initial Delivery authority boundary
 
-Use targeted profiles during development. Before committing, map acceptance
-criteria to implementation/tests, inspect the complete diff, exclude secrets,
-generated files, unrelated changes, and ignored evidence artifacts. Stage
-explicit paths only; do not use `git add .`. Create a scoped commit, run
-`workflow-delivery` against the clean committed head. On failure, inspect
-bounded evidence, repair with another scoped commit, and rerun. Push only the
-head that passed final validation. Re-read branch and remote-head identity.
+For **initial Delivery**, the Agent / Skill MAY:
 
-## Phase 4: PR and readiness
+- read the current Task and required scoped context;
+- understand, design, implement, diagnose, and explain the change;
+- edit files within approved Task scope;
+- run targeted validation while developing;
+- provide semantic completion metadata such as commit message, implementation
+  summary, risks, and limitations.
 
-### 4a. PR resolve or create
+For **initial Delivery**, the Agent / Skill MUST NOT directly:
 
-Use `tools/agent_workflow/pr_resolve.py` as the single PR resolve/create path.
-The helper enforces in code (not in Skill prose): single structured query with
-`--limit 2`, exit-code check, non-empty stdout, JSON parse; 0 matches → create
-with exit/stdout/URL checks; 1 match → reuse; >1 → fail-closed; identity
-verification with all required fields, no retry with modified fields; mismatch
-on number/URL/state/draft/base-head branch/base-head SHA → fail-closed. Never
-suppresses stderr, parses empty stdout as JSON, retries with modified fields,
-or falls back to text-mode.
+- choose or create the Task branch;
+- stage or commit the final candidate;
+- choose a remote/refspec or push;
+- choose a PR number or create/reuse/update the PR mechanically;
+- change Project lifecycle state;
+- invent or pass branch/SHA/base/PR identity as workflow authority;
+- start Independent Review, merge, close the Issue, or perform closeout.
 
-The PR must contain `Closes #<Task>`, describe implementation, validation,
-risks, and limitations, and contain only approved files and commits. Set
-Project Status to `Review` only after the PR exists.
+Those mechanics belong to LCK. If an LCK command returns STOP, do not fall back
+to direct Git/GitHub commands. Report the STOP reason and wait for the required
+maintainer or implementation action.
 
-### 4b. Checks
+## Initial Delivery procedure
 
-Wait for applicable checks. Distinguish no configured Required Checks, a
-recognized plan-limit `403`, and pending, failed, stale, cancelled, skipped,
-or unavailable checks.
+### 1. LCK Delivery Prepare
 
-### 4c. Semantic self-review artifact
+The first lifecycle action is:
 
-Before `delivery-readiness`, produce a structured self-review artifact using
-the schema from `tools/agent_workflow/self_review.py`. The artifact must: lock
-Task number, business base SHA, current head SHA, effective diff SHA-256, and
-PR number at generation time; re-confirm head has not changed before
-finalizing; map every acceptance criterion to `verified` |
-`partially_verified` | `not_verified` with implementation and validation
-evidence; group changed files into review areas derived from the actual diff;
-record per area: files, status, key behaviour changes, mapped criteria,
-mechanical validation results, findings, and remaining risk; enforce that
-`overall: "verified"` requires every area and criterion `verified` with
-evidence entries; never accept a keyword grep or file-exists check as semantic
-review; never claim provenance or canonical-state clearance without a
-corresponding mechanical validator result.
+```bash
+python tools/agent_workflow/lck.py delivery prepare <TASK>
+```
 
-Write to `.agents/evidence.local/self-reviews/` (Git-ignored, not committed).
-The artifact is bound to current head and diff; any new commit makes it stale.
+Proceed only when LCK returns a resolved Delivery context. LCK reacquires live
+Git/GitHub facts, verifies Task identity/readiness/blockers, and creates,
+selects, or restores the one correct Task workspace.
 
-### 4d. Delivery readiness
+Do not pass branch, expected SHA, base SHA, PR number, remote, or refspec.
 
-Generate `delivery-readiness`. Verify Task/PR identity, base/head, effective
-diff, files/commits, linkage, checks, reviews, threads, lifecycle, and scope.
-Stop on a new commit, drift, validation/check failure, blocking thread, state
-conflict, or unresolved Blocking/High/Medium self-finding.
+### 2. Semantic implementation
+
+Read the current Task body and implement the smallest complete change that
+satisfies Objective, Requirements, Critical Outcome, Acceptance Criteria, and
+explicit scope boundaries.
+
+During implementation, use a matching targeted Validation profile when useful:
+
+```bash
+tools/agent_workflow/wsl2_validation_runner.py targeted:tools-tests
+tools/agent_workflow/wsl2_validation_runner.py targeted:workflow-tests
+```
+
+Targeted validation is development feedback only. Do not treat it as final
+Delivery authorization and do not weaken tests to obtain a pass.
+
+Before completion, inspect the complete workspace diff semantically. Remove or
+repair unrelated, generated, secret-bearing, or prohibited changes. The
+workspace presented to LCK is the candidate Task tree.
+
+### 3. LCK Delivery Complete
+
+After semantic implementation is complete, invoke LCK with semantic metadata:
+
+```bash
+python tools/agent_workflow/lck.py delivery complete <TASK> \
+  --commit-message "<scoped commit message>" \
+  --summary "<implementation summary>" \
+  --risks "<risks or limitations>"
+```
+
+Do not supply branch, remote, SHA, base SHA, PR number, or refspec.
+
+Within one bounded invocation, LCK performs the deterministic sequence:
+
+```text
+reacquire live Task/Git/GitHub facts
+→ validate Delivery Complete eligibility
+→ parse current Task Critical Outcome
+→ stage current candidate tree
+→ run Critical Outcome verifier
+→ run formal Delivery validation
+→ prove validated staged tree is unchanged
+→ commit_current_tree
+→ ensure_remote_branch
+→ ensure_open_pr
+→ wait for applicable checks
+→ set Project Status Review
+→ reacquire live facts
+→ prove local HEAD == remote HEAD == PR head
+→ READY_FOR_REVIEW
+→ STOP at Human boundary
+```
+
+If the invocation resumes after an earlier partial side effect, LCK does not
+trust a previous receipt as authority. It reacquires current facts and reruns
+the applicable Critical Outcome / formal validation gates before continuing.
+
+`Critical Outcome FAIL`, formal validation failure, remote divergence,
+ambiguous PR identity, failed/unknown checks, stale lifecycle facts, or failed
+postconditions are terminal for that invocation. LCK does not rebase, force
+push, guess an identity, or route itself into repair.
+
+### 4. Initial Delivery reporting
+
+On `READY_FOR_REVIEW`, report:
+
+- canonical Task and PR URLs returned by current facts;
+- semantic changed-file summary;
+- Critical Outcome result;
+- formal Delivery validation result;
+- LCK effect receipts at summary level;
+- checks result and preserved limitations;
+- current lifecycle state;
+- remaining semantic risks or limitations;
+- exact fresh-session `task-pr-review-runner` prompt.
+
+Always state that Independent Review, Merge, Issue close, post-merge closeout,
+branch deletion, and Feature completion were not performed.
 
 ## Review remediation
 
-Use this mode when a `task-pr-review-runner` verdict requires changes or an
-objective gate must be re-evaluated for an existing open Task PR.
+This section applies only after a non-passing `task-pr-review-runner` handoff.
+Its lifecycle-control migration is intentionally outside the initial Delivery
+cutover.
 
-The remediation handoff must identify: Task and PR; reviewed head SHA; Review
-verdict; required Blocking, High, or Medium findings; unresolved objective
-gates; maintainer decisions, if any.
+The remediation handoff must identify Task and PR, reviewed head SHA, verdict,
+required Blocking/High/Medium findings, objective gates, and maintainer
+questions if any. `review-remediation` requires the bounded handoff. Missing or contradictory handoff identity is a semantic admission failure: stop before Runner or repair writes.
+Do not use the generic snapshot fallback to manufacture remediation authority.
 
-Re-read current Task, PR, branch, head, effective diff, checks, reviews, and
-threads. Verify that the PR is open, belongs to the expected Task branch, and
-matches the reviewed head. If the head changed and the change is not already
-explained by current repository facts, stop for clarification.
+Run the current deterministic remediation Preflight before editing:
 
-Classify every handoff item before editing: confirmed in-scope
-implementation/test/documentation/configuration finding → repair; pending or
-unavailable objective gate → recheck or wait; scope/acceptance-criteria/
-public-behavior/architecture change → stop for maintainer authorization;
-Low or Nit → leave unchanged unless maintainer explicitly requests it.
-
-Implement the smallest complete repair, add regression coverage, preserve Task
-scope, safety boundaries, and unrelated behavior. Create scoped repair commits,
-run final `workflow-delivery` against the clean committed head, push the
-validated head, wait for checks, regenerate `delivery-readiness`. Update PR
-description/validation summary when materially changed.
-
-The previous Review verdict applies only to its reviewed head; any new commit
-makes it stale. This Skill does not submit/resolve a GitHub Review, merge,
-close the Task, or perform closeout. Stop when the updated PR is ready for a
-new independent review. Report: handoff items addressed and how; items not
-addressed and why; old reviewed head and new head; repair commits and changed
-files; regression tests and final validation; checks, reviews, threads,
-remaining limitations; exact new-session `task-pr-review-runner` prompt.
-
-## Recovery and handoff
-
-Recovery rules apply only after Invocation Preflight has passed and never
-authorize remediation of a Preflight result. A valid non-pass Preflight is a
-terminal disposition, not a recoverable state.
-
-Resume from the first unverified gate by checking local preconditions plus
-drift from the Preflight snapshot for the target entry point. Verify completed
-writes instead of repeating them. For remediation, treat the supplied handoff
-as an index to independently verified findings and gates, not as permission to
-change Task scope. Stop on lifecycle conflict, identity drift, or entry-point
-state invalidation.
-
-This Skill never performs independent review. On a clean path, including after
-remediation, report: canonical Task/PR URLs, branch, base/head, changed-file
-summary; final validation/check summary, lifecycle state, thread count,
-limitations; self-review artifact path, overall verdict, summary of each area
-and acceptance criterion with evidence status; every `partial`/`unknown` from
-`delivery-readiness` preserved with original reason (never upgraded to `pass`
-by omission); mechanical validation conclusions (separate from semantic
-self-review); unverified or partially verified content with explicit gaps;
-and:
-
-```text
-Ready for independent review
+```bash
+tools/agent_workflow/wsl2_github_evidence_runner.py delivery \
+  --entry-point review-remediation \
+  --task <TASK> \
+  --expected-main-sha <CURRENT_MAIN_SHA> \
+  --pr <PR> \
+  --expected-base-sha <REVIEWED_BASE_SHA> \
+  --expected-head-sha <REVIEWED_HEAD_SHA>
 ```
 
-**Reporting contract:** Every conclusion must trace to a self-review evidence
-entry or mechanical validator result. Only `Verified` may be stated as fact.
-`Partially verified` must state covered scope and gaps. `Not verified` must
-not be rephrased as a pass. Do not expand a grep, file-exists check, or
-partial validator result into "all complete." When `delivery-readiness` is
-`partial`, retain the `partial`/`unknown` reasons.
+Proceed only on a valid passing result. `partial`, `unknown`, lifecycle
+conflict, identity conflict, or other valid non-pass is terminal; do not repair
+it automatically.
 
-End with the exact new-session `task-pr-review-runner` prompt and expected
-base/head SHAs. Use a detailed report for any finding, fallback,
-`partial`/`unknown`, failure, drift, conflict, or maintainer decision. Always
-state that Review, Merge, Issue close, post-merge work, branch deletion, and
-Feature completion were not performed.
+Classify every handoff item before editing: confirmed in-scope implementation,
+test, documentation, or configuration finding → repair; scope/AC/public
+behavior/architecture change → Human Gate; Low/Nit → leave unchanged unless
+explicitly requested.
+
+Implement the smallest complete repair and add regression coverage. Existing
+remediation mechanics continue to use the current Evidence / Validation Runner
+contract for this phase: create scoped repair commits, run `workflow-delivery`
+against the clean committed head, push only the validated head, reuse the
+existing Task PR, wait for checks, and regenerate `delivery-readiness`.
+
+The previous Review verdict applies only to its reviewed head. Any new commit
+requires a fresh independent review. Remediation never submits a GitHub Review,
+merges, closes the Task, performs closeout, or starts the new Review itself.
+
+Report the handoff items addressed, new head, validation/check result, remaining
+limitations, and the exact fresh-session review prompt.
+
+## Failure discipline
+
+Distinguish deterministic STOP from tool failure:
+
+- valid LCK / Runner STOP → stop; no alternate write route;
+- missing/unparseable tool result → at most one identical bounded retry;
+- semantic Task ambiguity or requested scope expansion → Human Gate;
+- remote divergence or identity ambiguity → stop; never force push or guess;
+- `partial` / `unknown` evidence remains `partial` / `unknown` in reporting.
+
+The Skill is a semantic procedure. It is not the lifecycle state machine.

--- a/.agents/skills/task-pr-review-runner/SKILL.md
+++ b/.agents/skills/task-pr-review-runner/SKILL.md
@@ -307,55 +307,58 @@ merges.
 
 ## Remediation handoff
 
-For `有条件通过，不得合并` or `不通过，需要修复`, emit one compact handoff after
-the verdict:
+For `有条件通过，不得合并` or `不通过，需要修复`, keep the human-readable
+Review report body separate from the next-lifecycle input. The report body
+must contain the verdict, mechanical verification, findings, Acceptance
+Criteria coverage, and relevant evidence. It must then end with exactly one
+canonical remediation section; do not emit a standalone handoff before it or
+wrap a second handoff around it.
 
-```text
-Remediation handoff
+The canonical final section is `## Remediation handoff` followed by exactly one
+fenced code block. The block is the complete, directly copyable Delivery
+prompt and must begin with the task-delivery instruction itself:
 
-Task: #<Task>
-PR: #<PR>
-Reviewed head SHA: <SHA>
-Verdict: <verdict>
-
-Required remediation:
-- [F1][Blocking|High|Medium] <defect, precise evidence, expected behavior>
-
-Objective gates:
-- <pending, unavailable, ambiguous, contradictory, or unstable gate>
-
-Maintainer decision required:
-- <scope, specification, public behavior, or architecture decision>
-```
-
-Rules:
-
-- include only findings that caused the non-passing verdict; the bounded
-  handoff semantics are authoritative in `docs/development/pr-review.md` §9;
-- include objective gates that require recheck or waiting;
-- include decisions that cannot be resolved without maintainer authorization;
-- exclude Low and Nit findings unless the maintainer explicitly made them
-  required;
-- state the defect and expected behavior, but do not design the implementation;
-- preserve finding IDs.
-
-End with this exact remediation prompt populated with current identities:
-
+````text
 ```text
 请按 task-delivery-runner 修复
 [Task] <当前完整标题> #<Task编号>
 对应 PR #<PR编号> 的独立审查问题，
 并继续处理，直到 PR 再次准备好接受新的独立审查。
 
-Review remediation handoff:
+Task: #<Task编号>
+PR: #<PR编号>
+Reviewed head SHA: <SHA>
+Verdict: <有条件通过，不得合并 | 不通过，需要修复>
 
-<上述 remediation handoff>
+Required remediation:
+- [F1][Blocking|High|Medium] <完整 finding，包含证据与预期行为>
+
+Objective gates:
+- <尚未满足、不可用、矛盾或需要重新验证的 gate>
+- 如无则写：无。
+
+Maintainer decision required:
+- <需要维护者授权的事项>
+- 如无则写：无。
 ```
+````
+
+Include only findings that caused the non-passing verdict; the bounded handoff
+semantics are authoritative in `docs/development/pr-review.md` §9. Include
+objective gates that require recheck or waiting, and decisions that cannot be
+resolved without maintainer authorization. Exclude Low and Nit findings unless
+the maintainer explicitly made them required. Preserve finding IDs and write
+each required finding in full exactly once. The block must be self-contained:
+do not refer to material outside it with phrases such as “上述”, “同上”, or
+“见前文”.
 
 A passing verdict does not emit a remediation handoff.
 
-**Enforcement**: Every non-passing verdict must output both handoff and Delivery
-prompt. A partial handoff without the Delivery prompt is non-compliant.
+**Enforcement**: Every non-passing verdict emits exactly one final
+`## Remediation handoff` section and exactly one fenced code block. The block
+itself is the single Delivery prompt; duplicate headings, wrapper labels, or
+repeated findings are non-compliant. A passing verdict emits no remediation
+section.
 
 ## Report and recovery
 

--- a/.claude/skills/task-delivery-runner/SKILL.md
+++ b/.claude/skills/task-delivery-runner/SKILL.md
@@ -1,14 +1,18 @@
 ---
 name: task-delivery-runner
-description: Deliver one maintainer-specified existing GitHub Task from readiness through implementation, Runner validation, commit, push, PR creation, checks, and handoff for independent review; or repair an existing Task PR from an independent review handoff and return it for a new independent review. Do not choose Tasks, review independently, merge, close Issues, clean unrelated branches, or assess Feature completion.
+description: Deliver one maintainer-specified existing GitHub Task through LCK initial Delivery, or repair an existing Task PR from an independent review handoff. Initial Delivery uses LCK for workspace preparation, Critical Outcome, formal validation, commit, push, PR resolution/creation, checks, and Project Status. Independent review, merge, closeout, and Feature completion remain outside this Skill.
 ---
 
 # Task delivery runner
 
-Use this Skill for one existing Task explicitly named by the maintainer. It
-supports initial delivery and independent-review remediation. A successful run
-ends with one non-Draft PR ready for a new-session
-`task-pr-review-runner`.
+Use this Skill for one existing Task explicitly named by the maintainer.
+
+Initial Delivery is controlled by **LCK**. Codex / Claude owns semantic work;
+LCK owns deterministic lifecycle mechanics. A successful initial Delivery ends
+at `READY_FOR_REVIEW` and a Human boundary. It never starts Independent Review.
+
+Review remediation remains the separate procedure at the end of this Skill
+until its LCK cutover is implemented by the Review / Remediation migration Task.
 
 ## Standard invocation
 
@@ -32,428 +36,203 @@ Review remediation handoff:
 ```
 
 The Issue number is the primary key; the current Issue title is canonical.
-A request may limit execution to one named Phase. Verify prior Phase facts using
-the Evidence Runner snapshot that Phase would have produced (`delivery` for
-identity/lifecycle, `delivery-readiness` for PR/check facts) — do not substitute
-direct `gh` or `git` queries for Runner snapshots — and stop at the requested
-boundary.
 
-## Policies and Runner interface
+## Policies and shared semantics
 
-Read applicable `AGENTS.md` and:
+Read applicable `AGENTS.md` and
+`.agents/policies/command-execution.md`, `.agents/policies/workflow-evidence.md`.
+Shared lifecycle semantics are owned by `docs/development/issue-workflow.md`.
+Read only the sections needed by the current invocation.
+
+The current Task body is the business specification. Do not default to reading comments, complete Parent/Epic bodies, dependency bodies, templates, workflows, validation sources, or linked docs/ADRs. Expand only when the current Task explicitly references them, the specification is missing or ambiguous, a dependency affects implementation, a safety/architecture constraint applies, or verification requires it.
+Verifying these mechanical facts does not require reading the full text of any source into the model context. Read the minimum relevant source/section, evaluate sufficiency, and expand further only if still insufficient.
+
+It must contain a valid `Critical Outcome` contract with:
 
 ```text
-.agents/policies/workflow-evidence.md
+Caller: ...
+Capability: ...
+Observable result: ...
+Verification test: tests/.../test_*.py::test_*
 ```
 
-Shared lifecycle semantics are owned by `docs/development/issue-workflow.md`
-(§3 lifecycle metadata, §4 readiness, §6 Delivery, §10 remediation). Read the
-minimal needed section for the current phase; do not duplicate lifecycle prose
-in this Skill.
+The verification target is data, not an arbitrary command. LCK executes only
+the bounded pytest verifier defined by the repository runtime.
 
-Use the current repository Runner interfaces:
+## Initial Delivery authority boundary
+
+For **initial Delivery**, the Agent / Skill MAY:
+
+- read the current Task and required scoped context;
+- understand, design, implement, diagnose, and explain the change;
+- edit files within approved Task scope;
+- run targeted validation while developing;
+- provide semantic completion metadata such as commit message, implementation
+  summary, risks, and limitations.
+
+For **initial Delivery**, the Agent / Skill MUST NOT directly:
+
+- choose or create the Task branch;
+- stage or commit the final candidate;
+- choose a remote/refspec or push;
+- choose a PR number or create/reuse/update the PR mechanically;
+- change Project lifecycle state;
+- invent or pass branch/SHA/base/PR identity as workflow authority;
+- start Independent Review, merge, close the Issue, or perform closeout.
+
+Those mechanics belong to LCK. If an LCK command returns STOP, do not fall back
+to direct Git/GitHub commands. Report the STOP reason and wait for the required
+maintainer or implementation action.
+
+## Initial Delivery procedure
+
+### 1. LCK Delivery Prepare
+
+The first lifecycle action is:
 
 ```bash
-tools/agent_workflow/wsl2_github_evidence_runner.py delivery \
-  --entry-point <ENTRY_POINT> \
-  --task <TASK> \
-  --expected-main-sha <LOCKED_MAIN_SHA> \
-  [--branch <BRANCH> --expected-base-sha <BASE> \
-   [--expected-head-sha <HEAD>] | --pr <PR>]
-
-tools/agent_workflow/wsl2_validation_runner.py workflow-delivery \
-  --base-sha <LOCKED_TASK_BASE_SHA>
-
-tools/agent_workflow/wsl2_github_evidence_runner.py delivery-readiness \
-  --task <TASK> \
-  --pr <PR> \
-  --expected-base-sha <LOCKED_TASK_BASE_SHA> \
-  --expected-head-sha <CURRENT_HEAD_SHA>
+python tools/agent_workflow/lck.py delivery prepare <TASK>
 ```
 
-| Entry point | Invoked at | Params beyond `--task`, `--expected-main-sha` |
-|---|---|---|
-| `delivery-start` | Phase 1 before any write | — |
-| `implementation` | Phase 2 before branch/implementation writes | `--branch --expected-base-sha` (`--bootstrap-verify` after creation) |
-| `final-validation` | Phase 3 before commit/`workflow-delivery` | `--branch --expected-base-sha --expected-head-sha` |
-| `pr-readiness` | Phase 4 before PR creation/push verification | `--branch --expected-base-sha --expected-head-sha` |
-| `review-remediation` | Review remediation before any repair edit | `--pr --expected-base-sha --expected-head-sha` |
+Proceed only when LCK returns a resolved Delivery context. LCK reacquires live
+Git/GitHub facts, verifies Task identity/readiness/blockers, and creates,
+selects, or restores the one correct Task workspace.
 
-During implementation, use a matching targeted Validation profile only when
-needed:
+Do not pass branch, expected SHA, base SHA, PR number, remote, or refspec.
+
+### 2. Semantic implementation
+
+Read the current Task body and implement the smallest complete change that
+satisfies Objective, Requirements, Critical Outcome, Acceptance Criteria, and
+explicit scope boundaries.
+
+During implementation, use a matching targeted Validation profile when useful:
+
+```bash
+tools/agent_workflow/wsl2_validation_runner.py targeted:tools-tests
+tools/agent_workflow/wsl2_validation_runner.py targeted:workflow-tests
+```
+
+Targeted validation is development feedback only. Do not treat it as final
+Delivery authorization and do not weaken tests to obtain a pass.
+
+Before completion, inspect the complete workspace diff semantically. Remove or
+repair unrelated, generated, secret-bearing, or prohibited changes. The
+workspace presented to LCK is the candidate Task tree.
+
+### 3. LCK Delivery Complete
+
+After semantic implementation is complete, invoke LCK with semantic metadata:
+
+```bash
+python tools/agent_workflow/lck.py delivery complete <TASK> \
+  --commit-message "<scoped commit message>" \
+  --summary "<implementation summary>" \
+  --risks "<risks or limitations>"
+```
+
+Do not supply branch, remote, SHA, base SHA, PR number, or refspec.
+
+Within one bounded invocation, LCK performs the deterministic sequence:
 
 ```text
-targeted
-targeted:tools-tests
-targeted:workflow-tests
+reacquire live Task/Git/GitHub facts
+→ validate Delivery Complete eligibility
+→ parse current Task Critical Outcome
+→ stage current candidate tree
+→ run Critical Outcome verifier
+→ run formal Delivery validation
+→ prove validated staged tree is unchanged
+→ commit_current_tree
+→ ensure_remote_branch
+→ ensure_open_pr
+→ wait for applicable checks
+→ set Project Status Review
+→ reacquire live facts
+→ prove local HEAD == remote HEAD == PR head
+→ READY_FOR_REVIEW
+→ STOP at Human boundary
 ```
 
-`workflow-delivery` is the final CI-equivalent validation for the committed
-candidate head. The Evidence Runner is the source for workflow facts covered by
-its snapshot. For `partial`, `unknown`, `fail`, truncation, schema mismatch, or
-drift, inspect only the named facts or failed commands and preserve the original
-status.
+If the invocation resumes after an earlier partial side effect, LCK does not
+trust a previous receipt as authority. It reacquires current facts and reruns
+the applicable Critical Outcome / formal validation gates before continuing.
 
-Evidence artifacts must record the actual Skill, Runner, profile/schema, target
-repository, base/head, and content hashes used in the run.
+`Critical Outcome FAIL`, formal validation failure, remote divergence,
+ambiguous PR identity, failed/unknown checks, stale lifecycle facts, or failed
+postconditions are terminal for that invocation. LCK does not rebase, force
+push, guess an identity, or route itself into repair.
 
-## Execution model
+### 4. Initial Delivery reporting
 
-Claude Code executes commands directly in the user's shell environment — there
-is no sandbox isolation layer. Git, `gh`, Python, subprocess, network, and
-filesystem access all work natively. The Codex Guardian sandbox/elevated routing
-model does not apply.
+On `READY_FOR_REVIEW`, report:
 
-Runner commands are deterministic Python CLI tools invoked from the repository
-root on the WSL2 Linux filesystem. They are never wrapped in `python`,
-`bash -c`, `sh -c`, `uv run`, command substitution, pipelines, redirection, or
-a generic shell string. Each Runner call is a single Bash tool invocation.
+- canonical Task and PR URLs returned by current facts;
+- semantic changed-file summary;
+- Critical Outcome result;
+- formal Delivery validation result;
+- LCK effect receipts at summary level;
+- checks result and preserved limitations;
+- current lifecycle state;
+- remaining semantic risks or limitations;
+- exact fresh-session `task-pr-review-runner` prompt.
 
-The Bash tool itself may prompt for user approval on first use. To suppress
-these prompts for the documented Runner invocations, pre-authorize in
-`.claude/settings.json`:
-
-```json
-{
-  "permissions": {
-    "allow": [
-      "Bash(tools/agent_workflow/wsl2_github_evidence_runner.py *)",
-      "Bash(tools/agent_workflow/wsl2_validation_runner.py *)"
-    ]
-  }
-}
-```
-
-Runner commands can fail, but not because of sandbox restrictions. Read the
-Runner's own output to classify:
-
-- `pass`: all commands succeeded, inspect the compact digest.
-- `fail`: one or more commands returned non-zero. Read the named failure
-  artifact before deciding whether to repair.
-- `blocked`: a Runner precondition failed (e.g. unclean worktree, wrong branch,
-  wrong cwd, identity mismatch). Fix the precondition; do not retry with
-  different arguments.
-- `partial` / `unknown`: bounded diagnostics in the artifact — inspect only the
-  named gates.
-
-Never fall back to an equivalent direct command chain after a Runner result.
-Never retry a Runner command with modified arguments to work around a failure.
-
-## Permission boundary
-
-After its prerequisite gates pass, this Skill may:
-
-- read Task, repository, Git, GitHub, Project, and Relationship facts;
-- move the exact Task through `Ready`, `In Progress`, and `Review`;
-- create or reuse the exact Task branch;
-- edit only approved Task scope;
-- run targeted and final Runner validation;
-- stage explicit paths, create scoped commits, and push normally;
-- create or reuse one matching non-Draft PR;
-- repair confirmed in-scope findings from an independent Review and update the exact existing Task PR;
-- wait for and read checks;
-- produce the independent-review handoff.
-
-It does not authorize Task-scope changes, unrelated writes, force push,
-`--admin`, protection bypass, destructive Git cleanup, GitHub Review
-submission, merge, Issue close, post-merge work, branch deletion, or Feature
-completion assessment. Proposed Task-specification changes require separate
-maintainer authorization.
-
-## Lifecycle state
-
-The label / Project `Status` mapping and readiness conditions are defined in
-`docs/development/issue-workflow.md` §3–§4; do not re-derive the table here.
-Implementation requires an open Task, `Ready` or `In Progress`, `codex:ready`,
-no `codex:blocked`, and this invocation. Stop before a state write if actual
-Project options differ.
-
-`codex:ready` and `codex:needs-spec` are mutually exclusive lifecycle labels.
-Their coexistence is a lifecycle conflict that fails Preflight; do not proceed.
-
-## Preflight gate (terminal admission gate, required first step)
-
-Every invocation MUST run the `delivery` Preflight as its first mechanical
-gate, before any Git, GitHub, or code write. Preflight is a **terminal
-admission gate**, not a remediation phase — there is no recovery path through
-a non-pass result.
-
-Only proceed when ALL hold: valid supported Runner result; identity matches
-Task, repository, entry point, branch, base, head, and PR; `status = pass`;
-`disposition.workflow_may_continue = true`; `disposition.write_actions_allowed = true`.
-
-Any valid non-pass — `fail`, `partial`, `unknown`, `blocked`, lifecycle
-conflict, identity conflict, incompatible entry state, or
-maintainer-decision-required — is a **final admission decision**. Stop
-immediately. Only read the compact digest and failing gate evidence, report
-the failure and required maintainer action, and state no writes were performed.
-Do NOT: modify code/config/GitHub state; `git add`/commit/push/stash/reset;
-auto-repair lifecycle; enter implementation/validation/PR/readiness/
-review-remediation; route to a remediation loop; or re-invoke the same profile.
-
-Distinguish: **no valid result** (Runner crash, transport break, unparseable
-schema, no artifact) → one strictly identical bounded retry or report blockage.
-**Valid non-pass** → final; no auto-remediation or retry.
-
-### Worktree compatibility
-
-`worktree_state_compatible` is per-entry-point, not universal:
-
-| Entry point | Dirty worktree | Handling |
-|---|---|---|
-| `delivery-start` | Allowed | Full flow takes custody of existing Task changes |
-| `implementation` | Allowed | Phase continues development, validation, and commit |
-| `final-validation` | Forbidden | Must bind clean committed head |
-| `pr-readiness` | Forbidden | Identity must be stable across local, remote, and PR head |
-| `review-remediation` | Forbidden (fail-closed) | Must start from determinate reviewed head |
-
-When dirty is allowed, Preflight records staged/unstaged/untracked files but
-never stages, commits, stashes, discards, resets, or edits — it only judges.
-Dirty with unrelated, generated, secret-bearing, or prohibited files → fail.
-
-### Invocation lifecycle
-
-- First action of every invocation: run Preflight with the appropriate entry point.
-- Full flow, phase-specific, and new-session: execute Preflight once.
-- Same-invocation later phases: check local preconditions + drift; do not repeat.
-- Phase-specific calls stop at the requested boundary.
-- Initial Delivery with no handoff/artifact: generate one minimal read-only snapshot.
-- `review-remediation` requires the bounded handoff from the prior Independent
-  Review. Missing handoff, missing reviewed-head identity, or Task/PR/head mismatch
-  is a semantic admission failure: stop before Runner or repair writes. Do not use
-  the generic snapshot fallback to manufacture remediation authority.
-- Valid handoff/artifact bound to same Task/branch/base/head: reuse; regenerate
-  only when missing, expired, contradictory, or insufficient.
-
-## Phase 1: identity and readiness
-
-Generate the `delivery` snapshot. The snapshot provides deterministic
-identity facts: repository/origin, workspace, refs/worktrees, synchronized
-main identity, Task type/title/state, Parent identity,
-dependencies/Relationships metadata, labels, Project fields, blocker state,
-and PR head/base/checks when applicable. Verifying these mechanical facts
-does not require reading the full text of any source into the model context.
-
-The current Task body is the business specification: read it and confirm
-that goal, scope, acceptance criteria, exceptions, and out-of-scope work are
-implementable without guessing. Do not default to reading comments, complete
-Parent/Epic bodies, dependency bodies, templates, workflows, validation
-sources, or linked docs/ADRs. Expand those only when a trigger applies: the
-Task body explicitly references them, the specification is missing or
-ambiguous, a conflict must be located, a dependency's state/contract affects
-implementation, a safety/architecture constraint applies, or verification
-requires them. Read the minimum relevant source/section, evaluate
-sufficiency, and expand further only if still insufficient.
-
-Independently confirm the readiness conclusions. The Issue title is
-canonical when a derived Project title lags. Apply and re-read lifecycle
-transitions only after readiness passes.
-
-## Phase 2: branch and implementation
-
-Start from clean synchronized `main` unless current facts prove a valid recovery
-point. Create or reuse one exact Task branch after verifying its identity,
-history, scope, and ownership. The implementation preflight classifies the
-branch state:
-
-- existing branch with proven Task identity, ownership, locked base, and a
-  clean worktree: reuse it;
-- absent branch with a clean locked `main`, no local/remote/worktree conflict,
-  and the canonical `task/<Issue number>-<slug>` name: `branch_bootstrap = pass`
-  is deterministic authorization for the Skill to create it;
-- ambiguous identity, ownership, or base: fail closed and require Human Gate.
-
-For the authorized new-branch path, the Skill creates directly from the locked
-base and never uses a noncanonical name such as `task-<Issue number>`:
-
-```text
-git switch -c task/<Issue number>-<slug> <LOCKED_MAIN_SHA>
-```
-
-Immediately rerun the implementation Evidence Runner with
-`--bootstrap-verify`. Continue only when it proves the actual branch name,
-HEAD and branch tip equal the locked base, branch base identity is correct, the
-worktree is clean, and no remote or other drift appeared. Existing numeric
-branch forms may be reused only when the Runner proves their Task ownership;
-they are never new-branch creation targets. The Runner supplies facts and
-classification; the Skill owns branch creation/reuse orchestration.
-
-Implement the smallest correct change. Follow scoped rules, preserve safety, add
-required tests/docs, inspect tracked and untracked scope, and do not weaken tests
-to obtain a pass. Source inspection and development commands remain available
-for implementation work.
-
-## Phase 3: commit, final validation, and push
-
-Use targeted profiles during development. Before committing, map acceptance
-criteria to implementation/tests, inspect the complete diff and untracked files,
-and exclude secrets, generated files, unrelated changes, and ignored evidence
-artifacts.
-
-Stage explicit paths only; do not use `git add .`. Create a scoped commit, then
-run `workflow-delivery` against the clean committed head. On failure, inspect
-bounded evidence, repair with another scoped commit, and rerun. Push only the
-head that passed final validation. Re-read branch and remote-head identity.
-
-## Phase 4: PR and readiness
-
-### 4a. PR resolve or create
-
-Use the deterministic `pr_resolve.py` helper in
-`tools/agent_workflow/pr_resolve.py` as the single PR resolve/create path.
-The helper enforces in code (not in Skill prose):
-
-- a single structured query for matching open PRs, `--limit 2`, with exit-code
-  check, non-empty stdout check, and JSON parse before acting on the result;
-- exactly zero matches → one PR creation with exit-code/stdout/URL checks;
-- exactly one match → reuse;
-- more than one match → fail-closed;
-- a single structured identity verification with all required fields, no
-  retry with modified fields;
-- identity mismatch on number, URL, state, draft, base/head branch, or
-  base/head SHA → fail-closed.
-
-The helper never suppresses stderr, never parses empty stdout as JSON, never
-retries with modified fields, and never falls back to a text-mode query.
-
-The PR must contain `Closes #<Task>`, describe implementation, validation,
-risks, and limitations, and contain only approved files and commits. Set
-Project Status to `Review` only after the PR exists.
-
-### 4b. Checks
-
-Wait for applicable checks. Distinguish no configured Required Checks, a
-recognized plan-limit `403`, and actual pending, failed, stale, cancelled,
-skipped, or unavailable checks.
-
-### 4c. Semantic self-review artifact
-
-Before `delivery-readiness`, produce a structured self-review artifact using
-the schema from `tools/agent_workflow/self_review.py`. The artifact must:
-
-- lock Task number, business base SHA, current head SHA, effective diff
-  SHA-256, and PR number at generation time;
-- re-confirm head has not changed before finalizing;
-- map every acceptance criterion to `verified` | `partially_verified` |
-  `not_verified` with implementation and validation evidence;
-- group every changed file into review areas derived from the actual diff;
-- record per area: files, status, key behaviour changes, mapped criteria,
-  mechanical validation results, findings, and remaining risk;
-- enforce that `overall: "verified"` requires every area and criterion to be
-  `verified`, and every verified assertion to have at least one evidence entry;
-- never accept a keyword grep or file-exists check as semantic review;
-- never claim provenance or canonical-state clearance without a corresponding
-  mechanical validator result.
-
-Write to `.agents/evidence.local/self-reviews/` (Git-ignored, not committed).
-The artifact is bound to current head and diff; any new commit makes it stale.
-
-### 4d. Delivery readiness
-
-Generate `delivery-readiness`. Verify Task/PR identity, base/head, effective
-diff, files/commits, linkage, checks, reviews, threads, lifecycle, and scope.
-
-Stop on a new commit, drift, validation/check failure, blocking thread, state
-conflict, or unresolved Blocking/High/Medium self-finding.
+Always state that Independent Review, Merge, Issue close, post-merge closeout,
+branch deletion, and Feature completion were not performed.
 
 ## Review remediation
 
-Use this mode when a `task-pr-review-runner` verdict requires changes or an
-objective gate must be re-evaluated for an existing open Task PR.
+This section applies only after a non-passing `task-pr-review-runner` handoff.
+Its lifecycle-control migration is intentionally outside the initial Delivery
+cutover.
 
-The remediation handoff must identify:
+The remediation handoff must identify Task and PR, reviewed head SHA, verdict,
+required Blocking/High/Medium findings, objective gates, and maintainer
+questions if any. `review-remediation` requires the bounded handoff. Missing or contradictory handoff identity is a semantic admission failure: stop before Runner or repair writes.
+Do not use the generic snapshot fallback to manufacture remediation authority.
 
-- Task and PR;
-- reviewed head SHA;
-- Review verdict;
-- required Blocking, High, or Medium findings;
-- unresolved objective gates;
-- maintainer decisions, if any.
+Run the current deterministic remediation Preflight before editing:
 
-Re-read current Task, PR, branch, head, effective diff, checks, reviews, and
-threads by regenerating the `delivery-readiness` snapshot. Verify that the PR is
-open, belongs to the expected Task branch, and matches the reviewed head. If the head changed and the change is not already
-explained by current repository facts, stop for clarification.
-
-Classify every handoff item before editing:
-
-- confirmed in-scope implementation, test, documentation, or configuration
-  finding: repair it;
-- pending or unavailable objective gate: recheck or wait without inventing a
-  code change;
-- requested change to Task scope, acceptance criteria, public behavior, or an
-  approved architecture decision: stop for maintainer authorization;
-- Low or Nit finding: leave unchanged unless the maintainer explicitly requests
-  it.
-
-Implement the smallest complete repair and add regression coverage where
-applicable. Preserve Task scope, safety boundaries, and unrelated behavior.
-
-Create scoped repair commits. Run final `workflow-delivery` validation against
-the clean committed head, push the validated head, wait for applicable checks,
-and regenerate `delivery-readiness`. Update the PR description or validation
-summary when the repair materially changes them.
-
-The previous Review verdict applies only to its reviewed head and becomes stale
-after any new commit. This Skill does not submit or resolve a GitHub Review,
-merge, close the Task, or perform closeout.
-
-Stop when the updated PR is ready for a new independent review. Report:
-
-- handoff items addressed and how;
-- items not addressed and why;
-- old reviewed head and new head;
-- repair commits and changed files;
-- regression tests and final validation;
-- checks, reviews, threads, and remaining limitations;
-- the exact new-session `task-pr-review-runner` prompt.
-
-## Recovery and handoff
-
-Recovery rules apply only after Invocation Preflight has passed and never
-authorize remediation of a Preflight result. Preflight is a terminal admission
-gate — a valid non-pass Preflight result is a final disposition, not a
-recoverable state.
-
-Resume from the first unverified gate by checking local preconditions plus
-drift from the Preflight snapshot for the target entry point (as applicable to
-the Phase). Verify completed writes instead of repeating them. For
-remediation, treat the supplied handoff as an index to independently verified
-findings and gates, not as permission to change Task scope. A Runner result
-does not replace semantic judgment. Stop on lifecycle conflict, identity
-drift, or entry-point state invalidation.
-
-This Skill never performs independent review. On a clean path, including after
-remediation, report:
-
-- canonical Task/PR URLs, branch, base/head, changed-file summary;
-- final validation/check summary, lifecycle state, thread count, limitations;
-- self-review artifact path, overall verdict (`verified` | `partial` |
-  `not_verified`), and a summary of each area and acceptance criterion with
-  its evidence status;
-- every `partial`/`unknown` from `delivery-readiness` preserved with its
-  original reason (never upgraded to `pass` by omission);
-- mechanical validation conclusions (explicitly separate from semantic
-  self-review conclusions);
-- unverified or partially verified content with explicit gaps;
-
-and:
-
-```text
-Ready for independent review
+```bash
+tools/agent_workflow/wsl2_github_evidence_runner.py delivery \
+  --entry-point review-remediation \
+  --task <TASK> \
+  --expected-main-sha <CURRENT_MAIN_SHA> \
+  --pr <PR> \
+  --expected-base-sha <REVIEWED_BASE_SHA> \
+  --expected-head-sha <REVIEWED_HEAD_SHA>
 ```
 
-**Reporting contract:**
+Proceed only on a valid passing result. `partial`, `unknown`, lifecycle
+conflict, identity conflict, or other valid non-pass is terminal; do not repair
+it automatically.
 
-Every conclusion must trace to a self-review evidence entry or mechanical
-validator result. Only `Verified` may be stated as fact. `Partially verified`
-must state covered scope and gaps. `Not verified` must not be rephrased as a
-pass. Do not expand a grep, file-exists check, or partial validator result
-into "all complete" or "all canonical-state". When `delivery-readiness` is
-`partial`, retain the `partial`/`unknown` reasons.
+Classify every handoff item before editing: confirmed in-scope implementation,
+test, documentation, or configuration finding → repair; scope/AC/public
+behavior/architecture change → Human Gate; Low/Nit → leave unchanged unless
+explicitly requested.
 
-End with the exact new-session `task-pr-review-runner` prompt and expected
-base/head SHAs. Use a detailed report for any finding, fallback,
-`partial`/`unknown`, failure, drift, conflict, or maintainer decision. Always
-state that Review, Merge, Issue close, post-merge work, branch deletion, and
-Feature completion were not performed.
+Implement the smallest complete repair and add regression coverage. Existing
+remediation mechanics continue to use the current Evidence / Validation Runner
+contract for this phase: create scoped repair commits, run `workflow-delivery`
+against the clean committed head, push only the validated head, reuse the
+existing Task PR, wait for checks, and regenerate `delivery-readiness`.
+
+The previous Review verdict applies only to its reviewed head. Any new commit
+requires a fresh independent review. Remediation never submits a GitHub Review,
+merges, closes the Task, performs closeout, or starts the new Review itself.
+
+Report the handoff items addressed, new head, validation/check result, remaining
+limitations, and the exact fresh-session review prompt.
+
+## Failure discipline
+
+Distinguish deterministic STOP from tool failure:
+
+- valid LCK / Runner STOP → stop; no alternate write route;
+- missing/unparseable tool result → at most one identical bounded retry;
+- semantic Task ambiguity or requested scope expansion → Human Gate;
+- remote divergence or identity ambiguity → stop; never force push or guess;
+- `partial` / `unknown` evidence remains `partial` / `unknown` in reporting.
+
+The Skill is a semantic procedure. It is not the lifecycle state machine.

--- a/.claude/skills/task-pr-review-runner/SKILL.md
+++ b/.claude/skills/task-pr-review-runner/SKILL.md
@@ -361,58 +361,58 @@ merges.
 
 ## Remediation handoff
 
-For `有条件通过，不得合并` or `不通过，需要修复`, emit one compact handoff after
-the verdict:
+For `有条件通过，不得合并` or `不通过，需要修复`, keep the human-readable
+Review report body separate from the next-lifecycle input. The report body
+must contain the verdict, mechanical verification, findings, Acceptance
+Criteria coverage, and relevant evidence. It must then end with exactly one
+canonical remediation section; do not emit a standalone handoff before it or
+wrap a second handoff around it.
 
-```text
-Remediation handoff
+The canonical final section is `## Remediation handoff` followed by exactly one
+fenced code block. The block is the complete, directly copyable Delivery
+prompt and must begin with the task-delivery instruction itself:
 
-Task: #<Task>
-PR: #<PR>
-Reviewed head SHA: <SHA>
-Verdict: <verdict>
-
-Required remediation:
-- [F1][Blocking|High|Medium] <defect, precise evidence, expected behavior>
-
-Objective gates:
-- <pending, unavailable, ambiguous, contradictory, or unstable gate>
-
-Maintainer decision required:
-- <scope, specification, public behavior, or architecture decision>
-```
-
-Rules:
-
-- include only findings that caused the non-passing verdict; the bounded
-  handoff semantics are authoritative in `docs/development/pr-review.md` §9;
-- include objective gates that require recheck or waiting;
-- include decisions that cannot be resolved without maintainer authorization;
-- exclude Low and Nit findings unless the maintainer explicitly made them
-  required;
-- state the defect and expected behavior, but do not design the implementation;
-- preserve finding IDs so the next Review can map repairs to the original
-  evidence.
-
-End with this exact remediation prompt populated with current identities:
-
+````text
 ```text
 请按 task-delivery-runner 修复
 [Task] <当前完整标题> #<Task编号>
 对应 PR #<PR编号> 的独立审查问题，
 并继续处理，直到 PR 再次准备好接受新的独立审查。
 
-Review remediation handoff:
+Task: #<Task编号>
+PR: #<PR编号>
+Reviewed head SHA: <SHA>
+Verdict: <有条件通过，不得合并 | 不通过，需要修复>
 
-<上述 remediation handoff>
+Required remediation:
+- [F1][Blocking|High|Medium] <完整 finding，包含证据与预期行为>
+
+Objective gates:
+- <尚未满足、不可用、矛盾或需要重新验证的 gate>
+- 如无则写：无。
+
+Maintainer decision required:
+- <需要维护者授权的事项>
+- 如无则写：无。
 ```
+````
+
+Include only findings that caused the non-passing verdict; the bounded handoff
+semantics are authoritative in `docs/development/pr-review.md` §9. Include
+objective gates that require recheck or waiting, and decisions that cannot be
+resolved without maintainer authorization. Exclude Low and Nit findings unless
+the maintainer explicitly made them required. Preserve finding IDs and write
+each required finding in full exactly once. The block must be self-contained:
+do not refer to material outside it with phrases such as “上述”, “同上”, or
+“见前文”.
 
 A passing verdict does not emit a remediation handoff.
 
-**Enforcement**: Every non-passing verdict must output both the handoff and the
-Delivery prompt. A partial handoff without the Delivery prompt is non-compliant.
-A handoff that omits objective gates when the verdict is `有条件通过` is
-non-compliant.
+**Enforcement**: Every non-passing verdict emits exactly one final
+`## Remediation handoff` section and exactly one fenced code block. The block
+itself is the single Delivery prompt; duplicate headings, wrapper labels, or
+repeated findings are non-compliant. A passing verdict emits no remediation
+section.
 
 ## Report and recovery
 

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -33,6 +33,19 @@ body:
       required: true
 
   - type: textarea
+    id: critical_outcome
+    attributes:
+      label: Critical Outcome
+      description: 定义本 Task 必须打通的真实 supported path。四个字段必须各占一行；Verification test 只能填写仓库 tests/ 下一个明确 pytest node id，不得填写任意 shell 命令。
+      placeholder: |
+        Caller: 真实受支持入口或调用方
+        Capability: 本 Task 新增或改变的能力
+        Observable result: 从该入口可观察到的预期结果
+        Verification test: tests/.../test_*.py::test_*
+    validations:
+      required: true
+
+  - type: textarea
     id: acceptance_criteria
     attributes:
       label: Acceptance Criteria

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ desktop.ini
 # Local workflow evidence and validation output
 .agents/evidence.local/
 .agents/validation.local/
+.workflow.local/

--- a/docs/development/issue-authoring.md
+++ b/docs/development/issue-authoring.md
@@ -96,12 +96,27 @@ OPTIONAL：`Context`、`Key Scenarios / Edge Cases`、`Constraints / Decisions`�
 
 ### Task — implementation contract（主要 coding-agent execution contract）
 
-REQUIRED：`Objective`、`Requirements`、`Acceptance Criteria`
+REQUIRED：`Objective`、`Requirements`、`Critical Outcome`、`Acceptance Criteria`
 OPTIONAL：`Context`、`Scope Boundary / Non-goals`、`Constraints / Decisions`、
 `References`、`Task-specific Verification`
 
 Task 必须满足：one primary objective、bounded scope、independently verifiable、
 normally one PR、minimal unrelated context、observable acceptance。
+
+`Critical Outcome` 是 Task-level end-to-end acceptance contract，必须使用固定四行格式：
+
+```text
+Caller: <真实受支持入口或调用方>
+Capability: <本 Task 新增或改变的能力>
+Observable result: <从 Caller 可观察到的结果>
+Verification test: tests/.../test_*.py::test_*
+```
+
+`Verification test` 只能绑定仓库 `tests/` 下一个明确 pytest node id。它不是任意
+shell command，也不能用 private helper/file-exists/grep 代替真实 supported path。LCK
+在 Delivery Complete 中运行该 verifier；FAIL 是 Delivery veto。Independent Review 仍需
+判断该测试是否真实覆盖 `Caller → Capability → Observable result`，不能仅因 pytest
+退出码为 0 就继承语义 verdict。
 
 Task 不得复制：parent Feature / Epic 完整正文、repository architecture summary、
 Git workflow、branch/commit/PR/merge instruction、标准 pytest / Ruff / mypy、

--- a/docs/development/issue-workflow.md
+++ b/docs/development/issue-workflow.md
@@ -113,29 +113,33 @@ intent 无法可靠解析时：**不要猜**。回退到 explicit Skill-name fal
 
 ## 6. Delivery semantics
 
-- 一次 Delivery 覆盖：readiness → branch → implementation → tests →
-  targeted validation → commit → push → PR → CI checks → delivery readiness →
-  handoff for Independent Review。
+- Task `Critical Outcome` 是正式 Delivery gate：LCK 从当前 Task body 读取结构化
+  contract，使用固定 pytest verifier 执行真实 supported path。缺失、malformed、unsafe
+  target 或 verifier failure 均 fail closed；不得用普通 unit/static check 替代。
+- Initial Delivery 的 lifecycle mechanics（workspace prepare、commit validated tree、
+  remote synchronization、OPEN PR resolve/create、Project Status → Review）由 LCK
+  deterministic control 执行；Agent/Skill 不提供 branch/SHA/PR/refspec authority。
+- 一次 Initial Delivery 覆盖：LCK Delivery Prepare → semantic implementation / targeted
+  development validation → LCK Delivery Complete → Critical Outcome → formal validation →
+  commit validated tree → ensure remote branch → ensure OPEN PR → CI checks → Project
+  Status `Review` → final live verification → `READY_FOR_REVIEW`。
 - 一个 Task 通常产生一个 PR（base = `main`）。
-- Initial Task branch bootstrap is a shared workflow contract: Delivery locks
-  the trusted `main`/base first, then the implementation preflight classifies
-  the target branch. An existing branch is reusable only when Task identity,
-  ownership, base, and a clean worktree are mechanically proven. A missing
-  branch is creatable
-  only when the worktree is clean, the current/local/remote `main` identities
-  equal the locked base, no local/remote/worktree conflict exists, and the
-  target uses canonical `task/<Issue number>-<slug>` naming. The Runner returns
-  the deterministic creation authorization; the Delivery Skill performs the
-  branch creation from that exact base and reruns mechanical verification
-  before implementation continues.
-- Noncanonical names such as `task-<Issue number>` are never new-branch
-  creation targets. Historical numeric forms may be reused only for an
-  existing branch whose ownership is proven. Ambiguous branch identity,
-  ownership, base, dirty bootstrap state, or post-creation drift fails closed
-  and enters Human Gate.
-- 实现只处理当前 leaf Task；不进行无关重构。
-- 提交前必须完成 target validation；PR 创建前必须完成 delivery readiness
-  验证（Runner 快照）。
+- Initial Task branch bootstrap is LCK-owned. An existing branch is reusable only when
+  Task identity, ownership, base, and the required worktree state are mechanically proven.
+  A missing branch is creatable only when current/local/remote `main` identities are
+  aligned, no local/remote/worktree conflict exists, and the target uses canonical
+  `task/<Issue number>-<slug>` naming. The Skill does not create the branch and has no
+  fallback write route.
+- Noncanonical names such as `task-<Issue number>` are never new-branch creation targets.
+  Historical numeric forms may be reused only for an existing branch whose ownership is
+  proven. Ambiguous identity or inconsistent live state fails closed.
+- 实现只处理当前 leaf Task；不进行无关重构。Targeted validation during implementation is
+  development feedback only. Final Delivery authorization is owned by LCK, which runs the
+  Critical Outcome and formal validation before committing the exact validated tree.
+- Within one `delivery complete` invocation, the observed Task body, `origin/main`, Task
+  branch and committed head are ephemeral preconditions. If they change before a later
+  side effect, LCK stops and the next invocation reacquires/revalidates current facts; no
+  cross-phase snapshot becomes authority.
 - Human Gate 事项未决时不得继续 Delivery（§9）。
 - Delivery 不执行 Independent Review、不 merge、不 close Issue、不 closeout。
 

--- a/docs/development/issue-workflow.md
+++ b/docs/development/issue-workflow.md
@@ -113,6 +113,10 @@ intent 无法可靠解析时：**不要猜**。回退到 explicit Skill-name fal
 
 ## 6. Delivery semantics
 
+Workflow-owned `uv` processes use `.workflow.local/uv-cache`. This is local
+runtime state and the directory is Git-ignored; an explicit `UV_CACHE_DIR`
+override remains supported.
+
 - Task `Critical Outcome` 是正式 Delivery gate：LCK 从当前 Task body 读取结构化
   contract，使用固定 pytest verifier 执行真实 supported path。缺失、malformed、unsafe
   target 或 verifier failure 均 fail closed；不得用普通 unit/static check 替代。

--- a/docs/development/pr-review.md
+++ b/docs/development/pr-review.md
@@ -106,14 +106,52 @@ CONDITIONAL 与 FAIL 都输出 bounded remediation handoff（§9）；
 
 ## 9. Remediation handoff
 
-非 PASS 的 Review（CONDITIONAL / FAIL，见 §8）输出 bounded remediation
-handoff，仅包含 Delivery Skill 修复所需的最小信息：
+非 PASS 的 Review（CONDITIONAL / FAIL，见 §8）在报告末尾输出一个且仅一个
+canonical remediation handoff。Review 报告正文与下一 lifecycle invocation
+输入分离：正文保留 Verdict、mechanical verification、findings、Acceptance
+Criteria coverage 和必要 evidence；handoff 是可以独立复制的完整 Delivery
+prompt。
+
+最终输出契约固定为：
+
+````text
+## Remediation handoff
+```text
+请按 task-delivery-runner 修复
+[Task] <当前完整标题> #<Task编号>
+对应 PR #<PR编号> 的独立审查问题，
+并继续处理，直到 PR 再次准备好接受新的独立审查。
+
+Task: #<Task编号>
+PR: #<PR编号>
+Reviewed head SHA: <SHA>
+Verdict: <有条件通过，不得合并 | 不通过，需要修复>
+
+Required remediation:
+- [F1][Blocking|High|Medium] <完整 finding，包含证据与预期行为>
+
+Objective gates:
+- <尚未满足、不可用、矛盾或需要重新验证的 gate>
+- 如无则写：无。
+
+Maintainer decision required:
+- <需要维护者授权的事项>
+- 如无则写：无。
+```
+````
+
+canonical code block 必须 self-contained；每个 required finding 在其中完整
+出现一次，不得使用“上述”“同上”“见前文”等依赖报告正文的引用。不得在此
+section 之前再输出 handoff，也不得再用 wrapper label 嵌套或重复该 block。
+
+handoff 仅包含 Delivery Skill 修复所需的最小信息：
 
 - findings（severity、位置、失败场景、最小修改方向）；
 - 当前锁定的 base/head；
 - 重新 review 的要求（new head → fresh re-review）。
 
-handoff 不得包含完整历史、无关 findings 或主观偏好。
+handoff 不得包含完整历史、无关 findings 或主观偏好。PASS 不输出
+remediation handoff section。
 
 Independent Review 保持 strict read-only，不向 GitHub 提交 Approve /
 Request changes / Comment Review。`review-remediation` 的 admission 不得依赖

--- a/docs/workflows/lck-v1-migration-matrix.md
+++ b/docs/workflows/lck-v1-migration-matrix.md
@@ -8,10 +8,12 @@ the semantic boundary remains while duplicate mechanics are removed, and
 `REMOVE` means the mechanism is not part of the target flow.
 
 Task #159 established live-state resolution, phase eligibility, and Delivery
-Prepare. Task #160 extends that same Runner-derived control plane through the
-**Initial Delivery** cutover: Critical Outcome + formal validation, validated-tree
-commit, remote synchronization, OPEN-PR resolve/create, checks, Project Status
-`Review`, and final `READY_FOR_REVIEW` verification. Review/Remediation, merge,
+Prepare. Task #160 implements the candidate **Initial Delivery** LCK controller:
+Critical Outcome + formal validation, validated-tree commit, remote
+synchronization, OPEN-PR resolve/create, checks, Project Status `Review`, and
+final `READY_FOR_REVIEW` verification. Task #160 itself is delivered through
+the pre-cutover Current Workflow; the candidate controller becomes lifecycle
+authority only after the maintainer merge boundary. Review/Remediation, merge,
 closeout, and recovery cutovers remain bounded follow-up work.
 
 | ID | #88 operation | Current owner | LCK v1 target | Task #159 boundary |
@@ -25,9 +27,9 @@ closeout, and recovery cutovers remain bounded follow-up work.
 | O07 | Targeted validation | Skill + Validation Runner | KEEP | KEEP |
 | O08 | Commit-ready identity | Skill / Git | MOVE | No commit effect here |
 | O09 | CI-equivalent validation | Validation Runner | KEEP | KEEP |
-| O10 | Push validated head | Skill / Agent | MOVE | Out of scope |
-| O11 | PR resolve/create | PR helper + Skill | MOVE | Out of scope |
-| O12 | Check wait/read and interpretation | Skill + Runner | SIMPLIFY | Live facts are returned; polling remains follow-up |
+| O10 | Push validated head | Skill / Agent | MOVE | Candidate implemented; Current Workflow remains authority for #160 pre-cutover delivery |
+| O11 | PR resolve/create | PR helper + Skill | MOVE | Candidate implemented; Current Workflow remains authority for #160 pre-cutover delivery |
+| O12 | Check wait/read and interpretation | Skill + Runner | SIMPLIFY | Candidate gate implemented; Current Workflow remains authority for #160 pre-cutover delivery |
 | O13 | Semantic self-review | Agent + helper | SIMPLIFY | Semantic judgement stays Agent-owned |
 | O14 | Delivery readiness snapshot | Evidence Runner + Skill | MOVE | Snapshot is diagnostic, not LCK authority |
 | O15 | Reviewed object identity lock | Review Skill + Runner | MOVE | Live resolver foundation only |
@@ -66,9 +68,9 @@ did not persist cross-phase authority, ignored CLOSED PRs when resolving the act
 PR, and exposed no commit/push/PR mutation. Task #160 intentionally extends only
 the Initial Delivery portion of that boundary.
 
-## Cumulative boundary after Task #160
+## Candidate boundary implemented by Task #160 (pre-activation)
 
-Initial Delivery now uses one LCK-owned path:
+The candidate Initial Delivery path uses one LCK-owned sequence after activation:
 
 1. `DeliveryPreparer` resolves and prepares the Task workspace.
 2. `DeliveryCompleter` reads the current Task Critical Outcome, stages the candidate
@@ -78,11 +80,16 @@ Initial Delivery now uses one LCK-owned path:
    push; divergence fails closed.
 4. `EnsureOpenPrEffect` re-resolves current identity and reuses or creates exactly one
    non-Draft OPEN PR using the existing deterministic PR helper.
-5. `DeliveryChecksGate` waits boundedly for applicable checks; failed/unknown checks
-   stop before Project Status moves to `Review`.
-6. Final live verification proves the Task body/base stayed stable within the operation
-   and local HEAD == remote Task branch == PR head before returning
-   `READY_FOR_REVIEW`.
+5. `DeliveryChecksGate` waits boundedly for applicable checks; failed, pending, or
+   unknown checks stop before Project Status moves to `Review`.
+6. Final live verification proves the Task body/base stayed stable within the
+   operation, the final state is the same PR/head observed by the checks gate,
+   applicable checks remain successful, and local HEAD == remote Task branch ==
+   PR head before returning `READY_FOR_REVIEW`.
+
+Until the maintainer merge boundary, #160 continues to use the pre-cutover
+Current Workflow for its own Delivery. The LCK path above is candidate behavior
+and is not retroactively treated as #160's lifecycle authority.
 
 The Task body now carries a required `Critical Outcome` contract. Its verification
 target is one bounded `tests/...::test_...` pytest node id; Issue text cannot inject

--- a/docs/workflows/lck-v1-migration-matrix.md
+++ b/docs/workflows/lck-v1-migration-matrix.md
@@ -100,3 +100,23 @@ The Initial Delivery section of `task-delivery-runner` is now semantic-only plus
 entrypoint guidance. The existing Review remediation procedure remains temporarily on
 the current Runner contract because its authority cutover belongs to the next migration
 Task; merge and closeout remain Human/later-task boundaries.
+
+## Mainline activation and rollback procedure
+
+The candidate becomes the Initial Delivery lifecycle authority only after all of the
+following have occurred:
+
+1. an independent Review of the current PR head passes;
+2. the maintainer performs the required Squash Merge;
+3. `main` is synchronized and the post-merge validation confirms the merged
+   LCK controller, provider-neutral Delivery Skill contract, and repository
+   workflow validators are coherent.
+
+If activation or post-merge validation fails, the maintainer must stop further
+LCK Initial Delivery activation, record the failure, and revert the candidate
+merge as one controlled change. The pre-cutover Current Workflow remains the
+authority while the revert is validated. The maintainer then synchronizes
+`main`, reruns the relevant post-merge validation, and records the restored
+authority boundary before any later reactivation attempt. A later activation
+requires a new reviewed head and a fresh maintainer merge decision; no Agent or
+Delivery Skill may bypass this rollback boundary.

--- a/docs/workflows/lck-v1-migration-matrix.md
+++ b/docs/workflows/lck-v1-migration-matrix.md
@@ -7,10 +7,12 @@ Design Charter. `KEEP` means the responsibility remains in its current layer,
 the semantic boundary remains while duplicate mechanics are removed, and
 `REMOVE` means the mechanism is not part of the target flow.
 
-Task #159 implements only the live-state, phase-eligibility, and Delivery
-Prepare rows marked `implemented here`. Commit, push, PR mutation, merge,
-closeout, and full Skill cutover remain bounded follow-up work owned by their
-respective Tasks.
+Task #159 established live-state resolution, phase eligibility, and Delivery
+Prepare. Task #160 extends that same Runner-derived control plane through the
+**Initial Delivery** cutover: Critical Outcome + formal validation, validated-tree
+commit, remote synchronization, OPEN-PR resolve/create, checks, Project Status
+`Review`, and final `READY_FOR_REVIEW` verification. Review/Remediation, merge,
+closeout, and recovery cutovers remain bounded follow-up work.
 
 | ID | #88 operation | Current owner | LCK v1 target | Task #159 boundary |
 |---|---|---|---|---|
@@ -47,7 +49,7 @@ respective Tasks.
 | O31 | Homogeneous Agent command grouping | Agent orchestration | SIMPLIFY | Optional; never hides failure boundaries |
 | O32 | Context Compiler beyond Retrieval v2 | No current owner | REMOVE | Not justified by the Charter |
 
-## Implemented LCK Core boundary
+## Task #159 Core baseline
 
 `tools/agent_workflow/lck.py` provides three deterministic layers:
 
@@ -59,6 +61,35 @@ respective Tasks.
 3. `DeliveryPreparer` creates, selects, or restores the uniquely resolved Task
    workspace and verifies the postcondition by reacquiring live facts.
 
-The core does not accept `expected_sha` or `snapshot_id`, does not persist
-cross-phase authority, ignores CLOSED PRs when resolving the active PR, and
-does not expose commit, push, PR-create, merge, or arbitrary shell effects.
+At the Task #159 baseline the core did not accept `expected_sha` or `snapshot_id`,
+did not persist cross-phase authority, ignored CLOSED PRs when resolving the active
+PR, and exposed no commit/push/PR mutation. Task #160 intentionally extends only
+the Initial Delivery portion of that boundary.
+
+## Cumulative boundary after Task #160
+
+Initial Delivery now uses one LCK-owned path:
+
+1. `DeliveryPreparer` resolves and prepares the Task workspace.
+2. `DeliveryCompleter` reads the current Task Critical Outcome, stages the candidate
+   tree, runs the bounded Critical Outcome verifier and repository formal validation,
+   and commits exactly the validated tree.
+3. `EnsureRemoteBranchEffect` synchronizes only the resolved Task branch without force
+   push; divergence fails closed.
+4. `EnsureOpenPrEffect` re-resolves current identity and reuses or creates exactly one
+   non-Draft OPEN PR using the existing deterministic PR helper.
+5. `DeliveryChecksGate` waits boundedly for applicable checks; failed/unknown checks
+   stop before Project Status moves to `Review`.
+6. Final live verification proves the Task body/base stayed stable within the operation
+   and local HEAD == remote Task branch == PR head before returning
+   `READY_FOR_REVIEW`.
+
+The Task body now carries a required `Critical Outcome` contract. Its verification
+target is one bounded `tests/...::test_...` pytest node id; Issue text cannot inject
+arbitrary shell commands. Operation-local base/body/head guards are ephemeral and are
+reacquired on retry rather than persisted as cross-phase authority.
+
+The Initial Delivery section of `task-delivery-runner` is now semantic-only plus LCK
+entrypoint guidance. The existing Review remediation procedure remains temporarily on
+the current Runner contract because its authority cutover belongs to the next migration
+Task; merge and closeout remain Human/later-task boundaries.

--- a/tests/tools/test_critical_outcome.py
+++ b/tests/tools/test_critical_outcome.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+AGENT_WORKFLOW = str(Path(__file__).parents[2] / "tools" / "agent_workflow")
+if AGENT_WORKFLOW not in sys.path:
+    sys.path.insert(0, AGENT_WORKFLOW)
+
+from critical_outcome import (  # type: ignore[import-not-found]  # noqa: E402
+    CriticalOutcomeError,
+    critical_outcome_snapshot,
+    parse_critical_outcome,
+)
+
+
+def _body(verification: str = "tests/tools/test_lck.py::test_canonical_branch_is_derived_from_current_issue_title") -> str:
+    return f"""### Objective
+Do one thing.
+
+### Critical Outcome
+Caller: task-delivery-runner initial Delivery
+Capability: LCK owns deterministic Delivery completion
+Observable result: validated Task head is committed, pushed and attached to one OPEN PR
+Verification test: {verification}
+
+### Acceptance Criteria
+- [ ] works
+"""
+
+
+def test_parse_critical_outcome_contract() -> None:
+    contract = parse_critical_outcome(_body())
+
+    assert contract.caller == "task-delivery-runner initial Delivery"
+    assert contract.capability == "LCK owns deterministic Delivery completion"
+    assert contract.observable_result.startswith("validated Task head")
+    assert contract.verification_test.startswith("tests/tools/test_lck.py::")
+
+
+def test_parser_accepts_markdown_bullet_and_bold_labels() -> None:
+    body = """### Critical Outcome
+- **Caller:** CLI
+- **Capability:** bounded effect
+- **Observable result:** observable result
+- **Verification test:** `tests/tools/test_lck.py::test_canonical_branch_is_derived_from_current_issue_title`
+"""
+    assert parse_critical_outcome(body).caller == "CLI"
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "### Objective\nmissing",
+        "### Critical Outcome\nCaller: x\nCapability: y\nObservable result: z",
+        _body("pytest tests/tools/test_lck.py"),
+        _body("../../tmp/test_bad.py::test_bad"),
+        _body("tests/tools/test_lck.py::test_x && rm -rf /"),
+    ],
+)
+def test_invalid_or_unsafe_contract_fails_closed(body: str) -> None:
+    with pytest.raises(CriticalOutcomeError):
+        parse_critical_outcome(body)
+
+
+def test_snapshot_is_compact_and_does_not_copy_issue_body() -> None:
+    snapshot = critical_outcome_snapshot(_body())
+
+    assert snapshot["status"] == "valid"
+    assert "body" not in snapshot
+    assert snapshot["contract"]["verification_test"].startswith("tests/")
+
+
+def test_task_issue_template_requires_critical_outcome() -> None:
+    root = Path(__file__).parents[2]
+    text = (root / ".github/ISSUE_TEMPLATE/task.yml").read_text(encoding="utf-8")
+    marker = "id: critical_outcome"
+    assert marker in text
+    section = text.split(marker, 1)[1].split("  - type:", 1)[0]
+    assert "label: Critical Outcome" in section
+    assert "required: true" in section
+    assert "Verification test: tests/.../test_*.py::test_*" in section

--- a/tests/tools/test_critical_outcome.py
+++ b/tests/tools/test_critical_outcome.py
@@ -16,7 +16,9 @@ from critical_outcome import (  # type: ignore[import-not-found]  # noqa: E402
 )
 
 
-def _body(verification: str = "tests/tools/test_lck.py::test_canonical_branch_is_derived_from_current_issue_title") -> str:
+def _body(
+    verification: str = "tests/tools/test_lck.py::test_canonical_branch_is_derived_from_current_issue_title",
+) -> str:
     return f"""### Objective
 Do one thing.
 

--- a/tests/tools/test_lck.py
+++ b/tests/tools/test_lck.py
@@ -630,6 +630,33 @@ def test_review_prepare_rejects_draft_open_pr(
     assert any("non-Draft" in reason for reason in decision.reasons)
 
 
+def test_delivery_complete_allows_review_status_for_partial_effect_recovery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    branch = "task/159-lck-core-live-state-resolution"
+    fake = FakeRunner(
+        branch=branch,
+        local_branches={branch},
+        remote_branches={branch: SHA},
+    )
+    issue = _issue()
+    issue["project_status"] = "Review"
+    _install_facts(
+        monkeypatch,
+        fake,
+        issue=issue,
+        open_pr=_open_pr(branch),
+    )
+
+    state = _resolver(fake).resolve(159)
+    decision = lck.PhaseEligibilityResolver().resolve(
+        state,
+        lck.Phase.DELIVERY_COMPLETE,
+    )
+
+    assert decision.eligible
+
+
 def test_remediation_prepare_keeps_draft_pr_observable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/tools/test_lck.py
+++ b/tests/tools/test_lck.py
@@ -790,9 +790,9 @@ def test_delivery_prepare_requires_valid_critical_outcome(
     _install_facts(monkeypatch, fake, issue=issue)
     state = _resolver(fake).resolve(159)
 
-    decision = lck.PhaseEligibilityResolver().resolve(
-        state, lck.Phase.DELIVERY_PREPARE
-    )
+    decision = lck.PhaseEligibilityResolver().resolve(state, lck.Phase.DELIVERY_PREPARE)
 
     assert decision.eligible is False
-    assert any("Critical Outcome contract invalid" in reason for reason in decision.reasons)
+    assert any(
+        "Critical Outcome contract invalid" in reason for reason in decision.reasons
+    )

--- a/tests/tools/test_lck.py
+++ b/tests/tools/test_lck.py
@@ -116,6 +116,15 @@ def _issue() -> dict[str, Any]:
         "state": "OPEN",
         "labels": {"items": ["type:task", "codex:ready"]},
         "project_status": "Ready",
+        "critical_outcome": {
+            "status": "valid",
+            "contract": {
+                "caller": "task-delivery-runner initial Delivery",
+                "capability": "LCK Delivery",
+                "observable_result": "READY_FOR_REVIEW",
+                "verification_test": "tests/tools/test_lck.py::test_canonical_branch_is_derived_from_current_issue_title",
+            },
+        },
     }
 
 
@@ -770,3 +779,20 @@ def test_closeout_eligibility_uses_merged_live_pr_state(
 
     assert state.merged is True
     assert decision.eligible
+
+
+def test_delivery_prepare_requires_valid_critical_outcome(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = FakeRunner()
+    issue = _issue()
+    issue["critical_outcome"] = {"status": "invalid", "detail": "missing"}
+    _install_facts(monkeypatch, fake, issue=issue)
+    state = _resolver(fake).resolve(159)
+
+    decision = lck.PhaseEligibilityResolver().resolve(
+        state, lck.Phase.DELIVERY_PREPARE
+    )
+
+    assert decision.eligible is False
+    assert any("Critical Outcome contract invalid" in reason for reason in decision.reasons)

--- a/tests/tools/test_lck_delivery.py
+++ b/tests/tools/test_lck_delivery.py
@@ -227,6 +227,47 @@ def test_formal_validation_gate_fails_closed(
         lck.FormalValidationGate(resolver).run(SHA)
 
 
+@pytest.mark.parametrize("mutation", ["merged", "wrong-branch"])
+def test_ensure_open_pr_rechecks_live_task_identity_before_resolution(
+    tmp_path: Path,
+    mutation: str,
+) -> None:
+    head = "b" * 40
+    state = _live_state(
+        head=head,
+        clean=True,
+        project_status="In Progress",
+        open_pr=None,
+        remote_oid=head,
+    )
+    if mutation == "merged":
+        state = lck.LiveState(**{**state.__dict__, "merged": True})
+        expected = "already merged"
+    else:
+        state = lck.LiveState(
+            **{
+                **state.__dict__,
+                "git": {**state.git, "branch": "main"},
+            }
+        )
+        expected = "not selected"
+    runner = CompletionRunner()
+    resolver = SequenceResolver(tmp_path, runner, [state])
+
+    with pytest.raises(lck.LckStopError, match=expected):
+        lck.EnsureOpenPrEffect(cast(Any, resolver)).execute(
+            160,
+            summary="Move initial Delivery mechanics into LCK.",
+            risks="None.",
+            critical_outcome=_critical_snapshot(),
+            validation={"status": "pass"},
+            expected_base_sha=SHA,
+            expected_body_sha256="e" * 64,
+        )
+
+    assert runner.commands == []
+
+
 def _critical_snapshot() -> dict[str, Any]:
     return {
         "status": "valid",
@@ -702,7 +743,7 @@ def test_delivery_complete_revalidates_clean_committed_head_and_stops_at_review_
         result.to_dict()["human_boundary"]
         == "Independent Review must be started separately"
     )
-    assert commit.calls == ["current_head_tree"]
+    assert commit.calls == ["current_head_tree", "verify_tree_unchanged"]
     assert remote.calls == pr.calls == status.calls == 1
     assert not any(
         "review" in " ".join(command).casefold() for command in runner.commands
@@ -782,6 +823,19 @@ def test_task_160_critical_outcome_initial_delivery_is_lck_owned(
         "ensure_open_pr",
         "set_review_status",
     ]
+
+
+def test_lck_migration_matrix_records_activation_rollback_procedure() -> None:
+    matrix = (
+        Path(__file__).parents[2] / "docs" / "workflows" / "lck-v1-migration-matrix.md"
+    ).read_text(encoding="utf-8")
+
+    assert "## Mainline activation and rollback procedure" in matrix
+    assert "independent Review" in matrix
+    assert "required Squash Merge" in matrix
+    assert "revert the candidate" in matrix
+    assert "pre-cutover Current Workflow" in matrix
+    assert "fresh maintainer merge decision" in matrix
 
 
 def _with_checks(state: lck.LiveState, checks: dict[str, Any]) -> lck.LiveState:

--- a/tests/tools/test_lck_delivery.py
+++ b/tests/tools/test_lck_delivery.py
@@ -310,9 +310,11 @@ class StubChecks:
             "observed": {
                 "count": 0,
                 "failed": 0,
+                "pending": 0,
                 "skipped_or_unknown": 0,
                 "all_success": None,
             },
+            "pr": {"number": 10, "head_sha": "b" * 40, "base_sha": SHA},
         }
 
 
@@ -862,8 +864,18 @@ def test_failed_checks_do_not_move_project_status_to_review(tmp_path: Path) -> N
     assert status.calls == 0
 
 
+@pytest.mark.parametrize(
+    ("category", "state_name"),
+    [
+        ("failed", "FAILURE"),
+        ("pending", "IN_PROGRESS"),
+        ("skipped-or-unknown", "CANCELLED"),
+    ],
+)
 def test_final_verification_stops_when_checks_regress_after_gate(
     tmp_path: Path,
+    category: str,
+    state_name: str,
 ) -> None:
     target = tmp_path / "tests" / "test_critical_path.py"
     target.parent.mkdir(parents=True)
@@ -908,7 +920,7 @@ def test_final_verification_stops_when_checks_regress_after_gate(
             open_pr={**pr},
             remote_oid=head,
         ),
-        _checks(category="failed", state_name="FAILURE"),
+        _checks(category=category, state_name=state_name),
     )
     runner = CompletionRunner()
     resolver = SequenceResolver(
@@ -934,3 +946,36 @@ def test_final_verification_stops_when_checks_regress_after_gate(
         )
 
     assert status.calls == 1
+
+
+def test_final_verification_requires_same_pr_as_checks_gate(tmp_path: Path) -> None:
+    head = "b" * 40
+    final_state = _live_state(
+        head=head,
+        clean=True,
+        project_status="Review",
+        open_pr={
+            "number": 11,
+            "state": "OPEN",
+            "isDraft": False,
+            "headRefOid": head,
+            "baseRefOid": SHA,
+        },
+        remote_oid=head,
+    )
+    resolver = SequenceResolver(tmp_path, CompletionRunner(), [final_state])
+
+    with pytest.raises(lck.LckStopError, match="check/lifecycle state is not aligned"):
+        lck.DeliveryCompleter(cast(Any, resolver))._final_verify(
+            final_state,
+            head,
+            base_sha=SHA,
+            body_sha256="e" * 64,
+            branch="task/160-delivery-cutover",
+            checks_result={
+                "status": "pass",
+                "configuration": "not-configured",
+                "required": [],
+                "pr": {"number": 10, "head_sha": head, "base_sha": SHA},
+            },
+        )

--- a/tests/tools/test_lck_delivery.py
+++ b/tests/tools/test_lck_delivery.py
@@ -1,0 +1,821 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+AGENT_WORKFLOW = str(Path(__file__).parents[2] / "tools" / "agent_workflow")
+if AGENT_WORKFLOW not in sys.path:
+    sys.path.insert(0, AGENT_WORKFLOW)
+
+import lck  # type: ignore[import-not-found]  # noqa: E402
+from workflow_common import (  # type: ignore[import-not-found]  # noqa: E402
+    CommandResult,
+    CommandRunner,
+)
+
+SHA = "a" * 40
+
+
+def _git(cwd: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=cwd, capture_output=True, text=True, check=True
+    )
+    return result.stdout.strip()
+
+
+def _repo(tmp_path: Path) -> tuple[Path, Path]:
+    repo = tmp_path / "repo"
+    origin = tmp_path / "origin.git"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.name", "Test")
+    _git(repo, "config", "user.email", "test@example.invalid")
+    (repo / "seed.txt").write_text("seed\n", encoding="utf-8")
+    _git(repo, "add", "seed.txt")
+    _git(repo, "commit", "-m", "seed")
+    subprocess.run(["git", "init", "--bare", str(origin)], check=True, capture_output=True)
+    _git(repo, "remote", "add", "origin", str(origin))
+    _git(repo, "push", "-u", "origin", "main")
+    return repo, origin
+
+
+def _resolver_for_repo(repo: Path) -> lck.LiveStateResolver:
+    return lck.LiveStateResolver(repo, runner=CommandRunner(repo), repository="owner/repo")
+
+
+def test_commit_current_tree_binds_validated_tree_to_commit(tmp_path: Path) -> None:
+    repo, _ = _repo(tmp_path)
+    _git(repo, "switch", "-c", "task/160-delivery")
+    (repo / "seed.txt").write_text("changed\n", encoding="utf-8")
+    effect = lck.CommitCurrentTreeEffect(_resolver_for_repo(repo))
+
+    tree = effect.stage_candidate_tree()
+    effect.verify_tree_unchanged(tree)
+    receipt = effect.execute(tree, "Implement delivery cutover")
+
+    assert receipt.action == "committed"
+    assert _git(repo, "rev-parse", "HEAD^{tree}") == tree
+    assert _git(repo, "status", "--porcelain") == ""
+
+
+def test_commit_current_tree_rejects_tree_change_after_validation(tmp_path: Path) -> None:
+    repo, _ = _repo(tmp_path)
+    _git(repo, "switch", "-c", "task/160-delivery")
+    (repo / "seed.txt").write_text("candidate\n", encoding="utf-8")
+    effect = lck.CommitCurrentTreeEffect(_resolver_for_repo(repo))
+    tree = effect.stage_candidate_tree()
+    (repo / "seed.txt").write_text("changed-after-validation\n", encoding="utf-8")
+
+    with pytest.raises(lck.LckStopError, match="changed during formal validation"):
+        effect.verify_tree_unchanged(tree)
+
+
+def test_ensure_remote_branch_create_then_idempotent(tmp_path: Path) -> None:
+    repo, _ = _repo(tmp_path)
+    _git(repo, "switch", "-c", "task/160-delivery")
+    (repo / "task.txt").write_text("task\n", encoding="utf-8")
+    _git(repo, "add", "task.txt")
+    _git(repo, "commit", "-m", "task")
+    effect = lck.EnsureRemoteBranchEffect(_resolver_for_repo(repo))
+
+    created = effect.execute("task/160-delivery")
+    repeated = effect.execute("task/160-delivery")
+
+    assert created.action == "created"
+    assert repeated.action == "already-synced"
+    assert created.details["head_sha"] == repeated.details["remote_oid"]
+
+
+def test_ensure_remote_branch_fast_forwards_only_when_remote_is_ancestor(
+    tmp_path: Path,
+) -> None:
+    repo, _ = _repo(tmp_path)
+    _git(repo, "switch", "-c", "task/160-delivery")
+    (repo / "task.txt").write_text("one\n", encoding="utf-8")
+    _git(repo, "add", "task.txt")
+    _git(repo, "commit", "-m", "one")
+    effect = lck.EnsureRemoteBranchEffect(_resolver_for_repo(repo))
+    effect.execute("task/160-delivery")
+
+    (repo / "task.txt").write_text("two\n", encoding="utf-8")
+    _git(repo, "commit", "-am", "two")
+    advanced = effect.execute("task/160-delivery")
+
+    assert advanced.action == "fast-forwarded"
+
+
+def test_ensure_remote_branch_stops_on_divergence(tmp_path: Path) -> None:
+    repo, origin = _repo(tmp_path)
+    _git(repo, "switch", "-c", "task/160-delivery")
+    (repo / "task.txt").write_text("one\n", encoding="utf-8")
+    _git(repo, "add", "task.txt")
+    _git(repo, "commit", "-m", "one")
+    effect = lck.EnsureRemoteBranchEffect(_resolver_for_repo(repo))
+    effect.execute("task/160-delivery")
+    shared = _git(repo, "rev-parse", "HEAD")
+
+    other = tmp_path / "other"
+    subprocess.run(["git", "clone", str(origin), str(other)], check=True, capture_output=True)
+    _git(other, "config", "user.name", "Other")
+    _git(other, "config", "user.email", "other@example.invalid")
+    _git(other, "switch", "task/160-delivery")
+    (other / "remote.txt").write_text("remote\n", encoding="utf-8")
+    _git(other, "add", "remote.txt")
+    _git(other, "commit", "-m", "remote")
+    _git(other, "push", "origin", "task/160-delivery")
+
+    _git(repo, "reset", "--hard", shared)
+    (repo / "local.txt").write_text("local\n", encoding="utf-8")
+    _git(repo, "add", "local.txt")
+    _git(repo, "commit", "-m", "local")
+
+    with pytest.raises(lck.LckStopError, match="ahead/diverged"):
+        effect.execute("task/160-delivery")
+
+
+class ValidationRunner:
+    def __init__(self, *, status: str = "pass", returncode: int = 0) -> None:
+        self.status = status
+        self.returncode = returncode
+        self.commands: list[tuple[str, ...]] = []
+
+    def run(
+        self,
+        argv: list[str] | tuple[str, ...],
+        *,
+        command_id: str,
+        **_: Any,
+    ) -> CommandResult:
+        command = tuple(str(item) for item in argv)
+        self.commands.append(command)
+        return CommandResult(
+            command_id=command_id,
+            argv=command,
+            returncode=self.returncode,
+            stdout=json.dumps({"status": self.status}),
+            stderr="",
+        )
+
+
+def test_formal_validation_gate_requires_structured_pass(tmp_path: Path) -> None:
+    runner = ValidationRunner()
+    resolver = lck.LiveStateResolver(tmp_path, runner=cast(Any, runner), repository="owner/repo")
+
+    payload = lck.FormalValidationGate(resolver).run(SHA)
+
+    assert payload["status"] == "pass"
+    assert "--phase" in runner.commands[0]
+    assert "delivery" in runner.commands[0]
+
+
+@pytest.mark.parametrize(("status", "returncode"), [("fail", 1), ("pass", 1)])
+def test_formal_validation_gate_fails_closed(
+    tmp_path: Path, status: str, returncode: int
+) -> None:
+    runner = ValidationRunner(status=status, returncode=returncode)
+    resolver = lck.LiveStateResolver(tmp_path, runner=cast(Any, runner), repository="owner/repo")
+
+    with pytest.raises(lck.LckStopError, match="formal Delivery validation failed"):
+        lck.FormalValidationGate(resolver).run(SHA)
+
+
+def _critical_snapshot() -> dict[str, Any]:
+    return {
+        "status": "valid",
+        "contract": {
+            "caller": "Delivery Skill",
+            "capability": "LCK Delivery complete",
+            "observable_result": "READY_FOR_REVIEW",
+            "verification_test": "tests/test_critical_path.py::test_critical_path",
+        },
+    }
+
+
+def _live_state(
+    *,
+    head: str,
+    clean: bool,
+    project_status: str,
+    open_pr: dict[str, Any] | None,
+    remote_oid: str | None,
+) -> lck.LiveState:
+    branch = "task/160-delivery-cutover"
+    return lck.LiveState(
+        task_number=160,
+        repository="owner/repo",
+        issue={
+            "number": 160,
+            "title": "[Task] 将 Delivery lifecycle control 迁移至 LCK",
+            "state": "OPEN",
+            "labels": {"items": ["type:task", "codex:ready"]},
+            "project_status": project_status,
+            "body_sha256": "e" * 64,
+            "critical_outcome": _critical_snapshot(),
+        },
+        relationships={
+            "available": True,
+            "issue_type": "Task",
+            "blocked_by": {"items": [], "count": 0, "truncated": False},
+        },
+        git={
+            "branch": branch,
+            "head_sha": head,
+            "local_main_sha": SHA,
+            "origin_main_sha": SHA,
+            "origin_fetch": "pass",
+            "clean": clean,
+        },
+        target_branch=branch,
+        local_task_branch=branch,
+        local_task_head=head,
+        remote_task_branch=branch if remote_oid else None,
+        remote_task_oid=remote_oid,
+        open_pr=open_pr,
+        merged_pr_numbers=(),
+        merged=False,
+        checks={"count": 0, "all_success": None},
+        cleanup={},
+    )
+
+
+class CompletionRunner:
+    def __init__(self, *, critical_returncode: int = 0) -> None:
+        self.commands: list[tuple[str, ...]] = []
+        self.critical_returncode = critical_returncode
+
+    def run(
+        self,
+        argv: list[str] | tuple[str, ...],
+        *,
+        command_id: str,
+        **_: Any,
+    ) -> CommandResult:
+        command = tuple(str(item) for item in argv)
+        self.commands.append(command)
+        if command[:3] == ("git", "diff", "--quiet"):
+            returncode = 1
+            stdout = ""
+        elif command and Path(command[0]).name == "uv":
+            returncode = self.critical_returncode
+            stdout = "1 passed\n" if returncode == 0 else "1 failed\n"
+        else:
+            returncode = 0
+            stdout = ""
+        return CommandResult(command_id, command, returncode, stdout, "")
+
+
+class SequenceResolver:
+    def __init__(self, repo_root: Path, runner: CompletionRunner, states: list[lck.LiveState]) -> None:
+        self.repo_root = repo_root
+        self.runner = cast(Any, runner)
+        self._states = states
+        self.calls = 0
+
+    def resolve(self, _task: int) -> lck.LiveState:
+        index = min(self.calls, len(self._states) - 1)
+        self.calls += 1
+        return self._states[index]
+
+
+class StubValidation:
+    def run(self, _base_sha: str) -> dict[str, Any]:
+        return {"status": "pass", "command_count": 6}
+
+
+class StubChecks:
+    def run(self, _task: int) -> dict[str, Any]:
+        return {"status": "pass", "configuration": "available"}
+
+
+class StubCommit:
+    def __init__(self, *, dirty: bool) -> None:
+        self.dirty = dirty
+        self.calls: list[str] = []
+
+    def current_head_tree(self) -> str:
+        self.calls.append("current_head_tree")
+        return "c" * 40
+
+    def stage_candidate_tree(self) -> str:
+        self.calls.append("stage_candidate_tree")
+        return "c" * 40
+
+    def verify_tree_unchanged(self, _tree: str) -> None:
+        self.calls.append("verify_tree_unchanged")
+
+    def execute(self, tree: str, _message: str) -> lck.EffectReceipt:
+        self.calls.append("execute")
+        return lck.EffectReceipt(
+            "commit_current_tree",
+            "committed",
+            {"head_sha": "b" * 40, "tree_oid": tree},
+        )
+
+
+class StubEffect:
+    def __init__(self, name: str, action: str) -> None:
+        self.name = name
+        self.action = action
+        self.calls = 0
+
+    def execute(self, *_args: Any, **_kwargs: Any) -> lck.EffectReceipt:
+        self.calls += 1
+        return lck.EffectReceipt(self.name, self.action, {})
+
+
+def test_delivery_complete_revalidates_clean_committed_head_and_stops_at_review_boundary(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "tests" / "test_critical_path.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("def test_critical_path(): pass\n", encoding="utf-8")
+    head = "b" * 40
+    pre = _live_state(
+        head=head,
+        clean=True,
+        project_status="In Progress",
+        open_pr=None,
+        remote_oid=None,
+    )
+    final_pr = {
+        "number": 10,
+        "state": "OPEN",
+        "isDraft": False,
+        "headRefOid": head,
+        "baseRefOid": SHA,
+    }
+    final = _live_state(
+        head=head,
+        clean=True,
+        project_status="Review",
+        open_pr=final_pr,
+        remote_oid=head,
+    )
+    remote = _live_state(
+        head=head,
+        clean=True,
+        project_status="In Progress",
+        open_pr=None,
+        remote_oid=head,
+    )
+    with_pr = _live_state(
+        head=head,
+        clean=True,
+        project_status="In Progress",
+        open_pr=final_pr,
+        remote_oid=head,
+    )
+    runner = CompletionRunner()
+    resolver = SequenceResolver(
+        tmp_path,
+        runner,
+        [pre, pre, remote, with_pr, with_pr, final],
+    )
+    commit = StubCommit(dirty=False)
+    remote = StubEffect("ensure_remote_branch", "created")
+    pr = StubEffect("ensure_open_pr", "created")
+    status = StubEffect("set_review_status", "updated")
+
+    result = lck.DeliveryCompleter(
+        cast(Any, resolver),
+        formal_validation=cast(Any, StubValidation()),
+        commit_effect=cast(Any, commit),
+        remote_effect=cast(Any, remote),
+        pr_effect=cast(Any, pr),
+        status_effect=cast(Any, status),
+        checks_gate=cast(Any, StubChecks()),
+    ).complete(
+        160,
+        commit_message="Implement LCK Delivery cutover",
+        summary="Move initial Delivery mechanics into LCK.",
+    )
+
+    assert result.status == "READY_FOR_REVIEW"
+    assert result.to_dict()["human_boundary"] == "Independent Review must be started separately"
+    assert commit.calls == ["current_head_tree"]
+    assert remote.calls == pr.calls == status.calls == 1
+    assert not any("review" in " ".join(command).casefold() for command in runner.commands)
+
+
+def test_task_160_critical_outcome_initial_delivery_is_lck_owned(
+    tmp_path: Path,
+) -> None:
+    root = Path(__file__).parents[2]
+    agent_skill = (root / ".agents/skills/task-delivery-runner/SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    claude_skill = (root / ".claude/skills/task-delivery-runner/SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    assert agent_skill == claude_skill
+    assert "lck.py delivery prepare" in agent_skill
+    assert "lck.py delivery complete" in agent_skill
+    initial_section = agent_skill.split("## Review remediation", 1)[0]
+    for direct_write in ("git commit", "git push", "gh pr create"):
+        assert direct_write not in initial_section
+    target = tmp_path / "tests" / "test_critical_path.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("def test_critical_path(): pass\n", encoding="utf-8")
+    old_head = "d" * 40
+    new_head = "b" * 40
+    pre = _live_state(
+        head=old_head,
+        clean=False,
+        project_status="In Progress",
+        open_pr=None,
+        remote_oid=None,
+    )
+    final = _live_state(
+        head=new_head,
+        clean=True,
+        project_status="Review",
+        open_pr={
+            "number": 10,
+            "state": "OPEN",
+            "isDraft": False,
+            "headRefOid": new_head,
+            "baseRefOid": SHA,
+        },
+        remote_oid=new_head,
+    )
+    after_commit = _live_state(
+        head=new_head,
+        clean=True,
+        project_status="In Progress",
+        open_pr=None,
+        remote_oid=None,
+    )
+    after_remote = _live_state(
+        head=new_head,
+        clean=True,
+        project_status="In Progress",
+        open_pr=None,
+        remote_oid=new_head,
+    )
+    with_pr = _live_state(
+        head=new_head,
+        clean=True,
+        project_status="In Progress",
+        open_pr={
+            "number": 10,
+            "state": "OPEN",
+            "isDraft": False,
+            "headRefOid": new_head,
+            "baseRefOid": SHA,
+        },
+        remote_oid=new_head,
+    )
+    runner = CompletionRunner()
+    resolver = SequenceResolver(
+        tmp_path,
+        runner,
+        [pre, pre, after_commit, after_remote, with_pr, with_pr, final],
+    )
+    commit = StubCommit(dirty=True)
+
+    result = lck.DeliveryCompleter(
+        cast(Any, resolver),
+        formal_validation=cast(Any, StubValidation()),
+        commit_effect=cast(Any, commit),
+        remote_effect=cast(Any, StubEffect("ensure_remote_branch", "created")),
+        pr_effect=cast(Any, StubEffect("ensure_open_pr", "created")),
+        status_effect=cast(Any, StubEffect("set_review_status", "updated")),
+        checks_gate=cast(Any, StubChecks()),
+    ).complete(
+        160,
+        commit_message="Implement LCK Delivery cutover",
+        summary="Move initial Delivery mechanics into LCK.",
+    )
+
+    assert result.status == "READY_FOR_REVIEW"
+    assert commit.calls == [
+        "stage_candidate_tree",
+        "verify_tree_unchanged",
+        "execute",
+    ]
+
+
+def _with_checks(state: lck.LiveState, checks: dict[str, Any]) -> lck.LiveState:
+    return lck.LiveState(
+        task_number=state.task_number,
+        repository=state.repository,
+        issue=state.issue,
+        relationships=state.relationships,
+        git=state.git,
+        target_branch=state.target_branch,
+        local_task_branch=state.local_task_branch,
+        local_task_head=state.local_task_head,
+        remote_task_branch=state.remote_task_branch,
+        remote_task_oid=state.remote_task_oid,
+        open_pr=state.open_pr,
+        merged_pr_numbers=state.merged_pr_numbers,
+        merged=state.merged,
+        checks=checks,
+        cleanup=state.cleanup,
+        status=state.status,
+        stop_reasons=state.stop_reasons,
+        warnings=state.warnings,
+    )
+
+
+def _checks(*, category: str, state_name: str) -> dict[str, Any]:
+    return {
+        "count": 1,
+        "success": 1 if category == "success" else 0,
+        "pending": 1 if category == "pending" else 0,
+        "failed": 1 if category == "failed" else 0,
+        "skipped_or_unknown": 1 if category == "skipped-or-unknown" else 0,
+        "all_success": category == "success",
+        "items": {
+            "items": [{"name": "quality", "state": state_name, "category": category}],
+            "count": 1,
+            "truncated": False,
+        },
+    }
+
+
+def test_delivery_checks_gate_requires_named_required_check_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    head = "b" * 40
+    base = _live_state(
+        head=head,
+        clean=True,
+        project_status="Review",
+        open_pr={
+            "number": 10,
+            "state": "OPEN",
+            "isDraft": False,
+            "headRefOid": head,
+            "baseRefOid": SHA,
+        },
+        remote_oid=head,
+    )
+    state = _with_checks(base, _checks(category="success", state_name="SUCCESS"))
+    resolver = SequenceResolver(tmp_path, CompletionRunner(), [state])
+    monkeypatch.setattr(
+        lck,
+        "_required_checks",
+        lambda *_args, **_kwargs: {
+            "configuration": "available",
+            "contexts": {"items": ["quality"], "count": 1, "truncated": False},
+        },
+    )
+
+    result = lck.DeliveryChecksGate(cast(Any, resolver), timeout_seconds=0).run(160)
+
+    assert result["status"] == "pass"
+    assert result["required"] == ["quality"]
+
+
+def test_delivery_checks_gate_stops_on_failed_check(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    head = "b" * 40
+    base = _live_state(
+        head=head,
+        clean=True,
+        project_status="Review",
+        open_pr={
+            "number": 10,
+            "state": "OPEN",
+            "isDraft": False,
+            "headRefOid": head,
+            "baseRefOid": SHA,
+        },
+        remote_oid=head,
+    )
+    state = _with_checks(base, _checks(category="failed", state_name="FAILURE"))
+    resolver = SequenceResolver(tmp_path, CompletionRunner(), [state])
+    monkeypatch.setattr(
+        lck,
+        "_required_checks",
+        lambda *_args, **_kwargs: {
+            "configuration": "available",
+            "contexts": {"items": ["quality"], "count": 1, "truncated": False},
+        },
+    )
+
+    with pytest.raises(lck.LckStopError, match="checks failed"):
+        lck.DeliveryChecksGate(cast(Any, resolver), timeout_seconds=0).run(160)
+
+
+def test_delivery_checks_gate_preserves_plan_limit_as_limitation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    head = "b" * 40
+    base = _live_state(
+        head=head,
+        clean=True,
+        project_status="Review",
+        open_pr={
+            "number": 10,
+            "state": "OPEN",
+            "isDraft": False,
+            "headRefOid": head,
+            "baseRefOid": SHA,
+        },
+        remote_oid=head,
+    )
+    state = _with_checks(base, _checks(category="success", state_name="SUCCESS"))
+    resolver = SequenceResolver(tmp_path, CompletionRunner(), [state])
+    monkeypatch.setattr(
+        lck,
+        "_required_checks",
+        lambda *_args, **_kwargs: {
+            "configuration": "plan-limited-403",
+            "contexts": {"items": [], "count": 0, "truncated": False},
+        },
+    )
+
+    result = lck.DeliveryChecksGate(cast(Any, resolver), timeout_seconds=0).run(160)
+
+    assert result["status"] == "pass"
+    assert result["limitation"] == "required-check configuration unavailable"
+
+
+class FailingChecks:
+    def run(self, _task: int) -> dict[str, Any]:
+        raise lck.LckStopError("checks failed")
+
+
+def test_delivery_complete_critical_outcome_failure_blocks_commit_and_remote(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "tests" / "test_critical_path.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("def test_critical_path(): pass\
+", encoding="utf-8")
+    pre = _live_state(
+        head="d" * 40,
+        clean=False,
+        project_status="In Progress",
+        open_pr=None,
+        remote_oid=None,
+    )
+    runner = CompletionRunner(critical_returncode=1)
+    resolver = SequenceResolver(tmp_path, runner, [pre])
+    commit = StubCommit(dirty=True)
+    remote = StubEffect("ensure_remote_branch", "created")
+
+    with pytest.raises(lck.LckStopError, match="Critical Outcome FAIL"):
+        lck.DeliveryCompleter(
+            cast(Any, resolver),
+            formal_validation=cast(Any, StubValidation()),
+            commit_effect=cast(Any, commit),
+            remote_effect=cast(Any, remote),
+            pr_effect=cast(Any, StubEffect("ensure_open_pr", "created")),
+            status_effect=cast(Any, StubEffect("set_review_status", "updated")),
+            checks_gate=cast(Any, StubChecks()),
+        ).complete(
+            160,
+            commit_message="Implement LCK Delivery cutover",
+            summary="Move initial Delivery mechanics into LCK.",
+        )
+
+    assert commit.calls == ["stage_candidate_tree"]
+    assert remote.calls == 0
+
+
+def test_delivery_complete_stops_before_commit_when_base_changes_during_validation(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "tests" / "test_critical_path.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("def test_critical_path(): pass\
+", encoding="utf-8")
+    pre = _live_state(
+        head="d" * 40,
+        clean=False,
+        project_status="In Progress",
+        open_pr=None,
+        remote_oid=None,
+    )
+    changed = lck.LiveState(
+        **{
+            **pre.__dict__,
+            "git": {**pre.git, "origin_main_sha": "f" * 40},
+        }
+    )
+    runner = CompletionRunner()
+    resolver = SequenceResolver(tmp_path, runner, [pre, changed])
+    commit = StubCommit(dirty=True)
+    remote = StubEffect("ensure_remote_branch", "created")
+
+    with pytest.raises(lck.LckStopError, match="origin/main changed"):
+        lck.DeliveryCompleter(
+            cast(Any, resolver),
+            formal_validation=cast(Any, StubValidation()),
+            commit_effect=cast(Any, commit),
+            remote_effect=cast(Any, remote),
+            pr_effect=cast(Any, StubEffect("ensure_open_pr", "created")),
+            status_effect=cast(Any, StubEffect("set_review_status", "updated")),
+            checks_gate=cast(Any, StubChecks()),
+        ).complete(
+            160,
+            commit_message="Implement LCK Delivery cutover",
+            summary="Move initial Delivery mechanics into LCK.",
+        )
+
+    assert commit.calls == ["stage_candidate_tree"]
+    assert remote.calls == 0
+
+
+def test_delivery_complete_stops_before_commit_when_task_body_changes(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "tests" / "test_critical_path.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("def test_critical_path(): pass\
+", encoding="utf-8")
+    pre = _live_state(
+        head="d" * 40,
+        clean=False,
+        project_status="In Progress",
+        open_pr=None,
+        remote_oid=None,
+    )
+    changed_issue = dict(pre.issue or {})
+    changed_issue["body_sha256"] = "f" * 64
+    changed = lck.LiveState(**{**pre.__dict__, "issue": changed_issue})
+    runner = CompletionRunner()
+    resolver = SequenceResolver(tmp_path, runner, [pre, changed])
+    commit = StubCommit(dirty=True)
+
+    with pytest.raises(lck.LckStopError, match="Task body changed"):
+        lck.DeliveryCompleter(
+            cast(Any, resolver),
+            formal_validation=cast(Any, StubValidation()),
+            commit_effect=cast(Any, commit),
+            remote_effect=cast(Any, StubEffect("ensure_remote_branch", "created")),
+            pr_effect=cast(Any, StubEffect("ensure_open_pr", "created")),
+            status_effect=cast(Any, StubEffect("set_review_status", "updated")),
+            checks_gate=cast(Any, StubChecks()),
+        ).complete(
+            160,
+            commit_message="Implement LCK Delivery cutover",
+            summary="Move initial Delivery mechanics into LCK.",
+        )
+
+    assert commit.calls == ["stage_candidate_tree"]
+
+
+def test_failed_checks_do_not_move_project_status_to_review(tmp_path: Path) -> None:
+    target = tmp_path / "tests" / "test_critical_path.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("def test_critical_path(): pass\
+", encoding="utf-8")
+    head = "b" * 40
+    pre = _live_state(
+        head=head,
+        clean=True,
+        project_status="In Progress",
+        open_pr=None,
+        remote_oid=None,
+    )
+    remote = _live_state(
+        head=head,
+        clean=True,
+        project_status="In Progress",
+        open_pr=None,
+        remote_oid=head,
+    )
+    pr = {
+        "number": 10,
+        "state": "OPEN",
+        "isDraft": False,
+        "headRefOid": head,
+        "baseRefOid": SHA,
+    }
+    with_pr = _live_state(
+        head=head,
+        clean=True,
+        project_status="In Progress",
+        open_pr=pr,
+        remote_oid=head,
+    )
+    runner = CompletionRunner()
+    resolver = SequenceResolver(tmp_path, runner, [pre, pre, remote, with_pr])
+    status = StubEffect("set_review_status", "updated")
+
+    with pytest.raises(lck.LckStopError, match="checks failed"):
+        lck.DeliveryCompleter(
+            cast(Any, resolver),
+            formal_validation=cast(Any, StubValidation()),
+            commit_effect=cast(Any, StubCommit(dirty=False)),
+            remote_effect=cast(Any, StubEffect("ensure_remote_branch", "created")),
+            pr_effect=cast(Any, StubEffect("ensure_open_pr", "created")),
+            status_effect=cast(Any, status),
+            checks_gate=cast(Any, FailingChecks()),
+        ).complete(
+            160,
+            commit_message="Implement LCK Delivery cutover",
+            summary="Move initial Delivery mechanics into LCK.",
+        )
+
+    assert status.calls == 0

--- a/tests/tools/test_lck_delivery.py
+++ b/tests/tools/test_lck_delivery.py
@@ -514,7 +514,9 @@ Verification test: tests/tools/test_lck_delivery.py::test_task_160_critical_outc
         if command and command[0] == "uv":
             return self._result(command_id, command, stdout="1 passed")
         if command_id == "lck-formal-delivery-validation":
-            return self._result(command_id, command, stdout=json.dumps({"status": "pass"}))
+            return self._result(
+                command_id, command, stdout=json.dumps({"status": "pass"})
+            )
 
         if args[:1] == ["fetch"]:
             return self._result(command_id, command)
@@ -556,7 +558,9 @@ Verification test: tests/tools/test_lck_delivery.py::test_task_160_critical_outc
             "status",
             "--porcelain=v1",
         ]:
-            return self._result(command_id, command, stdout=" M candidate.py" if self.dirty else "")
+            return self._result(
+                command_id, command, stdout=" M candidate.py" if self.dirty else ""
+            )
         if args[:2] == ["diff", "--cached"] and "--name-only" in args:
             return self._result(command_id, command, stdout="candidate.py")
         if args[:2] == ["diff", "--cached"] and "--quiet" in args:
@@ -589,9 +593,13 @@ Verification test: tests/tools/test_lck_delivery.py::test_task_160_critical_outc
             )
 
         if command[:3] == ("gh", "issue", "view"):
-            return self._result(command_id, command, stdout=json.dumps(self._issue_payload()))
+            return self._result(
+                command_id, command, stdout=json.dumps(self._issue_payload())
+            )
         if command[:3] == ("gh", "api", "graphql"):
-            return self._result(command_id, command, stdout=self._graphql_payload(command))
+            return self._result(
+                command_id, command, stdout=self._graphql_payload(command)
+            )
         if command[:3] == ("gh", "pr", "list"):
             state_index = command.index("--state") + 1
             state = command[state_index]
@@ -599,17 +607,25 @@ Verification test: tests/tools/test_lck_delivery.py::test_task_160_critical_outc
                 return self._result(command_id, command, stdout="[]")
             if state == "merged":
                 return self._result(command_id, command, stdout="[]")
-            return self._result(command_id, command, stdout=json.dumps([self._pr_payload()]))
+            return self._result(
+                command_id, command, stdout=json.dumps([self._pr_payload()])
+            )
         if command[:3] == ("gh", "pr", "view"):
-            return self._result(command_id, command, stdout=json.dumps(self._pr_payload()))
+            return self._result(
+                command_id, command, stdout=json.dumps(self._pr_payload())
+            )
         if command[:3] == ("gh", "pr", "create"):
             self.open_pr = True
-            return self._result(command_id, command, stdout="https://github.com/owner/repo/pull/165")
+            return self._result(
+                command_id, command, stdout="https://github.com/owner/repo/pull/165"
+            )
         if command[:3] == ("gh", "project", "item-edit"):
             self.project_status = "Review"
             return self._result(command_id, command)
         if command[:2] == ("gh", "api"):
-            return self._result(command_id, command, returncode=1, stderr="404 not configured")
+            return self._result(
+                command_id, command, returncode=1, stderr="404 not configured"
+            )
 
         return self._result(command_id, command)
 
@@ -713,7 +729,10 @@ def test_task_160_critical_outcome_initial_delivery_is_lck_owned(
         assert direct_write not in initial_section
     target = tmp_path / "tests" / "tools" / "test_lck_delivery.py"
     target.parent.mkdir(parents=True)
-    target.write_text("def test_task_160_critical_outcome_initial_delivery_is_lck_owned(): pass\n", encoding="utf-8")
+    target.write_text(
+        "def test_task_160_critical_outcome_initial_delivery_is_lck_owned(): pass\n",
+        encoding="utf-8",
+    )
     tool = tmp_path / "tools" / "agent_workflow" / "workflow_validation.py"
     tool.parent.mkdir(parents=True)
     tool.write_text("# deterministic external validation boundary\n", encoding="utf-8")
@@ -749,11 +768,15 @@ def test_task_160_critical_outcome_initial_delivery_is_lck_owned(
     assert "lck-formal-delivery-validation" in runner.command_ids
     assert "lck-commit-current-tree" in runner.command_ids
     assert "lck-push-task-branch" in runner.command_ids
-    assert any(command[0] == "gh" and command[1:3] == ("pr", "create") for command in runner.commands)
-    assert any(command[0] == "gh" and command[1:3] == ("project", "item-edit") for command in runner.commands)
-    assert [
-        receipt["effect"] for receipt in payload["effects"]
-    ] == [
+    assert any(
+        command[0] == "gh" and command[1:3] == ("pr", "create")
+        for command in runner.commands
+    )
+    assert any(
+        command[0] == "gh" and command[1:3] == ("project", "item-edit")
+        for command in runner.commands
+    )
+    assert [receipt["effect"] for receipt in payload["effects"]] == [
         "commit_current_tree",
         "ensure_remote_branch",
         "ensure_open_pr",

--- a/tests/tools/test_lck_delivery.py
+++ b/tests/tools/test_lck_delivery.py
@@ -81,6 +81,21 @@ def test_commit_current_tree_rejects_tree_change_after_validation(
         effect.verify_tree_unchanged(tree)
 
 
+def test_commit_current_tree_rejects_head_change_after_validation(
+    tmp_path: Path,
+) -> None:
+    repo, _ = _repo(tmp_path)
+    _git(repo, "switch", "-c", "task/160-delivery")
+    (repo / "seed.txt").write_text("candidate\n", encoding="utf-8")
+    effect = lck.CommitCurrentTreeEffect(_resolver_for_repo(repo))
+    original_head = _git(repo, "rev-parse", "HEAD")
+    tree = effect.stage_candidate_tree()
+    _git(repo, "commit", "-m", "concurrent")
+
+    with pytest.raises(lck.LckStopError, match="HEAD changed during formal validation"):
+        effect.verify_tree_unchanged(tree, expected_head_sha=original_head)
+
+
 def test_ensure_remote_branch_create_then_idempotent(tmp_path: Path) -> None:
     repo, _ = _repo(tmp_path)
     _git(repo, "switch", "-c", "task/160-delivery")
@@ -95,6 +110,22 @@ def test_ensure_remote_branch_create_then_idempotent(tmp_path: Path) -> None:
     assert created.action == "created"
     assert repeated.action == "already-synced"
     assert created.details["head_sha"] == repeated.details["remote_oid"]
+
+
+def test_ensure_remote_branch_rejects_unvalidated_local_head(
+    tmp_path: Path,
+) -> None:
+    repo, _ = _repo(tmp_path)
+    _git(repo, "switch", "-c", "task/160-delivery")
+    (repo / "task.txt").write_text("task\n", encoding="utf-8")
+    _git(repo, "add", "task.txt")
+    _git(repo, "commit", "-m", "task")
+    effect = lck.EnsureRemoteBranchEffect(_resolver_for_repo(repo))
+
+    with pytest.raises(lck.LckStopError, match="validated local Task HEAD changed"):
+        effect.execute("task/160-delivery", expected_head_sha="b" * 40)
+
+    assert _git(repo, "ls-remote", "--heads", "origin", "task/160-delivery") == ""
 
 
 def test_ensure_remote_branch_fast_forwards_only_when_remote_is_ancestor(
@@ -331,10 +362,18 @@ class StubCommit:
         self.calls.append("stage_candidate_tree")
         return "c" * 40
 
-    def verify_tree_unchanged(self, _tree: str) -> None:
+    def verify_tree_unchanged(
+        self, _tree: str, *, expected_head_sha: str | None = None
+    ) -> None:
         self.calls.append("verify_tree_unchanged")
 
-    def execute(self, tree: str, _message: str) -> lck.EffectReceipt:
+    def execute(
+        self,
+        tree: str,
+        _message: str,
+        *,
+        expected_parent_sha: str | None = None,
+    ) -> lck.EffectReceipt:
         self.calls.append("execute")
         return lck.EffectReceipt(
             "commit_current_tree",
@@ -979,3 +1018,33 @@ def test_final_verification_requires_same_pr_as_checks_gate(tmp_path: Path) -> N
                 "pr": {"number": 10, "head_sha": head, "base_sha": SHA},
             },
         )
+
+
+def test_set_review_status_requires_checks_gated_pr_identity(
+    tmp_path: Path,
+) -> None:
+    head = "b" * 40
+    current_pr = {
+        "number": 11,
+        "state": "OPEN",
+        "isDraft": False,
+        "headRefOid": head,
+        "baseRefOid": SHA,
+    }
+    state = _live_state(
+        head=head,
+        clean=True,
+        project_status="In Progress",
+        open_pr=current_pr,
+        remote_oid=head,
+    )
+    runner = CompletionRunner()
+    resolver = SequenceResolver(tmp_path, runner, [state])
+
+    with pytest.raises(lck.LckStopError, match="checks-gated PR identity changed"):
+        lck.SetReviewStatusEffect(cast(Any, resolver)).execute(
+            160,
+            expected_pr={"number": 10, "head_sha": head, "base_sha": SHA},
+        )
+
+    assert not any(command[:2] == ("gh", "project") for command in runner.commands)

--- a/tests/tools/test_lck_delivery.py
+++ b/tests/tools/test_lck_delivery.py
@@ -1219,6 +1219,13 @@ def test_final_verification_stops_when_checks_regress_after_gate(
         open_pr=pr,
         remote_oid=head,
     )
+    restored = _live_state(
+        head=head,
+        clean=True,
+        project_status="In Progress",
+        open_pr=pr,
+        remote_oid=head,
+    )
     failed_final = _with_checks(
         _live_state(
             head=head,
@@ -1233,9 +1240,9 @@ def test_final_verification_stops_when_checks_regress_after_gate(
     resolver = SequenceResolver(
         tmp_path,
         runner,
-        [pre, pre, remote, with_pr, with_pr, failed_final],
+        [pre, pre, remote, with_pr, with_pr, with_pr, failed_final, restored],
     )
-    status = StubEffect("set_review_status", "updated")
+    status = lck.SetReviewStatusEffect(cast(Any, resolver))
 
     with pytest.raises(lck.LckStopError, match="check/lifecycle state is not aligned"):
         lck.DeliveryCompleter(
@@ -1252,7 +1259,12 @@ def test_final_verification_stops_when_checks_regress_after_gate(
             summary="Move initial Delivery mechanics into LCK.",
         )
 
-    assert status.calls == 1
+    project_status_values = [
+        command[command.index("--value") + 1]
+        for command in runner.commands
+        if command[:3] == ("gh", "project", "item-edit")
+    ]
+    assert project_status_values == ["Review", "In Progress"]
 
 
 def test_final_verification_requires_same_pr_as_checks_gate(tmp_path: Path) -> None:
@@ -1313,6 +1325,46 @@ def test_set_review_status_requires_checks_gated_pr_identity(
         lck.SetReviewStatusEffect(cast(Any, resolver)).execute(
             160,
             expected_pr={"number": 10, "head_sha": head, "base_sha": SHA},
+        )
+
+    assert not any(command[:2] == ("gh", "project") for command in runner.commands)
+
+
+def test_set_review_status_rejects_regressed_checks_before_mutation(
+    tmp_path: Path,
+) -> None:
+    head = "b" * 40
+    current_pr = {
+        "number": 10,
+        "state": "OPEN",
+        "isDraft": False,
+        "headRefOid": head,
+        "baseRefOid": SHA,
+    }
+    state = _with_checks(
+        _live_state(
+            head=head,
+            clean=True,
+            project_status="In Progress",
+            open_pr=current_pr,
+            remote_oid=head,
+        ),
+        _checks(category="failed", state_name="FAILURE"),
+    )
+    runner = CompletionRunner()
+    resolver = SequenceResolver(tmp_path, runner, [state])
+    checks_result = {
+        "status": "pass",
+        "configuration": "not-configured",
+        "required": [],
+        "pr": {"number": 10, "head_sha": head, "base_sha": SHA},
+    }
+
+    with pytest.raises(lck.LckStopError, match="PR checks are no longer passing"):
+        lck.SetReviewStatusEffect(cast(Any, resolver)).execute(
+            160,
+            expected_pr=checks_result["pr"],
+            checks_result=checks_result,
         )
 
     assert not any(command[:2] == ("gh", "project") for command in runner.commands)

--- a/tests/tools/test_lck_delivery.py
+++ b/tests/tools/test_lck_delivery.py
@@ -393,6 +393,227 @@ class StubEffect:
         return lck.EffectReceipt(self.name, self.action, {})
 
 
+class CliDeliveryRunner:
+    """Deterministic external boundary for the real LCK Delivery CLI path."""
+
+    branch = "task/160-delivery-lifecycle-control-lck"
+    base_sha = "a" * 40
+    old_head = "d" * 40
+    new_head = "b" * 40
+    tree_oid = "c" * 40
+
+    def __init__(self) -> None:
+        self.commands: list[tuple[str, ...]] = []
+        self.command_ids: list[str] = []
+        self.remote_oid: str | None = None
+        self.open_pr = False
+        self.project_status = "In Progress"
+        self.dirty = True
+
+    def _result(
+        self,
+        command_id: str,
+        command: tuple[str, ...],
+        *,
+        stdout: str = "",
+        returncode: int = 0,
+        stderr: str = "",
+    ) -> CommandResult:
+        return CommandResult(
+            command_id=command_id,
+            argv=command,
+            returncode=returncode,
+            stdout=f"{stdout}\n" if stdout else "",
+            stderr=stderr,
+        )
+
+    def _issue_payload(self) -> dict[str, Any]:
+        body = """### Critical Outcome
+Caller: task-delivery-runner initial Delivery
+Capability: LCK owns deterministic initial Delivery completion
+Observable result: a semantically completed Task reaches READY_FOR_REVIEW
+Verification test: tests/tools/test_lck_delivery.py::test_task_160_critical_outcome_initial_delivery_is_lck_owned
+"""
+        return {
+            "number": 160,
+            "title": "[Task] 将 Delivery lifecycle control 迁移至 LCK",
+            "body": body,
+            "comments": [],
+            "state": "OPEN",
+            "labels": [
+                {"name": "type:task"},
+                {"name": "codex:ready"},
+            ],
+            "projectItems": [{"status": {"name": self.project_status}}],
+            "url": "https://github.com/owner/repo/issues/160",
+            "closedAt": None,
+            "closedByPullRequestsReferences": [],
+        }
+
+    def _pr_payload(self) -> dict[str, Any]:
+        return {
+            "number": 165,
+            "url": "https://github.com/owner/repo/pull/165",
+            "state": "OPEN",
+            "isDraft": False,
+            "baseRefName": "main",
+            "baseRefOid": self.base_sha,
+            "headRefName": self.branch,
+            "headRefOid": self.new_head,
+            "statusCheckRollup": [
+                {"name": "quality", "conclusion": "SUCCESS"},
+            ],
+        }
+
+    def _graphql_payload(self, command: tuple[str, ...]) -> str:
+        query = command[4] if len(command) > 4 else ""
+        if "closedByPullRequestsReferences" in query:
+            issue: dict[str, Any] = {
+                "state": "OPEN",
+                "closedAt": None,
+                "closedByPullRequestsReferences": {
+                    "nodes": [],
+                    "pageInfo": {"hasNextPage": False},
+                },
+                "timelineItems": {
+                    "nodes": [],
+                    "pageInfo": {"hasPreviousPage": False},
+                },
+            }
+        else:
+            issue = {
+                "issueType": {"name": "Task"},
+                "parent": None,
+                "subIssues": {
+                    "nodes": [],
+                    "pageInfo": {"hasNextPage": False},
+                },
+                "blockedBy": {
+                    "nodes": [],
+                    "pageInfo": {"hasNextPage": False},
+                },
+                "blocking": {
+                    "nodes": [],
+                    "pageInfo": {"hasNextPage": False},
+                },
+            }
+        return json.dumps({"data": {"repository": {"issue": issue}}})
+
+    def run(
+        self,
+        argv: list[str] | tuple[str, ...],
+        *,
+        command_id: str,
+        **_: Any,
+    ) -> CommandResult:
+        command = tuple(str(item) for item in argv)
+        self.commands.append(command)
+        self.command_ids.append(command_id)
+        args = list(command[1:]) if command and command[0] == "git" else list(command)
+
+        if command and command[0] == "uv":
+            return self._result(command_id, command, stdout="1 passed")
+        if command_id == "lck-formal-delivery-validation":
+            return self._result(command_id, command, stdout=json.dumps({"status": "pass"}))
+
+        if args[:1] == ["fetch"]:
+            return self._result(command_id, command)
+        if args == ["branch", "--show-current"]:
+            return self._result(command_id, command, stdout=self.branch)
+        if args == ["rev-parse", "HEAD"]:
+            return self._result(
+                command_id,
+                command,
+                stdout=self.new_head if not self.dirty else self.old_head,
+            )
+        if args == ["rev-parse", "HEAD^"]:
+            return self._result(command_id, command, stdout=self.old_head)
+        if args == ["rev-parse", "HEAD^{tree}"]:
+            return self._result(command_id, command, stdout=self.tree_oid)
+        if args == ["rev-parse", "FETCH_HEAD"]:
+            return self._result(command_id, command, stdout=self.remote_oid or "")
+        if args == ["rev-parse", "refs/heads/main"]:
+            return self._result(command_id, command, stdout=self.base_sha)
+        if args == ["rev-parse", "refs/remotes/origin/main"]:
+            return self._result(command_id, command, stdout=self.base_sha)
+        if args[:1] == ["rev-parse"] and len(args) == 2:
+            return self._result(
+                command_id,
+                command,
+                stdout=self.new_head if not self.dirty else self.old_head,
+            )
+        if args[:2] == ["for-each-ref", "--format=%(refname:short)"]:
+            return self._result(command_id, command, stdout=self.branch)
+        if args[:3] == ["ls-remote", "--heads", "origin"]:
+            if self.remote_oid is None:
+                return self._result(command_id, command)
+            return self._result(
+                command_id,
+                command,
+                stdout=f"{self.remote_oid}\trefs/heads/{self.branch}",
+            )
+        if args[:2] == ["status", "--short"] or args[:2] == [
+            "status",
+            "--porcelain=v1",
+        ]:
+            return self._result(command_id, command, stdout=" M candidate.py" if self.dirty else "")
+        if args[:2] == ["diff", "--cached"] and "--name-only" in args:
+            return self._result(command_id, command, stdout="candidate.py")
+        if args[:2] == ["diff", "--cached"] and "--quiet" in args:
+            return self._result(command_id, command, returncode=1)
+        if args == ["diff", "--quiet"] or (
+            len(args) == 3 and args[:2] == ["diff", "--quiet"]
+        ):
+            return self._result(command_id, command)
+        if args == ["diff", "--cached", "--check"]:
+            return self._result(command_id, command)
+        if args == ["diff", "--name-only"]:
+            return self._result(command_id, command, stdout="candidate.py")
+        if args == ["add", "-A", "--", ":/"]:
+            return self._result(command_id, command)
+        if args == ["write-tree"]:
+            return self._result(command_id, command, stdout=self.tree_oid)
+        if args[:2] == ["commit", "-m"]:
+            self.dirty = False
+            return self._result(command_id, command)
+        if args[:1] == ["push"]:
+            self.remote_oid = self.new_head
+            return self._result(command_id, command)
+        if args[:3] == ["merge-base", "--is-ancestor", self.remote_oid or ""]:
+            return self._result(command_id, command)
+        if args[:2] == ["worktree", "list"]:
+            return self._result(
+                command_id,
+                command,
+                stdout=f"worktree /tmp/test-repo\nbranch refs/heads/{self.branch}",
+            )
+
+        if command[:3] == ("gh", "issue", "view"):
+            return self._result(command_id, command, stdout=json.dumps(self._issue_payload()))
+        if command[:3] == ("gh", "api", "graphql"):
+            return self._result(command_id, command, stdout=self._graphql_payload(command))
+        if command[:3] == ("gh", "pr", "list"):
+            state_index = command.index("--state") + 1
+            state = command[state_index]
+            if not self.open_pr:
+                return self._result(command_id, command, stdout="[]")
+            if state == "merged":
+                return self._result(command_id, command, stdout="[]")
+            return self._result(command_id, command, stdout=json.dumps([self._pr_payload()]))
+        if command[:3] == ("gh", "pr", "view"):
+            return self._result(command_id, command, stdout=json.dumps(self._pr_payload()))
+        if command[:3] == ("gh", "pr", "create"):
+            self.open_pr = True
+            return self._result(command_id, command, stdout="https://github.com/owner/repo/pull/165")
+        if command[:3] == ("gh", "project", "item-edit"):
+            self.project_status = "Review"
+            return self._result(command_id, command)
+        if command[:2] == ("gh", "api"):
+            return self._result(command_id, command, returncode=1, stderr="404 not configured")
+
+        return self._result(command_id, command)
+
+
 def test_delivery_complete_revalidates_clean_committed_head_and_stops_at_review_boundary(
     tmp_path: Path,
 ) -> None:
@@ -474,6 +695,8 @@ def test_delivery_complete_revalidates_clean_committed_head_and_stops_at_review_
 
 def test_task_160_critical_outcome_initial_delivery_is_lck_owned(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
     root = Path(__file__).parents[2]
     agent_skill = (root / ".agents/skills/task-delivery-runner/SKILL.md").read_text(
@@ -488,85 +711,53 @@ def test_task_160_critical_outcome_initial_delivery_is_lck_owned(
     initial_section = agent_skill.split("## Review remediation", 1)[0]
     for direct_write in ("git commit", "git push", "gh pr create"):
         assert direct_write not in initial_section
-    target = tmp_path / "tests" / "test_critical_path.py"
+    target = tmp_path / "tests" / "tools" / "test_lck_delivery.py"
     target.parent.mkdir(parents=True)
-    target.write_text("def test_critical_path(): pass\n", encoding="utf-8")
-    old_head = "d" * 40
-    new_head = "b" * 40
-    pre = _live_state(
-        head=old_head,
-        clean=False,
-        project_status="In Progress",
-        open_pr=None,
-        remote_oid=None,
-    )
-    final = _live_state(
-        head=new_head,
-        clean=True,
-        project_status="Review",
-        open_pr={
-            "number": 10,
-            "state": "OPEN",
-            "isDraft": False,
-            "headRefOid": new_head,
-            "baseRefOid": SHA,
-        },
-        remote_oid=new_head,
-    )
-    after_commit = _live_state(
-        head=new_head,
-        clean=True,
-        project_status="In Progress",
-        open_pr=None,
-        remote_oid=None,
-    )
-    after_remote = _live_state(
-        head=new_head,
-        clean=True,
-        project_status="In Progress",
-        open_pr=None,
-        remote_oid=new_head,
-    )
-    with_pr = _live_state(
-        head=new_head,
-        clean=True,
-        project_status="In Progress",
-        open_pr={
-            "number": 10,
-            "state": "OPEN",
-            "isDraft": False,
-            "headRefOid": new_head,
-            "baseRefOid": SHA,
-        },
-        remote_oid=new_head,
-    )
-    runner = CompletionRunner()
-    resolver = SequenceResolver(
-        tmp_path,
-        runner,
-        [pre, pre, after_commit, after_remote, with_pr, with_pr, final],
-    )
-    commit = StubCommit(dirty=True)
+    target.write_text("def test_task_160_critical_outcome_initial_delivery_is_lck_owned(): pass\n", encoding="utf-8")
+    tool = tmp_path / "tools" / "agent_workflow" / "workflow_validation.py"
+    tool.parent.mkdir(parents=True)
+    tool.write_text("# deterministic external validation boundary\n", encoding="utf-8")
 
-    result = lck.DeliveryCompleter(
-        cast(Any, resolver),
-        formal_validation=cast(Any, StubValidation()),
-        commit_effect=cast(Any, commit),
-        remote_effect=cast(Any, StubEffect("ensure_remote_branch", "created")),
-        pr_effect=cast(Any, StubEffect("ensure_open_pr", "created")),
-        status_effect=cast(Any, StubEffect("set_review_status", "updated")),
-        checks_gate=cast(Any, StubChecks()),
-    ).complete(
-        160,
-        commit_message="Implement LCK Delivery cutover",
-        summary="Move initial Delivery mechanics into LCK.",
-    )
+    runner = CliDeliveryRunner()
+    monkeypatch.setattr(lck, "CommandRunner", lambda _repo_root: runner)
 
-    assert result.status == "READY_FOR_REVIEW"
-    assert commit.calls == [
-        "stage_candidate_tree",
-        "verify_tree_unchanged",
-        "execute",
+    exit_code = lck.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--repository",
+            "owner/repo",
+            "delivery",
+            "complete",
+            "160",
+            "--commit-message",
+            "Implement LCK Delivery cutover",
+            "--summary",
+            "Move initial Delivery mechanics into LCK.",
+        ]
+    )
+    output = capsys.readouterr().out
+    payload = json.loads(output)
+
+    assert exit_code == 0, output
+    assert payload["status"] == "READY_FOR_REVIEW"
+    assert payload["human_boundary"] == "Independent Review must be started separately"
+    assert payload["final_state"]["issue"]["project_status"] == "Review"
+    assert runner.remote_oid == runner.new_head
+    assert runner.open_pr is True
+    assert "lck-critical-outcome" in runner.command_ids
+    assert "lck-formal-delivery-validation" in runner.command_ids
+    assert "lck-commit-current-tree" in runner.command_ids
+    assert "lck-push-task-branch" in runner.command_ids
+    assert any(command[0] == "gh" and command[1:3] == ("pr", "create") for command in runner.commands)
+    assert any(command[0] == "gh" and command[1:3] == ("project", "item-edit") for command in runner.commands)
+    assert [
+        receipt["effect"] for receipt in payload["effects"]
+    ] == [
+        "commit_current_tree",
+        "ensure_remote_branch",
+        "ensure_open_pr",
+        "set_review_status",
     ]
 
 

--- a/tests/tools/test_lck_delivery.py
+++ b/tests/tools/test_lck_delivery.py
@@ -303,7 +303,17 @@ class StubValidation:
 
 class StubChecks:
     def run(self, _task: int) -> dict[str, Any]:
-        return {"status": "pass", "configuration": "available"}
+        return {
+            "status": "pass",
+            "configuration": "not-configured",
+            "required": [],
+            "observed": {
+                "count": 0,
+                "failed": 0,
+                "skipped_or_unknown": 0,
+                "all_success": None,
+            },
+        }
 
 
 class StubCommit:
@@ -850,3 +860,77 @@ def test_failed_checks_do_not_move_project_status_to_review(tmp_path: Path) -> N
         )
 
     assert status.calls == 0
+
+
+def test_final_verification_stops_when_checks_regress_after_gate(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "tests" / "test_critical_path.py"
+    target.parent.mkdir(parents=True)
+    target.write_text(
+        "def test_critical_path(): pass\n",
+        encoding="utf-8",
+    )
+    head = "b" * 40
+    pre = _live_state(
+        head=head,
+        clean=True,
+        project_status="In Progress",
+        open_pr=None,
+        remote_oid=None,
+    )
+    remote = _live_state(
+        head=head,
+        clean=True,
+        project_status="In Progress",
+        open_pr=None,
+        remote_oid=head,
+    )
+    pr = {
+        "number": 10,
+        "state": "OPEN",
+        "isDraft": False,
+        "headRefOid": head,
+        "baseRefOid": SHA,
+    }
+    with_pr = _live_state(
+        head=head,
+        clean=True,
+        project_status="In Progress",
+        open_pr=pr,
+        remote_oid=head,
+    )
+    failed_final = _with_checks(
+        _live_state(
+            head=head,
+            clean=True,
+            project_status="Review",
+            open_pr={**pr},
+            remote_oid=head,
+        ),
+        _checks(category="failed", state_name="FAILURE"),
+    )
+    runner = CompletionRunner()
+    resolver = SequenceResolver(
+        tmp_path,
+        runner,
+        [pre, pre, remote, with_pr, with_pr, failed_final],
+    )
+    status = StubEffect("set_review_status", "updated")
+
+    with pytest.raises(lck.LckStopError, match="check/lifecycle state is not aligned"):
+        lck.DeliveryCompleter(
+            cast(Any, resolver),
+            formal_validation=cast(Any, StubValidation()),
+            commit_effect=cast(Any, StubCommit(dirty=False)),
+            remote_effect=cast(Any, StubEffect("ensure_remote_branch", "created")),
+            pr_effect=cast(Any, StubEffect("ensure_open_pr", "created")),
+            status_effect=cast(Any, status),
+            checks_gate=cast(Any, StubChecks()),
+        ).complete(
+            160,
+            commit_message="Implement LCK Delivery cutover",
+            summary="Move initial Delivery mechanics into LCK.",
+        )
+
+    assert status.calls == 1

--- a/tests/tools/test_lck_delivery.py
+++ b/tests/tools/test_lck_delivery.py
@@ -38,14 +38,18 @@ def _repo(tmp_path: Path) -> tuple[Path, Path]:
     (repo / "seed.txt").write_text("seed\n", encoding="utf-8")
     _git(repo, "add", "seed.txt")
     _git(repo, "commit", "-m", "seed")
-    subprocess.run(["git", "init", "--bare", str(origin)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "init", "--bare", str(origin)], check=True, capture_output=True
+    )
     _git(repo, "remote", "add", "origin", str(origin))
     _git(repo, "push", "-u", "origin", "main")
     return repo, origin
 
 
 def _resolver_for_repo(repo: Path) -> lck.LiveStateResolver:
-    return lck.LiveStateResolver(repo, runner=CommandRunner(repo), repository="owner/repo")
+    return lck.LiveStateResolver(
+        repo, runner=CommandRunner(repo), repository="owner/repo"
+    )
 
 
 def test_commit_current_tree_binds_validated_tree_to_commit(tmp_path: Path) -> None:
@@ -63,7 +67,9 @@ def test_commit_current_tree_binds_validated_tree_to_commit(tmp_path: Path) -> N
     assert _git(repo, "status", "--porcelain") == ""
 
 
-def test_commit_current_tree_rejects_tree_change_after_validation(tmp_path: Path) -> None:
+def test_commit_current_tree_rejects_tree_change_after_validation(
+    tmp_path: Path,
+) -> None:
     repo, _ = _repo(tmp_path)
     _git(repo, "switch", "-c", "task/160-delivery")
     (repo / "seed.txt").write_text("candidate\n", encoding="utf-8")
@@ -120,7 +126,9 @@ def test_ensure_remote_branch_stops_on_divergence(tmp_path: Path) -> None:
     shared = _git(repo, "rev-parse", "HEAD")
 
     other = tmp_path / "other"
-    subprocess.run(["git", "clone", str(origin), str(other)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "clone", str(origin), str(other)], check=True, capture_output=True
+    )
     _git(other, "config", "user.name", "Other")
     _git(other, "config", "user.email", "other@example.invalid")
     _git(other, "switch", "task/160-delivery")
@@ -164,7 +172,9 @@ class ValidationRunner:
 
 def test_formal_validation_gate_requires_structured_pass(tmp_path: Path) -> None:
     runner = ValidationRunner()
-    resolver = lck.LiveStateResolver(tmp_path, runner=cast(Any, runner), repository="owner/repo")
+    resolver = lck.LiveStateResolver(
+        tmp_path, runner=cast(Any, runner), repository="owner/repo"
+    )
 
     payload = lck.FormalValidationGate(resolver).run(SHA)
 
@@ -178,7 +188,9 @@ def test_formal_validation_gate_fails_closed(
     tmp_path: Path, status: str, returncode: int
 ) -> None:
     runner = ValidationRunner(status=status, returncode=returncode)
-    resolver = lck.LiveStateResolver(tmp_path, runner=cast(Any, runner), repository="owner/repo")
+    resolver = lck.LiveStateResolver(
+        tmp_path, runner=cast(Any, runner), repository="owner/repo"
+    )
 
     with pytest.raises(lck.LckStopError, match="formal Delivery validation failed"):
         lck.FormalValidationGate(resolver).run(SHA)
@@ -270,7 +282,9 @@ class CompletionRunner:
 
 
 class SequenceResolver:
-    def __init__(self, repo_root: Path, runner: CompletionRunner, states: list[lck.LiveState]) -> None:
+    def __init__(
+        self, repo_root: Path, runner: CompletionRunner, states: list[lck.LiveState]
+    ) -> None:
         self.repo_root = repo_root
         self.runner = cast(Any, runner)
         self._states = states
@@ -396,10 +410,15 @@ def test_delivery_complete_revalidates_clean_committed_head_and_stops_at_review_
     )
 
     assert result.status == "READY_FOR_REVIEW"
-    assert result.to_dict()["human_boundary"] == "Independent Review must be started separately"
+    assert (
+        result.to_dict()["human_boundary"]
+        == "Independent Review must be started separately"
+    )
     assert commit.calls == ["current_head_tree"]
     assert remote.calls == pr.calls == status.calls == 1
-    assert not any("review" in " ".join(command).casefold() for command in runner.commands)
+    assert not any(
+        "review" in " ".join(command).casefold() for command in runner.commands
+    )
 
 
 def test_task_160_critical_outcome_initial_delivery_is_lck_owned(
@@ -649,8 +668,11 @@ def test_delivery_complete_critical_outcome_failure_blocks_commit_and_remote(
 ) -> None:
     target = tmp_path / "tests" / "test_critical_path.py"
     target.parent.mkdir(parents=True)
-    target.write_text("def test_critical_path(): pass\
-", encoding="utf-8")
+    target.write_text(
+        "def test_critical_path(): pass\
+",
+        encoding="utf-8",
+    )
     pre = _live_state(
         head="d" * 40,
         clean=False,
@@ -687,8 +709,11 @@ def test_delivery_complete_stops_before_commit_when_base_changes_during_validati
 ) -> None:
     target = tmp_path / "tests" / "test_critical_path.py"
     target.parent.mkdir(parents=True)
-    target.write_text("def test_critical_path(): pass\
-", encoding="utf-8")
+    target.write_text(
+        "def test_critical_path(): pass\
+",
+        encoding="utf-8",
+    )
     pre = _live_state(
         head="d" * 40,
         clean=False,
@@ -731,8 +756,11 @@ def test_delivery_complete_stops_before_commit_when_task_body_changes(
 ) -> None:
     target = tmp_path / "tests" / "test_critical_path.py"
     target.parent.mkdir(parents=True)
-    target.write_text("def test_critical_path(): pass\
-", encoding="utf-8")
+    target.write_text(
+        "def test_critical_path(): pass\
+",
+        encoding="utf-8",
+    )
     pre = _live_state(
         head="d" * 40,
         clean=False,
@@ -768,8 +796,11 @@ def test_delivery_complete_stops_before_commit_when_task_body_changes(
 def test_failed_checks_do_not_move_project_status_to_review(tmp_path: Path) -> None:
     target = tmp_path / "tests" / "test_critical_path.py"
     target.parent.mkdir(parents=True)
-    target.write_text("def test_critical_path(): pass\
-", encoding="utf-8")
+    target.write_text(
+        "def test_critical_path(): pass\
+",
+        encoding="utf-8",
+    )
     head = "b" * 40
     pre = _live_state(
         head=head,

--- a/tests/tools/test_workflow_common.py
+++ b/tests/tools/test_workflow_common.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+AGENT_WORKFLOW = str(Path(__file__).parents[2] / "tools" / "agent_workflow")
+if AGENT_WORKFLOW not in sys.path:
+    sys.path.insert(0, AGENT_WORKFLOW)
+
+from workflow_common import (  # type: ignore[import-not-found]  # noqa: E402
+    CommandRunner,
+    build_workflow_env,
+)
+
+
+def test_build_workflow_env_defaults_to_repo_local_uv_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("UV_CACHE_DIR", raising=False)
+
+    env = build_workflow_env(tmp_path)
+
+    assert env["UV_CACHE_DIR"] == str(tmp_path / ".workflow.local" / "uv-cache")
+
+
+def test_build_workflow_env_preserves_explicit_uv_cache_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    custom_cache = "/some/custom/cache"
+    monkeypatch.setenv("UV_CACHE_DIR", custom_cache)
+
+    env = build_workflow_env(tmp_path)
+
+    assert env["UV_CACHE_DIR"] == custom_cache
+
+
+def test_command_runner_passes_repo_local_uv_cache_to_subprocess(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    marker = tmp_path / "uv-cache-env.txt"
+    uv = tmp_path / "uv"
+    uv.write_text(
+        f"#!{sys.executable}\n"
+        "import os\n"
+        "from pathlib import Path\n"
+        f"Path({str(marker)!r}).write_text(os.environ['UV_CACHE_DIR'], encoding='utf-8')\n",
+        encoding="utf-8",
+    )
+    uv.chmod(0o755)
+    monkeypatch.delenv("UV_CACHE_DIR", raising=False)
+    monkeypatch.setenv("PATH", f"{tmp_path}{os.pathsep}{os.environ['PATH']}")
+
+    result = CommandRunner(tmp_path).run(
+        ["uv", "run", "--frozen", "pytest"],
+        command_id="test-uv-cache-env",
+        validation=True,
+    )
+
+    assert result.returncode == 0
+    assert marker.read_text(encoding="utf-8") == str(
+        tmp_path / ".workflow.local" / "uv-cache"
+    )

--- a/tests/tools/test_workflow_skills.py
+++ b/tests/tools/test_workflow_skills.py
@@ -58,8 +58,12 @@ def test_delivery_runner_uses_lck_for_initial_delivery_and_keeps_remediation() -
 
 
 def test_initial_delivery_lck_contract_is_shared_by_both_skills() -> None:
-    agent = (ROOT / ".agents/skills/task-delivery-runner/SKILL.md").read_text(encoding="utf-8")
-    claude = (ROOT / ".claude/skills/task-delivery-runner/SKILL.md").read_text(encoding="utf-8")
+    agent = (ROOT / ".agents/skills/task-delivery-runner/SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    claude = (ROOT / ".claude/skills/task-delivery-runner/SKILL.md").read_text(
+        encoding="utf-8"
+    )
     assert agent == claude
     for phrase in (
         "LCK Delivery Prepare",

--- a/tests/tools/test_workflow_skills.py
+++ b/tests/tools/test_workflow_skills.py
@@ -198,9 +198,11 @@ def test_review_skill_requires_remediation_handoff_for_non_pass() -> None:
         ROOT / ".claude/skills/task-pr-review-runner/SKILL.md",
     ):
         text = path.read_text(encoding="utf-8")
-        section = text[text.index("## Remediation handoff") : text.index(
-            "## Report and recovery", text.index("## Remediation handoff")
-        )]
+        section = text[
+            text.index("## Remediation handoff") : text.index(
+                "## Report and recovery", text.index("## Remediation handoff")
+            )
+        ]
         match = re.search(
             r"^```text\n(?P<body>.*?)\n```$", section, re.MULTILINE | re.DOTALL
         )

--- a/tests/tools/test_workflow_skills.py
+++ b/tests/tools/test_workflow_skills.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -192,12 +193,41 @@ def test_review_skill_has_shared_owner_contract_and_exact_tokens() -> None:
 
 
 def test_review_skill_requires_remediation_handoff_for_non_pass() -> None:
-    text = ACTIVE_SKILLS["task-pr-review-runner"].read_text(encoding="utf-8")
-    assert "Enforcement" in text
-    assert "non-passing verdict" in text.casefold()
-    assert "Delivery prompt" in text
-    assert "non-compliant" in text
-    assert "task-delivery-runner 修复" in text
+    for path in (
+        ROOT / ".agents/skills/task-pr-review-runner/SKILL.md",
+        ROOT / ".claude/skills/task-pr-review-runner/SKILL.md",
+    ):
+        text = path.read_text(encoding="utf-8")
+        section = text[text.index("## Remediation handoff") : text.index(
+            "## Report and recovery", text.index("## Remediation handoff")
+        )]
+        match = re.search(
+            r"^```text\n(?P<body>.*?)\n```$", section, re.MULTILINE | re.DOTALL
+        )
+        assert match is not None
+        body = match.group("body")
+        assert len(re.findall(r"^## Remediation handoff$", section, re.MULTILINE)) == 1
+        assert len(re.findall(r"^```text$", section, re.MULTILINE)) == 1
+        assert body.startswith("请按 task-delivery-runner 修复\n")
+        for field in (
+            "Task:",
+            "PR:",
+            "Reviewed head SHA:",
+            "Verdict:",
+            "Required remediation:",
+            "Objective gates:",
+            "Maintainer decision required:",
+        ):
+            assert field in body
+        for forbidden in ("上述", "同上", "见前文"):
+            assert forbidden not in body
+        assert "Review remediation handoff:" not in section
+        assert "<上述 remediation handoff>" not in section
+        assert body.count("[F1]") == 1
+        assert "exactly one final" in section
+        assert "duplicate" in section
+        assert "A passing verdict does not emit a remediation handoff." in section
+        assert "A passing verdict emits no remediation\nsection." in section
 
 
 def test_review_skill_has_semantic_review_evidence_matrix() -> None:

--- a/tests/tools/test_workflow_skills.py
+++ b/tests/tools/test_workflow_skills.py
@@ -41,41 +41,39 @@ def test_current_runner_skills_use_one_mechanical_path() -> None:
         assert "telemetry" not in text.casefold()
 
 
-def test_delivery_runner_has_current_profiles_and_remediation_loop() -> None:
+def test_delivery_runner_uses_lck_for_initial_delivery_and_keeps_remediation() -> None:
     text = ACTIVE_SKILLS["task-delivery-runner"].read_text(encoding="utf-8")
-    assert "--expected-main-sha" in text
-    assert "--entry-point" in text
-    assert "delivery-readiness" in text
-    assert "workflow-delivery" in text
-    assert "targeted:workflow-tests" in text
+    assert "tools/agent_workflow/lck.py delivery prepare" in text
+    assert "tools/agent_workflow/lck.py delivery complete" in text
+    assert "Critical Outcome" in text
+    assert "READY_FOR_REVIEW" in text
+    assert "Agent / Skill MUST NOT directly" in text
+    assert "branch, remote, SHA, base SHA, PR number, or refspec" in text
+    assert "no alternate write route" in text
     assert "## Review remediation" in text
     assert "reviewed head SHA" in text
-    assert "Low or Nit" in text
-    assert "new independent review" in text
-    assert "git add ." in text and "do not use" in text
-    assert "lifecycle conflict" in text.casefold()
-    assert "`review-remediation` requires the bounded handoff" in text
-    assert "stop before Runner or repair writes" in text
-    assert "branch_bootstrap" in text
-    assert "--bootstrap-verify" in text
+    assert "workflow-delivery" in text
+    assert "delivery-readiness" in text
+    assert "new commit" in text and "fresh independent review" in text
 
 
-def test_delivery_branch_bootstrap_contract_is_shared_by_both_skills() -> None:
-    for relative in (
-        ".agents/skills/task-delivery-runner/SKILL.md",
-        ".claude/skills/task-delivery-runner/SKILL.md",
+def test_initial_delivery_lck_contract_is_shared_by_both_skills() -> None:
+    agent = (ROOT / ".agents/skills/task-delivery-runner/SKILL.md").read_text(encoding="utf-8")
+    claude = (ROOT / ".claude/skills/task-delivery-runner/SKILL.md").read_text(encoding="utf-8")
+    assert agent == claude
+    for phrase in (
+        "LCK Delivery Prepare",
+        "LCK Delivery Complete",
+        "commit_current_tree",
+        "ensure_remote_branch",
+        "ensure_open_pr",
+        "READY_FOR_REVIEW",
+        "The Skill is a semantic procedure",
     ):
-        text = (ROOT / relative).read_text(encoding="utf-8").casefold()
-        for phrase in (
-            "branch_bootstrap = pass",
-            "task/<issue number>-<slug>",
-            "--bootstrap-verify",
-            "fail closed",
-            "clean worktree",
-            "existing numeric",
-            "branch forms may be reused",
-        ):
-            assert phrase in text, (relative, phrase)
+        assert phrase in agent
+    assert "git switch -c task/<Issue number>-<slug>" not in agent
+    assert "branch_bootstrap = pass" not in agent
+    assert "--bootstrap-verify" not in agent
 
 
 def test_review_runner_is_read_only_and_emits_bounded_remediation_handoff() -> None:
@@ -126,7 +124,6 @@ def test_active_skills_have_bounded_failure_contract_without_evolution_traces() 
         text = path.read_text(encoding="utf-8").casefold()
         assert "partial" in text
         assert "unknown" in text
-        assert "drift" in text
         assert "bounded" in text or "only the named" in text
         for trace in forbidden_traces:
             assert trace not in text

--- a/tests/tools/test_wsl2_github_evidence_runner.py
+++ b/tests/tools/test_wsl2_github_evidence_runner.py
@@ -17,6 +17,7 @@ IDENTITY_FILES = (
     Path("tools/agent_workflow/wsl2_github_evidence_profiles.json"),
     Path(".codex/rules/tracequant-wsl-evidence.rules"),
     Path("tools/agent_workflow/workflow_evidence.py"),
+    Path("tools/agent_workflow/critical_outcome.py"),
     Path("tools/agent_workflow/workflow_common.py"),
 )
 REAL_GIT_OPTIONAL = shutil.which("git")

--- a/tests/tools/test_wsl2_validation_runner.py
+++ b/tests/tools/test_wsl2_validation_runner.py
@@ -35,6 +35,7 @@ def _clean_test_env() -> dict[str, str]:
     env = os.environ.copy()
     for key in REMOVED_TRUSTED_ENV_KEYS:
         env.pop(key, None)
+    env.pop("UV_CACHE_DIR", None)
     return env
 
 
@@ -65,7 +66,8 @@ def _copy_runner_repo(tmp_path: Path, *, name: str = "repo") -> Path:
         WORKFLOW_COMMON, repo / "tools" / "agent_workflow" / WORKFLOW_COMMON.name
     )
     (repo / ".gitignore").write_text(
-        ".agents/validation.local/\n.agents/evidence.local/\n", encoding="utf-8"
+        ".agents/validation.local/\n.agents/evidence.local/\n.workflow.local/\n",
+        encoding="utf-8",
     )
     (repo / "uv.lock").write_text("version = 1\n", encoding="utf-8")
     (repo / "pyproject.toml").write_text(
@@ -118,10 +120,12 @@ def _write_fake_tools(
     fail_id: str | None = None,
     sleep_id: str | None = None,
     grandchild_marker: Path | None = None,
+    cache_marker: Path | None = None,
 ) -> Path:
     suffix = (
         f"{branch}-{fail_id or 'pass'}-{sleep_id or 'nosleep'}-"
-        f"{dirty}-{grandchild_marker.name if grandchild_marker else 'nochild'}"
+        f"{dirty}-{grandchild_marker.name if grandchild_marker else 'nochild'}-"
+        f"{cache_marker.name if cache_marker else 'nocache'}"
     )
     bin_dir = tmp_path / f"bin-{repo.name}-{suffix}"
     bin_dir.mkdir()
@@ -189,14 +193,19 @@ sys.exit(0)
     uv = bin_dir / "uv"
     uv.write_text(
         f"""#!{PYTHON}
+import os
 import subprocess
 import sys
 import time
+from pathlib import Path
 args = sys.argv[1:]
 key = '-'.join(args)
 fail = {fail_id!r}
 sleep = {sleep_id!r}
 marker = {str(grandchild_marker) if grandchild_marker else None!r}
+cache_marker = {str(cache_marker) if cache_marker else None!r}
+if cache_marker:
+    Path(cache_marker).write_text(os.environ.get('UV_CACHE_DIR', ''), encoding='utf-8')
 if sleep and sleep in key:
     if marker:
         child_code = (
@@ -280,6 +289,19 @@ def test_current_ci_equivalent_success_digest_and_logs(tmp_path: Path) -> None:
     assert stored["commands"][0]["argv"] == ["uv", "lock", "--check"]
     assert stored["commands"][-1]["id"] == "git-diff-check"
     assert stored["integrity"]["rules_sha256"]
+
+
+def test_uv_subprocess_uses_repo_local_cache_by_default(tmp_path: Path) -> None:
+    repo = _copy_runner_repo(tmp_path)
+    cache_marker = tmp_path / "uv-cache-env.txt"
+    bin_dir = _write_fake_tools(tmp_path, repo, cache_marker=cache_marker)
+
+    result = _run(repo, bin_dir, "targeted")
+
+    assert result.returncode == 0, result.stderr
+    assert cache_marker.read_text(encoding="utf-8") == str(
+        repo / ".workflow.local" / "uv-cache"
+    )
 
 
 def test_targeted_profile_is_not_ci_equivalent(tmp_path: Path) -> None:

--- a/tools/agent_workflow/critical_outcome.py
+++ b/tools/agent_workflow/critical_outcome.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Task Critical Outcome contract parsing and deterministic verification.
+
+The Issue body owns the semantic contract.  Execution is intentionally bounded:
+the contract may name one repository pytest node id, but it cannot inject an
+arbitrary command line into the workflow runtime.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Final
+
+from workflow_common import CommandRunner, safe_text
+
+_SECTION_HEADING: Final = re.compile(r"^###\s+Critical Outcome\s*$", re.IGNORECASE)
+_NEXT_HEADING: Final = re.compile(r"^#{1,6}\s+")
+_FIELD_LINE: Final = re.compile(
+    r"^\s*(?:[-*+]\s*)?(?:\*\*)?"
+    r"(?P<key>Caller|Capability|Observable result|Verification test)"
+    r"(?:\*\*)?\s*:\s*(?:\*\*)?\s*(?P<value>.+?)\s*$",
+    re.IGNORECASE,
+)
+_NODE_ID: Final = re.compile(
+    r"^tests/(?:[A-Za-z0-9_.-]+/)*test_[A-Za-z0-9_.-]+\.py::test_[A-Za-z0-9_]+$"
+)
+_REQUIRED_KEYS: Final = (
+    "caller",
+    "capability",
+    "observable_result",
+    "verification_test",
+)
+
+
+class CriticalOutcomeError(ValueError):
+    """The Task Critical Outcome contract is missing, malformed, or unsafe."""
+
+
+@dataclass(frozen=True)
+class CriticalOutcomeContract:
+    caller: str
+    capability: str
+    observable_result: str
+    verification_test: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "caller": self.caller,
+            "capability": self.capability,
+            "observable_result": self.observable_result,
+            "verification_test": self.verification_test,
+        }
+
+
+@dataclass(frozen=True)
+class CriticalOutcomeResult:
+    status: str
+    contract: CriticalOutcomeContract
+    exit_code: int
+    summary: str | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "contract": self.contract.to_dict(),
+            "exit_code": self.exit_code,
+            "summary": self.summary,
+        }
+
+
+def _normalize_key(value: str) -> str:
+    return value.casefold().replace(" ", "_")
+
+
+def parse_critical_outcome(body: str | None) -> CriticalOutcomeContract:
+    """Parse the single required ``### Critical Outcome`` section.
+
+    The section uses four one-line fields so the semantic contract remains
+    human-readable while the verification target stays machine-checkable.
+    """
+    if not isinstance(body, str) or not body.strip():
+        raise CriticalOutcomeError("Task body is unavailable")
+
+    lines = body.splitlines()
+    section_starts = [
+        index for index, line in enumerate(lines) if _SECTION_HEADING.fullmatch(line.strip())
+    ]
+    if len(section_starts) != 1:
+        raise CriticalOutcomeError(
+            "Task body must contain exactly one '### Critical Outcome' section"
+        )
+
+    values: dict[str, str] = {}
+    for raw in lines[section_starts[0] + 1 :]:
+        if _NEXT_HEADING.match(raw.strip()):
+            break
+        match = _FIELD_LINE.fullmatch(raw)
+        if match is None:
+            continue
+        key = _normalize_key(match.group("key"))
+        if key in values:
+            raise CriticalOutcomeError(f"Critical Outcome field is duplicated: {key}")
+        value = match.group("value").strip().strip("`").strip()
+        if not value:
+            raise CriticalOutcomeError(f"Critical Outcome field is empty: {key}")
+        values[key] = value
+
+    missing = [key for key in _REQUIRED_KEYS if not values.get(key)]
+    if missing:
+        raise CriticalOutcomeError(
+            "Critical Outcome is missing required fields: " + ", ".join(missing)
+        )
+
+    verification_test = values["verification_test"]
+    if _NODE_ID.fullmatch(verification_test) is None:
+        raise CriticalOutcomeError(
+            "Verification test must be one pytest node id under tests/: "
+            "tests/.../test_*.py::test_*"
+        )
+
+    return CriticalOutcomeContract(
+        caller=values["caller"],
+        capability=values["capability"],
+        observable_result=values["observable_result"],
+        verification_test=verification_test,
+    )
+
+
+def critical_outcome_snapshot(body: str | None) -> dict[str, Any]:
+    """Return a compact structured contract without exposing the full Issue body."""
+    try:
+        contract = parse_critical_outcome(body)
+    except CriticalOutcomeError as exc:
+        return {"status": "invalid", "detail": str(exc)}
+    return {"status": "valid", "contract": contract.to_dict()}
+
+
+def contract_from_snapshot(value: Any) -> CriticalOutcomeContract:
+    if not isinstance(value, Mapping) or value.get("status") != "valid":
+        detail = value.get("detail") if isinstance(value, Mapping) else None
+        raise CriticalOutcomeError(str(detail or "Critical Outcome contract is invalid"))
+    contract = value.get("contract")
+    if not isinstance(contract, Mapping):
+        raise CriticalOutcomeError("Critical Outcome contract payload is unavailable")
+    data = {key: contract.get(key) for key in _REQUIRED_KEYS}
+    if not all(isinstance(item, str) and item for item in data.values()):
+        raise CriticalOutcomeError("Critical Outcome contract payload is malformed")
+    verification_test = str(data["verification_test"])
+    if _NODE_ID.fullmatch(verification_test) is None:
+        raise CriticalOutcomeError("Critical Outcome verification target is unsafe")
+    return CriticalOutcomeContract(
+        caller=str(data["caller"]),
+        capability=str(data["capability"]),
+        observable_result=str(data["observable_result"]),
+        verification_test=verification_test,
+    )
+
+
+def verify_critical_outcome(
+    repo_root: Path,
+    runner: CommandRunner,
+    contract: CriticalOutcomeContract,
+) -> CriticalOutcomeResult:
+    """Run the bounded Task-specific Critical Outcome verifier."""
+    file_part = contract.verification_test.split("::", 1)[0]
+    target = (repo_root / file_part).resolve()
+    try:
+        target.relative_to(repo_root.resolve())
+    except ValueError as exc:
+        raise CriticalOutcomeError("Critical Outcome target escapes repository root") from exc
+    if not target.is_file():
+        raise CriticalOutcomeError(
+            f"Critical Outcome verification test does not exist: {file_part}"
+        )
+
+    result = runner.run(
+        [
+            "uv",
+            "run",
+            "--frozen",
+            "pytest",
+            "-q",
+            contract.verification_test,
+        ],
+        command_id="lck-critical-outcome",
+        validation=True,
+    )
+    combined = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    summary = safe_text(combined[-1], limit=240) if combined else None
+    return CriticalOutcomeResult(
+        status="pass" if result.returncode == 0 else "fail",
+        contract=contract,
+        exit_code=result.returncode,
+        summary=summary,
+    )

--- a/tools/agent_workflow/critical_outcome.py
+++ b/tools/agent_workflow/critical_outcome.py
@@ -86,7 +86,9 @@ def parse_critical_outcome(body: str | None) -> CriticalOutcomeContract:
 
     lines = body.splitlines()
     section_starts = [
-        index for index, line in enumerate(lines) if _SECTION_HEADING.fullmatch(line.strip())
+        index
+        for index, line in enumerate(lines)
+        if _SECTION_HEADING.fullmatch(line.strip())
     ]
     if len(section_starts) != 1:
         raise CriticalOutcomeError(
@@ -141,7 +143,9 @@ def critical_outcome_snapshot(body: str | None) -> dict[str, Any]:
 def contract_from_snapshot(value: Any) -> CriticalOutcomeContract:
     if not isinstance(value, Mapping) or value.get("status") != "valid":
         detail = value.get("detail") if isinstance(value, Mapping) else None
-        raise CriticalOutcomeError(str(detail or "Critical Outcome contract is invalid"))
+        raise CriticalOutcomeError(
+            str(detail or "Critical Outcome contract is invalid")
+        )
     contract = value.get("contract")
     if not isinstance(contract, Mapping):
         raise CriticalOutcomeError("Critical Outcome contract payload is unavailable")
@@ -170,7 +174,9 @@ def verify_critical_outcome(
     try:
         target.relative_to(repo_root.resolve())
     except ValueError as exc:
-        raise CriticalOutcomeError("Critical Outcome target escapes repository root") from exc
+        raise CriticalOutcomeError(
+            "Critical Outcome target escapes repository root"
+        ) from exc
     if not target.is_file():
         raise CriticalOutcomeError(
             f"Critical Outcome verification test does not exist: {file_part}"

--- a/tools/agent_workflow/lck.py
+++ b/tools/agent_workflow/lck.py
@@ -501,7 +501,10 @@ class PhaseEligibilityResolver:
                 reasons.append("Project Status is unavailable or unknown")
             if phase in {Phase.DELIVERY_PREPARE, Phase.DELIVERY_COMPLETE}:
                 critical = issue.get("critical_outcome")
-                if not isinstance(critical, Mapping) or critical.get("status") != "valid":
+                if (
+                    not isinstance(critical, Mapping)
+                    or critical.get("status") != "valid"
+                ):
                     detail = (
                         critical.get("detail")
                         if isinstance(critical, Mapping)
@@ -545,7 +548,9 @@ class PhaseEligibilityResolver:
             if state.local_task_branch is None:
                 reasons.append("Delivery Complete requires a local Task branch")
             if state.git.get("branch") != state.target_branch:
-                reasons.append("Delivery Complete requires the resolved Task branch selected")
+                reasons.append(
+                    "Delivery Complete requires the resolved Task branch selected"
+                )
             if not is_sha(state.local_task_head):
                 reasons.append("Delivery Complete requires a current local Task head")
             if state.open_pr is not None and state.open_pr.get("isDraft") is not False:
@@ -735,7 +740,12 @@ class FormalValidationGate:
     def run(self, base_sha: str) -> dict[str, Any]:
         if not is_sha(base_sha):
             raise LckStopError("formal validation base SHA is unavailable")
-        tool = self.resolver.repo_root / "tools" / "agent_workflow" / "workflow_validation.py"
+        tool = (
+            self.resolver.repo_root
+            / "tools"
+            / "agent_workflow"
+            / "workflow_validation.py"
+        )
         result = self.resolver.runner.run(
             [
                 sys.executable,
@@ -759,7 +769,9 @@ class FormalValidationGate:
                 + (result.stderr.strip() or f"exit {result.returncode}")
             )
         try:
-            payload = read_json_text(result.stdout, field="lck-formal-delivery-validation")
+            payload = read_json_text(
+                result.stdout, field="lck-formal-delivery-validation"
+            )
         except WorkflowToolError as exc:
             raise LckStopError(str(exc)) from exc
         if not isinstance(payload, dict):
@@ -812,7 +824,9 @@ class CommitCurrentTreeEffect:
                 "staged Delivery diff failed git diff --check: "
                 + (check.stderr.strip() or check.stdout.strip())
             )
-        tree = self._run(["git", "write-tree"], "lck-write-candidate-tree").stdout.strip()
+        tree = self._run(
+            ["git", "write-tree"], "lck-write-candidate-tree"
+        ).stdout.strip()
         if not is_sha(tree):
             raise LckStopError("candidate tree OID is unavailable")
         return tree
@@ -857,14 +871,20 @@ class CommitCurrentTreeEffect:
             ["git", "write-tree"], "lck-write-tree-pre-commit"
         ).stdout.strip()
         if current_tree != expected_tree:
-            raise LckStopError("commit precondition failed: staged tree is not validated tree")
+            raise LckStopError(
+                "commit precondition failed: staged tree is not validated tree"
+            )
         self._run(["git", "commit", "-m", message], "lck-commit-current-tree")
-        head = self._run(["git", "rev-parse", "HEAD"], "lck-head-after-commit").stdout.strip()
+        head = self._run(
+            ["git", "rev-parse", "HEAD"], "lck-head-after-commit"
+        ).stdout.strip()
         tree = self._run(
             ["git", "rev-parse", "HEAD^{tree}"], "lck-tree-after-commit"
         ).stdout.strip()
         if not is_sha(head) or tree != expected_tree:
-            raise LckStopError("commit postcondition failed: committed tree != validated tree")
+            raise LckStopError(
+                "commit postcondition failed: committed tree != validated tree"
+            )
         status = self._run(
             ["git", "status", "--porcelain=v1", "--untracked-files=all"],
             "lck-status-after-commit",
@@ -927,7 +947,9 @@ class EnsureRemoteBranchEffect:
                 command_id="lck-fetched-remote-task-head",
             )
             if fetched.returncode != 0 or fetched.stdout.strip() != remote_oid:
-                raise LckStopError("remote Task branch changed during push precondition check")
+                raise LckStopError(
+                    "remote Task branch changed during push precondition check"
+                )
             ancestor = self.resolver.runner.run(
                 ["git", "merge-base", "--is-ancestor", remote_oid, head],
                 command_id="lck-remote-fast-forward-check",
@@ -946,11 +968,14 @@ class EnsureRemoteBranchEffect:
         )
         if push.returncode != 0:
             raise LckStopError(
-                "Task branch push failed: " + (push.stderr.strip() or push.stdout.strip())
+                "Task branch push failed: "
+                + (push.stderr.strip() or push.stdout.strip())
             )
         final_head, final_remote = self._identity(branch)
         if final_head != head or final_remote != head:
-            raise LckStopError("push postcondition failed: local and remote heads differ")
+            raise LckStopError(
+                "push postcondition failed: local and remote heads differ"
+            )
         return EffectReceipt(
             effect="ensure_remote_branch",
             action=action,
@@ -1051,7 +1076,9 @@ class SetReviewStatusEffect:
         if state.status is not ResolutionStatus.RESOLVED or state.repository is None:
             raise LckStopError("cannot set Review status from unresolved live state")
         if state.open_pr is None:
-            raise LckStopError("Project Status may move to Review only after OPEN PR exists")
+            raise LckStopError(
+                "Project Status may move to Review only after OPEN PR exists"
+            )
         if state.project_status == "Review":
             return EffectReceipt(
                 effect="set_review_status", action="already-review", details={}
@@ -1129,7 +1156,10 @@ class DeliveryChecksGate:
 
         while True:
             current = self.resolver.resolve(task_number)
-            if current.status is not ResolutionStatus.RESOLVED or current.open_pr is None:
+            if (
+                current.status is not ResolutionStatus.RESOLVED
+                or current.open_pr is None
+            ):
                 raise LckStopError("PR identity changed while waiting for checks")
             checks = current.checks
             observed = self._observed_categories(checks)
@@ -1148,7 +1178,8 @@ class DeliveryChecksGate:
                 }
                 if failed_required:
                     raise LckStopError(
-                        "required PR checks failed: " + ", ".join(sorted(failed_required))
+                        "required PR checks failed: "
+                        + ", ".join(sorted(failed_required))
                     )
                 if all(observed.get(name) == "success" for name in required_names):
                     return {
@@ -1186,7 +1217,9 @@ class DeliveryChecksGate:
                     f"required={sorted(required_names)}, observed={sorted(observed)}, "
                     f"pending={pending}, configuration={config}"
                 )
-                raise LckStopError("timed out waiting for successful PR checks: " + detail)
+                raise LckStopError(
+                    "timed out waiting for successful PR checks: " + detail
+                )
             time.sleep(self.poll_seconds)
 
 
@@ -1296,9 +1329,13 @@ class DeliveryCompleter:
         if not isinstance(issue, Mapping) or issue.get("body_sha256") != body_sha256:
             raise LckStopError("Delivery operation guard stopped: Task body changed")
         if state.target_branch != branch:
-            raise LckStopError("Delivery operation guard stopped: Task branch identity changed")
+            raise LckStopError(
+                "Delivery operation guard stopped: Task branch identity changed"
+            )
         if head_sha is not None and state.local_task_head != head_sha:
-            raise LckStopError("Delivery operation guard stopped: local Task head changed")
+            raise LckStopError(
+                "Delivery operation guard stopped: local Task head changed"
+            )
         return state
 
     def _final_verify(
@@ -1313,7 +1350,8 @@ class DeliveryCompleter:
         state = self.resolver.resolve(task_number)
         if state.status is not ResolutionStatus.RESOLVED:
             raise LckStopError(
-                "Delivery final verification unresolved: " + "; ".join(state.stop_reasons)
+                "Delivery final verification unresolved: "
+                + "; ".join(state.stop_reasons)
             )
         issue = state.issue
         pr_head = state.open_pr.get("headRefOid") if state.open_pr else None
@@ -1368,7 +1406,9 @@ class DeliveryCompleter:
         effects: list[EffectReceipt] = []
         if state.git.get("clean") is True:
             if not self._has_task_diff(base_sha):
-                raise LckStopError("Delivery Complete found no Task diff against origin/main")
+                raise LckStopError(
+                    "Delivery Complete found no Task diff against origin/main"
+                )
             # Stateless recovery path: re-run all gates on the existing clean head
             # instead of trusting a receipt from a previous interrupted invocation.
             validated_tree = self.commit_effect.current_head_tree()

--- a/tools/agent_workflow/lck.py
+++ b/tools/agent_workflow/lck.py
@@ -840,7 +840,12 @@ class CommitCurrentTreeEffect:
             raise LckStopError("current HEAD tree OID is unavailable")
         return tree
 
-    def verify_tree_unchanged(self, expected_tree: str) -> None:
+    def verify_tree_unchanged(
+        self,
+        expected_tree: str,
+        *,
+        expected_head_sha: str | None = None,
+    ) -> None:
         unstaged = self.resolver.runner.run(
             ["git", "diff", "--quiet"],
             command_id="lck-post-validation-unstaged-check",
@@ -863,8 +868,21 @@ class CommitCurrentTreeEffect:
         ).stdout.strip()
         if current_tree != expected_tree:
             raise LckStopError("validated candidate tree changed before commit")
+        if expected_head_sha is not None:
+            current_head = self._run(
+                ["git", "rev-parse", "HEAD"],
+                "lck-post-validation-head",
+            ).stdout.strip()
+            if current_head != expected_head_sha:
+                raise LckStopError("local Task HEAD changed during formal validation")
 
-    def execute(self, expected_tree: str, message: str) -> EffectReceipt:
+    def execute(
+        self,
+        expected_tree: str,
+        message: str,
+        *,
+        expected_parent_sha: str | None = None,
+    ) -> EffectReceipt:
         if not message.strip() or "\x00" in message or len(message) > 240:
             raise LckStopError("commit message must be non-empty and <= 240 characters")
         current_tree = self._run(
@@ -874,10 +892,28 @@ class CommitCurrentTreeEffect:
             raise LckStopError(
                 "commit precondition failed: staged tree is not validated tree"
             )
+        if expected_parent_sha is not None:
+            current_parent = self._run(
+                ["git", "rev-parse", "HEAD"],
+                "lck-commit-parent-head",
+            ).stdout.strip()
+            if current_parent != expected_parent_sha:
+                raise LckStopError(
+                    "commit precondition failed: local Task HEAD changed"
+                )
         self._run(["git", "commit", "-m", message], "lck-commit-current-tree")
         head = self._run(
             ["git", "rev-parse", "HEAD"], "lck-head-after-commit"
         ).stdout.strip()
+        if expected_parent_sha is not None:
+            parent = self._run(
+                ["git", "rev-parse", "HEAD^"],
+                "lck-parent-after-commit",
+            ).stdout.strip()
+            if parent != expected_parent_sha:
+                raise LckStopError(
+                    "commit postcondition failed: commit parent HEAD changed"
+                )
         tree = self._run(
             ["git", "rev-parse", "HEAD^{tree}"], "lck-tree-after-commit"
         ).stdout.strip()
@@ -904,7 +940,12 @@ class EnsureRemoteBranchEffect:
     def __init__(self, resolver: LiveStateResolver) -> None:
         self.resolver = resolver
 
-    def _identity(self, branch: str) -> tuple[str, str | None]:
+    def _identity(
+        self,
+        branch: str,
+        *,
+        expected_head_sha: str | None = None,
+    ) -> tuple[str, str | None]:
         branch_result = self.resolver.runner.run(
             ["git", "branch", "--show-current"], command_id="lck-push-current-branch"
         )
@@ -917,6 +958,10 @@ class EnsureRemoteBranchEffect:
         head = head_result.stdout.strip()
         if current_branch != branch or not is_sha(head):
             raise LckStopError("push precondition failed: local Task identity changed")
+        if expected_head_sha is not None and head != expected_head_sha:
+            raise LckStopError(
+                "push precondition failed: validated local Task HEAD changed"
+            )
         remote_result = self.resolver.runner.run(
             ["git", "ls-remote", "--heads", "origin", f"refs/heads/{branch}"],
             command_id="lck-push-remote-head",
@@ -927,8 +972,16 @@ class EnsureRemoteBranchEffect:
         remote_oid = refs.get(branch)
         return head, remote_oid
 
-    def execute(self, branch: str) -> EffectReceipt:
-        head, remote_oid = self._identity(branch)
+    def execute(
+        self,
+        branch: str,
+        *,
+        expected_head_sha: str | None = None,
+    ) -> EffectReceipt:
+        head, remote_oid = self._identity(
+            branch,
+            expected_head_sha=expected_head_sha,
+        )
         if remote_oid == head:
             return EffectReceipt(
                 effect="ensure_remote_branch",
@@ -963,7 +1016,13 @@ class EnsureRemoteBranchEffect:
             action = "created"
 
         push = self.resolver.runner.run(
-            ["git", "push", "-u", "origin", f"HEAD:refs/heads/{branch}"],
+            [
+                "git",
+                "push",
+                "-u",
+                "origin",
+                f"{head}:refs/heads/{branch}",
+            ],
             command_id="lck-push-task-branch",
         )
         if push.returncode != 0:
@@ -971,7 +1030,10 @@ class EnsureRemoteBranchEffect:
                 "Task branch push failed: "
                 + (push.stderr.strip() or push.stdout.strip())
             )
-        final_head, final_remote = self._identity(branch)
+        final_head, final_remote = self._identity(
+            branch,
+            expected_head_sha=expected_head_sha,
+        )
         if final_head != head or final_remote != head:
             raise LckStopError(
                 "push postcondition failed: local and remote heads differ"
@@ -1071,7 +1133,12 @@ class SetReviewStatusEffect:
     def __init__(self, resolver: LiveStateResolver) -> None:
         self.resolver = resolver
 
-    def execute(self, task_number: int) -> EffectReceipt:
+    def execute(
+        self,
+        task_number: int,
+        *,
+        expected_pr: Mapping[str, Any] | None = None,
+    ) -> EffectReceipt:
         state = self.resolver.resolve(task_number)
         if state.status is not ResolutionStatus.RESOLVED or state.repository is None:
             raise LckStopError("cannot set Review status from unresolved live state")
@@ -1079,6 +1146,17 @@ class SetReviewStatusEffect:
             raise LckStopError(
                 "Project Status may move to Review only after OPEN PR exists"
             )
+        if expected_pr is not None:
+            current_pr = DeliveryChecksGate._pr_identity(state)
+            expected_identity = {
+                "number": expected_pr.get("number"),
+                "head_sha": expected_pr.get("head_sha"),
+                "base_sha": expected_pr.get("base_sha"),
+            }
+            if current_pr != expected_identity:
+                raise LckStopError(
+                    "Project Status precondition failed: checks-gated PR identity changed"
+                )
         if state.project_status == "Review":
             return EffectReceipt(
                 effect="set_review_status", action="already-review", details={}
@@ -1092,6 +1170,14 @@ class SetReviewStatusEffect:
         final = self.resolver.resolve(task_number)
         if final.project_status != "Review":
             raise LckStopError("Project Status postcondition failed: expected Review")
+        if expected_pr is not None and DeliveryChecksGate._pr_identity(final) != {
+            "number": expected_pr.get("number"),
+            "head_sha": expected_pr.get("head_sha"),
+            "base_sha": expected_pr.get("base_sha"),
+        }:
+            raise LckStopError(
+                "Project Status postcondition failed: checks-gated PR identity changed"
+            )
         return EffectReceipt(
             effect="set_review_status", action="updated", details={"status": "Review"}
         )
@@ -1493,9 +1579,17 @@ class DeliveryCompleter:
                 base_sha=base_sha,
                 body_sha256=body_sha256,
                 branch=branch,
+                head_sha=state.local_task_head,
             )
-            self.commit_effect.verify_tree_unchanged(validated_tree)
-            commit = self.commit_effect.execute(validated_tree, commit_message)
+            self.commit_effect.verify_tree_unchanged(
+                validated_tree,
+                expected_head_sha=state.local_task_head,
+            )
+            commit = self.commit_effect.execute(
+                validated_tree,
+                commit_message,
+                expected_parent_sha=state.local_task_head,
+            )
             effects.append(commit)
             head = commit.details.get("head_sha")
             if not is_sha(head):
@@ -1508,7 +1602,12 @@ class DeliveryCompleter:
             branch=branch,
             head_sha=str(head),
         )
-        effects.append(self.remote_effect.execute(branch))
+        effects.append(
+            self.remote_effect.execute(
+                branch,
+                expected_head_sha=str(head),
+            )
+        )
         self._operation_guard(
             task_number,
             base_sha=base_sha,
@@ -1542,7 +1641,15 @@ class DeliveryCompleter:
             branch=branch,
             head_sha=str(head),
         )
-        effects.append(self.status_effect.execute(task_number))
+        checks_pr = checks.get("pr")
+        if not isinstance(checks_pr, Mapping):
+            raise LckStopError("checks result did not contain PR identity")
+        effects.append(
+            self.status_effect.execute(
+                task_number,
+                expected_pr=checks_pr,
+            )
+        )
         # The status effect may race with GitHub check transitions. Reacquire
         # one final live state after the effect and verify that exact state.
         final_state = self.resolver.resolve(task_number)

--- a/tools/agent_workflow/lck.py
+++ b/tools/agent_workflow/lck.py
@@ -1338,6 +1338,39 @@ class DeliveryCompleter:
             )
         return state
 
+    @staticmethod
+    def _checks_postcondition(
+        state: LiveState,
+        checks_result: Mapping[str, Any],
+    ) -> bool:
+        """Require the latest live PR checks to match the completed gate."""
+        if checks_result.get("status") != "pass":
+            return False
+        checks = state.checks
+        try:
+            failed = int(checks.get("failed", 0) or 0)
+            unknown = int(checks.get("skipped_or_unknown", 0) or 0)
+            count = int(checks.get("count", 0) or 0)
+        except (TypeError, ValueError):
+            return False
+        if failed > 0 or unknown > 0:
+            return False
+
+        required = checks_result.get("required")
+        required_names = (
+            {item for item in required if isinstance(item, str) and item}
+            if isinstance(required, list)
+            else set()
+        )
+        if required_names:
+            observed = DeliveryChecksGate._observed_categories(checks)
+            return all(observed.get(name) == "success" for name in required_names)
+
+        configuration = checks_result.get("configuration")
+        if configuration in {"configured-empty", "not-configured"}:
+            return count == 0 or checks.get("all_success") is True
+        return count > 0 and checks.get("all_success") is True
+
     def _final_verify(
         self,
         task_number: int,
@@ -1346,6 +1379,7 @@ class DeliveryCompleter:
         base_sha: str,
         body_sha256: str,
         branch: str,
+        checks_result: Mapping[str, Any],
     ) -> LiveState:
         state = self.resolver.resolve(task_number)
         if state.status is not ResolutionStatus.RESOLVED:
@@ -1370,9 +1404,10 @@ class DeliveryCompleter:
             and state.open_pr is not None
             and state.open_pr.get("isDraft") is False
             and state.project_status == "Review"
+            and self._checks_postcondition(state, checks_result)
         ):
             raise LckStopError(
-                "Delivery final verification failed: Task/base/local/remote/PR/lifecycle "
+                "Delivery final verification failed: Task/base/local/remote/PR/check/lifecycle "
                 "state is not aligned"
             )
         return state
@@ -1489,6 +1524,7 @@ class DeliveryCompleter:
             base_sha=base_sha,
             body_sha256=body_sha256,
             branch=branch,
+            checks_result=checks,
         )
         return DeliveryCompletionResult(
             task_number=task_number,

--- a/tools/agent_workflow/lck.py
+++ b/tools/agent_workflow/lck.py
@@ -492,7 +492,11 @@ class PhaseEligibilityResolver:
             project = issue.get("project_status")
             allowed_projects = {
                 Phase.DELIVERY_PREPARE: {"Ready", "In Progress"},
-                Phase.DELIVERY_COMPLETE: {"Ready", "In Progress"},
+                # A prior status write may have moved the Task to Review before
+                # a later final verification stopped.  Allow the same LCK
+                # Delivery Complete path to reacquire and safely finish that
+                # partial invocation.
+                Phase.DELIVERY_COMPLETE: {"Ready", "In Progress", "Review"},
                 Phase.REVIEW_PREPARE: {"Review", "In Progress"},
                 Phase.REMEDIATION_PREPARE: {"Review"},
                 Phase.CLOSEOUT: {"In Progress", "Review", "Done"},
@@ -1081,6 +1085,18 @@ class EnsureOpenPrEffect:
             or not isinstance(issue, Mapping)
         ):
             raise LckStopError("OPEN PR preconditions are incomplete")
+        if state.merged is not False:
+            raise LckStopError(
+                "OPEN PR precondition failed: Task merge state is unavailable "
+                "or already merged"
+            )
+        if (
+            state.local_task_branch != state.target_branch
+            or state.git.get("branch") != state.target_branch
+        ):
+            raise LckStopError(
+                "OPEN PR precondition failed: resolved Task branch is not selected"
+            )
         if base != expected_base_sha:
             raise LckStopError("OPEN PR precondition failed: origin/main changed")
         if issue.get("body_sha256") != expected_body_sha256:
@@ -1560,9 +1576,14 @@ class DeliveryCompleter:
             validated_tree = self.commit_effect.current_head_tree()
             critical = self._run_critical_outcome(state)
             validation = self.formal_validation.run(base_sha)
-            head = state.local_task_head
-            if not is_sha(head):
+            validated_head = state.local_task_head
+            if not is_sha(validated_head):
                 raise LckStopError("current Task head is unavailable")
+            self.commit_effect.verify_tree_unchanged(
+                validated_tree,
+                expected_head_sha=validated_head,
+            )
+            head = validated_head
             effects.append(
                 EffectReceipt(
                     effect="commit_current_tree",

--- a/tools/agent_workflow/lck.py
+++ b/tools/agent_workflow/lck.py
@@ -1139,6 +1139,17 @@ class DeliveryChecksGate:
                 values[name] = category
         return values
 
+    @staticmethod
+    def _pr_identity(state: LiveState) -> dict[str, Any]:
+        pr = state.open_pr
+        if not isinstance(pr, Mapping):
+            return {}
+        return {
+            "number": pr.get("number"),
+            "head_sha": pr.get("headRefOid"),
+            "base_sha": pr.get("baseRefOid"),
+        }
+
     def run(self, task_number: int) -> dict[str, Any]:
         state = self.resolver.resolve(task_number)
         if state.status is not ResolutionStatus.RESOLVED or state.repository is None:
@@ -1170,47 +1181,51 @@ class DeliveryChecksGate:
             if failed > 0 or unknown > 0:
                 raise LckStopError("PR checks failed, cancelled, skipped, or unknown")
 
-            if required_names:
-                failed_required = {
-                    name
-                    for name in required_names
-                    if observed.get(name) not in {None, "success", "pending"}
-                }
-                if failed_required:
-                    raise LckStopError(
-                        "required PR checks failed: "
-                        + ", ".join(sorted(failed_required))
-                    )
-                if all(observed.get(name) == "success" for name in required_names):
-                    return {
-                        "status": "pass",
-                        "configuration": config,
-                        "required": sorted(required_names),
-                        "observed": checks,
-                        "warnings": warnings,
+            if pending == 0:
+                if required_names:
+                    failed_required = {
+                        name
+                        for name in required_names
+                        if observed.get(name) not in {None, "success", "pending"}
                     }
-            elif config in {"configured-empty", "not-configured"}:
-                if checks.get("count") == 0 or checks.get("all_success") is True:
+                    if failed_required:
+                        raise LckStopError(
+                            "required PR checks failed: "
+                            + ", ".join(sorted(failed_required))
+                        )
+                    if all(observed.get(name) == "success" for name in required_names):
+                        return {
+                            "status": "pass",
+                            "configuration": config,
+                            "required": sorted(required_names),
+                            "observed": checks,
+                            "pr": self._pr_identity(current),
+                            "warnings": warnings,
+                        }
+                elif config in {"configured-empty", "not-configured"}:
+                    if checks.get("count") == 0 or checks.get("all_success") is True:
+                        return {
+                            "status": "pass",
+                            "configuration": config,
+                            "required": [],
+                            "observed": checks,
+                            "pr": self._pr_identity(current),
+                            "warnings": warnings,
+                        }
+                elif checks.get("count", 0) > 0 and checks.get("all_success") is True:
+                    # GitHub can hide branch-protection configuration behind a plan
+                    # boundary. Successful observed checks are preserved as a
+                    # capability-limited fact instead of being upgraded to proof of
+                    # required-check configuration.
                     return {
                         "status": "pass",
                         "configuration": config,
                         "required": [],
                         "observed": checks,
+                        "pr": self._pr_identity(current),
                         "warnings": warnings,
+                        "limitation": "required-check configuration unavailable",
                     }
-            elif checks.get("count", 0) > 0 and checks.get("all_success") is True:
-                # GitHub can hide branch-protection configuration behind a plan
-                # boundary. Successful observed checks are preserved as a
-                # capability-limited fact instead of being upgraded to proof of
-                # required-check configuration.
-                return {
-                    "status": "pass",
-                    "configuration": config,
-                    "required": [],
-                    "observed": checks,
-                    "warnings": warnings,
-                    "limitation": "required-check configuration unavailable",
-                }
 
             if time.monotonic() >= deadline:
                 detail = (
@@ -1346,14 +1361,25 @@ class DeliveryCompleter:
         """Require the latest live PR checks to match the completed gate."""
         if checks_result.get("status") != "pass":
             return False
+        current_pr = state.open_pr
+        gated_pr = checks_result.get("pr")
+        if not isinstance(current_pr, Mapping) or not isinstance(gated_pr, Mapping):
+            return False
+        if (
+            gated_pr.get("number") != current_pr.get("number")
+            or gated_pr.get("head_sha") != current_pr.get("headRefOid")
+            or gated_pr.get("base_sha") != current_pr.get("baseRefOid")
+        ):
+            return False
         checks = state.checks
         try:
             failed = int(checks.get("failed", 0) or 0)
+            pending = int(checks.get("pending", 0) or 0)
             unknown = int(checks.get("skipped_or_unknown", 0) or 0)
             count = int(checks.get("count", 0) or 0)
         except (TypeError, ValueError):
             return False
-        if failed > 0 or unknown > 0:
+        if failed > 0 or pending > 0 or unknown > 0:
             return False
 
         required = checks_result.get("required")
@@ -1373,7 +1399,7 @@ class DeliveryCompleter:
 
     def _final_verify(
         self,
-        task_number: int,
+        state: LiveState,
         head: str,
         *,
         base_sha: str,
@@ -1381,7 +1407,6 @@ class DeliveryCompleter:
         branch: str,
         checks_result: Mapping[str, Any],
     ) -> LiveState:
-        state = self.resolver.resolve(task_number)
         if state.status is not ResolutionStatus.RESOLVED:
             raise LckStopError(
                 "Delivery final verification unresolved: "
@@ -1518,8 +1543,11 @@ class DeliveryCompleter:
             head_sha=str(head),
         )
         effects.append(self.status_effect.execute(task_number))
+        # The status effect may race with GitHub check transitions. Reacquire
+        # one final live state after the effect and verify that exact state.
+        final_state = self.resolver.resolve(task_number)
         final_state = self._final_verify(
-            task_number,
+            final_state,
             str(head),
             base_sha=base_sha,
             body_sha256=body_sha256,

--- a/tools/agent_workflow/lck.py
+++ b/tools/agent_workflow/lck.py
@@ -1154,6 +1154,7 @@ class SetReviewStatusEffect:
         task_number: int,
         *,
         expected_pr: Mapping[str, Any] | None = None,
+        checks_result: Mapping[str, Any] | None = None,
     ) -> EffectReceipt:
         state = self.resolver.resolve(task_number)
         if state.status is not ResolutionStatus.RESOLVED or state.repository is None:
@@ -1173,9 +1174,20 @@ class SetReviewStatusEffect:
                 raise LckStopError(
                     "Project Status precondition failed: checks-gated PR identity changed"
                 )
+        if checks_result is not None and not DeliveryChecksGate._checks_postcondition(
+            state, checks_result
+        ):
+            raise LckStopError(
+                "Project Status precondition failed: PR checks are no longer passing"
+            )
         if state.project_status == "Review":
             return EffectReceipt(
                 effect="set_review_status", action="already-review", details={}
+            )
+        previous_status = state.project_status
+        if previous_status not in {"Ready", "In Progress"}:
+            raise LckStopError(
+                "Project Status precondition failed: prior status cannot be restored"
             )
         set_project_status_with_runner(
             self.resolver.runner,
@@ -1183,17 +1195,49 @@ class SetReviewStatusEffect:
             task_number,
             value="Review",
         )
-        final = self.resolver.resolve(task_number)
-        if final.project_status != "Review":
-            raise LckStopError("Project Status postcondition failed: expected Review")
-        if expected_pr is not None and DeliveryChecksGate._pr_identity(final) != {
-            "number": expected_pr.get("number"),
-            "head_sha": expected_pr.get("head_sha"),
-            "base_sha": expected_pr.get("base_sha"),
-        }:
+        try:
+            final = self.resolver.resolve(task_number)
+            if final.project_status != "Review":
+                raise LckStopError(
+                    "Project Status postcondition failed: expected Review"
+                )
+            if expected_pr is not None and DeliveryChecksGate._pr_identity(final) != {
+                "number": expected_pr.get("number"),
+                "head_sha": expected_pr.get("head_sha"),
+                "base_sha": expected_pr.get("base_sha"),
+            }:
+                raise LckStopError(
+                    "Project Status postcondition failed: checks-gated PR identity changed"
+                )
+            if (
+                checks_result is not None
+                and not DeliveryChecksGate._checks_postcondition(final, checks_result)
+            ):
+                raise LckStopError(
+                    "Project Status postcondition failed: check/lifecycle state is not aligned"
+                )
+        except LckStopError as exc:
+            try:
+                set_project_status_with_runner(
+                    self.resolver.runner,
+                    state.repository,
+                    task_number,
+                    value=previous_status,
+                )
+                restored = self.resolver.resolve(task_number)
+            except Exception as restore_exc:
+                raise LckStopError(
+                    "Project Status postcondition failed and compensation could not "
+                    f"restore {previous_status!r}"
+                ) from restore_exc
+            if restored.project_status != previous_status:
+                raise LckStopError(
+                    "Project Status postcondition failed and compensation did not "
+                    f"restore {previous_status!r}"
+                )
             raise LckStopError(
-                "Project Status postcondition failed: checks-gated PR identity changed"
-            )
+                f"{exc}; restored Project Status to {previous_status!r}"
+            ) from exc
         return EffectReceipt(
             effect="set_review_status", action="updated", details={"status": "Review"}
         )
@@ -1251,6 +1295,50 @@ class DeliveryChecksGate:
             "head_sha": pr.get("headRefOid"),
             "base_sha": pr.get("baseRefOid"),
         }
+
+    @staticmethod
+    def _checks_postcondition(
+        state: LiveState,
+        checks_result: Mapping[str, Any],
+    ) -> bool:
+        """Require the latest live PR checks to match the completed gate."""
+        if checks_result.get("status") != "pass":
+            return False
+        current_pr = state.open_pr
+        gated_pr = checks_result.get("pr")
+        if not isinstance(current_pr, Mapping) or not isinstance(gated_pr, Mapping):
+            return False
+        if (
+            gated_pr.get("number") != current_pr.get("number")
+            or gated_pr.get("head_sha") != current_pr.get("headRefOid")
+            or gated_pr.get("base_sha") != current_pr.get("baseRefOid")
+        ):
+            return False
+        checks = state.checks
+        try:
+            failed = int(checks.get("failed", 0) or 0)
+            pending = int(checks.get("pending", 0) or 0)
+            unknown = int(checks.get("skipped_or_unknown", 0) or 0)
+            count = int(checks.get("count", 0) or 0)
+        except (TypeError, ValueError):
+            return False
+        if failed > 0 or pending > 0 or unknown > 0:
+            return False
+
+        required = checks_result.get("required")
+        required_names = (
+            {item for item in required if isinstance(item, str) and item}
+            if isinstance(required, list)
+            else set()
+        )
+        if required_names:
+            observed = DeliveryChecksGate._observed_categories(checks)
+            return all(observed.get(name) == "success" for name in required_names)
+
+        configuration = checks_result.get("configuration")
+        if configuration in {"configured-empty", "not-configured"}:
+            return count == 0 or checks.get("all_success") is True
+        return count > 0 and checks.get("all_success") is True
 
     def run(self, task_number: int) -> dict[str, Any]:
         state = self.resolver.resolve(task_number)
@@ -1460,44 +1548,7 @@ class DeliveryCompleter:
         state: LiveState,
         checks_result: Mapping[str, Any],
     ) -> bool:
-        """Require the latest live PR checks to match the completed gate."""
-        if checks_result.get("status") != "pass":
-            return False
-        current_pr = state.open_pr
-        gated_pr = checks_result.get("pr")
-        if not isinstance(current_pr, Mapping) or not isinstance(gated_pr, Mapping):
-            return False
-        if (
-            gated_pr.get("number") != current_pr.get("number")
-            or gated_pr.get("head_sha") != current_pr.get("headRefOid")
-            or gated_pr.get("base_sha") != current_pr.get("baseRefOid")
-        ):
-            return False
-        checks = state.checks
-        try:
-            failed = int(checks.get("failed", 0) or 0)
-            pending = int(checks.get("pending", 0) or 0)
-            unknown = int(checks.get("skipped_or_unknown", 0) or 0)
-            count = int(checks.get("count", 0) or 0)
-        except (TypeError, ValueError):
-            return False
-        if failed > 0 or pending > 0 or unknown > 0:
-            return False
-
-        required = checks_result.get("required")
-        required_names = (
-            {item for item in required if isinstance(item, str) and item}
-            if isinstance(required, list)
-            else set()
-        )
-        if required_names:
-            observed = DeliveryChecksGate._observed_categories(checks)
-            return all(observed.get(name) == "success" for name in required_names)
-
-        configuration = checks_result.get("configuration")
-        if configuration in {"configured-empty", "not-configured"}:
-            return count == 0 or checks.get("all_success") is True
-        return count > 0 and checks.get("all_success") is True
+        return DeliveryChecksGate._checks_postcondition(state, checks_result)
 
     def _final_verify(
         self,
@@ -1669,6 +1720,7 @@ class DeliveryCompleter:
             self.status_effect.execute(
                 task_number,
                 expected_pr=checks_pr,
+                checks_result=checks,
             )
         )
         # The status effect may race with GitHub check transitions. Reacquire

--- a/tools/agent_workflow/lck.py
+++ b/tools/agent_workflow/lck.py
@@ -1,15 +1,12 @@
 #!/usr/bin/env python3
 # ruff: noqa: E402, I001
-"""Local Control Kernel v1 live-state resolution and Delivery Prepare.
+"""Local Control Kernel v1 live-state resolution and Delivery control.
 
-This module is intentionally limited to the first LCK migration boundary:
-resolving current mechanical facts, evaluating phase eligibility, and preparing
-the local Task workspace.  Commit, push, PR mutation, lifecycle writes, merge,
-and closeout effects remain outside this Task.
-
-The resolver delegates Issue, relationship, Git snapshot, and PR query details
-to the existing workflow helpers.  It does not use a snapshot, expected SHA,
-or session handoff as authority.
+The resolver reacquires current Git/GitHub authority. Delivery effects are
+bounded, operation-local, and fail closed: Critical Outcome + formal validation
+bind the candidate tree before commit; only the resulting head may be pushed
+and attached to one OPEN PR. No snapshot, expected SHA, or Agent-provided
+branch/PR identity is workflow authority.
 """
 
 from __future__ import annotations
@@ -18,6 +15,8 @@ import argparse
 import json
 import re
 import sys
+import tempfile
+import time
 import unicodedata
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
@@ -28,17 +27,25 @@ from typing import Any, Final, cast
 if __name__ != "__main__" or not any(p.endswith("agent_workflow") for p in sys.path):
     sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+from critical_outcome import (
+    CriticalOutcomeError,
+    contract_from_snapshot,
+    verify_critical_outcome,
+)
 from pr_resolve import (
     PrResolveError,
     list_matching_prs,
     resolve_open_pr,
+    resolve_or_create_pr,
 )
+from project_status import set_project_status_with_runner
 from workflow_common import (
     CommandRunner,
     WorkflowToolError,
     command_warning,
     is_sha,
     print_json,
+    read_json_text,
 )
 from workflow_evidence import (
     _git_snapshot,
@@ -46,6 +53,7 @@ from workflow_evidence import (
     _normalize_checks,
     _relationship_snapshot,
     _formal_blockers_gate,
+    _required_checks,
     _repository_slug,
 )
 
@@ -61,6 +69,7 @@ class Phase(StrEnum):
     """LCK phase capabilities exposed by the v1 core."""
 
     DELIVERY_PREPARE = "Delivery Prepare"
+    DELIVERY_COMPLETE = "Delivery Complete"
     REVIEW_PREPARE = "Review Prepare"
     REMEDIATION_PREPARE = "Remediation Prepare"
     CLOSEOUT = "Closeout"
@@ -332,12 +341,9 @@ class LiveStateResolver:
                 warnings.append(command_warning(result))
                 reasons.append("local Task branch tip unavailable")
         remote_oid = remote_branches.get(target_branch)
-        if (
-            local_head is not None
-            and remote_oid is not None
-            and local_head != remote_oid
-        ):
-            reasons.append("local and remote Task branch tips differ")
+        # Tip differences are live facts, not global resolver ambiguity.
+        # Delivery Prepare rejects them; Delivery Complete may legitimately
+        # observe a local validated commit that is not pushed yet.
 
         open_pr: Mapping[str, Any] | None = None
         merged_numbers: tuple[int, ...] = ()
@@ -386,10 +392,6 @@ class LiveStateResolver:
             elif local_branch is None and remote_branch is None:
                 reasons.append("current OPEN PR has no local or remote Task branch")
             else:
-                if local_head is not None and local_head != pr_head_oid:
-                    reasons.append(
-                        "current OPEN PR head OID differs from local Task branch tip"
-                    )
                 if remote_oid is not None and remote_oid != pr_head_oid:
                     reasons.append(
                         "current OPEN PR head OID differs from remote Task branch tip"
@@ -490,12 +492,22 @@ class PhaseEligibilityResolver:
             project = issue.get("project_status")
             allowed_projects = {
                 Phase.DELIVERY_PREPARE: {"Ready", "In Progress"},
+                Phase.DELIVERY_COMPLETE: {"Ready", "In Progress"},
                 Phase.REVIEW_PREPARE: {"Review", "In Progress"},
                 Phase.REMEDIATION_PREPARE: {"Review"},
                 Phase.CLOSEOUT: {"In Progress", "Review", "Done"},
             }[phase]
             if project not in allowed_projects:
                 reasons.append("Project Status is unavailable or unknown")
+            if phase in {Phase.DELIVERY_PREPARE, Phase.DELIVERY_COMPLETE}:
+                critical = issue.get("critical_outcome")
+                if not isinstance(critical, Mapping) or critical.get("status") != "valid":
+                    detail = (
+                        critical.get("detail")
+                        if isinstance(critical, Mapping)
+                        else "contract unavailable"
+                    )
+                    reasons.append(f"Critical Outcome contract invalid: {detail}")
 
         blocker_gate = _formal_blockers_gate(relationships)
         if blocker_gate.get("status") != "pass":
@@ -514,6 +526,12 @@ class PhaseEligibilityResolver:
             if state.local_task_head and state.remote_task_oid:
                 if state.local_task_head != state.remote_task_oid:
                     reasons.append("Task branch has divergent local and remote tips")
+            if state.open_pr is not None and state.local_task_head is not None:
+                pr_head = state.open_pr.get("headRefOid")
+                if is_sha(pr_head) and state.local_task_head != pr_head:
+                    reasons.append(
+                        "current OPEN PR head OID differs from local Task branch tip"
+                    )
             if not state.local_task_branch and not state.remote_task_branch:
                 if not _is_clean_current_main(state.git):
                     reasons.append(
@@ -521,6 +539,25 @@ class PhaseEligibilityResolver:
                         "HEAD == local main == origin/main"
                     )
             capabilities = ("prepare_task_workspace",)
+        elif phase is Phase.DELIVERY_COMPLETE:
+            if state.merged is True:
+                reasons.append("Task already has a merged PR")
+            if state.local_task_branch is None:
+                reasons.append("Delivery Complete requires a local Task branch")
+            if state.git.get("branch") != state.target_branch:
+                reasons.append("Delivery Complete requires the resolved Task branch selected")
+            if not is_sha(state.local_task_head):
+                reasons.append("Delivery Complete requires a current local Task head")
+            if state.open_pr is not None and state.open_pr.get("isDraft") is not False:
+                reasons.append("Delivery Complete cannot continue with a Draft OPEN PR")
+            capabilities = (
+                "verify_critical_outcome",
+                "run_formal_validation",
+                "commit_current_tree",
+                "ensure_remote_branch",
+                "ensure_open_pr",
+                "set_review_status",
+            )
         elif phase is Phase.REVIEW_PREPARE:
             if state.open_pr is None:
                 reasons.append("no current OPEN PR")
@@ -675,6 +712,757 @@ class DeliveryPreparer:
         )
 
 
+@dataclass(frozen=True)
+class EffectReceipt:
+    effect: str
+    action: str
+    details: Mapping[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "effect": self.effect,
+            "action": self.action,
+            "details": _jsonable(self.details),
+        }
+
+
+class FormalValidationGate:
+    """Run the repository-owned deterministic Delivery validation plan."""
+
+    def __init__(self, resolver: LiveStateResolver) -> None:
+        self.resolver = resolver
+
+    def run(self, base_sha: str) -> dict[str, Any]:
+        if not is_sha(base_sha):
+            raise LckStopError("formal validation base SHA is unavailable")
+        tool = self.resolver.repo_root / "tools" / "agent_workflow" / "workflow_validation.py"
+        result = self.resolver.runner.run(
+            [
+                sys.executable,
+                str(tool),
+                "run",
+                "--repo-root",
+                str(self.resolver.repo_root),
+                "--phase",
+                "delivery",
+                "--base-sha",
+                base_sha,
+                "--include-skill-validators",
+                "--require-skill-validator",
+            ],
+            command_id="lck-formal-delivery-validation",
+            validation=True,
+        )
+        if not result.stdout.strip():
+            raise LckStopError(
+                "formal Delivery validation produced no structured result: "
+                + (result.stderr.strip() or f"exit {result.returncode}")
+            )
+        try:
+            payload = read_json_text(result.stdout, field="lck-formal-delivery-validation")
+        except WorkflowToolError as exc:
+            raise LckStopError(str(exc)) from exc
+        if not isinstance(payload, dict):
+            raise LckStopError("formal Delivery validation result is not an object")
+        if result.returncode != 0 or payload.get("status") != "pass":
+            raise LckStopError(
+                "formal Delivery validation failed: "
+                + str(payload.get("status") or result.returncode)
+            )
+        return payload
+
+
+class CommitCurrentTreeEffect:
+    """Commit exactly the staged tree that passed Critical Outcome + validation."""
+
+    def __init__(self, resolver: LiveStateResolver) -> None:
+        self.resolver = resolver
+
+    def _run(self, argv: Sequence[str], command_id: str) -> Any:
+        result = self.resolver.runner.run(argv, command_id=command_id)
+        if result.returncode != 0:
+            raise LckStopError(
+                f"{command_id} failed with exit code {result.returncode}: "
+                f"{result.stderr.strip() or result.stdout.strip()}"
+            )
+        return result
+
+    def stage_candidate_tree(self) -> str:
+        status = self._run(
+            ["git", "status", "--porcelain=v1", "--untracked-files=all"],
+            "lck-delivery-status-before-stage",
+        )
+        if not status.stdout.strip():
+            raise LckStopError("Delivery Complete found no uncommitted Task changes")
+        self._run(["git", "add", "-A", "--", ":/"], "lck-stage-current-tree")
+        cached = self.resolver.runner.run(
+            ["git", "diff", "--cached", "--quiet"],
+            command_id="lck-staged-diff-present",
+        )
+        if cached.returncode == 0:
+            raise LckStopError("Delivery candidate contains no staged changes")
+        if cached.returncode not in {0, 1}:
+            raise LckStopError("unable to determine staged Delivery diff")
+        check = self.resolver.runner.run(
+            ["git", "diff", "--cached", "--check"],
+            command_id="lck-staged-diff-check",
+        )
+        if check.returncode != 0:
+            raise LckStopError(
+                "staged Delivery diff failed git diff --check: "
+                + (check.stderr.strip() or check.stdout.strip())
+            )
+        tree = self._run(["git", "write-tree"], "lck-write-candidate-tree").stdout.strip()
+        if not is_sha(tree):
+            raise LckStopError("candidate tree OID is unavailable")
+        return tree
+
+    def current_head_tree(self) -> str:
+        tree = self._run(
+            ["git", "rev-parse", "HEAD^{tree}"],
+            "lck-current-head-tree",
+        ).stdout.strip()
+        if not is_sha(tree):
+            raise LckStopError("current HEAD tree OID is unavailable")
+        return tree
+
+    def verify_tree_unchanged(self, expected_tree: str) -> None:
+        unstaged = self.resolver.runner.run(
+            ["git", "diff", "--quiet"],
+            command_id="lck-post-validation-unstaged-check",
+        )
+        if unstaged.returncode != 0:
+            if unstaged.returncode == 1:
+                raise LckStopError("working tree changed during formal validation")
+            raise LckStopError("unable to verify post-validation working tree")
+        status = self._run(
+            ["git", "status", "--porcelain=v1", "--untracked-files=all"],
+            "lck-post-validation-status",
+        )
+        # Staged entries are expected. Any untracked/unstaged entry makes status
+        # contain a line not represented by the staged tree; git diff --quiet
+        # already rejects tracked unstaged changes, and untracked paths start '??'.
+        if any(line.startswith("??") for line in status.stdout.splitlines()):
+            raise LckStopError("untracked files appeared during formal validation")
+        current_tree = self._run(
+            ["git", "write-tree"], "lck-write-tree-post-validation"
+        ).stdout.strip()
+        if current_tree != expected_tree:
+            raise LckStopError("validated candidate tree changed before commit")
+
+    def execute(self, expected_tree: str, message: str) -> EffectReceipt:
+        if not message.strip() or "\x00" in message or len(message) > 240:
+            raise LckStopError("commit message must be non-empty and <= 240 characters")
+        current_tree = self._run(
+            ["git", "write-tree"], "lck-write-tree-pre-commit"
+        ).stdout.strip()
+        if current_tree != expected_tree:
+            raise LckStopError("commit precondition failed: staged tree is not validated tree")
+        self._run(["git", "commit", "-m", message], "lck-commit-current-tree")
+        head = self._run(["git", "rev-parse", "HEAD"], "lck-head-after-commit").stdout.strip()
+        tree = self._run(
+            ["git", "rev-parse", "HEAD^{tree}"], "lck-tree-after-commit"
+        ).stdout.strip()
+        if not is_sha(head) or tree != expected_tree:
+            raise LckStopError("commit postcondition failed: committed tree != validated tree")
+        status = self._run(
+            ["git", "status", "--porcelain=v1", "--untracked-files=all"],
+            "lck-status-after-commit",
+        )
+        if status.stdout.strip():
+            raise LckStopError("commit postcondition failed: worktree is not clean")
+        return EffectReceipt(
+            effect="commit_current_tree",
+            action="committed",
+            details={"head_sha": head, "tree_oid": tree},
+        )
+
+
+class EnsureRemoteBranchEffect:
+    """Ensure origin Task branch equals current local HEAD without force push."""
+
+    def __init__(self, resolver: LiveStateResolver) -> None:
+        self.resolver = resolver
+
+    def _identity(self, branch: str) -> tuple[str, str | None]:
+        branch_result = self.resolver.runner.run(
+            ["git", "branch", "--show-current"], command_id="lck-push-current-branch"
+        )
+        head_result = self.resolver.runner.run(
+            ["git", "rev-parse", "HEAD"], command_id="lck-push-current-head"
+        )
+        if branch_result.returncode != 0 or head_result.returncode != 0:
+            raise LckStopError("cannot resolve local branch identity before push")
+        current_branch = branch_result.stdout.strip()
+        head = head_result.stdout.strip()
+        if current_branch != branch or not is_sha(head):
+            raise LckStopError("push precondition failed: local Task identity changed")
+        remote_result = self.resolver.runner.run(
+            ["git", "ls-remote", "--heads", "origin", f"refs/heads/{branch}"],
+            command_id="lck-push-remote-head",
+        )
+        if remote_result.returncode != 0:
+            raise LckStopError("cannot resolve remote Task branch before push")
+        refs = _remote_refs(remote_result.stdout)
+        remote_oid = refs.get(branch)
+        return head, remote_oid
+
+    def execute(self, branch: str) -> EffectReceipt:
+        head, remote_oid = self._identity(branch)
+        if remote_oid == head:
+            return EffectReceipt(
+                effect="ensure_remote_branch",
+                action="already-synced",
+                details={"head_sha": head, "remote_oid": remote_oid},
+            )
+        if remote_oid is not None:
+            fetch = self.resolver.runner.run(
+                ["git", "fetch", "--no-tags", "origin", f"refs/heads/{branch}"],
+                command_id="lck-fetch-observed-remote-task-branch",
+            )
+            if fetch.returncode != 0:
+                raise LckStopError("cannot verify existing remote Task branch ancestry")
+            fetched = self.resolver.runner.run(
+                ["git", "rev-parse", "FETCH_HEAD"],
+                command_id="lck-fetched-remote-task-head",
+            )
+            if fetched.returncode != 0 or fetched.stdout.strip() != remote_oid:
+                raise LckStopError("remote Task branch changed during push precondition check")
+            ancestor = self.resolver.runner.run(
+                ["git", "merge-base", "--is-ancestor", remote_oid, head],
+                command_id="lck-remote-fast-forward-check",
+            )
+            if ancestor.returncode != 0:
+                raise LckStopError(
+                    "remote Task branch is ahead/diverged; LCK will not rebase or force push"
+                )
+            action = "fast-forwarded"
+        else:
+            action = "created"
+
+        push = self.resolver.runner.run(
+            ["git", "push", "-u", "origin", f"HEAD:refs/heads/{branch}"],
+            command_id="lck-push-task-branch",
+        )
+        if push.returncode != 0:
+            raise LckStopError(
+                "Task branch push failed: " + (push.stderr.strip() or push.stdout.strip())
+            )
+        final_head, final_remote = self._identity(branch)
+        if final_head != head or final_remote != head:
+            raise LckStopError("push postcondition failed: local and remote heads differ")
+        return EffectReceipt(
+            effect="ensure_remote_branch",
+            action=action,
+            details={"head_sha": head, "remote_oid": final_remote},
+        )
+
+
+class EnsureOpenPrEffect:
+    """Resolve or create exactly one non-Draft OPEN PR from live identity."""
+
+    def __init__(self, resolver: LiveStateResolver) -> None:
+        self.resolver = resolver
+
+    def execute(
+        self,
+        task_number: int,
+        *,
+        summary: str,
+        risks: str,
+        critical_outcome: Mapping[str, Any],
+        validation: Mapping[str, Any],
+        expected_base_sha: str,
+        expected_body_sha256: str,
+    ) -> EffectReceipt:
+        state = self.resolver.resolve(task_number)
+        if state.status is not ResolutionStatus.RESOLVED:
+            raise LckStopError(
+                "cannot ensure OPEN PR from unresolved live state: "
+                + "; ".join(state.stop_reasons)
+            )
+        repository = state.repository
+        head = state.local_task_head
+        remote = state.remote_task_oid
+        base = state.git.get("origin_main_sha")
+        issue = state.issue
+        if (
+            not isinstance(repository, str)
+            or not is_sha(head)
+            or remote != head
+            or not is_sha(base)
+            or not isinstance(issue, Mapping)
+        ):
+            raise LckStopError("OPEN PR preconditions are incomplete")
+        if base != expected_base_sha:
+            raise LckStopError("OPEN PR precondition failed: origin/main changed")
+        if issue.get("body_sha256") != expected_body_sha256:
+            raise LckStopError("OPEN PR precondition failed: Task body changed")
+        title = issue.get("title")
+        if not isinstance(title, str) or not title.strip():
+            raise LckStopError("Task title is unavailable for PR creation")
+        body = (
+            f"Closes #{task_number}\n\n"
+            "## Summary\n"
+            f"{summary.strip()}\n\n"
+            "## Validation\n"
+            f"- Critical Outcome: {critical_outcome.get('status')}\n"
+            f"- Formal Delivery validation: {validation.get('status')}\n\n"
+            "## Risks / limitations\n"
+            f"{risks.strip() or 'None identified.'}\n"
+        )
+        warnings: list[dict[str, Any]] = []
+        with tempfile.TemporaryDirectory(prefix="lck-pr-") as temp_dir:
+            body_file = Path(temp_dir) / "body.md"
+            body_file.write_text(body, encoding="utf-8", newline="\n")
+            try:
+                result = resolve_or_create_pr(
+                    self.resolver.runner,
+                    repository,
+                    state.target_branch,
+                    BASE_BRANCH,
+                    title,
+                    body_file,
+                    head,
+                    str(base),
+                    warnings,
+                )
+            except PrResolveError as exc:
+                raise LckStopError(str(exc)) from exc
+        return EffectReceipt(
+            effect="ensure_open_pr",
+            action=str(result.get("action")),
+            details={
+                "number": result.get("number"),
+                "url": result.get("url"),
+                "head_sha": result.get("head_sha"),
+                "base_sha": result.get("base_sha"),
+                "warnings": warnings,
+            },
+        )
+
+
+class SetReviewStatusEffect:
+    def __init__(self, resolver: LiveStateResolver) -> None:
+        self.resolver = resolver
+
+    def execute(self, task_number: int) -> EffectReceipt:
+        state = self.resolver.resolve(task_number)
+        if state.status is not ResolutionStatus.RESOLVED or state.repository is None:
+            raise LckStopError("cannot set Review status from unresolved live state")
+        if state.open_pr is None:
+            raise LckStopError("Project Status may move to Review only after OPEN PR exists")
+        if state.project_status == "Review":
+            return EffectReceipt(
+                effect="set_review_status", action="already-review", details={}
+            )
+        set_project_status_with_runner(
+            self.resolver.runner,
+            state.repository,
+            task_number,
+            value="Review",
+        )
+        final = self.resolver.resolve(task_number)
+        if final.project_status != "Review":
+            raise LckStopError("Project Status postcondition failed: expected Review")
+        return EffectReceipt(
+            effect="set_review_status", action="updated", details={"status": "Review"}
+        )
+
+
+class DeliveryChecksGate:
+    """Wait boundedly for applicable PR checks using current GitHub facts."""
+
+    def __init__(
+        self,
+        resolver: LiveStateResolver,
+        *,
+        timeout_seconds: float = 600.0,
+        poll_seconds: float = 5.0,
+    ) -> None:
+        self.resolver = resolver
+        self.timeout_seconds = max(0.0, timeout_seconds)
+        self.poll_seconds = max(0.0, poll_seconds)
+
+    @staticmethod
+    def _required_names(required: Mapping[str, Any]) -> set[str]:
+        contexts = required.get("contexts")
+        if not isinstance(contexts, Mapping):
+            return set()
+        items = contexts.get("items")
+        if not isinstance(items, list):
+            return set()
+        return {str(item) for item in items if isinstance(item, str) and item}
+
+    @staticmethod
+    def _observed_categories(checks: Mapping[str, Any]) -> dict[str, str]:
+        bounded = checks.get("items")
+        if not isinstance(bounded, Mapping):
+            return {}
+        items = bounded.get("items")
+        if not isinstance(items, list):
+            return {}
+        values: dict[str, str] = {}
+        for item in items:
+            if not isinstance(item, Mapping):
+                continue
+            name = item.get("name")
+            category = item.get("category")
+            if isinstance(name, str) and isinstance(category, str):
+                values[name] = category
+        return values
+
+    def run(self, task_number: int) -> dict[str, Any]:
+        state = self.resolver.resolve(task_number)
+        if state.status is not ResolutionStatus.RESOLVED or state.repository is None:
+            raise LckStopError("cannot evaluate checks from unresolved live state")
+        warnings: list[dict[str, Any]] = []
+        required = _required_checks(
+            self.resolver.runner,
+            state.repository,
+            BASE_BRANCH,
+            warnings,
+        )
+        required_names = self._required_names(required)
+        config = required.get("configuration")
+        deadline = time.monotonic() + self.timeout_seconds
+
+        while True:
+            current = self.resolver.resolve(task_number)
+            if current.status is not ResolutionStatus.RESOLVED or current.open_pr is None:
+                raise LckStopError("PR identity changed while waiting for checks")
+            checks = current.checks
+            observed = self._observed_categories(checks)
+            failed = int(checks.get("failed", 0) or 0)
+            unknown = int(checks.get("skipped_or_unknown", 0) or 0)
+            pending = int(checks.get("pending", 0) or 0)
+
+            if failed > 0 or unknown > 0:
+                raise LckStopError("PR checks failed, cancelled, skipped, or unknown")
+
+            if required_names:
+                failed_required = {
+                    name
+                    for name in required_names
+                    if observed.get(name) not in {None, "success", "pending"}
+                }
+                if failed_required:
+                    raise LckStopError(
+                        "required PR checks failed: " + ", ".join(sorted(failed_required))
+                    )
+                if all(observed.get(name) == "success" for name in required_names):
+                    return {
+                        "status": "pass",
+                        "configuration": config,
+                        "required": sorted(required_names),
+                        "observed": checks,
+                        "warnings": warnings,
+                    }
+            elif config in {"configured-empty", "not-configured"}:
+                if checks.get("count") == 0 or checks.get("all_success") is True:
+                    return {
+                        "status": "pass",
+                        "configuration": config,
+                        "required": [],
+                        "observed": checks,
+                        "warnings": warnings,
+                    }
+            elif checks.get("count", 0) > 0 and checks.get("all_success") is True:
+                # GitHub can hide branch-protection configuration behind a plan
+                # boundary. Successful observed checks are preserved as a
+                # capability-limited fact instead of being upgraded to proof of
+                # required-check configuration.
+                return {
+                    "status": "pass",
+                    "configuration": config,
+                    "required": [],
+                    "observed": checks,
+                    "warnings": warnings,
+                    "limitation": "required-check configuration unavailable",
+                }
+
+            if time.monotonic() >= deadline:
+                detail = (
+                    f"required={sorted(required_names)}, observed={sorted(observed)}, "
+                    f"pending={pending}, configuration={config}"
+                )
+                raise LckStopError("timed out waiting for successful PR checks: " + detail)
+            time.sleep(self.poll_seconds)
+
+
+@dataclass(frozen=True)
+class DeliveryCompletionResult:
+    task_number: int
+    status: str
+    branch: str
+    head_sha: str
+    critical_outcome: Mapping[str, Any]
+    validation: Mapping[str, Any]
+    checks: Mapping[str, Any]
+    effects: tuple[EffectReceipt, ...]
+    final_state: LiveState
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": LCK_SCHEMA_VERSION,
+            "operation": "delivery-complete",
+            "task_number": self.task_number,
+            "status": self.status,
+            "branch": self.branch,
+            "head_sha": self.head_sha,
+            "critical_outcome": _jsonable(self.critical_outcome),
+            "validation": _jsonable(self.validation),
+            "checks": _jsonable(self.checks),
+            "effects": [item.to_dict() for item in self.effects],
+            "final_state": self.final_state.to_dict(),
+            "human_boundary": "Independent Review must be started separately",
+        }
+
+
+class DeliveryCompleter:
+    """Complete initial Delivery using bounded LCK-owned lifecycle effects."""
+
+    def __init__(
+        self,
+        resolver: LiveStateResolver,
+        *,
+        eligibility: PhaseEligibilityResolver | None = None,
+        formal_validation: FormalValidationGate | None = None,
+        commit_effect: CommitCurrentTreeEffect | None = None,
+        remote_effect: EnsureRemoteBranchEffect | None = None,
+        pr_effect: EnsureOpenPrEffect | None = None,
+        status_effect: SetReviewStatusEffect | None = None,
+        checks_gate: DeliveryChecksGate | None = None,
+    ) -> None:
+        self.resolver = resolver
+        self.eligibility = eligibility or PhaseEligibilityResolver()
+        self.formal_validation = formal_validation or FormalValidationGate(resolver)
+        self.commit_effect = commit_effect or CommitCurrentTreeEffect(resolver)
+        self.remote_effect = remote_effect or EnsureRemoteBranchEffect(resolver)
+        self.pr_effect = pr_effect or EnsureOpenPrEffect(resolver)
+        self.status_effect = status_effect or SetReviewStatusEffect(resolver)
+        self.checks_gate = checks_gate or DeliveryChecksGate(resolver)
+
+    def _run_critical_outcome(self, state: LiveState) -> dict[str, Any]:
+        issue = state.issue
+        snapshot = issue.get("critical_outcome") if isinstance(issue, Mapping) else None
+        try:
+            contract = contract_from_snapshot(snapshot)
+            result = verify_critical_outcome(
+                self.resolver.repo_root,
+                self.resolver.runner,
+                contract,
+            )
+        except CriticalOutcomeError as exc:
+            raise LckStopError(f"Critical Outcome contract invalid: {exc}") from exc
+        payload = result.to_dict()
+        if result.status != "pass":
+            raise LckStopError(
+                "Critical Outcome FAIL: "
+                f"{contract.verification_test} exited {result.exit_code}"
+            )
+        return payload
+
+    def _has_task_diff(self, base_sha: str) -> bool:
+        result = self.resolver.runner.run(
+            ["git", "diff", "--quiet", f"{base_sha}...HEAD"],
+            command_id="lck-task-diff-present",
+        )
+        if result.returncode == 1:
+            return True
+        if result.returncode == 0:
+            return False
+        raise LckStopError("unable to verify Task diff against current origin/main")
+
+    def _operation_guard(
+        self,
+        task_number: int,
+        *,
+        base_sha: str,
+        body_sha256: str,
+        branch: str,
+        head_sha: str | None = None,
+    ) -> LiveState:
+        """Reacquire the facts that must stay stable within this invocation."""
+        state = self.resolver.resolve(task_number)
+        decision = self.eligibility.resolve(state, Phase.DELIVERY_COMPLETE)
+        if not decision.eligible:
+            raise LckStopError(
+                "Delivery operation guard stopped: " + "; ".join(decision.reasons)
+            )
+        issue = state.issue
+        if state.git.get("origin_main_sha") != base_sha:
+            raise LckStopError("Delivery operation guard stopped: origin/main changed")
+        if not isinstance(issue, Mapping) or issue.get("body_sha256") != body_sha256:
+            raise LckStopError("Delivery operation guard stopped: Task body changed")
+        if state.target_branch != branch:
+            raise LckStopError("Delivery operation guard stopped: Task branch identity changed")
+        if head_sha is not None and state.local_task_head != head_sha:
+            raise LckStopError("Delivery operation guard stopped: local Task head changed")
+        return state
+
+    def _final_verify(
+        self,
+        task_number: int,
+        head: str,
+        *,
+        base_sha: str,
+        body_sha256: str,
+        branch: str,
+    ) -> LiveState:
+        state = self.resolver.resolve(task_number)
+        if state.status is not ResolutionStatus.RESOLVED:
+            raise LckStopError(
+                "Delivery final verification unresolved: " + "; ".join(state.stop_reasons)
+            )
+        issue = state.issue
+        pr_head = state.open_pr.get("headRefOid") if state.open_pr else None
+        pr_base = state.open_pr.get("baseRefOid") if state.open_pr else None
+        if not (
+            state.target_branch == branch
+            and state.git.get("branch") == branch
+            and state.git.get("clean") is True
+            and state.git.get("origin_main_sha") == base_sha
+            and isinstance(issue, Mapping)
+            and issue.get("body_sha256") == body_sha256
+            and state.local_task_head == head
+            and state.remote_task_oid == head
+            and pr_head == head
+            and pr_base == base_sha
+            and state.open_pr is not None
+            and state.open_pr.get("isDraft") is False
+            and state.project_status == "Review"
+        ):
+            raise LckStopError(
+                "Delivery final verification failed: Task/base/local/remote/PR/lifecycle "
+                "state is not aligned"
+            )
+        return state
+
+    def complete(
+        self,
+        task_number: int,
+        *,
+        commit_message: str,
+        summary: str,
+        risks: str = "",
+    ) -> DeliveryCompletionResult:
+        if not summary.strip():
+            raise LckStopError("Delivery summary must be non-empty")
+        state = self.resolver.resolve(task_number)
+        decision = self.eligibility.resolve(state, Phase.DELIVERY_COMPLETE)
+        if not decision.eligible:
+            raise LckStopError(
+                f"Delivery Complete STOP for Task #{task_number}: "
+                + "; ".join(decision.reasons)
+            )
+        base_sha = state.git.get("origin_main_sha")
+        if not is_sha(base_sha):
+            raise LckStopError("current origin/main identity is unavailable")
+        issue = state.issue
+        body_sha256 = issue.get("body_sha256") if isinstance(issue, Mapping) else None
+        if not isinstance(body_sha256, str) or not body_sha256:
+            raise LckStopError("current Task body identity is unavailable")
+        branch = state.target_branch
+
+        effects: list[EffectReceipt] = []
+        if state.git.get("clean") is True:
+            if not self._has_task_diff(base_sha):
+                raise LckStopError("Delivery Complete found no Task diff against origin/main")
+            # Stateless recovery path: re-run all gates on the existing clean head
+            # instead of trusting a receipt from a previous interrupted invocation.
+            validated_tree = self.commit_effect.current_head_tree()
+            critical = self._run_critical_outcome(state)
+            validation = self.formal_validation.run(base_sha)
+            head = state.local_task_head
+            if not is_sha(head):
+                raise LckStopError("current Task head is unavailable")
+            effects.append(
+                EffectReceipt(
+                    effect="commit_current_tree",
+                    action="already-committed-revalidated",
+                    details={"head_sha": head, "tree_oid": validated_tree},
+                )
+            )
+        else:
+            validated_tree = self.commit_effect.stage_candidate_tree()
+            critical = self._run_critical_outcome(state)
+            validation = self.formal_validation.run(base_sha)
+            self._operation_guard(
+                task_number,
+                base_sha=base_sha,
+                body_sha256=body_sha256,
+                branch=branch,
+            )
+            self.commit_effect.verify_tree_unchanged(validated_tree)
+            commit = self.commit_effect.execute(validated_tree, commit_message)
+            effects.append(commit)
+            head = commit.details.get("head_sha")
+            if not is_sha(head):
+                raise LckStopError("commit receipt did not contain a valid head SHA")
+
+        self._operation_guard(
+            task_number,
+            base_sha=base_sha,
+            body_sha256=body_sha256,
+            branch=branch,
+            head_sha=str(head),
+        )
+        effects.append(self.remote_effect.execute(branch))
+        self._operation_guard(
+            task_number,
+            base_sha=base_sha,
+            body_sha256=body_sha256,
+            branch=branch,
+            head_sha=str(head),
+        )
+        effects.append(
+            self.pr_effect.execute(
+                task_number,
+                summary=summary,
+                risks=risks,
+                critical_outcome=critical,
+                validation=validation,
+                expected_base_sha=base_sha,
+                expected_body_sha256=body_sha256,
+            )
+        )
+        self._operation_guard(
+            task_number,
+            base_sha=base_sha,
+            body_sha256=body_sha256,
+            branch=branch,
+            head_sha=str(head),
+        )
+        checks = self.checks_gate.run(task_number)
+        self._operation_guard(
+            task_number,
+            base_sha=base_sha,
+            body_sha256=body_sha256,
+            branch=branch,
+            head_sha=str(head),
+        )
+        effects.append(self.status_effect.execute(task_number))
+        final_state = self._final_verify(
+            task_number,
+            str(head),
+            base_sha=base_sha,
+            body_sha256=body_sha256,
+            branch=branch,
+        )
+        return DeliveryCompletionResult(
+            task_number=task_number,
+            status="READY_FOR_REVIEW",
+            branch=final_state.target_branch,
+            head_sha=str(head),
+            critical_outcome=critical,
+            validation=validation,
+            checks=checks,
+            effects=tuple(effects),
+            final_state=final_state,
+        )
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="LCK v1 live state operations")
     parser.add_argument("--repo-root", type=Path, default=Path.cwd())
@@ -688,6 +1476,12 @@ def _build_parser() -> argparse.ArgumentParser:
     delivery_commands = delivery.add_subparsers(dest="delivery_command", required=True)
     prepare = delivery_commands.add_parser("prepare")
     prepare.add_argument("task", type=int)
+    complete = delivery_commands.add_parser("complete")
+    complete.add_argument("task", type=int)
+    complete.add_argument("--commit-message", required=True)
+    complete.add_argument("--summary", required=True)
+    complete.add_argument("--risks", default="")
+    complete.add_argument("--check-timeout-seconds", type=float, default=600.0)
     return parser
 
 
@@ -705,6 +1499,20 @@ def main(argv: Sequence[str] | None = None) -> int:
         if args.delivery_command == "prepare":
             context = DeliveryPreparer(resolver).prepare(args.task)
             print_json(context.to_dict(), pretty=True)
+            return 0
+        if args.delivery_command == "complete":
+            result = DeliveryCompleter(
+                resolver,
+                checks_gate=DeliveryChecksGate(
+                    resolver, timeout_seconds=args.check_timeout_seconds
+                ),
+            ).complete(
+                args.task,
+                commit_message=args.commit_message,
+                summary=args.summary,
+                risks=args.risks,
+            )
+            print_json(result.to_dict(), pretty=True)
             return 0
         raise LckStopError("unsupported LCK command")
     except WorkflowToolError as exc:

--- a/tools/agent_workflow/project_status.py
+++ b/tools/agent_workflow/project_status.py
@@ -12,8 +12,51 @@ import subprocess
 import sys
 from typing import Final
 
+from workflow_common import CommandRunner, WorkflowToolError
+
 _REPO: Final = "PhoenixSss/tracequant"
 _ISSUE_URL_PREFIX: Final = f"https://github.com/{_REPO}/issues/"
+
+
+def set_project_status_with_runner(
+    runner: CommandRunner,
+    repository: str,
+    task: int,
+    *,
+    project_number: int = 1,
+    field: str = "Status",
+    value: str = "Review",
+) -> None:
+    """Update one Task Project field through the shared deterministic runner."""
+    if task <= 0:
+        raise WorkflowToolError("Task number must be positive")
+    owner, separator, _name = repository.partition("/")
+    if not separator or not owner:
+        raise WorkflowToolError("repository must be owner/name")
+    url = f"https://github.com/{repository}/issues/{task}"
+    result = runner.run(
+        [
+            "gh",
+            "project",
+            "item-edit",
+            str(project_number),
+            "--owner",
+            owner,
+            "--url",
+            url,
+            "--field",
+            field,
+            "--value",
+            value,
+        ],
+        command_id="lck-project-status",
+    )
+    if result.returncode != 0:
+        raise WorkflowToolError(
+            f"gh project item-edit failed (exit {result.returncode}): "
+            f"task={task}, field={field!r}, value={value!r}: "
+            f"{result.stderr.strip() or result.stdout.strip()}"
+        )
 
 
 def set_project_status(

--- a/tools/agent_workflow/skill_path_audit.py
+++ b/tools/agent_workflow/skill_path_audit.py
@@ -27,10 +27,12 @@ CLAUDE_SKILLS: Final = {
 }
 REQUIRED: Final = {
     "task-delivery-runner": (
+        "tools/agent_workflow/lck.py",
+        "delivery prepare",
+        "delivery complete",
+        "Critical Outcome",
         "wsl2_github_evidence_runner.py",
         "wsl2_validation_runner.py",
-        "delivery-readiness",
-        "workflow-delivery",
         "Review remediation",
     ),
     "task-pr-review-runner": (

--- a/tools/agent_workflow/workflow_common.py
+++ b/tools/agent_workflow/workflow_common.py
@@ -38,6 +38,21 @@ class WorkflowToolError(RuntimeError):
     """Expected user-facing workflow tooling error."""
 
 
+def build_workflow_env(repo_root: Path) -> dict[str, str]:
+    """Build the shared environment for Workflow-owned subprocesses.
+
+    Workflow runtime state belongs under the repository, not in a user HOME
+    cache that may be unavailable in a sandbox. An explicit caller override
+    remains authoritative.
+    """
+    env = os.environ.copy()
+    env.setdefault(
+        "UV_CACHE_DIR",
+        str(repo_root.resolve() / ".workflow.local" / "uv-cache"),
+    )
+    return env
+
+
 @dataclass(frozen=True)
 class CommandResult:
     command_id: str
@@ -68,7 +83,7 @@ class CommandRunner:
     ) -> CommandResult:
         if not argv:
             raise WorkflowToolError("command argv cannot be empty")
-        process_env = os.environ.copy()
+        process_env = build_workflow_env(self.repo_root)
         process_env.setdefault("PYTHONUTF8", "1")
         process_env.setdefault("PYTHONIOENCODING", "utf-8")
         if env:

--- a/tools/agent_workflow/workflow_evidence.py
+++ b/tools/agent_workflow/workflow_evidence.py
@@ -16,6 +16,7 @@ from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any, Final
 
+from critical_outcome import critical_outcome_snapshot
 from workflow_common import (
     CommandResult,
     CommandRunner,
@@ -460,7 +461,9 @@ def _issue_view(
         "number": value.get("number"),
         "title": safe_text(value.get("title")),
         "content_sha256": sha256_json(content_facts),
+        "body_sha256": sha256_json({"body": body}),
         "body_characters": len(body) if body is not None else None,
+        "critical_outcome": critical_outcome_snapshot(body),
         "comment_count": len(comment_facts),
         "state": safe_text(value.get("state")),
         "labels": bounded_list(sorted(normalized_labels)),

--- a/tools/agent_workflow/wsl2_github_evidence_runner.py
+++ b/tools/agent_workflow/wsl2_github_evidence_runner.py
@@ -26,6 +26,7 @@ SPEC_PATH: Final = "tools/agent_workflow/wsl2_github_evidence_profiles.json"
 RULES_PATH: Final = ".codex/rules/tracequant-wsl-evidence.rules"
 EVIDENCE_TOOL_PATH: Final = "tools/agent_workflow/workflow_evidence.py"
 COMMON_TOOL_PATH: Final = "tools/agent_workflow/workflow_common.py"
+CRITICAL_OUTCOME_TOOL_PATH: Final = "tools/agent_workflow/critical_outcome.py"
 STDIO_LIMIT_BYTES: Final = 8192
 SHA_PATTERN: Final = re.compile(r"^[0-9a-f]{40}$")
 SNAPSHOT_ID_PATTERN: Final = re.compile(r"^ev-[0-9a-f]{16}$")
@@ -95,6 +96,7 @@ IDENTITY_PATHS: Final = (
     RULES_PATH,
     EVIDENCE_TOOL_PATH,
     COMMON_TOOL_PATH,
+    CRITICAL_OUTCOME_TOOL_PATH,
 )
 ALLOWED_ENV: Final = (
     "PATH",

--- a/tools/agent_workflow/wsl2_validation_runner.py
+++ b/tools/agent_workflow/wsl2_validation_runner.py
@@ -18,6 +18,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Final
 
+from workflow_common import build_workflow_env
+
 SCHEMA_VERSION: Final = 1
 RUNNER_VERSION: Final = "1.2.0"
 OUTPUT_ROOT: Final = ".agents/validation.local/wsl2-runs"
@@ -286,14 +288,13 @@ def _run_quiet(
         text=True,
         encoding="utf-8",
         errors="replace",
-        env=_command_env(),
+        env=_command_env(repo_root),
     )
 
 
-def _command_env() -> dict[str, str]:
-    env = {
-        key: value for key in ALLOWED_ENV if (value := os.environ.get(key)) is not None
-    }
+def _command_env(repo_root: Path) -> dict[str, str]:
+    inherited = build_workflow_env(repo_root)
+    env = {key: inherited[key] for key in ALLOWED_ENV if key in inherited}
     env.setdefault("PYTHONUTF8", "1")
     env.setdefault("PYTHONIOENCODING", "utf-8")
     env.setdefault("NO_COLOR", "1")
@@ -583,7 +584,7 @@ def _run_command(
         text=True,
         encoding="utf-8",
         errors="replace",
-        env=_command_env(),
+        env=_command_env(repo_root),
         start_new_session=True,
     )
     timed_out = False


### PR DESCRIPTION
Closes #160

## Summary

- Add the Critical Outcome Task contract and bounded pytest verification path.
- Move the candidate Initial Delivery lifecycle effects into LCK with fail-closed live-state checks.
- Re-fetch final live state after `SetReviewStatusEffect` and bind `READY_FOR_REVIEW` to the same PR/head and successful applicable checks.
- Route Workflow-owned `uv` subprocesses to the Git-ignored `.workflow.local/uv-cache` while preserving explicit overrides.
- Unify Independent Review FAIL remediation output into one self-contained, directly copyable handoff code block.
- Align the LCK v1 migration matrix with the #160 pre-cutover boundary.

## Validation

- `tools/agent_workflow/wsl2_validation_runner.py targeted:tools-tests` — pass
- `tools/agent_workflow/wsl2_validation_runner.py targeted:workflow-tests` — pass
- `tools/agent_workflow/wsl2_validation_runner.py workflow-delivery --base-sha 9223f4fb21a9348ea9fa6cd5fec4e5bf4baa91a6` — pass
- Structured self-review for head `0120a515381d43e17b844dd5b7af5598e0c77cf2` — valid
- GitHub `quality` check — pending after this push

## Contract boundary

- The live Task #160 contract requires Codex and Claude to use the same provider-neutral Initial Delivery contract with regression coverage.
- #160 itself uses the pre-cutover Current Workflow; the candidate LCK controller is not its lifecycle authority before the maintainer merge boundary.
- Mainline activation and rollback are recorded as a post-merge LCK v1 Feature acceptance item and are not a pre-merge acceptance gate for this PR.

## Risks and limitations

- This is the candidate LCK Initial Delivery controller and requires a fresh independent review before maintainer merge.
- Independent Review, merge, Issue closeout, and branch cleanup were not performed.