### PR TITLE
[Task] 将 Independent Review 与 Remediation lifecycle control 迁移至 LCK

### DIFF
--- a/.agents/execution-profile.example.toml
+++ b/.agents/execution-profile.example.toml
@@ -6,13 +6,6 @@ schema_version = 1
 default_route = "sandbox-first"
 
 [[rules]]
-name = "python-skill-validator"
-executable = "python"
-argument_prefix = ["-X", "utf8"]
-route = "elevated-first"
-reason = "Repeated login-session isolation on this workstation"
-
-[[rules]]
 name = "uv-toolchain"
 executable = "uv"
 argument_prefix = []

--- a/.agents/policies/workflow-evidence.md
+++ b/.agents/policies/workflow-evidence.md
@@ -3,43 +3,52 @@
 ## Responsibilities
 
 ```text
-Skill       authorization, phases, semantic judgment, findings, verdict
-Evidence    deterministic current Git/GitHub facts and stability snapshots
+LCK         lifecycle control and current mechanical authority for migrated phases
+Skill       semantic procedure, judgment, findings, and human-facing report
+Evidence    deterministic compatibility/audit facts for non-migrated or historical paths
 Validation  deterministic command plans, exit codes, and bounded diagnostics
-Maintainer  manual Merge and Feature closeout
+Maintainer  explicit remediation start, manual Merge, and Feature closeout
 ```
 
 Evidence and Validation never authorize repository or GitHub writes and never
-replace semantic correctness review.
+replace semantic correctness review. For migrated Delivery / Review / Remediation
+phases, LCK reacquires the current mechanical facts itself; persisted Evidence
+snapshots and cross-phase handoffs are not lifecycle authority.
 
 ## Current front doors
 
-Runner Skills use the current repository entries directly:
+Migrated lifecycle phases enter through LCK:
+
+```text
+tools/agent_workflow/lck.py delivery prepare|complete
+tools/agent_workflow/lck.py review prepare|complete
+tools/agent_workflow/lck.py remediation prepare|complete
+```
+
+The Evidence / Validation Runners remain current for non-migrated phases and
+for bounded deterministic validation internals:
 
 ```text
 tools/agent_workflow/wsl2_github_evidence_runner.py
 tools/agent_workflow/wsl2_validation_runner.py
 ```
 
-The implementation CLIs are Runner internals:
+Their implementation CLIs are Runner/LCK internals, not alternate Skill write routes:
 
 ```text
 tools/agent_workflow/workflow_evidence.py
 tools/agent_workflow/workflow_validation.py
 ```
 
-For each phase, the named Runner is the single mechanical source. Do not run its
-implementation CLI or a second equivalent Git/`gh`/`uv` chain after a valid
-result.
-
-| Workflow phase | Evidence profile | Validation profile |
+| Workflow phase | Current mechanical front door | Validation |
 | --- | --- | --- |
-| Runner Delivery preflight | `delivery` | named `targeted*` only when useful |
-| Runner Delivery final | `delivery-readiness` | `workflow-delivery --base-sha <base>` |
-| Independent Runner Review | `review`, then `recheck` | `workflow-review --base-sha <base>` |
+| Initial Delivery | `lck.py delivery prepare|complete` | LCK runs formal Delivery validation |
+| Independent Review | `lck.py review prepare|complete` | LCK runs formal Review validation on the live-resolved head |
+| Explicit Remediation | `lck.py remediation prepare|complete` | LCK reuses migrated Delivery validation/effects |
 | Closeout | `closeout-readonly`, then `recheck` | `workflow-closeout --base-sha <PR base>` |
 
-Validation is not reused across Delivery, Review, and Closeout. A targeted
+The old Evidence `review` / `recheck` path remains historical compatibility only;
+it must not select or authorize the current Review target. A targeted validation
 profile is not CI-equivalent.
 
 ## Execution identity
@@ -57,9 +66,10 @@ Every result artifact records, when applicable:
 - repository head and clean/dirty state;
 - Task, PR, base/head/effective-diff, audited-main, or merge identities.
 
-Content identity is reproducibility evidence, not a source hierarchy. Final
-Delivery and Review validation bind a clean committed current head. Object SHA
-locks remain mandatory even though control-plane version locks do not.
+Content identity is reproducibility evidence, not a source hierarchy. LCK binds
+formal Delivery / Review validation to the current invocation target. Review
+head/base applicability is invocation-local; it is not a reusable cross-phase
+freshness contract or persisted authorization token.
 
 When a PR changes Skills, Runners, Rules, profiles, or workflow governance, an
 independent Review directly evaluates those changes, tests, permissions, and
@@ -113,7 +123,7 @@ absolute paths.
 
 ## Evidence contract
 
-The Evidence Runner supports:
+The Evidence Runner still supports its historical profiles:
 
 ```text
 delivery
@@ -124,9 +134,11 @@ closeout-readonly
 recheck
 ```
 
-It validates complete argv, repository identity, fixed queries, and fixed
-read-only Git operations. It accepts no arbitrary repository, API path, raw
-`gh`/Git argv, shell string, output path, or cwd.
+After the LCK cutover, `review` / `recheck` are compatibility and audit tools,
+not the formal Independent Review selector or freshness authority. The Runner
+validates complete argv, repository identity, fixed queries, and fixed read-only
+Git operations. It accepts no arbitrary repository, API path, raw `gh`/Git argv,
+shell string, output path, or cwd.
 
 Snapshots contain bounded normalized facts, explicit `pass`/`fail`/`unknown`
 gates, operation counts, truncation state, content identities, snapshot ID, and
@@ -159,8 +171,10 @@ workflow-closeout --base-sha <PR base>
 ```
 
 Workflow profiles run the current CI-equivalent plan and all repository Skill
-validators. Delivery and Review require a clean committed worktree.
-`workflow-closeout` additionally requires clean local `main == origin/main`.
+validators. LCK invokes formal Review validation inside the isolated exact-head
+Review worktree before sealing implementation files read-only; the profile result
+is invocation evidence, not a cross-phase snapshot. `workflow-closeout` additionally
+requires clean local `main == origin/main`.
 
 Success stdout is a compact digest. Full redacted results and bounded failure
 diagnostics remain in the ignored validation directory.
@@ -179,17 +193,17 @@ Preflight pass returns `disposition.workflow_may_continue = true` and
 all write operations, auto-remediation, state modification, and re-invocation
 of the same profile to obtain `pass`.
 
-The `worktree_state_compatible` gate evaluates worktree cleanliness per
-entry point. `delivery-start` and `implementation` may accept a dirty
-worktree with Task-owned changes; `final-validation`, `pr-readiness`, and
-`review-remediation` require a clean committed head.
+The `worktree_state_compatible` gate evaluates worktree cleanliness for the
+legacy Evidence Runner entry points. `delivery-start` and `implementation` may
+accept a dirty worktree with Task-owned changes; `final-validation` and
+`pr-readiness` require a clean committed head.
 
-For `review-remediation`, a GitHub submitted Review is **not** canonical
-admission evidence. Independent Review is strictly read-only and returns a
-bounded remediation handoff to the Delivery Skill. The Runner mechanically
-locks the open PR plus expected base/head identity and head fixability; the
-Delivery Skill is responsible for validating the supplied handoff. Any new
-commit invalidates the prior Review and requires a fresh independent re-review.
+`review-remediation` remains implemented only as **pre-cutover compatibility /
+diagnostic behavior** for historical evidence and tests. It is not part of the
+LCK Review / Remediation lifecycle and MUST NOT authorize a current repair from
+an expected base/head or bounded handoff. Current remediation authority is
+`lck.py remediation prepare`, which reacquires the live Task/PR/head/base and
+uses the failed Review record only for semantic findings.
 
 ## Failure expansion
 

--- a/.agents/skills/task-delivery-runner/SKILL.md
+++ b/.agents/skills/task-delivery-runner/SKILL.md
@@ -35,6 +35,17 @@ record are not write authorization.
 
 The Issue number is the primary key; the current Issue title is canonical.
 
+Before the first LCK command, verify the project launcher:
+
+```bash
+command -v uv
+uv --version
+uv run --frozen python --version
+```
+
+If this preflight fails, report an environment/launcher failure. It is not a
+Delivery or Review verdict, and must not be converted into `STOP_REQUIRED`.
+
 ## Policies and shared semantics
 
 Read applicable `AGENTS.md` and
@@ -89,7 +100,7 @@ maintainer or implementation action.
 The first lifecycle action is:
 
 ```bash
-python tools/agent_workflow/lck.py delivery prepare <TASK>
+uv run --frozen python tools/agent_workflow/lck.py delivery prepare <TASK>
 ```
 
 Proceed only when LCK returns a resolved Delivery context. LCK reacquires live
@@ -123,7 +134,7 @@ workspace presented to LCK is the candidate Task tree.
 After semantic implementation is complete, invoke LCK with semantic metadata:
 
 ```bash
-python tools/agent_workflow/lck.py delivery complete <TASK> \
+uv run --frozen python tools/agent_workflow/lck.py delivery complete <TASK> \
   --commit-message "<scoped commit message>" \
   --summary "<implementation summary>" \
   --risks "<risks or limitations>"
@@ -192,7 +203,7 @@ all actionable mechanical identity from current live Git / GitHub state.
 ### 1. LCK Remediation Prepare
 
 ```bash
-python tools/agent_workflow/lck.py remediation prepare <TASK> \
+uv run --frozen python tools/agent_workflow/lck.py remediation prepare <TASK> \
   --review-id <FAILED_REVIEW_ID>
 ```
 
@@ -221,7 +232,7 @@ new Review.
 After the repair is ready:
 
 ```bash
-python tools/agent_workflow/lck.py remediation complete <TASK> \
+uv run --frozen python tools/agent_workflow/lck.py remediation complete <TASK> \
   --review-id <FAILED_REVIEW_ID> \
   --commit-message "<scoped repair commit message>" \
   --summary "<repair summary>" \

--- a/.agents/skills/task-delivery-runner/SKILL.md
+++ b/.agents/skills/task-delivery-runner/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: task-delivery-runner
-description: Deliver one maintainer-specified existing GitHub Task through LCK initial Delivery, or repair an existing Task PR from an independent review handoff. Initial Delivery uses LCK for workspace preparation, Critical Outcome, formal validation, commit, push, PR resolution/creation, checks, and Project Status. Independent review, merge, closeout, and Feature completion remain outside this Skill.
+description: Deliver one maintainer-specified existing GitHub Task through LCK, including explicitly requested remediation after a failed Independent Review. LCK owns workspace preparation, live identity, Critical Outcome, formal validation, commit, push, PR reuse/create as phase-appropriate, checks, and lifecycle boundaries. Review, merge, closeout, and Feature completion remain separate.
 ---
 
 # Task delivery runner
@@ -11,8 +11,8 @@ Initial Delivery is controlled by **LCK**. Codex / Claude owns semantic work;
 LCK owns deterministic lifecycle mechanics. A successful initial Delivery ends
 at `READY_FOR_REVIEW` and a Human boundary. It never starts Independent Review.
 
-Review remediation remains the separate procedure at the end of this Skill
-until its LCK cutover is implemented by the Review / Remediation migration Task.
+Review remediation is also LCK-controlled after cutover, but starts only from an
+explicit Human request that identifies a failed LCK `review_id`.
 
 ## Standard invocation
 
@@ -22,18 +22,16 @@ until its LCK cutover is implemented by the Review / Remediation migration Task.
 直到 PR 准备好接受独立审查。
 ```
 
-For remediation after an independent review:
+For remediation after an Independent Review FAIL:
 
 ```text
-请按 task-delivery-runner 修复
-[Task] <当前完整标题> #<Task编号>
-对应 PR #<PR编号> 的独立审查问题，
-并继续处理，直到 PR 再次准备好接受新的独立审查。
-
-Review remediation handoff:
-
-<粘贴 task-pr-review-runner 输出的 remediation handoff>
+请按 task-delivery-runner 对 Task #<Task编号> 显式执行 remediation。
+Failed Review ID: <REVIEW_ID>
 ```
+
+The failed `review_id` locates semantic findings only. LCK independently reacquires
+the current Task / PR / base / head / branch state; mechanical facts from the Review
+record are not write authorization.
 
 The Issue number is the primary key; the current Issue title is canonical.
 
@@ -182,48 +180,70 @@ branch deletion, and Feature completion were not performed.
 
 ## Review remediation
 
-This section applies only after a non-passing `task-pr-review-runner` handoff.
-Its lifecycle-control migration is intentionally outside the initial Delivery
-cutover.
+This section applies only after the latest completed LCK Independent Review returned
+`FAIL` / `STOP_REQUIRED` and the maintainer explicitly requests repair. A successful
+remediation forces a fresh Review before any later remediation can start.
 
-The remediation handoff must identify Task and PR, reviewed head SHA, verdict,
-required Blocking/High/Medium findings, objective gates, and maintainer
-questions if any. `review-remediation` requires the bounded handoff. Missing or contradictory handoff identity is a semantic admission failure: stop before Runner or repair writes.
-Do not use the generic snapshot fallback to manufacture remediation authority.
+The Agent / Skill MUST NOT accept a bounded mechanical handoff, expected SHA, base SHA,
+PR number, checks snapshot, validation snapshot, or old Evidence Runner snapshot as
+Remediation authority. The failed Review record supplies semantic findings; LCK resolves
+all actionable mechanical identity from current live Git / GitHub state.
 
-Run the current deterministic remediation Preflight before editing:
+### 1. LCK Remediation Prepare
 
 ```bash
-tools/agent_workflow/wsl2_github_evidence_runner.py delivery \
-  --entry-point review-remediation \
-  --task <TASK> \
-  --expected-main-sha <CURRENT_MAIN_SHA> \
-  --pr <PR> \
-  --expected-base-sha <REVIEWED_BASE_SHA> \
-  --expected-head-sha <REVIEWED_HEAD_SHA>
+python tools/agent_workflow/lck.py remediation prepare <TASK> \
+  --review-id <FAILED_REVIEW_ID>
 ```
 
-Proceed only on a valid passing result. `partial`, `unknown`, lifecycle
-conflict, identity conflict, or other valid non-pass is terminal; do not repair
-it automatically.
+Proceed only on `READY_FOR_REMEDIATION`. LCK verifies that the record is a failed
+Independent Review, reads its findings as semantic input, reacquires the current OPEN
+non-Draft PR/head/base and Task branch, and selects/restores the current implementation
+workspace.
 
-Classify every handoff item before editing: confirmed in-scope implementation,
-test, documentation, or configuration finding → repair; scope/AC/public
-behavior/architecture change → Human Gate; Low/Nit → leave unchanged unless
-explicitly requested.
+Do not pass expected head/base/PR identity. If current live identity is ambiguous,
+diverged, missing, or unsafe, STOP; do not use the pre-cutover `review-remediation`
+Evidence Runner as a fallback.
 
-Implement the smallest complete repair and add regression coverage. Existing
-remediation mechanics continue to use the current Evidence / Validation Runner
-contract for this phase: create scoped repair commits, run `workflow-delivery`
-against the clean committed head, push only the validated head, reuse the
-existing Task PR, wait for checks, and regenerate `delivery-readiness`.
+### 2. Semantic repair
 
-The previous Review verdict applies only to its reviewed head. Any new commit
-requires a fresh independent review. Remediation never submits a GitHub Review,
-merges, closes the Task, performs closeout, or starts the new Review itself.
+Read the returned findings, confirm them against the current implementation, implement
+the smallest complete repair, and add regression coverage. If a finding requires a true
+scope/architecture/product decision, stop at Human Gate rather than silently expanding
+the Task.
 
-Report the handoff items addressed, new head, validation/check result, remaining
-limitations, and the exact fresh-session review prompt.
+The Agent may edit and run targeted development validation. It MUST NOT directly stage
+the final tree, commit, push, create/replace the PR, mutate lifecycle state, or start a
+new Review.
+
+### 3. LCK Remediation Complete
+
+After the repair is ready:
+
+```bash
+python tools/agent_workflow/lck.py remediation complete <TASK> \
+  --review-id <FAILED_REVIEW_ID> \
+  --commit-message "<scoped repair commit message>" \
+  --summary "<repair summary>" \
+  --risks "<risks or limitations>"
+```
+
+LCK reuses the Task-2 Delivery effects for Critical Outcome, formal validation, exact
+validated-tree commit, remote synchronization, checks, and final local/remote/PR head
+verification. Unlike Initial Delivery, Remediation must reuse existing OPEN PR state; it never
+creates a replacement PR.
+
+A successful result is:
+
+```text
+READY_FOR_NEW_REVIEW
+→ STOP
+```
+
+The new head invalidates the earlier semantic Review result. Remediation MUST NOT start
+Independent Review automatically. Report the repaired findings, new head,
+validation/check results, limitations, and tell the maintainer to start a new fresh
+`task-pr-review-runner` invocation.
 
 ## Failure discipline
 

--- a/.agents/skills/task-pr-review-runner/SKILL.md
+++ b/.agents/skills/task-pr-review-runner/SKILL.md
@@ -1,381 +1,96 @@
 ---
 name: task-pr-review-runner
-description: Independently and strictly read-only review one maintainer-specified Task PR in a fresh session. Lock base/head/effective diff, inspect the complete change, run Review Runners, classify findings, output one fixed verdict, and when the verdict is not passing emit a bounded remediation handoff for task-delivery-runner. Never fix, write GitHub state, submit a review, merge, close Issues, perform closeout, or assess Feature completion.
+description: Independently review the current live Task PR in a fresh, implementation-read-only LCK context. LCK resolves the PR/base/head/effective diff/Task Contract/validation from live state and guards verdict applicability. The Review Agent only Inspect/Reason/Judge/Report; it never fixes, writes GitHub state, merges, closes Issues, or starts remediation.
 ---
 
 # Task PR review runner
 
-Use this Skill for one existing Task PR in a new session that did not
-participate in specification interpretation, implementation, fixes, commit,
-push, or PR creation. Otherwise stop with:
+Use this Skill only in a fresh session that did not implement or remediate the head
+being reviewed. Shared semantics are owned by `docs/development/pr-review.md` and
+lifecycle placement by `docs/development/issue-workflow.md`.
+Read applicable `AGENTS.md` and `.agents/policies/command-execution.md`; Review has no direct Git/GitHub write authority.
+
+## Invocation
 
 ```text
-本会话不能提供独立审查
+请使用 task-pr-review-runner，独立只读审查 Task #<TASK> 的当前 OPEN PR。
 ```
 
-A Delivery handoff locates the object but is not correctness evidence
-(no-verdict-inheritance, `docs/development/pr-review.md` §1).
+The Task number is the only mechanical key supplied to LCK. A maintainer may mention
+a PR number for human intent, but the Agent MUST NOT pass PR/base/head/checks/snapshot
+facts from Delivery as Review authority.
 
-## Standard invocation
-
-```text
-请使用 task-pr-review-runner，独立只读审查
-[Task] <当前完整标题> #<Task编号>
-对应的 PR #<PR编号>。
-
-Expected base SHA: <base SHA>
-Expected head SHA: <head SHA>
-```
-
-Task and PR numbers are primary keys; the current Issue title is canonical.
-A request may limit execution to one named Phase. Verify prior Phase facts and
-stop at the requested boundary.
-
-## Policies and Runner interface
-
-Read applicable agent rules and:
-
-```text
-.agents/policies/command-execution.md
-.agents/policies/workflow-evidence.md
-```
-
-Shared review semantics (fresh session, head lock, independent judgement,
-verdict semantics, remediation handoff) are owned by
-`docs/development/pr-review.md`. Read the minimal needed section for the
-current phase; do not duplicate review-semantic prose in this Skill.
-
-Use the current repository Runner interfaces in this order:
+## 1. LCK Review Prepare
 
 ```bash
-tools/agent_workflow/wsl2_github_evidence_runner.py review \
-  --task <TASK> \
-  --pr <PR> \
-  --expected-base-sha <LOCKED_BASE_SHA> \
-  --expected-head-sha <LOCKED_HEAD_SHA> \
-  --skill-path .agents/skills/task-pr-review-runner/SKILL.md
-
-tools/agent_workflow/wsl2_validation_runner.py workflow-review \
-  --base-sha <LOCKED_BASE_SHA> \
-  --skill-path .agents/skills/task-pr-review-runner/SKILL.md
-
-tools/agent_workflow/wsl2_github_evidence_runner.py \
-  recheck --snapshot-id <LOCKED_SNAPSHOT_ID> \
-  --skill-path .agents/skills/task-pr-review-runner/SKILL.md
+python tools/agent_workflow/lck.py review prepare <TASK>
 ```
 
-The `--skill-path` argument records the actual calling Skill identity in every
-artifact. Codex callers pass `.agents/skills/task-pr-review-runner/SKILL.md`;
-Claude Code callers pass `.claude/skills/task-pr-review-runner/SKILL.md`. The
-Runner re-hashes content independently and **fails closed** when the path is
-not within an allowed Skill root (`.agents/skills/` or `.claude/skills/`).
+Proceed only on `READY_FOR_SEMANTIC_REVIEW`. Use the returned `review_id`, current
+Task Contract, current review target, validation/check state, and `review_root`.
+The `review_root` is a detached, clean, implementation-read-only worktree for the
+live-resolved head.
 
-The initial snapshot defines the reviewed identity. `workflow-review` is the
-independent CI-equivalent validation for the locked head. `recheck` verifies
-stability before verdict.
+If LCK returns STOP or stale, do not fall back to Evidence Runner snapshots, expected
+SHAs, direct `gh` selection, or a Delivery handoff.
 
-For `partial`, `unknown`, `fail`, truncation, schema mismatch, or drift, inspect
-only the named facts or failed commands. Semantic review may read any code or
-context needed to judge correctness.
+## 2. Semantic Review
 
-Record the actual Review Skill, Runner, profile/schema, repository, reviewed
-base/head/diff, and content hashes in the evidence artifacts. When the PR
-changes Skills, Runners, Rules, or workflow governance, review those changes,
-their tests, permissions, and failure behavior explicitly; Runner success alone
-is not proof of correctness.
-
-## Tool discipline
-
-Before every tool invocation the Reviewer must verify:
-
-1. **File existence**: Confirm the target file exists in the changed-file
-   inventory or via a lightweight existence check before reading. A deleted
-   file is an observation, not an error to surface as a tool failure.
-
-2. **Tool availability**: Only use tools the current session environment
-   actually provides. Do not try a tool, observe failure, and then fall back to
-   an alternative; choose the correct tool first.
-
-3. **Runner result independence**: A Runner non-zero exit code does not mean
-   failure — verify whether the Runner produced a valid artifact with a
-   `partial` / `unknown` / `fail` status before rejecting it. Conversely,
-   a valid artifact with `partial` status is not `pass`.
-
-4. **Search completeness**: A keyword grep or `diff --stat` does not satisfy
-   the semantic review gate. The Reviewer must read the actual changed-file
-   content per the evidence matrix requirements in Phase 3.
-
-## Permission boundary
-
-Review is strictly read-only for code, Git history, GitHub, Project, reviews,
-threads, labels, Relationships, and lifecycle state. It may fetch refs, use one
-isolated worktree for the locked reviewed head, run validation, and write exact
-ignored local evidence artifacts.
-
-It does not authorize file fixes, Issue/PR/Project edits, GitHub Review
-submission, thread resolution, commits, pushes, merge, Issue close, branch
-deletion, closeout, or Feature completion assessment.
-
-## Phase 1: identify and lock
-
-Generate `review`. Verify same-repository Task/PR, Task type/state, exact closing
-linkage, PR open and non-Draft, expected base/head, complete files/commits,
-checks, reviews, threads, mergeability, and Required-Checks classification.
-
-Lock and report:
+Inside the read-only review context, do exactly:
 
 ```text
-Reviewed base SHA
-Reviewed head SHA
-Merge base / effective-diff baseline
-Effective diff digest
-Complete file and commit inventory
-Snapshot ID
+Inspect
+Reason
+Judge
+Report
 ```
 
-Stop on material repository, Task, linkage, state, base, or head mismatch.
+Read the complete effective diff and necessary related code. Build an independent AC
+coverage/evidence matrix. The current Task Contract, effective diff, and necessary related
+code are the default semantic context. Comments, Parent/Epic bodies, and other hierarchy
+or history are not default Review input; expand only when the current Task explicitly
+references them or a concrete ambiguity/dependency requires it. Check correctness, failure
+behavior, tests, docs/config/public interfaces, and workflow/security boundaries when
+applicable. Delivery conclusions, old Review verdicts, and old remediation rationale are
+not evidence.
 
-## Phase 2: read complete evidence
+Findings use Blocking, High, Medium, Low, Nit. Blocking/High/Medium defects or unmet
+Task requirements produce FAIL.
 
-Independently read the current Task body, PR body and effective diff, every
-changed file in context, commits, tests/docs/config/public interfaces,
-relevant unchanged code, current reviews/threads/checks, and
-review-relevant repository constraints.
+## 3. Complete the same Review invocation
 
-Do not inherit Delivery conclusions or accept comments, test names, or green
-checks without inspecting coverage.
+PASS:
 
-Comments, Parent/Epic bodies, and other hierarchy/history are not default
-review input. Expand to them only when the review scope, risk, or ambiguity
-requires it — for example an acceptance criterion references a historical
-decision, the Task body is insufficient to judge a change, or a conflict
-must be located. Expansion is bounded: read the minimum relevant source or
-section and stop once the question is resolved.
-
-## Phase 3: semantic review with evidence matrix
-
-### Evidence matrix
-
-Before evaluating findings, build a structured evidence matrix binding the
-current Task, PR, base SHA, head SHA, and effective diff. This matrix is the
-single source of truth for all deterministic claims in the final report.
-
-The matrix lives alongside the Runner artifacts in the same ignored local
-evidence root. Its digest is recorded in the review report.
-
-```json
-{
-  "task": "<TASK>",
-  "pr": "<PR>",
-  "base_sha": "<LOCKED_BASE_SHA>",
-  "head_sha": "<LOCKED_HEAD_SHA>",
-  "effective_diff_sha256": "<DIFF_DIGEST>",
-  "review_skill": {
-    "path": ".agents/skills/task-pr-review-runner/SKILL.md",
-    "sha256": "<CONTENT_HASH>"
-  },
-  "changed_file_groups": [
-    {
-      "name": "<group-name>",
-      "files": ["<repo-relative-path>"],
-      "status": "verified | partially_verified | not_verified",
-      "evidence": ["<deterministic-tool-reference>"],
-      "findings": ["<finding-id-reference>"],
-      "remaining_risk": "<explanation when not verified>"
-    }
-  ],
-  "acceptance_criteria": [
-    {
-      "id": "AC-<n>",
-      "text": "<criterion text>",
-      "status": "verified | partially_verified | not_verified",
-      "implementation_evidence": ["<file:line or tool reference>"],
-      "validation_evidence": ["<test or Runner reference>"],
-      "remaining_risk": "<explanation when not verified>"
-    }
-  ],
-  "evidence_gates": {
-    "review": "pass | partial | unknown | fail",
-    "validation": "pass | fail",
-    "recheck": "pass | partial | unknown | fail"
-  },
-  "overall": "verified | partial | not_verified"
-}
+```bash
+python tools/agent_workflow/lck.py review complete <TASK> \
+  --review-id <REVIEW_ID> \
+  --verdict PASS
 ```
 
-### File coverage rules
+FAIL: write the complete blocking findings to an ignored or temporary file outside the
+read-only implementation worktree, then:
 
-- Every changed file in the `review` snapshot must be assigned to exactly one
-  group.
-- Groups are derived from the actual diff, not guessed.
-- If any file is not covered by at least one group, overall must not be
-  `verified`.
-- Each group must have at least one deterministic evidence reference (file
-  content read, tool output, test result, Runner artifact).
-- Read necessary unchanged related code to verify interface, caller, and
-  failure-path consistency.
-
-### Acceptance criteria mapping
-
-- Extract every acceptance criterion from the Task body.
-- Assign a stable ID (`AC-1`, `AC-2`, …) in the order they appear.
-- Each criterion gets an independent status, evidence, and risk assessment.
-- Multiple criteria may reference the same evidence but must not be compressed
-  into a single "all satisfied" summary.
-- Validation Runner `pass` proves command success, not semantic coverage.
-
-### Mechanical assertions — deterministic standard
-
-| Claim | Required evidence |
-| --- | --- |
-| Historical Skill matches source commit blob | Git `cat-file -p <commit>:<path>` output compared byte-for-byte with current file |
-| All target Skills are canonical-state | All applicable Skill files individually verified with path-audit or equivalent |
-| Trusted-version / deprecated path completely removed | Full-text search of the entire repository worktree |
-| Runner / profile / schema / Rules contract consistent | Runner's spec-validation step passed AND manual verification of each contract pair |
-| Provenance manifest matches actual Git content | Byte-for-byte verification or deterministic manifest tool |
-| Permission configuration has no overly-broad authorization | Read and verify every permission entry in `.claude/settings.json` and `.codex/rules/` |
-
-A file-existence check, partial grep, or inspection of only a subset of Skills
-must not be enlarged into a comprehensive claim. When the deterministic
-evidence is unavailable, mark the assertion `partially_verified` or
-`not_verified` — do not guess.
-
-## Phase 4: validation
-
-Run `workflow-review`. Do not reuse Delivery validation. A real validation
-failure, an incomplete applicable check, stale evidence, or unavailable required
-evidence prevents an unconditional pass.
-
-A recognized plan-limit `403` is not a successful Required-Checks query.
-Approved fallback check evidence may support a passing verdict only when it is
-complete, consistent, and non-contradictory.
-
-## Phase 5: stability recheck
-
-Run `recheck` against the initial snapshot. Recollect identity, base/head,
-effective diff, files/commits, checks, reviews, and threads. Any new commit or
-base/head/effective-diff change invalidates the review and requires a new
-independent session. Evaluate check/thread-only changes under current gates.
-
-Verify the recheck uses the same Skill identity as the initial review (same
-`--skill-path`). Skill identity drift invalidates the review.
-
-## Evidence status and verdict mapping
-
-The Evidence Runner produces a process exit code and a `status` field
-(`pass`, `partial`, `fail`). Process success (exit code 0) is not gate pass:
-read the `status` field and map it deterministically.
-
-Verdict conditions and the full mapping from evidence status, objective
-gates, and findings to PASS / CONDITIONAL / FAIL are authoritative in
-`docs/development/pr-review.md` §8. Read §8 when reaching a verdict; do not
-re-derive the mapping here.
-
-Plan-limit `403` (`required_checks_configuration = unknown`) defaults to
-`Conditional pass — do not merge`; never self-approve a fallback without a
-formally committed capability-limited policy (pr-review.md §8). A `recheck`
-that returns `fail` or detects diff drift invalidates the review.
-
-## Findings and verdicts
-
-Use exactly: Blocking, High, Medium, Low, and Nit. Cite precise files/lines, Task
-clauses, state, or validation evidence. Any unresolved Blocking/High/Medium
-finding prevents pass (pr-review.md §8).
-
-Output exactly one verdict; the verdict conditions and severity-to-verdict
-mapping are authoritative in `docs/development/pr-review.md` §8:
-
-```text
-通过，可以人工合并
+```bash
+python tools/agent_workflow/lck.py review complete <TASK> \
+  --review-id <REVIEW_ID> \
+  --verdict FAIL \
+  --findings-file <FINDINGS_FILE>
 ```
 
-```text
-有条件通过，不得合并
-```
+LCK re-resolves the current target before accepting the verdict. A head/base change
+returns `REVIEW_STALE_HEAD` / `REVIEW_STALE_BASE`; stale Review output is not PASS and
+requires a new fresh Review invocation.
 
-```text
-不通过，需要修复
-```
+## 4. Report
 
-Minimal summary — apply the authoritative verdict mapping from pr-review.md
-§8: PASS is the only mergeable state; CONDITIONAL is never mergeable;
-incomplete evidence or an incomplete evidence matrix cannot produce PASS.
+On PASS, report `通过，可以人工合并` / `READY_FOR_HUMAN_MERGE`, the reviewed live head/base/diff, AC coverage,
+validation/checks, limitations, and that the workflow stopped at the maintainer manual
+Squash Merge boundary.
 
-Head change during review is review invalidation, not a verdict:
-`REVIEW INVALIDATED — HEAD CHANGED` (pr-review.md §8). The Reviewer never
-merges.
+On FAIL, report `不通过，需要修复`, the findings and evidence, the returned
+`STOP_REQUIRED`, and the failed `review_id` that the maintainer may explicitly use for
+Remediation while it remains the latest completed Review. Do not emit an automatic
+Delivery prompt and do not start Remediation.
 
-## Remediation handoff
-
-For `有条件通过，不得合并` or `不通过，需要修复`, keep the human-readable
-Review report body separate from the next-lifecycle input. The report body
-must contain the verdict, mechanical verification, findings, Acceptance
-Criteria coverage, and relevant evidence. It must then end with exactly one
-canonical remediation section; do not emit a standalone handoff before it or
-wrap a second handoff around it.
-
-The canonical final section is `## Remediation handoff` followed by exactly one
-fenced code block. The block is the complete, directly copyable Delivery
-prompt and must begin with the task-delivery instruction itself:
-
-````text
-```text
-请按 task-delivery-runner 修复
-[Task] <当前完整标题> #<Task编号>
-对应 PR #<PR编号> 的独立审查问题，
-并继续处理，直到 PR 再次准备好接受新的独立审查。
-
-Task: #<Task编号>
-PR: #<PR编号>
-Reviewed head SHA: <SHA>
-Verdict: <有条件通过，不得合并 | 不通过，需要修复>
-
-Required remediation:
-- [F1][Blocking|High|Medium] <完整 finding，包含证据与预期行为>
-
-Objective gates:
-- <尚未满足、不可用、矛盾或需要重新验证的 gate>
-- 如无则写：无。
-
-Maintainer decision required:
-- <需要维护者授权的事项>
-- 如无则写：无。
-```
-````
-
-Include only findings that caused the non-passing verdict; the bounded handoff
-semantics are authoritative in `docs/development/pr-review.md` §9. Include
-objective gates that require recheck or waiting, and decisions that cannot be
-resolved without maintainer authorization. Exclude Low and Nit findings unless
-the maintainer explicitly made them required. Preserve finding IDs and write
-each required finding in full exactly once. The block must be self-contained:
-do not refer to material outside it with phrases such as “上述”, “同上”, or
-“见前文”.
-
-A passing verdict does not emit a remediation handoff.
-
-**Enforcement**: Every non-passing verdict emits exactly one final
-`## Remediation handoff` section and exactly one fenced code block. The block
-itself is the single Delivery prompt; duplicate headings, wrapper labels, or
-repeated findings are non-compliant. A passing verdict emits no remediation
-section.
-
-## Report and recovery
-
-On clean success, report canonical Task/PR URLs, reviewed base/head/diff digest,
-changed files/commits, acceptance coverage, findings, validation/checks,
-reviews/threads/mergeability, limitations, actions not performed, one fixed
-verdict, and:
-
-```text
-Reviewed head SHA: <actual SHA>
-```
-
-Every deterministic claim in the final report must be traceable to an evidence
-matrix entry, a Runner artifact field, or a directly cited file:line.
-
-Use a detailed report for any finding, fallback, `partial`/`unknown`, failure,
-drift, conflict, or maintainer decision. For a conditional or failing verdict,
-include the bounded remediation handoff and exact `task-delivery-runner` prompt.
-Remove any temporary worktree by its exact path without destructive broad
-cleanup. Never inherit an earlier verdict.
+Independent Review never modifies implementation, submits a GitHub Review, merges,
+closes the Task, performs Closeout, or assesses Feature completion.

--- a/.agents/skills/task-pr-review-runner/SKILL.md
+++ b/.agents/skills/task-pr-review-runner/SKILL.md
@@ -20,10 +20,21 @@ The Task number is the only mechanical key supplied to LCK. A maintainer may men
 a PR number for human intent, but the Agent MUST NOT pass PR/base/head/checks/snapshot
 facts from Delivery as Review authority.
 
+Before the first LCK command, verify the project launcher:
+
+```bash
+command -v uv
+uv --version
+uv run --frozen python --version
+```
+
+If this preflight fails, report an environment/launcher failure. It is not a
+Review verdict, and must not be converted into `STOP_REQUIRED`.
+
 ## 1. LCK Review Prepare
 
 ```bash
-python tools/agent_workflow/lck.py review prepare <TASK>
+uv run --frozen python tools/agent_workflow/lck.py review prepare <TASK>
 ```
 
 Proceed only on `READY_FOR_SEMANTIC_REVIEW`. Use the returned `review_id`, current
@@ -62,7 +73,7 @@ Task requirements produce FAIL.
 PASS:
 
 ```bash
-python tools/agent_workflow/lck.py review complete <TASK> \
+uv run --frozen python tools/agent_workflow/lck.py review complete <TASK> \
   --review-id <REVIEW_ID> \
   --verdict PASS
 ```
@@ -71,7 +82,7 @@ FAIL: write the complete blocking findings to an ignored or temporary file outsi
 read-only implementation worktree, then:
 
 ```bash
-python tools/agent_workflow/lck.py review complete <TASK> \
+uv run --frozen python tools/agent_workflow/lck.py review complete <TASK> \
   --review-id <REVIEW_ID> \
   --verdict FAIL \
   --findings-file <FINDINGS_FILE>

--- a/.claude/skills/task-delivery-runner/SKILL.md
+++ b/.claude/skills/task-delivery-runner/SKILL.md
@@ -35,6 +35,17 @@ record are not write authorization.
 
 The Issue number is the primary key; the current Issue title is canonical.
 
+Before the first LCK command, verify the project launcher:
+
+```bash
+command -v uv
+uv --version
+uv run --frozen python --version
+```
+
+If this preflight fails, report an environment/launcher failure. It is not a
+Delivery or Review verdict, and must not be converted into `STOP_REQUIRED`.
+
 ## Policies and shared semantics
 
 Read applicable `AGENTS.md` and
@@ -89,7 +100,7 @@ maintainer or implementation action.
 The first lifecycle action is:
 
 ```bash
-python tools/agent_workflow/lck.py delivery prepare <TASK>
+uv run --frozen python tools/agent_workflow/lck.py delivery prepare <TASK>
 ```
 
 Proceed only when LCK returns a resolved Delivery context. LCK reacquires live
@@ -123,7 +134,7 @@ workspace presented to LCK is the candidate Task tree.
 After semantic implementation is complete, invoke LCK with semantic metadata:
 
 ```bash
-python tools/agent_workflow/lck.py delivery complete <TASK> \
+uv run --frozen python tools/agent_workflow/lck.py delivery complete <TASK> \
   --commit-message "<scoped commit message>" \
   --summary "<implementation summary>" \
   --risks "<risks or limitations>"
@@ -192,7 +203,7 @@ all actionable mechanical identity from current live Git / GitHub state.
 ### 1. LCK Remediation Prepare
 
 ```bash
-python tools/agent_workflow/lck.py remediation prepare <TASK> \
+uv run --frozen python tools/agent_workflow/lck.py remediation prepare <TASK> \
   --review-id <FAILED_REVIEW_ID>
 ```
 
@@ -221,7 +232,7 @@ new Review.
 After the repair is ready:
 
 ```bash
-python tools/agent_workflow/lck.py remediation complete <TASK> \
+uv run --frozen python tools/agent_workflow/lck.py remediation complete <TASK> \
   --review-id <FAILED_REVIEW_ID> \
   --commit-message "<scoped repair commit message>" \
   --summary "<repair summary>" \

--- a/.claude/skills/task-delivery-runner/SKILL.md
+++ b/.claude/skills/task-delivery-runner/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: task-delivery-runner
-description: Deliver one maintainer-specified existing GitHub Task through LCK initial Delivery, or repair an existing Task PR from an independent review handoff. Initial Delivery uses LCK for workspace preparation, Critical Outcome, formal validation, commit, push, PR resolution/creation, checks, and Project Status. Independent review, merge, closeout, and Feature completion remain outside this Skill.
+description: Deliver one maintainer-specified existing GitHub Task through LCK, including explicitly requested remediation after a failed Independent Review. LCK owns workspace preparation, live identity, Critical Outcome, formal validation, commit, push, PR reuse/create as phase-appropriate, checks, and lifecycle boundaries. Review, merge, closeout, and Feature completion remain separate.
 ---
 
 # Task delivery runner
@@ -11,8 +11,8 @@ Initial Delivery is controlled by **LCK**. Codex / Claude owns semantic work;
 LCK owns deterministic lifecycle mechanics. A successful initial Delivery ends
 at `READY_FOR_REVIEW` and a Human boundary. It never starts Independent Review.
 
-Review remediation remains the separate procedure at the end of this Skill
-until its LCK cutover is implemented by the Review / Remediation migration Task.
+Review remediation is also LCK-controlled after cutover, but starts only from an
+explicit Human request that identifies a failed LCK `review_id`.
 
 ## Standard invocation
 
@@ -22,18 +22,16 @@ until its LCK cutover is implemented by the Review / Remediation migration Task.
 直到 PR 准备好接受独立审查。
 ```
 
-For remediation after an independent review:
+For remediation after an Independent Review FAIL:
 
 ```text
-请按 task-delivery-runner 修复
-[Task] <当前完整标题> #<Task编号>
-对应 PR #<PR编号> 的独立审查问题，
-并继续处理，直到 PR 再次准备好接受新的独立审查。
-
-Review remediation handoff:
-
-<粘贴 task-pr-review-runner 输出的 remediation handoff>
+请按 task-delivery-runner 对 Task #<Task编号> 显式执行 remediation。
+Failed Review ID: <REVIEW_ID>
 ```
+
+The failed `review_id` locates semantic findings only. LCK independently reacquires
+the current Task / PR / base / head / branch state; mechanical facts from the Review
+record are not write authorization.
 
 The Issue number is the primary key; the current Issue title is canonical.
 
@@ -182,48 +180,70 @@ branch deletion, and Feature completion were not performed.
 
 ## Review remediation
 
-This section applies only after a non-passing `task-pr-review-runner` handoff.
-Its lifecycle-control migration is intentionally outside the initial Delivery
-cutover.
+This section applies only after the latest completed LCK Independent Review returned
+`FAIL` / `STOP_REQUIRED` and the maintainer explicitly requests repair. A successful
+remediation forces a fresh Review before any later remediation can start.
 
-The remediation handoff must identify Task and PR, reviewed head SHA, verdict,
-required Blocking/High/Medium findings, objective gates, and maintainer
-questions if any. `review-remediation` requires the bounded handoff. Missing or contradictory handoff identity is a semantic admission failure: stop before Runner or repair writes.
-Do not use the generic snapshot fallback to manufacture remediation authority.
+The Agent / Skill MUST NOT accept a bounded mechanical handoff, expected SHA, base SHA,
+PR number, checks snapshot, validation snapshot, or old Evidence Runner snapshot as
+Remediation authority. The failed Review record supplies semantic findings; LCK resolves
+all actionable mechanical identity from current live Git / GitHub state.
 
-Run the current deterministic remediation Preflight before editing:
+### 1. LCK Remediation Prepare
 
 ```bash
-tools/agent_workflow/wsl2_github_evidence_runner.py delivery \
-  --entry-point review-remediation \
-  --task <TASK> \
-  --expected-main-sha <CURRENT_MAIN_SHA> \
-  --pr <PR> \
-  --expected-base-sha <REVIEWED_BASE_SHA> \
-  --expected-head-sha <REVIEWED_HEAD_SHA>
+python tools/agent_workflow/lck.py remediation prepare <TASK> \
+  --review-id <FAILED_REVIEW_ID>
 ```
 
-Proceed only on a valid passing result. `partial`, `unknown`, lifecycle
-conflict, identity conflict, or other valid non-pass is terminal; do not repair
-it automatically.
+Proceed only on `READY_FOR_REMEDIATION`. LCK verifies that the record is a failed
+Independent Review, reads its findings as semantic input, reacquires the current OPEN
+non-Draft PR/head/base and Task branch, and selects/restores the current implementation
+workspace.
 
-Classify every handoff item before editing: confirmed in-scope implementation,
-test, documentation, or configuration finding → repair; scope/AC/public
-behavior/architecture change → Human Gate; Low/Nit → leave unchanged unless
-explicitly requested.
+Do not pass expected head/base/PR identity. If current live identity is ambiguous,
+diverged, missing, or unsafe, STOP; do not use the pre-cutover `review-remediation`
+Evidence Runner as a fallback.
 
-Implement the smallest complete repair and add regression coverage. Existing
-remediation mechanics continue to use the current Evidence / Validation Runner
-contract for this phase: create scoped repair commits, run `workflow-delivery`
-against the clean committed head, push only the validated head, reuse the
-existing Task PR, wait for checks, and regenerate `delivery-readiness`.
+### 2. Semantic repair
 
-The previous Review verdict applies only to its reviewed head. Any new commit
-requires a fresh independent review. Remediation never submits a GitHub Review,
-merges, closes the Task, performs closeout, or starts the new Review itself.
+Read the returned findings, confirm them against the current implementation, implement
+the smallest complete repair, and add regression coverage. If a finding requires a true
+scope/architecture/product decision, stop at Human Gate rather than silently expanding
+the Task.
 
-Report the handoff items addressed, new head, validation/check result, remaining
-limitations, and the exact fresh-session review prompt.
+The Agent may edit and run targeted development validation. It MUST NOT directly stage
+the final tree, commit, push, create/replace the PR, mutate lifecycle state, or start a
+new Review.
+
+### 3. LCK Remediation Complete
+
+After the repair is ready:
+
+```bash
+python tools/agent_workflow/lck.py remediation complete <TASK> \
+  --review-id <FAILED_REVIEW_ID> \
+  --commit-message "<scoped repair commit message>" \
+  --summary "<repair summary>" \
+  --risks "<risks or limitations>"
+```
+
+LCK reuses the Task-2 Delivery effects for Critical Outcome, formal validation, exact
+validated-tree commit, remote synchronization, checks, and final local/remote/PR head
+verification. Unlike Initial Delivery, Remediation must reuse existing OPEN PR state; it never
+creates a replacement PR.
+
+A successful result is:
+
+```text
+READY_FOR_NEW_REVIEW
+→ STOP
+```
+
+The new head invalidates the earlier semantic Review result. Remediation MUST NOT start
+Independent Review automatically. Report the repaired findings, new head,
+validation/check results, limitations, and tell the maintainer to start a new fresh
+`task-pr-review-runner` invocation.
 
 ## Failure discipline
 

--- a/.claude/skills/task-pr-review-runner/SKILL.md
+++ b/.claude/skills/task-pr-review-runner/SKILL.md
@@ -20,10 +20,21 @@ The Task number is the only mechanical key supplied to LCK. A maintainer may men
 a PR number for human intent, but the Agent MUST NOT pass PR/base/head/checks/snapshot
 facts from Delivery as Review authority.
 
+Before the first LCK command, verify the project launcher:
+
+```bash
+command -v uv
+uv --version
+uv run --frozen python --version
+```
+
+If this preflight fails, report an environment/launcher failure. It is not a
+Review verdict, and must not be converted into `STOP_REQUIRED`.
+
 ## 1. LCK Review Prepare
 
 ```bash
-python tools/agent_workflow/lck.py review prepare <TASK>
+uv run --frozen python tools/agent_workflow/lck.py review prepare <TASK>
 ```
 
 Proceed only on `READY_FOR_SEMANTIC_REVIEW`. Use the returned `review_id`, current
@@ -62,7 +73,7 @@ Task requirements produce FAIL.
 PASS:
 
 ```bash
-python tools/agent_workflow/lck.py review complete <TASK> \
+uv run --frozen python tools/agent_workflow/lck.py review complete <TASK> \
   --review-id <REVIEW_ID> \
   --verdict PASS
 ```
@@ -71,7 +82,7 @@ FAIL: write the complete blocking findings to an ignored or temporary file outsi
 read-only implementation worktree, then:
 
 ```bash
-python tools/agent_workflow/lck.py review complete <TASK> \
+uv run --frozen python tools/agent_workflow/lck.py review complete <TASK> \
   --review-id <REVIEW_ID> \
   --verdict FAIL \
   --findings-file <FINDINGS_FILE>

--- a/.claude/skills/task-pr-review-runner/SKILL.md
+++ b/.claude/skills/task-pr-review-runner/SKILL.md
@@ -1,435 +1,96 @@
 ---
 name: task-pr-review-runner
-description: Independently and strictly read-only review one maintainer-specified Task PR in a fresh session. Lock base/head/effective diff, inspect the complete change, run Review Runners, classify findings, output one fixed verdict, and when the verdict is not passing emit a bounded remediation handoff for task-delivery-runner. Never fix, write GitHub state, submit a review, merge, close Issues, perform closeout, or assess Feature completion.
+description: Independently review the current live Task PR in a fresh, implementation-read-only LCK context. LCK resolves the PR/base/head/effective diff/Task Contract/validation from live state and guards verdict applicability. The Review Agent only Inspect/Reason/Judge/Report; it never fixes, writes GitHub state, merges, closes Issues, or starts remediation.
 ---
 
 # Task PR review runner
 
-Use this Skill for one existing Task PR in a new session that did not
-participate in specification interpretation, implementation, fixes, commit,
-push, or PR creation. Otherwise stop with:
+Use this Skill only in a fresh session that did not implement or remediate the head
+being reviewed. Shared semantics are owned by `docs/development/pr-review.md` and
+lifecycle placement by `docs/development/issue-workflow.md`.
+Read applicable `AGENTS.md` and `.agents/policies/command-execution.md`; Review has no direct Git/GitHub write authority.
+
+## Invocation
 
 ```text
-本会话不能提供独立审查
+请使用 task-pr-review-runner，独立只读审查 Task #<TASK> 的当前 OPEN PR。
 ```
 
-A Delivery handoff locates the object but is not correctness evidence
-(no-verdict-inheritance, `docs/development/pr-review.md` §1).
+The Task number is the only mechanical key supplied to LCK. A maintainer may mention
+a PR number for human intent, but the Agent MUST NOT pass PR/base/head/checks/snapshot
+facts from Delivery as Review authority.
 
-## Standard invocation
-
-```text
-请使用 task-pr-review-runner，独立只读审查
-[Task] <当前完整标题> #<Task编号>
-对应的 PR #<PR编号>。
-
-Expected base SHA: <base SHA>
-Expected head SHA: <head SHA>
-```
-
-Task and PR numbers are primary keys; the current Issue title is canonical.
-A request may limit execution to one named Phase. Verify prior Phase facts using
-the Evidence Runner snapshot that Phase would have produced (`review` for
-identity/lock, `recheck` for stability) — do not substitute direct `gh` or
-`git` queries for Runner snapshots — and stop at the requested boundary.
-
-## Policies and Runner interface
-
-Read applicable `AGENTS.md` and:
-
-```text
-.agents/policies/workflow-evidence.md
-```
-
-Shared review semantics (fresh session, head lock, independent judgement,
-verdict semantics, remediation handoff) are owned by
-`docs/development/pr-review.md`. Read the minimal needed section for the
-current phase; do not duplicate review-semantic prose in this Skill.
-
-Use the current repository Runner interfaces in this order:
+## 1. LCK Review Prepare
 
 ```bash
-tools/agent_workflow/wsl2_github_evidence_runner.py review \
-  --task <TASK> \
-  --pr <PR> \
-  --expected-base-sha <LOCKED_BASE_SHA> \
-  --expected-head-sha <LOCKED_HEAD_SHA> \
-  --skill-path .claude/skills/task-pr-review-runner/SKILL.md
-
-tools/agent_workflow/wsl2_validation_runner.py workflow-review \
-  --base-sha <LOCKED_BASE_SHA> \
-  --skill-path .claude/skills/task-pr-review-runner/SKILL.md
-
-tools/agent_workflow/wsl2_github_evidence_runner.py \
-  recheck --snapshot-id <LOCKED_SNAPSHOT_ID> \
-  --skill-path .claude/skills/task-pr-review-runner/SKILL.md
+python tools/agent_workflow/lck.py review prepare <TASK>
 ```
 
-The `--skill-path` argument records the actual calling Skill identity in every
-artifact. Claude Code callers pass `.claude/skills/task-pr-review-runner/SKILL.md`;
-Codex callers pass `.agents/skills/task-pr-review-runner/SKILL.md`. The Runner
-re-hashes content independently and **fails closed** when the path is not within
-an allowed Skill root (`.agents/skills/` or `.claude/skills/`).
+Proceed only on `READY_FOR_SEMANTIC_REVIEW`. Use the returned `review_id`, current
+Task Contract, current review target, validation/check state, and `review_root`.
+The `review_root` is a detached, clean, implementation-read-only worktree for the
+live-resolved head.
 
-The initial snapshot defines the reviewed identity. `workflow-review` is the
-independent CI-equivalent validation for the locked head. `recheck` verifies
-stability before verdict.
+If LCK returns STOP or stale, do not fall back to Evidence Runner snapshots, expected
+SHAs, direct `gh` selection, or a Delivery handoff.
 
-For `partial`, `unknown`, `fail`, truncation, schema mismatch, or drift, inspect
-only the named facts or failed commands. Semantic review may read any code or
-context needed to judge correctness.
+## 2. Semantic Review
 
-Record the actual Review Skill, Runner, profile/schema, repository, reviewed
-base/head/diff, and content hashes in the evidence artifacts. When the PR
-changes Skills, Runners, Rules, or workflow governance, review those changes,
-their tests, permissions, and failure behavior explicitly; Runner success alone
-is not proof of correctness.
-
-## Execution model
-
-Claude Code executes commands directly in the user's shell environment — there
-is no sandbox isolation layer. Git, `gh`, Python, subprocess, network, and
-filesystem access all work natively. The Codex Guardian sandbox/elevated routing
-model does not apply.
-
-Runner commands are deterministic Python CLI tools invoked from the repository
-root on the WSL2 Linux filesystem. They are never wrapped in `python`,
-`bash -c`, `sh -c`, `uv run`, command substitution, pipelines, redirection, or
-a generic shell string. Each Runner call is a single Bash tool invocation.
-
-The Bash tool itself may prompt for user approval on first use. To suppress
-these prompts for the documented Runner invocations, pre-authorize in
-`.claude/settings.json`:
-
-```json
-{
-  "permissions": {
-    "allow": [
-      "Bash(tools/agent_workflow/wsl2_github_evidence_runner.py *)",
-      "Bash(tools/agent_workflow/wsl2_validation_runner.py *)"
-    ]
-  }
-}
-```
-
-Runner commands can fail, but not because of sandbox restrictions. Read the
-Runner's own output to classify:
-
-- `pass`: all commands succeeded, inspect the compact digest.
-- `fail`: one or more commands returned non-zero. Read the named failure
-  artifact before deciding how to proceed.
-- `blocked`: a Runner precondition failed (e.g. unclean worktree, wrong branch,
-  wrong cwd, identity mismatch). Fix the precondition; do not retry with
-  different arguments.
-- `partial` / `unknown`: bounded diagnostics in the artifact — inspect only the
-  named gates.
-
-Never fall back to an equivalent direct command chain after a Runner result.
-Never retry a Runner command with modified arguments to work around a failure.
-
-## Tool discipline
-
-This Skill runs in an agent session with a specific set of available tools.
-Before every tool invocation the Reviewer must verify:
-
-1. **File existence**: Confirm the target file exists in the changed-file
-   inventory or via a lightweight existence check before reading. A deleted
-   file is an observation, not an error to surface as a tool failure.
-
-2. **Tool availability**: Only use tools the current session environment
-   actually provides. Do not invoke `Grep` for structured searches — use
-   `grep` via Bash or the Read tool. Do not try a tool, observe failure, and
-   then fall back to an alternative; choose the correct tool first.
-
-3. **Runner result independence**: A Runner non-zero exit code does not mean
-   failure — verify whether the Runner produced a valid artifact with a
-   `partial` / `unknown` / `fail` status before rejecting it. Conversely,
-   a valid artifact with `partial` status is not `pass`.
-
-4. **Search completeness**: A keyword grep or `diff --stat` does not satisfy
-   the semantic review gate. The Reviewer must read the actual changed-file
-   content per the evidence matrix requirements in Phase 3.
-
-## Permission boundary
-
-Review is strictly read-only for code, Git history, GitHub, Project, reviews,
-threads, labels, Relationships, and lifecycle state. It may fetch refs, use one
-isolated worktree for the locked reviewed head, run validation, and write exact
-ignored local evidence artifacts.
-
-It does not authorize file fixes, Issue/PR/Project edits, GitHub Review
-submission, thread resolution, commits, pushes, merge, Issue close, branch
-deletion, closeout, or Feature completion assessment.
-
-## Phase 1: identify and lock
-
-Generate `review`. Verify same-repository Task/PR, Task type/state, exact closing
-linkage, PR open and non-Draft, expected base/head, complete files/commits,
-checks, reviews, threads, mergeability, and Required-Checks classification.
-
-Lock and report:
+Inside the read-only review context, do exactly:
 
 ```text
-Reviewed base SHA
-Reviewed head SHA
-Merge base / effective-diff baseline
-Effective diff digest
-Complete file and commit inventory
-Snapshot ID
+Inspect
+Reason
+Judge
+Report
 ```
 
-Stop on material repository, Task, linkage, state, base, or head mismatch.
+Read the complete effective diff and necessary related code. Build an independent AC
+coverage/evidence matrix. The current Task Contract, effective diff, and necessary related
+code are the default semantic context. Comments, Parent/Epic bodies, and other hierarchy
+or history are not default Review input; expand only when the current Task explicitly
+references them or a concrete ambiguity/dependency requires it. Check correctness, failure
+behavior, tests, docs/config/public interfaces, and workflow/security boundaries when
+applicable. Delivery conclusions, old Review verdicts, and old remediation rationale are
+not evidence.
 
-## Phase 2: read complete evidence
+Findings use Blocking, High, Medium, Low, Nit. Blocking/High/Medium defects or unmet
+Task requirements produce FAIL.
 
-Independently read the current Task body, PR body and effective diff, every
-changed file in context, commits, tests/docs/config/public interfaces,
-relevant unchanged code, current reviews/threads/checks, and
-review-relevant repository constraints.
+## 3. Complete the same Review invocation
 
-Do not inherit Delivery conclusions or accept comments, test names, or green
-checks without inspecting coverage.
+PASS:
 
-Comments, Parent/Epic bodies, and other hierarchy/history are not default
-review input. Expand to them only when the review scope, risk, or ambiguity
-requires it — for example an acceptance criterion references a historical
-decision, the Task body is insufficient to judge a change, or a conflict
-must be located. Expansion is bounded: read the minimum relevant source or
-section and stop once the question is resolved.
-
-## Phase 3: semantic review with evidence matrix
-
-### Evidence matrix
-
-Before evaluating findings, build a structured evidence matrix binding the
-current Task, PR, base SHA, head SHA, and effective diff. This matrix is the
-single source of truth for all deterministic claims in the final report.
-
-The matrix lives alongside the Runner artifacts in the same ignored local
-evidence root. Its digest is recorded in the review report.
-
-```json
-{
-  "task": "<TASK>",
-  "pr": "<PR>",
-  "base_sha": "<LOCKED_BASE_SHA>",
-  "head_sha": "<LOCKED_HEAD_SHA>",
-  "effective_diff_sha256": "<DIFF_DIGEST>",
-  "review_skill": {
-    "path": ".claude/skills/task-pr-review-runner/SKILL.md",
-    "sha256": "<CONTENT_HASH>"
-  },
-  "changed_file_groups": [
-    {
-      "name": "<group-name>",
-      "files": ["<repo-relative-path>"],
-      "status": "verified | partially_verified | not_verified",
-      "evidence": ["<deterministic-tool-reference>"],
-      "findings": ["<finding-id-reference>"],
-      "remaining_risk": "<explanation when not verified>"
-    }
-  ],
-  "acceptance_criteria": [
-    {
-      "id": "AC-<n>",
-      "text": "<criterion text>",
-      "status": "verified | partially_verified | not_verified",
-      "implementation_evidence": ["<file:line or tool reference>"],
-      "validation_evidence": ["<test or Runner reference>"],
-      "remaining_risk": "<explanation when not verified>"
-    }
-  ],
-  "evidence_gates": {
-    "review": "pass | partial | unknown | fail",
-    "validation": "pass | fail",
-    "recheck": "pass | partial | unknown | fail"
-  },
-  "overall": "verified | partial | not_verified"
-}
+```bash
+python tools/agent_workflow/lck.py review complete <TASK> \
+  --review-id <REVIEW_ID> \
+  --verdict PASS
 ```
 
-### File coverage rules
+FAIL: write the complete blocking findings to an ignored or temporary file outside the
+read-only implementation worktree, then:
 
-- Every changed file in the `review` snapshot must be assigned to exactly one
-  group.
-- Groups are derived from the actual diff, not guessed. Examples:
-  `runner-implementation`, `profiles-and-schema`, `rules-and-permissions`,
-  `codex-skills`, `claude-skills`, `workflow-policies`, `pr-tooling`,
-  `tests`, `documentation`, `provenance-or-migration`.
-- If any file is not covered by at least one group, overall must not be
-  `verified`.
-- Each group must have at least one deterministic evidence reference (file
-  content read, tool output, test result, Runner artifact).
-- Read necessary unchanged related code to verify interface, caller, and
-  failure-path consistency. Record those reads in the evidence references.
-
-### Acceptance criteria mapping
-
-- Extract every acceptance criterion from the Task body.
-- Assign a stable ID (`AC-1`, `AC-2`, …) in the order they appear.
-- Each criterion gets an independent status, evidence, and risk assessment.
-- Multiple criteria may reference the same evidence but must not be compressed
-  into a single "all satisfied" summary.
-- Validation Runner `pass` proves command success, not semantic coverage.
-  Criterion-level status must reflect whether the implementation, tests, and
-  failure behavior genuinely satisfy the criterion.
-
-### Mechanical assertions — deterministic standard
-
-The following claims may only be marked as verified when the named
-deterministic evidence exists:
-
-| Claim | Required evidence |
-| --- | --- |
-| Historical Skill matches source commit blob | Git `cat-file -p <commit>:<path>` output compared byte-for-byte with current file |
-| All target Skills are canonical-state | All applicable Skill files individually verified with path-audit or equivalent tool |
-| Trusted-version / deprecated path completely removed | Full-text search of the entire repository worktree (not just grep of a few files) |
-| Runner / profile / schema / Rules contract consistent | Runner's spec-validation step passed AND manual verification of each contract pair |
-| Provenance manifest matches actual Git content | Byte-for-byte verification or deterministic manifest tool with matching hash |
-| Permission configuration has no overly-broad authorization | Read and verify every permission entry in `.claude/settings.json` and `.codex/rules/` |
-
-A file-existence check, partial grep, or inspection of only a subset of Skills
-must not be enlarged into a comprehensive claim. When the deterministic
-evidence is unavailable, mark the assertion `partially_verified` or
-`not_verified` — do not guess.
-
-## Phase 4: validation
-
-Run `workflow-review`. Do not reuse Delivery validation. A real validation
-failure, an incomplete applicable check, stale evidence, or unavailable required
-evidence prevents an unconditional pass.
-
-A recognized plan-limit `403` is not a successful Required-Checks query.
-Approved fallback check evidence may support a passing verdict only when it is
-complete, consistent, and non-contradictory.
-
-## Phase 5: stability recheck
-
-Run `recheck` against the initial snapshot. Recollect identity, base/head,
-effective diff, files/commits, checks, reviews, and threads. Any new commit or
-base/head/effective-diff change invalidates the review and requires a new
-independent session. Evaluate check/thread-only changes under current gates.
-
-Verify the recheck uses the same Skill identity as the initial review (same
-`--skill-path`). Skill identity drift invalidates the review.
-
-## Evidence status and verdict mapping
-
-The Evidence Runner produces a **process** exit code (0, 3, 4) and a **status**
-field in the output (`pass`, `partial`, `fail`). Process success (exit code 0)
-is not gate pass: read the `status` field and map it deterministically.
-
-Verdict conditions and the full mapping from evidence status, objective
-gates, and findings to PASS / CONDITIONAL / FAIL are authoritative in
-`docs/development/pr-review.md` §8. Read §8 when reaching a verdict; do not
-re-derive the mapping here.
-
-Plan-limit `403` (`required_checks_configuration = unknown`) defaults to
-`Conditional pass — do not merge`; never self-approve a fallback without a
-formally committed capability-limited policy (pr-review.md §8). A `recheck`
-that returns `fail` or detects diff drift invalidates the review; a `recheck`
-`partial` keeps the evidence ceiling at Conditional.
-
-## Findings and verdicts
-
-Use exactly: Blocking, High, Medium, Low, and Nit. Cite precise files/lines, Task
-clauses, state, or validation evidence. Any unresolved Blocking/High/Medium
-finding prevents pass (pr-review.md §8).
-
-Output exactly one verdict; the verdict conditions and severity-to-verdict
-mapping are authoritative in `docs/development/pr-review.md` §8:
-
-```text
-通过，可以人工合并
+```bash
+python tools/agent_workflow/lck.py review complete <TASK> \
+  --review-id <REVIEW_ID> \
+  --verdict FAIL \
+  --findings-file <FINDINGS_FILE>
 ```
 
-```text
-有条件通过，不得合并
-```
+LCK re-resolves the current target before accepting the verdict. A head/base change
+returns `REVIEW_STALE_HEAD` / `REVIEW_STALE_BASE`; stale Review output is not PASS and
+requires a new fresh Review invocation.
 
-```text
-不通过，需要修复
-```
+## 4. Report
 
-Minimal summary — apply the authoritative verdict mapping from pr-review.md
-§8: PASS is the only mergeable state; CONDITIONAL is never mergeable;
-incomplete evidence or an incomplete evidence matrix cannot produce PASS.
+On PASS, report `通过，可以人工合并` / `READY_FOR_HUMAN_MERGE`, the reviewed live head/base/diff, AC coverage,
+validation/checks, limitations, and that the workflow stopped at the maintainer manual
+Squash Merge boundary.
 
-Head change during review is review invalidation, not a verdict:
-`REVIEW INVALIDATED — HEAD CHANGED` (pr-review.md §8). The Reviewer never
-merges.
+On FAIL, report `不通过，需要修复`, the findings and evidence, the returned
+`STOP_REQUIRED`, and the failed `review_id` that the maintainer may explicitly use for
+Remediation while it remains the latest completed Review. Do not emit an automatic
+Delivery prompt and do not start Remediation.
 
-## Remediation handoff
-
-For `有条件通过，不得合并` or `不通过，需要修复`, keep the human-readable
-Review report body separate from the next-lifecycle input. The report body
-must contain the verdict, mechanical verification, findings, Acceptance
-Criteria coverage, and relevant evidence. It must then end with exactly one
-canonical remediation section; do not emit a standalone handoff before it or
-wrap a second handoff around it.
-
-The canonical final section is `## Remediation handoff` followed by exactly one
-fenced code block. The block is the complete, directly copyable Delivery
-prompt and must begin with the task-delivery instruction itself:
-
-````text
-```text
-请按 task-delivery-runner 修复
-[Task] <当前完整标题> #<Task编号>
-对应 PR #<PR编号> 的独立审查问题，
-并继续处理，直到 PR 再次准备好接受新的独立审查。
-
-Task: #<Task编号>
-PR: #<PR编号>
-Reviewed head SHA: <SHA>
-Verdict: <有条件通过，不得合并 | 不通过，需要修复>
-
-Required remediation:
-- [F1][Blocking|High|Medium] <完整 finding，包含证据与预期行为>
-
-Objective gates:
-- <尚未满足、不可用、矛盾或需要重新验证的 gate>
-- 如无则写：无。
-
-Maintainer decision required:
-- <需要维护者授权的事项>
-- 如无则写：无。
-```
-````
-
-Include only findings that caused the non-passing verdict; the bounded handoff
-semantics are authoritative in `docs/development/pr-review.md` §9. Include
-objective gates that require recheck or waiting, and decisions that cannot be
-resolved without maintainer authorization. Exclude Low and Nit findings unless
-the maintainer explicitly made them required. Preserve finding IDs and write
-each required finding in full exactly once. The block must be self-contained:
-do not refer to material outside it with phrases such as “上述”, “同上”, or
-“见前文”.
-
-A passing verdict does not emit a remediation handoff.
-
-**Enforcement**: Every non-passing verdict emits exactly one final
-`## Remediation handoff` section and exactly one fenced code block. The block
-itself is the single Delivery prompt; duplicate headings, wrapper labels, or
-repeated findings are non-compliant. A passing verdict emits no remediation
-section.
-
-## Report and recovery
-
-On clean success, report canonical Task/PR URLs, reviewed base/head/diff digest,
-changed files/commits, acceptance coverage, findings, validation/checks,
-reviews/threads/mergeability, limitations, actions not performed, one fixed
-verdict, and:
-
-```text
-Reviewed head SHA: <actual SHA>
-```
-
-Every deterministic claim in the final report must be traceable to an evidence
-matrix entry, a Runner artifact field, or a directly cited file:line.
-
-Use a detailed report for any finding, fallback, `partial`/`unknown`, failure,
-drift, conflict, or maintainer decision. For a conditional or failing verdict,
-include the bounded remediation handoff and exact `task-delivery-runner` prompt.
-Remove any temporary worktree by its exact path without destructive broad
-cleanup. Never inherit an earlier verdict.
+Independent Review never modifies implementation, submits a GitHub Review, merges,
+closes the Task, performs Closeout, or assesses Feature completion.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,7 +158,7 @@ Tasks. No workflow Skill may merge a Pull Request.
 
 Maintainers can start a workflow with Agent-neutral natural language:
 
-- `实现 Issue #N` → Delivery (readiness, implementation, PR, review handoff)
+- `实现 Issue #N` → Delivery (readiness, implementation, PR, Human review boundary)
 - `审查 PR #N` → Independent Review (fresh session, read-only)
 - `PR #N 已人工合并，请完成 closeout` → Closeout (merge identity, convergence)
 - Feature completion audit request → `feature-completion-audit` (hierarchy-aware)
@@ -181,9 +181,10 @@ clearly identify different work.
 Independent PR Review runs in a fresh session that did not participate in
 implementation or remediation of the reviewed head. It is strictly read-only,
 does not submit a GitHub Review, does not fix findings, and never merges. A
-non-passing Review emits a bounded remediation handoff for the Delivery Skill;
-any new commit requires a fresh independent Review session. Detailed shared
-semantics: `docs/development/pr-review.md`.
+failing Review returns `STOP_REQUIRED`; remediation starts only after explicit
+Human intent and LCK reacquires the current mechanical target. Any new commit
+requires a fresh independent Review session. Detailed shared semantics:
+`docs/development/pr-review.md`.
 
 A final merge decision requires a passing Review for the current PR head,
 followed by maintainer manual merge.

--- a/docs/development/issue-workflow.md
+++ b/docs/development/issue-workflow.md
@@ -161,11 +161,12 @@ override remains supported.
 
 shared semantics 由 `docs/development/pr-review.md` 权威定义：
 fresh session、strict read-only、head lock、independent judgement、
-no Delivery verdict inheritance、verdict semantics、remediation handoff、
-new head → fresh re-review。
+no Delivery mechanical authority inheritance、LCK live target resolution、
+invocation-local stale guard、PASS / FAIL、new head → fresh re-review。
 
 本文件只声明其在 lifecycle 中的位置：Review 在 CI checks 通过后、
-maintainer merge 前执行；review 未通过时进入 remediation（§10）。
+maintainer merge 前执行；Review FAIL 必须先 STOP，只有 Human 显式发起后
+才进入 remediation（§10）。
 
 ## 9. Human Gate
 
@@ -184,9 +185,14 @@ Issue comments（Retrieval v2 comments default-off 仍适用）。
 
 ## 10. Remediation after failed Review
 
-- Review 非 passing 时输出 bounded remediation handoff（仅包含修复所需
-  的最小信息）。
-- Delivery Skill 按 handoff 修复，产生 new head。
+- Review FAIL → LCK 返回 `STOP_REQUIRED`，不得自动启动修复。
+- Human 显式提供当前 Task 最新 completed FAIL 的 `review_id` 启动 remediation；
+  Review record 中只有 findings 可作为 semantic input，current PR/head/base 必须由
+  LCK live reacquire。
+- Implementation Agent 修复后由 LCK 完成 validation / commit / push / existing
+  PR reuse，产生 new head，并在 `READY_FOR_NEW_REVIEW` 再次 STOP。
+- successful remediation 设置 `fresh-review-required` negative boundary；在新的 Review
+  verdict 被接受前不得再次 remediation。该 boundary 不携带 target authorization。
 - 任何新 commit 都需要 **fresh independent re-review**；不得复用旧 verdict。
 
 ## 11. Manual Squash Merge boundary
@@ -202,8 +208,9 @@ Issue comments（Retrieval v2 comments default-off 仍适用）。
 | Specification ambiguity | 按 expansion trigger 顺序展开 → 仍不 resolve → **Human Gate**，绝不猜测 |
 | Conflict（body / parent / ADR / 实现） | **fail closed**；无法安全定位 → Human Gate |
 | Missing dependency | native relationship / 最小相关源 → unresolved → Human Gate |
-| Review failure | bounded remediation handoff → new head → fresh re-review |
-| Head changed during Review | **invalidate review**，重新锁定后重审 |
+| Review failure | `STOP_REQUIRED` → Human explicit remediation → new head → fresh re-review |
+| Head changed during Review | `REVIEW_STALE_HEAD`，本次 verdict 无效并重新 Review |
+| Relevant base changed during Review | `REVIEW_STALE_BASE`，本次 verdict 无效并重新 Review |
 | Merge head ≠ reviewed head | **block closeout**，人工介入 |
 | NL entry 无法解析 | explicit Skill-name fallback / Human Gate |
 

--- a/docs/development/pr-review.md
+++ b/docs/development/pr-review.md
@@ -22,12 +22,25 @@ Report
 
 Review 不修复实现、不提交 GitHub Review、不改 Issue / PR / Project、不 merge。
 
-## 2. LCK live target resolution
+## 2. LCK launcher preflight
+
+在第一次调用 LCK 前，先确认项目解释器入口可用：
+
+```bash
+command -v uv
+uv --version
+uv run --frozen python --version
+```
+
+该检查失败属于 environment/launcher failure，不是 Review verdict，也不得转换为
+`STOP_REQUIRED`。裸 `python` 不是本仓库的环境依赖；不要通过全局 alias 或软链接规避。
+
+## 3. LCK live target resolution
 
 Review 必须从以下入口开始：
 
 ```bash
-python tools/agent_workflow/lck.py review prepare <TASK>
+uv run --frozen python tools/agent_workflow/lck.py review prepare <TASK>
 ```
 
 调用方只提供 Task number。不得向 Review LCK 传入 Delivery 提供的 base SHA、head
@@ -46,7 +59,7 @@ LCK 在本次 invocation 开始时从 live Git / GitHub 重新解析：
 checks 和 isolated `review_root`。这些机械事实来自本次 LCK live acquisition，
 不是 Delivery handoff。
 
-## 3. Fresh semantic context and read-only workspace
+## 4. Fresh semantic context and read-only workspace
 
 LCK 创建 reviewed head 的 detached isolated worktree，先在该 exact head 上运行正式
 Review validation，然后将 implementation workspace 封为 read-only。
@@ -59,14 +72,14 @@ Review Agent 可以读取完整 effective diff、相关 unchanged code、tests�
 和 public interfaces；必须逐项判断 Acceptance Criteria、正确性、failure paths、
 安全边界与回归风险。
 
-## 4. Review completion and invocation-local stale guard
+## 5. Review completion and invocation-local stale guard
 
 语义审查结束后必须调用同一个 invocation 的 completion：
 
 PASS：
 
 ```bash
-python tools/agent_workflow/lck.py review complete <TASK> \
+uv run --frozen python tools/agent_workflow/lck.py review complete <TASK> \
   --review-id <REVIEW_ID> \
   --verdict PASS
 ```
@@ -75,7 +88,7 @@ FAIL：先把 blocking findings 写入 review workspace 之外的临时/ignored 
 再调用：
 
 ```bash
-python tools/agent_workflow/lck.py review complete <TASK> \
+uv run --frozen python tools/agent_workflow/lck.py review complete <TASK> \
   --review-id <REVIEW_ID> \
   --verdict FAIL \
   --findings-file <FINDINGS_FILE>
@@ -100,7 +113,7 @@ freshness contract 或 snapshot lineage；guard 只在本次 Review prepare → 
 任何 stale result 都不会发布为有效 PASS，旧 semantic verdict 不可复用；必须重新
 执行新的 Independent Review invocation。
 
-## 5. Verdict semantics
+## 6. Verdict semantics
 
 正式 Review 只有两种 semantic verdict：
 
@@ -143,7 +156,7 @@ Low / Nit 可以报告，但不应伪装成 blocking finding。
 formal validation / checks 自身无法产生 PASS 时，LCK 在 objective gate 处 STOP；
 不要通过 `CONDITIONAL`、fallback snapshot 或旧 Delivery evidence 绕过 gate。
 
-## 6. Review record boundary
+## 7. Review record boundary
 
 `review complete` 可以把 Review 结果写到 ignored `.workflow.local/lck/reviews/`
 作为 audit / diagnostic record。它可记录 reviewed identity、validation、checks 和
@@ -153,13 +166,13 @@ semantic findings，用于回答“当时审查了什么”。
 必须重新获取各自所需的 live Git / GitHub facts。尤其不得把 record 中的旧 head、
 base、checks 或 validation 当作后续写操作的 expected identity。
 
-## 7. Explicit Remediation
+## 8. Explicit Remediation
 
 Remediation 只能由 Human 明确发起，并且必须引用当前 Task **最新已完成且为 FAIL**
 的 LCK `review_id`：
 
 ```bash
-python tools/agent_workflow/lck.py remediation prepare <TASK> \
+uv run --frozen python tools/agent_workflow/lck.py remediation prepare <TASK> \
   --review-id <FAILED_REVIEW_ID>
 ```
 
@@ -187,12 +200,12 @@ Understand findings
 
 不得直接 commit / push / create PR / change lifecycle state。
 
-## 8. Remediation completion
+## 9. Remediation completion
 
 语义修复完成后：
 
 ```bash
-python tools/agent_workflow/lck.py remediation complete <TASK> \
+uv run --frozen python tools/agent_workflow/lck.py remediation complete <TASK> \
   --review-id <FAILED_REVIEW_ID> \
   --commit-message "<repair commit message>" \
   --summary "<repair summary>" \
@@ -223,14 +236,14 @@ Remediation 不允许创建替代 PR；current existing OPEN PR 若不存在或�
 重新启动 Independent Review。只有新的 Review verdict 被 LCK 正式接受后，该 boundary
 才解除；因此旧 FAIL `review_id` 不能连续驱动第二次 remediation。
 
-## 9. Provider neutrality
+## 10. Provider neutrality
 
 Codex 与 Claude 使用同一个 LCK mechanical contract。二者都可以作为
 Implementation Agent 或 fresh Review Agent；provider 选择不改变 lifecycle
 correctness、live-state authority、read-only Review、stale guard、Human boundary
 或 no-auto-remediation 规则。
 
-## 10. Merge / Closeout interaction
+## 11. Merge / Closeout interaction
 
 PASS 只表示当前 Review invocation 对当时 live-resolved reviewed object 可进入
 Human merge decision。实际 merge 前仍必须由 deterministic merge preflight / Human

--- a/docs/development/pr-review.md
+++ b/docs/development/pr-review.md
@@ -1,422 +1,240 @@
-# PR Independent Review（Agent-neutral Review Semantics）
+# PR Independent Review（LCK Review / Remediation Semantics）
 
-本文件是 TraceQuant Independent PR Review 的 **shared semantic owner**：
-fresh-session、strict read-only、head lock、independent judgement、
-verdict semantics 与 remediation 规则由本文件权威定义，Codex / Claude 的
-`task-pr-review-runner` Skills 引用本文件，各自保留 agent-specific
-executable procedure（命令序列、权限行为、Runner argv 等）。
+本文件是 TraceQuant Independent Review 与 Remediation 的 shared semantic owner。
+Review / Remediation 的机械生命周期控制属于 LCK；Codex / Claude 只承担语义角色。
+Git / GitHub current state 是机械事实权威，Delivery 输出、旧 snapshot、expected SHA、
+PR identity handoff 或 validation snapshot 都不能授权后续 Review / Remediation。
 
-> **读取纪律**：Review Skill 启动时按 intent 读取本文件最小必要 section；
-> 不因本文件存在而默认加载 Delivery / Closeout / Feature Completion 内容。
+## 1. Purpose / independence
 
-## 1. Purpose / Independence
+Independent Review 是一个单独、fresh 的只读 invocation。Review Agent 不得参与
+被审查 head 的 implementation 或 remediation，也不得继承 Delivery 的正确性、
+风险、AC 覆盖或推荐结论。
 
-- Review 是对一个 Task PR 的**独立**质量门禁：fresh session 中由未参与
-  该 head 实现或 remediation 的 session 执行。
-- Review 的结论基于 current Task specification + effective diff +
-  relevant code/tests/checks 的完整证据，不继承 Delivery 的 self-check
-  结论（no Delivery verdict inheritance）。
-- Review 不修复 findings、不改变 Issue/PR/Project state、不 merge。
+Review Agent 只负责：
 
-## 2. Fresh-session requirement
-
-Review 必须在 fresh session 执行：该 session 未参与 implementation 或
-remediation of the reviewed head。任何新 commit 后都必须由新的独立
-Review session 重新审查；不得复用旧 session 或旧 verdict。
-
-## 3. Strict read-only
-
-Review 对 repository / Issue / PR / Project 完全只读：不写文件、
-不修改 GitHub state、不提交 GitHub Review、不 merge。
-
-## 4. Review identity
-
-Review 锁定以下身份（确定性验证，非模型解读）：
-
-- target Task（number 为主键，current title 为 canonical）；
-- target PR（base / head SHA）；
-- 当前 Task specification（leaf body + 有效 spec）。
-
-## 5. Head lock
-
-- 必须锁定 reviewed head：base SHA / head SHA / effective diff 在审查期间
-  保持不变。
-- 审查期间 head 若发生变化：**invalidate review**；重新锁定后重审，
-  旧结论无效。
-- merge 时 merged head ≠ reviewed head：**block closeout**（见 §10）。
-
-## 6. Effective diff
-
-Review 的对象是 effective diff（base → head 的全部变更），而非部分 commit
-或摘要。必须完整阅读变更，并检查变更涉及的代码、测试、文档与相关调用方。
-
-## 7. Evidence expectations
-
-- 机械事实（Issue state、labels、Status、PR identity、checks、diff digest）
-  以 deterministic Runner 快照为准（.agents/policies/workflow-evidence.md）。
-- 语义证据（正确性、范围、验收覆盖）由 Review session 独立形成
-  evidence matrix：逐项对照 Acceptance Criteria、scope boundary、
-  相关代码与测试。
-- evidence status 与 verdict 的映射必须确定性：不完整证据不得产生
-  passing verdict。
-
-## 8. Verdict semantics
-
-Review 输出**三态** verdict（与两套 `task-pr-review-runner` Skills 的
-executable contract 一致）：
-
-### 1. PASS / `通过，可以人工合并`
-
-只在 semantic review PASS、objective gates PASS、review identity / head
-stable 时允许。这是唯一允许进入 maintainer manual merge decision 的状态。
-
-### 2. CONDITIONAL / `有条件通过，不得合并`
-
-当 semantic review 本身无 BLOCKER / HIGH / MEDIUM finding，但一个或多个
-objective gate 为 `partial` / `unknown` / temporarily unverifiable，且不
-存在已证明的 semantic failure 或 identity drift 时使用。
-
-- CONDITIONAL ≠ semantic approval for merge；它仍然 **DO NOT MERGE**。
-- 必须先恢复 / 重新验证客观 gate。典型例子：remote-ref / GitHub network
-  verification 因瞬时网络故障变为 `partial`。
-
-### 3. FAIL / `不通过，需要修复`
-
-当存在 BLOCKER / HIGH / MEDIUM finding、identity / head / diff drift、
-required semantic requirement FAIL、或其他确定性 gate 明确 fail 时使用。
-
-CONDITIONAL 与 FAIL 都输出 bounded remediation handoff（§9）；
-每个 Review 只有一个最终 verdict。
-
-### Deterministic mapping principle
-
-- gate = `pass` + no blocking findings → **PASS**
-- gate = `partial` / `unknown` + no blocking findings + identity stable →
-  **CONDITIONAL — DO NOT MERGE**
-- `unknown` 因 plan-limit `403`：默认 **CONDITIONAL — DO NOT MERGE**。403
-  本身不等于 Required-Checks 查询成功；只有仓库存在正式版本化、明确授权、
-  并确定性定义条件与证据负担的 capability-limited fallback policy，且
-  当前证据满足全部条件时，才允许 upgrade 至 pass。
-- `unknown`（其他原因）/ unsupported schema / lifecycle conflict →
-  review incomplete / failing（证据不足，不产生 passing verdict）。
-- semantic failure / gate `fail` / identity drift → **FAIL**（review invalid
-  as applicable）
-- head changed during review → **REVIEW INVALIDATED — HEAD CHANGED**
-  （是 review invalidation，不是普通 conditional pass）
-
-## 9. Remediation handoff
-
-非 PASS 的 Review（CONDITIONAL / FAIL，见 §8）在报告末尾输出一个且仅一个
-canonical remediation handoff。Review 报告正文与下一 lifecycle invocation
-输入分离：正文保留 Verdict、mechanical verification、findings、Acceptance
-Criteria coverage 和必要 evidence；handoff 是可以独立复制的完整 Delivery
-prompt。
-
-最终输出契约固定为：
-
-````text
-## Remediation handoff
 ```text
-请按 task-delivery-runner 修复
-[Task] <当前完整标题> #<Task编号>
-对应 PR #<PR编号> 的独立审查问题，
-并继续处理，直到 PR 再次准备好接受新的独立审查。
-
-Task: #<Task编号>
-PR: #<PR编号>
-Reviewed head SHA: <SHA>
-Verdict: <有条件通过，不得合并 | 不通过，需要修复>
-
-Required remediation:
-- [F1][Blocking|High|Medium] <完整 finding，包含证据与预期行为>
-
-Objective gates:
-- <尚未满足、不可用、矛盾或需要重新验证的 gate>
-- 如无则写：无。
-
-Maintainer decision required:
-- <需要维护者授权的事项>
-- 如无则写：无。
+Inspect
+Reason
+Judge
+Report
 ```
-````
 
-canonical code block 必须 self-contained；每个 required finding 在其中完整
-出现一次，不得使用“上述”“同上”“见前文”等依赖报告正文的引用。不得在此
-section 之前再输出 handoff，也不得再用 wrapper label 嵌套或重复该 block。
+Review 不修复实现、不提交 GitHub Review、不改 Issue / PR / Project、不 merge。
 
-handoff 仅包含 Delivery Skill 修复所需的最小信息：
+## 2. LCK live target resolution
 
-- findings（severity、位置、失败场景、最小修改方向）；
-- 当前锁定的 base/head；
-- 重新 review 的要求（new head → fresh re-review）。
+Review 必须从以下入口开始：
 
-handoff 不得包含完整历史、无关 findings 或主观偏好。PASS 不输出
-remediation handoff section。
+```bash
+python tools/agent_workflow/lck.py review prepare <TASK>
+```
 
-Independent Review 保持 strict read-only，不向 GitHub 提交 Approve /
-Request changes / Comment Review。`review-remediation` 的 admission 不得依赖
-GitHub submitted Review；其语义输入是上述 bounded remediation handoff，
-Runner 只负责锁定 Task/PR/base/head 等机械身份。
+调用方只提供 Task number。不得向 Review LCK 传入 Delivery 提供的 base SHA、head
+SHA、PR number、checks snapshot、validation snapshot 或 snapshot id 作为 authority。
+
+LCK 在本次 invocation 开始时从 live Git / GitHub 重新解析：
+
+- current OPEN non-Draft PR；
+- current PR base / head；
+- current effective diff、merge base、changed-file inventory；
+- current Task Contract；
+- current applicable checks；
+- current formal Review validation state。
+
+`review prepare` 返回 `review_id`、live review target、Task Contract、validation、
+checks 和 isolated `review_root`。这些机械事实来自本次 LCK live acquisition，
+不是 Delivery handoff。
+
+## 3. Fresh semantic context and read-only workspace
+
+LCK 创建 reviewed head 的 detached isolated worktree，先在该 exact head 上运行正式
+Review validation，然后将 implementation workspace 封为 read-only。
+
+Reviewer 只从 `review_root`、当前 Task Contract 和必要的 current GitHub context
+建立新的 semantic context。不得把 Delivery self-review、旧 Review verdict、旧
+remediation rationale 或 persuasive framing 当作 evidence。
+
+Review Agent 可以读取完整 effective diff、相关 unchanged code、tests、docs、config
+和 public interfaces；必须逐项判断 Acceptance Criteria、正确性、failure paths、
+安全边界与回归风险。
+
+## 4. Review completion and invocation-local stale guard
+
+语义审查结束后必须调用同一个 invocation 的 completion：
+
+PASS：
+
+```bash
+python tools/agent_workflow/lck.py review complete <TASK> \
+  --review-id <REVIEW_ID> \
+  --verdict PASS
+```
+
+FAIL：先把 blocking findings 写入 review workspace 之外的临时/ignored 文本文件，
+再调用：
+
+```bash
+python tools/agent_workflow/lck.py review complete <TASK> \
+  --review-id <REVIEW_ID> \
+  --verdict FAIL \
+  --findings-file <FINDINGS_FILE>
+```
+
+`review_id` 只定位本次 ephemeral applicability guard 和 diagnostic Review record；
+它不把旧机械事实升级成跨阶段 authority。
+
+在接受 verdict 前，LCK 重新解析 current OPEN PR、base/head、Task Contract 和
+effective diff。至少执行以下 invocation-local stale preconditions：
+
+```text
+PR head changed → REVIEW_STALE_HEAD
+PR base changed → REVIEW_STALE_BASE
+```
+
+Task Contract 或 effective diff 在同一 invocation 内发生变化时，LCK 也会以明确的
+`REVIEW_STALE_*` 结果使本次 Review 失效。这里没有 generic drift graph、跨阶段
+freshness contract 或 snapshot lineage；guard 只在本次 Review prepare → complete
+之间有效。
+
+任何 stale result 都不会发布为有效 PASS，旧 semantic verdict 不可复用；必须重新
+执行新的 Independent Review invocation。
+
+## 5. Verdict semantics
+
+正式 Review 只有两种 semantic verdict：
+
+### PASS / `通过，可以人工合并`
+
+要求：semantic Review 无 blocking finding，prepare 时 formal Review validation
+通过，completion 时 live identity 仍适用，current applicable checks 仍通过。
+
+LCK 返回：
+
+```text
+READY_FOR_HUMAN_MERGE
+```
+
+随后立即停在 Human manual Squash Merge boundary。Agent / Skill / LCK v1 都不
+自动 merge。
+
+### FAIL / `不通过，需要修复`
+
+当当前 reviewed object 存在 Blocking / High / Medium semantic finding，或 Task
+要求未满足时使用。FAIL 必须提供可供后续修复理解的 findings。
+
+LCK 返回：
+
+```text
+STOP_REQUIRED
+```
+
+并且：
+
+```text
+Review FAIL
+→ STOP
+→ Human decides what to do
+```
+
+绝不自动进入 Remediation，也不存在 Review → Delivery → Review 自动循环。
+Low / Nit 可以报告，但不应伪装成 blocking finding。
+
+formal validation / checks 自身无法产生 PASS 时，LCK 在 objective gate 处 STOP；
+不要通过 `CONDITIONAL`、fallback snapshot 或旧 Delivery evidence 绕过 gate。
+
+## 6. Review record boundary
+
+`review complete` 可以把 Review 结果写到 ignored `.workflow.local/lck/reviews/`
+作为 audit / diagnostic record。它可记录 reviewed identity、validation、checks 和
+semantic findings，用于回答“当时审查了什么”。
+
+该 record **不是当前机械授权**。后续 Remediation、merge preflight、Closeout 都
+必须重新获取各自所需的 live Git / GitHub facts。尤其不得把 record 中的旧 head、
+base、checks 或 validation 当作后续写操作的 expected identity。
+
+## 7. Explicit Remediation
+
+Remediation 只能由 Human 明确发起，并且必须引用当前 Task **最新已完成且为 FAIL**
+的 LCK `review_id`：
+
+```bash
+python tools/agent_workflow/lck.py remediation prepare <TASK> \
+  --review-id <FAILED_REVIEW_ID>
+```
+
+LCK 从 failed Review record 读取 **semantic findings only**，同时独立从 live
+Git / GitHub 重新解析：
+
+- current Task；
+- current OPEN PR；
+- current PR head/base；
+- current local/remote Task branch；
+- current workspace state。
+
+旧 Review record 里的 SHA / base / PR identity 不具有 admission authority；即使
+当前 head 已变化，机械 target 也以 live state 为准，findings 仅作为待理解的语义
+输入。
+
+Implementation Agent 在 LCK 准备的 current Task workspace 上：
+
+```text
+Understand findings
+→ Repair
+→ Diagnose
+→ add regression coverage
+```
+
+不得直接 commit / push / create PR / change lifecycle state。
+
+## 8. Remediation completion
+
+语义修复完成后：
+
+```bash
+python tools/agent_workflow/lck.py remediation complete <TASK> \
+  --review-id <FAILED_REVIEW_ID> \
+  --commit-message "<repair commit message>" \
+  --summary "<repair summary>" \
+  --risks "<risks or limitations>"
+```
+
+LCK 复用 Initial Delivery 已迁移的 bounded effects：
+
+```text
+reacquire live facts
+→ Critical Outcome
+→ formal Delivery validation
+→ commit exact validated repair tree
+→ ensure remote Task branch
+→ reuse existing OPEN PR
+→ current checks
+→ verify final local/remote/PR head alignment
+→ READY_FOR_NEW_REVIEW
+→ STOP
+```
+
+Remediation 不允许创建替代 PR；current existing OPEN PR 若不存在或身份不再唯一，
+必须 STOP。Remediation complete 也不会自动启动 Review。成功 completion 会写入一个本地
+`fresh-review-required` **negative lifecycle boundary**：它只阻止再次 remediation，
+不选择或授权 PR/head/base；机械 target 仍完全由下一阶段 live state 解析。
+
+任何 repair commit 产生 new head 后，都必须由 Human 在新的 fresh invocation 中
+重新启动 Independent Review。只有新的 Review verdict 被 LCK 正式接受后，该 boundary
+才解除；因此旧 FAIL `review_id` 不能连续驱动第二次 remediation。
+
+## 9. Provider neutrality
+
+Codex 与 Claude 使用同一个 LCK mechanical contract。二者都可以作为
+Implementation Agent 或 fresh Review Agent；provider 选择不改变 lifecycle
+correctness、live-state authority、read-only Review、stale guard、Human boundary
+或 no-auto-remediation 规则。
 
 ## 10. Merge / Closeout interaction
 
-- merge 前必须存在当前 PR head 的 passing Review + maintainer manual
-  Squash Merge。
-- merged head ≠ reviewed head → closeout 必须被阻塞，人工介入。
-- merge 后如需验证（closeout），由 closeout Skill 独立执行
-  （docs/development/issue-workflow.md §13）。
+PASS 只表示当前 Review invocation 对当时 live-resolved reviewed object 可进入
+Human merge decision。实际 merge 前仍必须由 deterministic merge preflight / Human
+确认 current PR 状态；LCK v1 不自动 merge。
 
-## 11. Fact trust boundary and inheritance
-
-Review 输入分成两层：
-
-1. **可继承的机械事实**：由 Git / GitHub / CI / deterministic Runner 或
-   等价可信事实源产生，具有明确 object identity，可由 Reviewer 重新校验，且
-   不包含语义结论。
-2. **Reviewer 的语义判断**：对当前 Task specification、effective diff、
-   相关代码 / 测试和风险的独立阅读、映射与结论。它不能从 Delivery 或旧
-   Review 继承。
-
-“可继承”只表示某个 bounded handoff 可以携带该事实作为重新获取的索引或
-候选输入，不表示 Reviewer 可以盲信 snapshot。下列 allowlist 是完整边界；
-不在其中的 Delivery 内容默认不是 Review trusted fact。
-
-### 11.1 Allowlisted mechanical facts
-
-| Fact | 可携带的内容 | 最低可信条件 |
-|---|---|---|
-| Task / PR identity | Task number、current canonical title、PR number、repository、base/head branch | 能由当前 GitHub 对象重新确认，且 Task 与 PR 关系明确 |
-| Reviewed object | `base_sha`、`head_sha`、merge-base、effective-diff identity | SHA 可解析，base/head 关系和 effective diff 可重算 |
-| Changed files | effective diff 的完整 repository-relative manifest | 来自完整 diff，不是摘要、glob 或手工挑选 |
-| Specification identity | Task body hash、Acceptance Criteria identifiers | 当前 leaf body 可重新读取；hash 和 AC 集合可重算 |
-| Check facts | required / observed check 的原始状态、名称、run identity、时间 | 来自当前 CI / GitHub 查询；不得携带“因此可合并”的解释 |
-| Validation facts | profile、schema / runner identity、exit status、raw result locator、trusted digest | profile 与 base/head 绑定，原始结果可读取并按 freshness contract 重验 |
-| Review threads | unresolved-thread count 和 thread identifiers | 来自当前 PR / Review 查询；不携带 finding 的接受或修复结论 |
-| Workflow identity | workflow、profile、schema、Runner / Skill content identity | 内容 hash / version 可锁定，且能确认适用于 reviewed object |
-| Immutable source locators | commit-pinned 文件、diff、CI result 或 GitHub object locator | locator 指向不可变对象或带有足够 identity 的可重查对象 |
-
-机械事实的来源可以被 handoff 引用，但 source locator、object identity、
-freshness contract 任一缺失时，事实不能进入 trusted input。
-
-### 11.2 Facts that always require independent revalidation
-
-Reviewer 至少必须独立确认以下当前事实；handoff 中相同字段不能替代确认：
-
-- 当前 Task / PR identity、repository、canonical title 与两者关系；
-- 当前 PR base / head，以及 branch、merge-base 和 effective diff；
-- effective diff 的完整内容和 changed-files manifest；
-- Task specification hash、Acceptance Criteria identifiers 与当前 body；
-- 影响 merge eligibility 的 checks、required-check configuration、Review
-  threads 和其它当前状态；
-- validation profile、result freshness、Runner / schema identity 与结果；
-- merge 时需要的其它当前对象状态（包括 PR open / merged state 和 exact
-  merge identity）。
-
-重新校验必须使用当前可信事实源。若 object identity、source freshness 或
-字段之间的关系无法确认，Reviewer 必须 fail closed，而不是采用旧值继续
-形成 verdict。
-
-### 11.3 Prohibited inherited content
-
-以下内容绝不能成为 Review trusted facts、Acceptance Criteria evidence 或
-风险证据：
-
-- “实现正确”“所有 AC 已满足”或“风险可接受”；
-- “无需额外测试”或任何对测试充分性的 Delivery 判断；
-- Delivery self-review verdict、Delivery 对争议设计的辩护或建议审查方向；
-- Delivery reasoning / chain-of-thought；
-- 已失败检查的合理化或把暂时未知解释为通过；
-- 旧 Review 的 semantic verdict、findings 结论或推荐结果。
-
-调试或 provenance 需要保留 rationale 时，必须逐项标记为
-`UNTRUSTED_CLAIM_TO_REVIEW`。该标记内容可以帮助定位来源，但不能进入
-evidence matrix，也不能改变 Reviewer 的问题、范围或结论。
-
-### 11.4 Bounded Review Fact Handoff
-
-Fact Handoff 是受限的机械事实包，而不是 Review 报告或语义预审。其最小
-字段契约为：
-
-```text
-schema_version
-task_id
-pr_id
-task_spec_hash
-base_sha
-head_sha
-effective_diff_sha256
-changed_files_manifest
-acceptance_criteria_ids
-raw_check_facts
-validation_facts
-workflow_identity
-created_at
-source_identity
-freshness_contract
-```
-
-字段规则：
-
-- `task_id` / `pr_id` 必须绑定同一 repository；`task_spec_hash`、base、
-  head、diff、manifest 和 AC identifiers 共同定义一个 reviewed object。
-- `raw_check_facts` 与 `validation_facts` 只记录可重查的原始状态、profile、
-  result locator 和 digest，不把它们改写成质量或合并结论。
-- `source_identity` 必须能说明来源对象、查询或 profile identity；
-  `freshness_contract` 必须说明哪些当前条件不再满足时 handoff 失效。
-- `created_at` 记录产生时间，但不得单独作为 freshness 证明；本契约不
-  预设一个可绕过 object revalidation 的固定 TTL。
-- 是否把 handoff 实现为 durable artifact 不由本文件预先决定；#91 可以
-  实验 artifact 形式，但不能改变字段边界和重新校验要求。
-
-Handoff **不得**包含或派生出以下字段：
-
-```text
-delivery_correctness_verdict
-delivery_risk_verdict
-delivery_ac_satisfaction_verdict
-review_conclusion
-recommended_review_outcome
-```
-
-任何额外的 rationale、priority、suggested focus 或 remediation preference
-若被保留，必须是 `UNTRUSTED_CLAIM_TO_REVIEW`，不得被解析为事实字段。
-
-## 12. Drift and invalidation model
-
-下表定义八类 drift 的最低处理。所有“旧 semantic verdict 失效”均指旧的
-整体 Review verdict 不得再作为当前 Review / merge eligibility 证据；这不
-妨碍未来实验比较是否可以减少重复的机械读取，但不能跳过当前契约要求的
-重新确认。
-
-| Drift | 失效的 inherited facts | 重建 handoff | 必须重新运行 / 获取的 mechanical validation | semantic verdict / judgment context |
-|---|---|---|---|---|
-| `TASK_SPEC_DRIFT` | body hash、AC identifiers，以及从它们派生的 object / evidence | 是 | 重新读取 Task body、重算 spec / AC identity，并重新确认 diff、相关 checks 与 validation | 旧 verdict 失效；必须开始新的 Review judgment context |
-| `BASE_DRIFT` | base、merge-base、effective diff、manifest、相关 validation | 是 | 重新锁定 base/head、重算完整 diff，并运行适用 validation / checks | 旧 verdict 失效；必须开始新的 context |
-| `HEAD_DRIFT` | head、diff、manifest、checks / validation freshness 和 handoff identity | 是 | 重新锁定 head、重算 diff、重新获取 checks 并运行适用 validation | 旧 verdict 失效；必须开始新的 context |
-| `EFFECTIVE_DIFF_DRIFT` | diff digest、changed-files、object identity 和受影响 evidence | 是 | 重新计算完整 diff / manifest，并重新运行受影响的 mechanical validation | 旧 verdict 失效；必须开始新的 context |
-| `CHECKS_DRIFT` | raw check facts、required-check freshness、merge-eligibility evidence | 是 | 重新获取当前 checks、threads 和 merge eligibility；validation freshness 受影响时一并重跑 | 旧整体 verdict 失效；至少必须在新的 context 中重新判断 objective gates |
-| `VALIDATION_DRIFT` | validation profile / result / digest / freshness | 是 | 使用相同锁定对象重新运行适用 validation profile，并重验 Runner / schema identity | 旧整体 verdict 失效；必须在新的 context 中重新确认验证证据 |
-| `WORKFLOW_RULE_DRIFT` | workflow、profile、schema、Runner / Skill identity 与其结果 | 是 | 按当前有效规则重新获取 identity，并重新运行受影响的 mechanical validation | 旧 verdict 失效；必须开始新的 context |
-| `HANDOFF_SCHEMA_DRIFT` | handoff schema、字段解释、来源和 freshness contract | 是 | 用当前 schema 重新构造并校验 handoff，重新确认其中全部 object / source facts | 旧 verdict 失效；必须开始新的 context |
-
-具体规则：
-
-1. `TASK_SPEC_DRIFT`、`BASE_DRIFT`、`HEAD_DRIFT` 或
-   `EFFECTIVE_DIFF_DRIFT` 出现时，Review 对象已经改变；不得以“代码没有
-   变”或“只是 rebase”保留旧 verdict。
-2. checks / validation / workflow drift 即使没有改变代码，也会改变当前
-   objective gate、证据 freshness 或规则解释；旧整体 verdict 不能用于
-   merge，必须重新获取相应事实。
-3. 任何 drift 若不能归类，或无法确定 drift 前后的对象关系，按
-   `OBJECT_IDENTITY_UNCONFIRMED` 处理：停止、fail closed、丢弃旧 handoff
-   和 verdict，等待新的完整锁定。
-4. new implementation head、effective diff 改变或 relevant spec / AC 改变
-   是强制的 semantic verdict invalidation；这三类不得通过 handoff 复用
-   旧 semantic judgement。
-
-## 13. Session isolation semantics
-
-以下概念必须分开，不能用 “fresh session” 一个词替代：
-
-| Concept | 定义 | 不代表什么 |
-|---|---|---|
-| `fresh top-level session` | 未参与该 reviewed head 实现或 remediation 的新 root session / execution | 不自动保证没有读到 Delivery 结论 |
-| `fresh semantic reviewer context` | 只以当前 spec、effective diff 和独立获取的事实建立判断上下文，不带入 Delivery / 旧 Review 的结论、辩护或推荐 | 不要求固定一种进程、CLI 或编排方式 |
-| `fact reacquisition` | Reviewer 从 Git / GitHub / CI / Runner 重新读取并核对 facts | 不等于 semantic review 已通过 |
-| `fact handoff` | 受 schema、identity 和 freshness 约束的 bounded mechanical facts 包 | 不等于 snapshot 永久可信，也不等于 verdict |
-| `delivery reasoning isolation` | 不向 Review trusted input 传递 Delivery reasoning / chain-of-thought / persuasive framing | 不禁止审查者读取必要的实现、测试和规范上下文 |
-| `review verdict isolation` | verdict 由当前 Reviewer 独立生成，旧 verdict 只能作为被禁止的 claim 处理 | 不允许 Delivery 预先指定 Review outcome |
-
-满足本契约的候选 execution strategy 至少包括：
-
-| Candidate | Root / semantic context | Mechanical facts |
-|---|---|---|
-| A | fresh root + fresh semantic reviewer context | full reacquisition |
-| B | fresh root + fresh semantic reviewer context | bounded verified handoff，再由 Reviewer revalidate |
-| C | alternative isolated reviewer context + fresh semantic reviewer context | full reacquisition |
-| D | alternative isolated reviewer context + fresh semantic reviewer context | bounded verified handoff，再由 Reviewer revalidate |
-
-候选只是 #91 的实验输入，不是本 Task 的架构选择。无论采用哪一项，
-strict read-only、no Delivery verdict inheritance、current-object revalidation、
-independent AC / correctness / safety judgement 和 drift invalidation 都是
-不可变 hard gates。
-
-在 #91 作出决定前，当前 `fresh top-level session + full reacquisition` 仍
-是正式 operational baseline。该 baseline 的保留不等于宣告它是唯一正确的
-最终实现。
-
-## 14. Experimental and downstream protocol input
-
-本节是 #91 可直接消费的契约输入。一个实验 arm 必须先固定同一个 reviewed
-object tuple：
-
-```text
-task_id
-pr_id
-task_spec_hash
-base_sha
-head_sha
-effective_diff_sha256
-changed_files_manifest
-acceptance_criteria_ids
-```
-
-在固定 tuple 之后，#91 可以比较上表 A–D 的可选子集，但每个 arm 都必须：
-
-- 以同一组 invariants 为硬门禁，而不是把成本或输入体积下降当作质量豁免；
-- 区分 full reacquisition 与 bounded handoff，并记录每个 fact 的来源、
-  revalidation 结果和 freshness；
-- 对八类 drift 至少验证“旧 handoff / verdict 是否被阻断、是否能重建当前
-  object”；
-- 单独记录 semantic findings、Acceptance Criteria mapping、objective
-  gates 和 session / fact strategy，不把 Delivery self-review 当作 control
-  或 evidence；
-- 若改变 candidate 矩阵、handoff schema 或 reviewed object，开始新的
-  experiment identity，不在同一 arm 中静默替换输入。
-
-因此本契约为实验定义“比较什么”和“哪些结果不可接受”，但不预先决定
-session、Context Compiler、durable state 或其它 coordinator 的实现。
-
-## 15. Recovery and closeout consumption
-
-Recovery / closeout 可以在新会话中重建本契约的 mechanical facts：Task / PR
-identity、base/head、merge-base / diff、changed files、spec / AC hash、checks、
-validation、threads 和 workflow identity。重建必须从可信源重新获取并按照
-§11.2 校验，不能把恢复的 handoff 当作历史 verdict。
-
-semantic verdict 必须绑定以下 exact reviewed object：
-
-```text
-task_id + pr_id + task_spec_hash + base_sha + head_sha
-    + effective_diff_sha256 + changed_files_manifest
-    + acceptance_criteria_ids + workflow_identity
-```
-
-Closeout / recovery 消费 Review verdict 时至少必须证明：
-
-1. 当前 Task / PR 与 Review record 是同一对象，且 Review record 的来源和
-   verdict identity 可定位；
-2. 当前 PR base、reviewed head、effective diff、spec / AC identity 和相关
-   workflow facts 与 Review record 完全一致；
-3. maintainer 实际 merge 的 head 等于 reviewed head，并且 merge tree / scope
-   与 reviewed object 一致；
-4. 任何 head、spec / AC、effective diff、check / validation 或 workflow drift
-   都会阻止继续消费旧 verdict，直到按 §12 重新建立事实和新的 Review
-   judgment context。
-
-Independent Review 不提交 GitHub Approve / Request Changes，也不 Merge；因此
-“存在可消费的 passing Review”不能被实现为要求一个 GitHub Review 记录。消费
-者必须使用符合本契约的 bounded Review record / evidence locator，并独立验证
-其 exact identity。#79 的 recovery / closeout、以及后续 #93/#95 的 identity
-binding 应复用这些证明条件，不得新增一个绕过 head/spec/diff binding 的捷径。
-
-## 16. Relationship to Skills and policies
-
-- shared semantics：本文件。
-- executable procedure：Codex `.agents/skills/task-pr-review-runner/`、
-  Claude `.claude/skills/task-pr-review-runner/`（含工具纪律、Runner argv、
-  权限行为）。
-- mechanical gates / evidence：`.agents/policies/workflow-evidence.md` +
-  `tools/agent_workflow/`。
-- `AGENTS.md` 仅保留必须 always-loaded 的 hard invariant（fresh independent
-  session、review independence、fail closed / head identity safety）。
+Closeout redesign 不属于本 cutover。任何 Closeout consumer 都不得因为存在旧
+snapshot / handoff 就跳过 current merged identity 的重新确认。

--- a/docs/workflows/lck-v1-migration-matrix.md
+++ b/docs/workflows/lck-v1-migration-matrix.md
@@ -1,6 +1,6 @@
 # LCK v1 Current → Target Migration Matrix
 
-This matrix is the Task #159 implementation boundary. It normalizes the
+This matrix tracks the LCK v1 migration boundary. It normalizes the
 operation inventory from the Task #88 architecture audit against the LCK v1
 Design Charter. `KEEP` means the responsibility remains in its current layer,
 `MOVE` means deterministic lifecycle authority moves into LCK, `SIMPLIFY` means
@@ -11,10 +11,12 @@ Task #159 established live-state resolution, phase eligibility, and Delivery
 Prepare. Task #160 implements the candidate **Initial Delivery** LCK controller:
 Critical Outcome + formal validation, validated-tree commit, remote
 synchronization, OPEN-PR resolve/create, checks, Project Status `Review`, and
-final `READY_FOR_REVIEW` verification. Task #160 itself is delivered through
-the pre-cutover Current Workflow; the candidate controller becomes lifecycle
-authority only after the maintainer merge boundary. Review/Remediation, merge,
-closeout, and recovery cutovers remain bounded follow-up work.
+final `READY_FOR_REVIEW` verification. Task #161 cuts over **Independent Review
+and explicit Remediation**: Review target identity is reacquired live, Review runs
+in an isolated implementation-read-only worktree with invocation-local stale
+guards, Review FAIL returns `STOP_REQUIRED`, and Human-started Remediation reuses
+the Task #160 Delivery effects while requiring the existing OPEN PR. Merge,
+Closeout redesign, and later recovery work remain bounded follow-up work.
 
 | ID | #88 operation | Current owner | LCK v1 target | Task #159 boundary |
 |---|---|---|---|---|
@@ -32,20 +34,20 @@ closeout, and recovery cutovers remain bounded follow-up work.
 | O12 | Check wait/read and interpretation | Skill + Runner | SIMPLIFY | Candidate gate implemented; Current Workflow remains authority for #160 pre-cutover delivery |
 | O13 | Semantic self-review | Agent + helper | SIMPLIFY | Semantic judgement stays Agent-owned |
 | O14 | Delivery readiness snapshot | Evidence Runner + Skill | MOVE | Snapshot is diagnostic, not LCK authority |
-| O15 | Reviewed object identity lock | Review Skill + Runner | MOVE | Live resolver foundation only |
+| O15 | Reviewed object identity lock | Review Skill + Runner | MOVE | LCK live Review target + invocation-local guard |
 | O16 | Complete effective-diff inspection | Review Agent | KEEP | KEEP |
 | O17 | Review correctness / AC / risk judgement | Review Agent | KEEP | KEEP |
-| O18 | Review CI-equivalent validation | Review Skill + Runner | KEEP | KEEP |
-| O19 | Review recheck and stability | Runner + Review Skill | SIMPLIFY | Invocation-local recheck only |
-| O20 | Review verdict and handoff | Review Agent + Skill | KEEP | KEEP |
-| O21 | Remediation admission | Delivery Skill + Runner | MOVE | Phase resolver exposes eligibility only |
-| O22 | Repair and new head | Agent + Delivery Skill | MOVE | Out of scope |
+| O18 | Review CI-equivalent validation | Review Skill + Runner | KEEP | LCK runs formal Review validation on exact isolated head |
+| O19 | Review recheck and stability | Runner + Review Skill | SIMPLIFY | `REVIEW_STALE_HEAD` / `REVIEW_STALE_BASE` invocation-local guard only |
+| O20 | Review verdict and handoff | Review Agent + Skill | SIMPLIFY | Review Agent returns PASS/FAIL; LCK records diagnostic result; no mechanical handoff authority |
+| O21 | Remediation admission | Delivery Skill + Runner | MOVE | Explicit `lck remediation prepare`; live mechanics + semantic findings only |
+| O22 | Repair and new head | Agent + Delivery Skill | MOVE | LCK completion reuses Delivery effects and existing PR, then STOP before new Review |
 | O23 | Manual Squash Merge checkpoint | Maintainer | KEEP | KEEP |
 | O24 | Closeout read-only plan | Closeout Skill + Runner | MOVE | Closeout phase eligibility only |
 | O25 | Main sync and post-merge validation | Skill + Runner | MOVE | Out of scope |
 | O26 | Lifecycle metadata convergence | Closeout Skill / GitHub | MOVE | Out of scope |
 | O27 | Exact Task branch cleanup | Closeout Skill | MOVE | Out of scope |
-| O28 | Recovery after valid gate / drift | Skill + Agent | MOVE | Reacquire live facts; no lineage |
+| O28 | Recovery after valid gate / drift | Skill + Agent | MOVE | Reacquire live facts; no lineage; Review uses only invocation-local stale guards |
 | O29 | Feature child-set / completion mechanics | Feature Audit Skill + Agent | MOVE | Separate Feature audit boundary |
 | O30 | Repeated fact re-query / reformat | Agent / Skill ad hoc | REMOVE | No snapshot authority |
 | O31 | Homogeneous Agent command grouping | Agent orchestration | SIMPLIFY | Optional; never hides failure boundaries |
@@ -96,10 +98,39 @@ target is one bounded `tests/...::test_...` pytest node id; Issue text cannot in
 arbitrary shell commands. Operation-local base/body/head guards are ephemeral and are
 reacquired on retry rather than persisted as cross-phase authority.
 
-The Initial Delivery section of `task-delivery-runner` is now semantic-only plus LCK
-entrypoint guidance. The existing Review remediation procedure remains temporarily on
-the current Runner contract because its authority cutover belongs to the next migration
-Task; merge and closeout remain Human/later-task boundaries.
+The Initial Delivery and explicit Remediation sections of `task-delivery-runner` are now
+semantic-only plus LCK entrypoint guidance. The Review Skill likewise receives its
+mechanical target only from LCK. The pre-cutover `review-remediation` Evidence Runner
+entry point may remain for historical compatibility/diagnostics, but it is no longer a
+formal lifecycle authorization path. Merge and closeout remain Human/later-task
+boundaries.
+
+## Review / Remediation cutover implemented by Task #161
+
+The active path is now:
+
+1. `review prepare <Task>` resolves the current OPEN PR, base/head, current Task
+   Contract, effective diff and checks from live authority; no expected SHA/PR input is
+   accepted.
+2. LCK creates a detached clean worktree for the reviewed head, runs formal Review
+   validation there, then removes implementation write bits before the semantic Agent
+   inspects it.
+3. A random `review_id` locates only the bounded prepare→complete applicability guard.
+   Completion reacquires live facts; a changed head/base produces
+   `REVIEW_STALE_HEAD` / `REVIEW_STALE_BASE` instead of accepting the verdict.
+4. PASS returns `READY_FOR_HUMAN_MERGE`; FAIL returns `STOP_REQUIRED`. Neither path
+   starts another lifecycle phase automatically.
+5. A failed Review record is diagnostic/audit state. Human-started Remediation uses its
+   findings as semantic input, while `remediation prepare` independently reacquires the
+   current Task/PR/head/base/workspace.
+6. `remediation complete` requires actual repair changes, reruns Critical Outcome and
+   formal Delivery validation, commits the exact validated tree, synchronizes the Task
+   branch, reuses the existing OPEN PR, waits for current checks, and returns
+   `READY_FOR_NEW_REVIEW` followed by STOP.
+
+This cutover intentionally deletes the former formal dependence on bounded verified
+fact handoff, cross-phase freshness contracts, snapshot-derived Review target authority,
+and generalized drift categories. Historical evidence remains audit-only.
 
 ## Mainline activation and rollback procedure
 

--- a/tests/tools/test_agent_neutral_workflow.py
+++ b/tests/tools/test_agent_neutral_workflow.py
@@ -1,9 +1,4 @@
-"""Focused validation for the Agent-neutral workflow / instruction architecture.
-
-Task #120: shared semantic owner docs (docs/development/issue-workflow.md,
-docs/development/pr-review.md), natural-language routing, dual-layer
-source-of-truth model, and Codex / Claude skill semantic parity.
-"""
+"""Focused validation for the Agent-neutral workflow / instruction architecture."""
 
 from __future__ import annotations
 
@@ -13,28 +8,21 @@ import sys
 from pathlib import Path
 
 ROOT = Path(__file__).parents[2]
-
 PATH_AUDIT = ROOT / "tools/agent_workflow/skill_path_audit.py"
-
 ISSUE_WORKFLOW = ROOT / "docs/development/issue-workflow.md"
 PR_REVIEW = ROOT / "docs/development/pr-review.md"
 AGENTS = ROOT / "AGENTS.md"
 CLAUDE_MD = ROOT / "CLAUDE.md"
 AGENT_SKILLS_GUIDE = ROOT / "docs/workflows/agent-skills.md"
-
-ACTIVE_SKILL_ROOTS = (
-    ROOT / ".agents" / "skills",
-    ROOT / ".claude" / "skills",
-)
-
+ACTIVE_SKILL_ROOTS = (ROOT / ".agents/skills", ROOT / ".claude/skills")
 REVIEW_SKILLS = ("task-pr-review-runner",)
 LIFECYCLE_SKILLS = ("task-delivery-runner", "task-closeout", "feature-completion-audit")
 
 
 def _skill_text(name: str) -> tuple[str, str]:
     return (
-        (ROOT / ".agents" / "skills" / name / "SKILL.md").read_text(encoding="utf-8"),
-        (ROOT / ".claude" / "skills" / name / "SKILL.md").read_text(encoding="utf-8"),
+        (ROOT / ".agents/skills" / name / "SKILL.md").read_text(encoding="utf-8"),
+        (ROOT / ".claude/skills" / name / "SKILL.md").read_text(encoding="utf-8"),
     )
 
 
@@ -81,20 +69,33 @@ def test_source_of_truth_is_dual_layer_not_linear_precedence() -> None:
     assert "不得覆盖 current Issue requirement" in text
 
 
-def test_failure_and_ambiguity_handling_is_defined() -> None:
+def test_failure_and_ambiguity_handling_has_review_stop_and_local_stale_results() -> (
+    None
+):
     text = ISSUE_WORKFLOW.read_text(encoding="utf-8")
     assert "Failure / Ambiguity handling" in text
     assert "fail closed" in text
-    assert "invalidate review" in text
+    assert "STOP_REQUIRED" in text
+    assert "Human explicit remediation" in text
+    assert "REVIEW_STALE_HEAD" in text
+    assert "REVIEW_STALE_BASE" in text
     assert "block closeout" in text
-    assert "bounded remediation handoff" in text
+    assert "bounded remediation handoff" not in text
 
 
-def test_delivery_remediation_requires_review_handoff_for_both_agents() -> None:
+def test_delivery_remediation_is_explicit_and_live_for_both_agents() -> None:
     for text in _skill_text("task-delivery-runner"):
-        assert "`review-remediation` requires the bounded handoff" in text
-        assert "stop before Runner or repair writes" in text
-        assert "generic snapshot fallback" in text
+        assert "tools/agent_workflow/lck.py remediation prepare" in text
+        assert "tools/agent_workflow/lck.py remediation complete" in text
+        assert "failed `review_id` locates semantic findings only" in text
+        assert (
+            "mechanical facts from the Review\nrecord are not write authorization"
+            in text
+        )
+        assert "READY_FOR_NEW_REVIEW" in text
+        assert "review-remediation`\nEvidence Runner as a fallback" in text
+        assert "bounded mechanical handoff" in text
+        assert "MUST NOT accept" in text
 
 
 def test_closeout_entry_owns_merge_identity_and_convergence() -> None:
@@ -104,72 +105,72 @@ def test_closeout_entry_owns_merge_identity_and_convergence() -> None:
     assert "reviewed head == 实际 merged head" in text
 
 
-def test_pr_review_doc_owns_review_semantics() -> None:
+def test_pr_review_doc_owns_lck_review_semantics() -> None:
     text = PR_REVIEW.read_text(encoding="utf-8")
     for marker in (
-        "fresh session",
-        "完全只读",
-        "Head lock",
-        "Effective diff",
+        "fresh",
+        "read-only",
+        "LCK live target resolution",
+        "current effective diff",
+        "current Task Contract",
+        "invocation-local stale guard",
+        "REVIEW_STALE_HEAD",
+        "REVIEW_STALE_BASE",
         "Verdict semantics",
-        "Remediation handoff",
-        "block closeout",
+        "Explicit Remediation",
+        "Provider neutrality",
     ):
         assert marker in text
 
 
-def test_pr_review_doc_has_tri_state_verdict_contract() -> None:
+def test_pr_review_doc_has_binary_pass_fail_stop_contract() -> None:
     text = PR_REVIEW.read_text(encoding="utf-8")
-    # Tri-state verdict contract (aligned with the executable Review Skills).
-    for verdict in ("通过，可以人工合并", "有条件通过，不得合并", "不通过，需要修复"):
-        assert verdict in text
-    # Conditional is explicitly not merge approval.
-    assert "DO NOT MERGE" in text
-    assert "CONDITIONAL" in text
-    # partial / unknown objective gates map to conditional, not to pass.
-    assert "partial" in text
-    assert "unknown" in text
-    # Semantic failure / gate fail / identity drift must not map to conditional.
-    assert "identity drift" in text
-    assert "FAIL" in text
-    # Head change during review is invalidation, not conditional pass.
-    assert "REVIEW INVALIDATED" in text
-    # The binary-era claim that conditional pass does not exist must not return.
-    assert "不产出「conditional pass」" not in text
+    assert "PASS / `通过，可以人工合并`" in text
+    assert "FAIL / `不通过，需要修复`" in text
+    assert "READY_FOR_HUMAN_MERGE" in text
+    assert "STOP_REQUIRED" in text
+    assert "不自动进入 Remediation" in text
+    assert "Review → Delivery → Review 自动循环" in text
+    assert "CONDITIONAL" in text  # named only as a forbidden bypass
+    assert "有条件通过，不得合并" not in text
 
 
-def test_pr_review_doc_owns_full_mapping_and_skills_do_not_duplicate() -> None:
-    owner = PR_REVIEW.read_text(encoding="utf-8")
+def test_pr_review_doc_removes_cross_phase_mechanical_handoff_authority() -> None:
+    text = PR_REVIEW.read_text(encoding="utf-8")
+    assert "Delivery 输出、旧 snapshot、expected SHA" in text
+    assert "不能授权后续 Review / Remediation" in text
+    assert "generic drift graph" in text
+    assert "跨阶段\nfreshness contract" in text
+    assert "snapshot lineage" in text
+    assert "diagnostic Review record" in text
+    assert "不是当前机械授权" in text
+    assert "semantic findings only" in text
+
+
+def test_review_skills_share_binary_lck_contract() -> None:
     codex, claude = _skill_text("task-pr-review-runner")
-    # The shared owner holds the full verdict mapping (incl. plan-limit 403).
-    assert "Deterministic mapping principle" in owner
-    assert "gate = `pass`" in owner
-    assert "plan-limit `403`" in owner
-    assert "REVIEW INVALIDATED — HEAD CHANGED" in owner
-    # Both Skills reference the owner sections for verdict / remediation.
+    assert codex == claude
     for text in (codex, claude):
         assert "docs/development/pr-review.md" in text
-        assert "§8" in text
-        assert "§9" in text
-    # Exact executable verdict tokens and the invalidation token are retained.
-    for text in (codex, claude):
-        for verdict in (
-            "通过，可以人工合并",
-            "有条件通过，不得合并",
-            "不通过，需要修复",
-        ):
-            assert verdict in text
-        assert "REVIEW INVALIDATED — HEAD CHANGED" in text
-    # Neither Skill duplicates the full shared mapping table.
-    for text in (codex, claude):
-        assert "### Deterministic mapping" not in text
-        assert "| Evidence `status` | Permitted verdict ceiling |" not in text
-        assert "### Verdict rules" not in text
+        assert "tools/agent_workflow/lck.py review prepare" in text
+        assert "tools/agent_workflow/lck.py review complete" in text
+        assert "READY_FOR_SEMANTIC_REVIEW" in text
+        assert "READY_FOR_HUMAN_MERGE" in text
+        assert "STOP_REQUIRED" in text
+        assert "REVIEW_STALE_HEAD" in text
+        assert "REVIEW_STALE_BASE" in text
+        assert "通过，可以人工合并" in text
+        assert "不通过，需要修复" in text
+        assert "有条件通过，不得合并" not in text
+        assert "workflow-review" not in text
+        assert "recheck --snapshot-id" not in text
+        assert "Remediation handoff" not in text
 
 
-def test_issue_workflow_doc_keeps_identity_locking_and_no_version_gate() -> None:
+def test_issue_workflow_doc_keeps_phase_identity_preconditions_and_no_version_gate() -> (
+    None
+):
     text = ISSUE_WORKFLOW.read_text(encoding="utf-8")
-    # Workflow identity locking is owned by the shared doc.
     for marker in (
         "Workflow identity locking",
         "必须锁定",
@@ -178,14 +179,12 @@ def test_issue_workflow_doc_keeps_identity_locking_and_no_version_gate() -> None
         "merge SHA",
     ):
         assert marker in text
-    # Skill / Runner version is not a default reload gate.
     for marker in (
         "Skill / Runner version is not itself a workflow gate",
         "不要求",
         "重新加载",
     ):
         assert marker in text
-    # Old trusted-version mechanisms are named only as explicitly rejected.
     assert "不重新引入" in text
     assert "trusted Skill" in text
     assert "main-only Skill" in text
@@ -217,10 +216,9 @@ def test_skill_path_audit_covers_both_roots_and_shared_docs() -> None:
     assert result.returncode == 0, result.stdout + result.stderr
     value = json.loads(result.stdout)
     assert value["status"] == "pass"
+    assert value["schema_version"] == 5
     assert set(value["claude_skills"]) == set(value["active_skills"])
-    for entry in value["active_skills"].values():
-        assert entry["missing_shared_doc_refs"] == []
-    for entry in value["claude_skills"].values():
+    for entry in (*value["active_skills"].values(), *value["claude_skills"].values()):
         assert entry["missing_shared_doc_refs"] == []
         assert entry["direct_command_paths"] == []
         assert entry["evolution_traces"] == []
@@ -255,10 +253,7 @@ def test_agent_skills_guide_is_registry_and_navigation_only() -> None:
 
 
 def test_legacy_skills_are_retired_from_active_namespace() -> None:
-    for relative in (
-        ".agents/skills/task-delivery",
-        ".agents/skills/task-pr-review",
-    ):
+    for relative in (".agents/skills/task-delivery", ".agents/skills/task-pr-review"):
         assert not (ROOT / relative).exists(), relative
     agents = AGENTS.read_text(encoding="utf-8")
     claude = CLAUDE_MD.read_text(encoding="utf-8")

--- a/tests/tools/test_lck.py
+++ b/tests/tools/test_lck.py
@@ -1162,6 +1162,52 @@ def test_review_pass_stops_at_human_merge_boundary(
     assert checks.calls == 1
 
 
+def test_review_complete_rechecks_identity_after_pass_checks_gate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    start = _review_identity_value()
+    current = _review_identity_value(head="b" * 40)
+    state = _review_state()
+    resolver = cast(Any, StaticResolver(tmp_path, state))
+    store = lck.ReviewInvocationStore(tmp_path)
+    review_id = store.new_id()
+    store.write_guard(
+        review_id,
+        {
+            "task_number": 159,
+            "identity": start.to_dict(),
+            "review_root": str(tmp_path / "review-root"),
+            "checks": {"status": "pass"},
+            "validation": {"status": "pass"},
+        },
+    )
+
+    monkeypatch.setattr(
+        lck,
+        "_live_task_contract",
+        lambda *_args: {"body_sha256": "d" * 64},
+    )
+    identities = iter((start, current))
+    monkeypatch.setattr(lck, "_review_identity", lambda *_args: next(identities))
+
+    class AdvancingChecks(FakeReviewChecks):
+        def run(self, _task: int) -> dict[str, Any]:
+            assert state.open_pr is not None
+            state.open_pr["headRefOid"] = "b" * 40
+            return super().run(_task)
+
+    with pytest.raises(lck.ReviewStaleError) as exc_info:
+        lck.ReviewCompleter(
+            resolver,
+            store=store,
+            workspace=cast(Any, FakeReviewWorkspace(tmp_path / "review-root")),
+            checks_gate=cast(Any, AdvancingChecks()),
+        ).complete(159, review_id, verdict="PASS")
+
+    assert exc_info.value.code == "REVIEW_STALE_HEAD"
+
+
 def test_review_complete_rechecks_current_review_eligibility(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/tools/test_lck.py
+++ b/tests/tools/test_lck.py
@@ -683,6 +683,31 @@ def test_remediation_prepare_rejects_draft_pr(
     assert any("non-Draft" in reason for reason in decision.reasons)
 
 
+def test_remediation_requires_pr_base_to_match_current_main(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    branch = "task/159-lck-core-live-state-resolution"
+    fake = FakeRunner(
+        branch=branch, local_branches={branch}, remote_branches={branch: SHA}
+    )
+    issue = _issue()
+    issue["project_status"] = "Review"
+    pr = _open_pr(branch)
+    pr["baseRefOid"] = "b" * 40
+    _install_facts(monkeypatch, fake, issue=issue, open_pr=pr)
+
+    state = _resolver(fake).resolve(159)
+    decision = lck.PhaseEligibilityResolver().resolve(
+        state,
+        lck.Phase.REMEDIATION_PREPARE,
+    )
+
+    assert not decision.eligible
+    assert any(
+        "base must match current origin/main" in reason for reason in decision.reasons
+    )
+
+
 def test_multiple_task_branches_stop_fail_closed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1313,6 +1338,58 @@ def test_review_workspace_seal_removes_write_bits(tmp_path: Path) -> None:
     assert nested.stat().st_mode & 0o222 == 0
     assert target.stat().st_mode & 0o222 == 0
     lck.ReviewWorkspaceManager._make_removable(root)
+
+
+def test_review_workspace_remove_rejects_unvalidated_path(tmp_path: Path) -> None:
+    resolver = cast(Any, StaticResolver(tmp_path, _review_state()))
+    manager = lck.ReviewWorkspaceManager(resolver)
+
+    with pytest.raises(lck.LckStopError, match="cleanup path"):
+        manager.remove(tmp_path / "not-an-lck-worktree")
+
+
+def test_review_validation_artifacts_are_preserved_outside_review_worktree(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    review_root = tmp_path / "review-root"
+    tool = review_root / "tools" / "agent_workflow" / "workflow_validation.py"
+    tool.parent.mkdir(parents=True)
+    tool.write_text("# validation stub\n", encoding="utf-8")
+    output_dir = review_root / ".agents" / "validation.local" / "run"
+    output_dir.mkdir(parents=True)
+    (output_dir / "pytest.log").write_text("pass\n", encoding="utf-8")
+
+    class ValidationRunner:
+        def run(self, argv: Any, *, command_id: str, **_: Any) -> CommandResult:
+            payload = {
+                "status": "pass",
+                "output_dir": ".agents/validation.local/run",
+                "commands": [
+                    {
+                        "status": "pass",
+                        "log_path": ".agents/validation.local/run/pytest.log",
+                    }
+                ],
+            }
+            return CommandResult(
+                command_id=command_id,
+                argv=tuple(str(item) for item in argv),
+                returncode=0,
+                stdout=json.dumps(payload),
+                stderr="",
+            )
+
+    resolver = cast(Any, StaticResolver(repo_root, _review_state()))
+    resolver.runner = ValidationRunner()
+    validation = lck.ReviewValidationGate(resolver).run(review_root, SHA)
+
+    durable_output = repo_root / validation["output_dir"]
+    durable_log = repo_root / validation["commands"][0]["log_path"]
+    assert validation["output_dir"].startswith(".agents/validation.local/lck-review-")
+    assert durable_output.is_dir()
+    assert durable_log.read_text(encoding="utf-8") == "pass\n"
 
 
 def test_remediation_prepare_uses_live_head_not_review_record_identity(

--- a/tests/tools/test_lck.py
+++ b/tests/tools/test_lck.py
@@ -969,6 +969,39 @@ def test_review_prepare_builds_context_only_from_live_resolution(
     assert checks.calls == 2
 
 
+def test_review_prepare_rechecks_eligibility_after_validation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = _review_state()
+    resolver = cast(Any, StaticResolver(tmp_path, state))
+    identity = _review_identity_value()
+    monkeypatch.setattr(
+        lck,
+        "_live_task_contract",
+        lambda *_args: {"number": 159, "body_sha256": "d" * 64},
+    )
+    monkeypatch.setattr(lck, "_review_identity", lambda *_args: identity)
+
+    class DraftingValidation(FakeReviewValidation):
+        def run(self, _root: Path, _base: str) -> dict[str, Any]:
+            assert state.open_pr is not None
+            state.open_pr["isDraft"] = True
+            return super().run(_root, _base)
+
+    workspace = FakeReviewWorkspace(tmp_path / "review-root")
+    with pytest.raises(lck.LckStopError, match="post-validation STOP"):
+        lck.ReviewPreparer(
+            resolver,
+            validation=cast(Any, DraftingValidation()),
+            checks_gate=cast(Any, FakeReviewChecks()),
+            workspace=cast(Any, workspace),
+            store=lck.ReviewInvocationStore(tmp_path),
+        ).prepare(159)
+
+    assert workspace.removed == [tmp_path / "review-root"]
+
+
 def test_review_complete_head_change_is_review_stale_head(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1127,6 +1160,48 @@ def test_review_pass_stops_at_human_merge_boundary(
     assert result.status == "READY_FOR_HUMAN_MERGE"
     assert "manual merge" in result.to_dict()["human_boundary"]
     assert checks.calls == 1
+
+
+def test_review_complete_rechecks_current_review_eligibility(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = _review_state()
+    assert state.open_pr is not None
+    state.open_pr["isDraft"] = True
+    resolver = cast(Any, StaticResolver(tmp_path, state))
+    store = lck.ReviewInvocationStore(tmp_path)
+    review_id = store.new_id()
+    store.write_guard(
+        review_id,
+        {
+            "task_number": 159,
+            "identity": _review_identity_value().to_dict(),
+            "review_root": str(tmp_path / "review-root"),
+            "checks": {"status": "pass"},
+            "validation": {"status": "pass"},
+        },
+    )
+    monkeypatch.setattr(
+        lck,
+        "_live_task_contract",
+        lambda *_args: {"body_sha256": "d" * 64},
+    )
+    monkeypatch.setattr(
+        lck, "_review_identity", lambda *_args: _review_identity_value()
+    )
+    workspace = FakeReviewWorkspace(tmp_path / "review-root")
+
+    with pytest.raises(lck.LckStopError, match="Review Complete STOP"):
+        lck.ReviewCompleter(
+            resolver,
+            store=store,
+            workspace=cast(Any, workspace),
+            checks_gate=cast(Any, FakeReviewChecks()),
+        ).complete(159, review_id, verdict="PASS")
+
+    assert workspace.removed == [tmp_path / "review-root"]
+    assert not store.guard_path(review_id).exists()
 
 
 def test_review_workspace_seal_removes_write_bits(tmp_path: Path) -> None:

--- a/tests/tools/test_lck.py
+++ b/tests/tools/test_lck.py
@@ -920,7 +920,10 @@ class FakeReviewChecks:
 
     def run(self, _task: int) -> dict[str, Any]:
         self.calls += 1
-        return {"status": "pass", "pr": {"number": 200}}
+        return {
+            "status": "pass",
+            "pr": {"number": 200, "head_sha": SHA, "base_sha": SHA},
+        }
 
 
 class FakeReviewValidation:
@@ -1206,6 +1209,53 @@ def test_review_complete_rechecks_identity_after_pass_checks_gate(
         ).complete(159, review_id, verdict="PASS")
 
     assert exc_info.value.code == "REVIEW_STALE_HEAD"
+
+
+def test_review_complete_rejects_checks_drift_after_pass_checks_gate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = _review_state()
+    resolver = cast(Any, StaticResolver(tmp_path, state))
+    store = lck.ReviewInvocationStore(tmp_path)
+    review_id = store.new_id()
+    identity = _review_identity_value()
+    store.write_guard(
+        review_id,
+        {
+            "task_number": 159,
+            "identity": identity.to_dict(),
+            "review_root": str(tmp_path / "review-root"),
+            "checks": {"status": "pass"},
+            "validation": {"status": "pass"},
+        },
+    )
+    monkeypatch.setattr(
+        lck,
+        "_live_task_contract",
+        lambda *_args: {"body_sha256": "d" * 64},
+    )
+    monkeypatch.setattr(lck, "_review_identity", lambda *_args: identity)
+
+    class ChecksDriftAfterGate(FakeReviewChecks):
+        def run(self, _task: int) -> dict[str, Any]:
+            result = {
+                "status": "pass",
+                "pr": {"number": 200, "head_sha": SHA, "base_sha": SHA},
+            }
+            state.checks["failed"] = 1
+            state.checks["all_success"] = False
+            return result
+
+    with pytest.raises(lck.LckStopError, match="current PR checks"):
+        lck.ReviewCompleter(
+            resolver,
+            store=store,
+            workspace=cast(Any, FakeReviewWorkspace(tmp_path / "review-root")),
+            checks_gate=cast(Any, ChecksDriftAfterGate()),
+        ).complete(159, review_id, verdict="PASS")
+
+    assert not store.record_path(159, review_id).exists()
 
 
 def test_review_complete_rechecks_current_review_eligibility(

--- a/tests/tools/test_lck.py
+++ b/tests/tools/test_lck.py
@@ -657,7 +657,7 @@ def test_delivery_complete_allows_review_status_for_partial_effect_recovery(
     assert decision.eligible
 
 
-def test_remediation_prepare_keeps_draft_pr_observable(
+def test_remediation_prepare_rejects_draft_pr(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     branch = "task/159-lck-core-live-state-resolution"
@@ -679,7 +679,8 @@ def test_remediation_prepare_keeps_draft_pr_observable(
         lck.Phase.REMEDIATION_PREPARE,
     )
 
-    assert decision.eligible
+    assert not decision.eligible
+    assert any("non-Draft" in reason for reason in decision.reasons)
 
 
 def test_multiple_task_branches_stop_fail_closed(
@@ -823,3 +824,541 @@ def test_delivery_prepare_requires_valid_critical_outcome(
     assert any(
         "Critical Outcome contract invalid" in reason for reason in decision.reasons
     )
+
+
+def _review_state(
+    *,
+    head: str = SHA,
+    base: str = SHA,
+    clean: bool = True,
+) -> lck.LiveState:
+    branch = "task/159-lck-core-live-state-resolution"
+    issue = _issue()
+    issue.update(
+        {
+            "project_status": "Review",
+            "body_sha256": "d" * 64,
+        }
+    )
+    pr = _open_pr(branch)
+    pr.update({"headRefOid": head, "baseRefOid": base})
+    return lck.LiveState(
+        task_number=159,
+        repository="owner/repo",
+        issue=issue,
+        relationships=_relationships(),
+        git={
+            "branch": branch,
+            "head_sha": head,
+            "local_main_sha": base,
+            "origin_main_sha": base,
+            "origin_fetch": "pass",
+            "clean": clean,
+        },
+        target_branch=branch,
+        local_task_branch=branch,
+        local_task_head=head,
+        remote_task_branch=branch,
+        remote_task_oid=head,
+        open_pr=pr,
+        merged_pr_numbers=(),
+        merged=False,
+        checks={
+            "count": 1,
+            "failed": 0,
+            "pending": 0,
+            "skipped_or_unknown": 0,
+            "all_success": True,
+        },
+        cleanup={},
+    )
+
+
+def _review_identity_value(*, head: str = SHA, base: str = SHA) -> lck.ReviewIdentity:
+    return lck.ReviewIdentity(
+        task_number=159,
+        pr_number=200,
+        base_sha=base,
+        head_sha=head,
+        task_body_sha256="d" * 64,
+        merge_base_sha=base,
+        effective_diff_sha256="e" * 64,
+        changed_files=("tools/agent_workflow/lck.py",),
+    )
+
+
+class StaticResolver:
+    def __init__(self, repo_root: Path, state: lck.LiveState) -> None:
+        self.repo_root = repo_root
+        self.state = state
+        self.runner = cast(Any, FakeRunner())
+
+    def resolve(self, _task_number: int) -> lck.LiveState:
+        return self.state
+
+
+class FakeReviewWorkspace:
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.sealed: list[Path] = []
+        self.removed: list[Path] = []
+
+    def create(self, _task: int, _head: str) -> Path:
+        self.root.mkdir(parents=True, exist_ok=True)
+        return self.root
+
+    def seal_read_only(self, path: Path) -> None:
+        self.sealed.append(path)
+
+    def remove(self, path: Path) -> None:
+        self.removed.append(path)
+
+
+class FakeReviewChecks:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def run(self, _task: int) -> dict[str, Any]:
+        self.calls += 1
+        return {"status": "pass", "pr": {"number": 200}}
+
+
+class FakeReviewValidation:
+    def run(self, _root: Path, _base: str) -> dict[str, Any]:
+        return {"status": "pass", "phase": "review"}
+
+
+def test_review_prepare_builds_context_only_from_live_resolution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = _review_state()
+    resolver = cast(Any, StaticResolver(tmp_path, state))
+    identity = _review_identity_value()
+    monkeypatch.setattr(
+        lck,
+        "_live_task_contract",
+        lambda *_args: {
+            "number": 159,
+            "title": _issue()["title"],
+            "body": "Task Contract",
+            "body_sha256": "d" * 64,
+        },
+    )
+    monkeypatch.setattr(lck, "_review_identity", lambda *_args: identity)
+    workspace = FakeReviewWorkspace(tmp_path / "review-root")
+    checks = FakeReviewChecks()
+    store = lck.ReviewInvocationStore(tmp_path)
+
+    context = lck.ReviewPreparer(
+        resolver,
+        validation=cast(Any, FakeReviewValidation()),
+        checks_gate=cast(Any, checks),
+        workspace=cast(Any, workspace),
+        store=store,
+    ).prepare(159)
+
+    value = context.to_dict()
+    assert value["review_target"]["head_sha"] == SHA
+    assert value["review_target"]["base_sha"] == SHA
+    assert value["task_contract"]["body"] == "Task Contract"
+    assert value["workspace_mode"] == "implementation-read-only"
+    assert value["mechanical_authority"].startswith("live Git/GitHub")
+    assert workspace.sealed == [tmp_path / "review-root"]
+    assert store.guard_path(context.review_id).is_file()
+    assert checks.calls == 2
+
+
+def test_review_complete_head_change_is_review_stale_head(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    start = _review_identity_value()
+    current = _review_identity_value(head="b" * 40)
+    state = _review_state(head="b" * 40)
+    resolver = cast(Any, StaticResolver(tmp_path, state))
+    store = lck.ReviewInvocationStore(tmp_path)
+    review_id = store.new_id()
+    store.write_guard(
+        review_id,
+        {
+            "task_number": 159,
+            "identity": start.to_dict(),
+            "review_root": str(tmp_path / "review-root"),
+            "checks": {"status": "pass"},
+            "validation": {"status": "pass"},
+        },
+    )
+    monkeypatch.setattr(
+        lck,
+        "_live_task_contract",
+        lambda *_args: {"body_sha256": "d" * 64},
+    )
+    monkeypatch.setattr(lck, "_review_identity", lambda *_args: current)
+    workspace = FakeReviewWorkspace(tmp_path / "review-root")
+
+    with pytest.raises(lck.ReviewStaleError) as exc_info:
+        lck.ReviewCompleter(
+            resolver,
+            store=store,
+            workspace=cast(Any, workspace),
+            checks_gate=cast(Any, FakeReviewChecks()),
+        ).complete(159, review_id, verdict="PASS")
+
+    assert exc_info.value.code == "REVIEW_STALE_HEAD"
+    assert workspace.removed == [tmp_path / "review-root"]
+    assert not store.guard_path(review_id).exists()
+
+
+def test_review_complete_base_change_is_review_stale_base(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    start = _review_identity_value()
+    current = _review_identity_value(base="b" * 40)
+    state = _review_state(base="b" * 40)
+    resolver = cast(Any, StaticResolver(tmp_path, state))
+    store = lck.ReviewInvocationStore(tmp_path)
+    review_id = store.new_id()
+    store.write_guard(
+        review_id,
+        {
+            "task_number": 159,
+            "identity": start.to_dict(),
+            "review_root": str(tmp_path / "review-root"),
+            "checks": {"status": "pass"},
+            "validation": {"status": "pass"},
+        },
+    )
+    monkeypatch.setattr(
+        lck,
+        "_live_task_contract",
+        lambda *_args: {"body_sha256": "d" * 64},
+    )
+    monkeypatch.setattr(lck, "_review_identity", lambda *_args: current)
+
+    with pytest.raises(lck.ReviewStaleError) as exc_info:
+        lck.ReviewCompleter(
+            resolver,
+            store=store,
+            workspace=cast(Any, FakeReviewWorkspace(tmp_path / "review-root")),
+        ).complete(159, review_id, verdict="PASS")
+
+    assert exc_info.value.code == "REVIEW_STALE_BASE"
+
+
+def test_review_fail_returns_stop_required_without_starting_remediation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    identity = _review_identity_value()
+    state = _review_state()
+    resolver = cast(Any, StaticResolver(tmp_path, state))
+    store = lck.ReviewInvocationStore(tmp_path)
+    review_id = store.new_id()
+    store.write_guard(
+        review_id,
+        {
+            "task_number": 159,
+            "identity": identity.to_dict(),
+            "review_root": str(tmp_path / "review-root"),
+            "checks": {"status": "pass"},
+            "validation": {"status": "pass"},
+        },
+    )
+    findings = tmp_path / "findings.md"
+    findings.write_text("[F1][Medium] Repair this behavior.\n", encoding="utf-8")
+    monkeypatch.setattr(
+        lck,
+        "_live_task_contract",
+        lambda *_args: {"body_sha256": "d" * 64},
+    )
+    monkeypatch.setattr(lck, "_review_identity", lambda *_args: identity)
+    checks = FakeReviewChecks()
+
+    result = lck.ReviewCompleter(
+        resolver,
+        store=store,
+        workspace=cast(Any, FakeReviewWorkspace(tmp_path / "review-root")),
+        checks_gate=cast(Any, checks),
+    ).complete(159, review_id, verdict="FAIL", findings_file=findings)
+
+    assert result.status == "STOP_REQUIRED"
+    assert result.to_dict()["automatic_remediation"] is False
+    assert checks.calls == 0
+    record = store.read_record(159, review_id)
+    assert record["findings"].startswith("[F1][Medium]")
+    assert record["authority_note"].startswith("record is diagnostic")
+
+
+def test_review_pass_stops_at_human_merge_boundary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    identity = _review_identity_value()
+    resolver = cast(Any, StaticResolver(tmp_path, _review_state()))
+    store = lck.ReviewInvocationStore(tmp_path)
+    review_id = store.new_id()
+    store.write_guard(
+        review_id,
+        {
+            "task_number": 159,
+            "identity": identity.to_dict(),
+            "review_root": str(tmp_path / "review-root"),
+            "checks": {"status": "pass"},
+            "validation": {"status": "pass"},
+        },
+    )
+    monkeypatch.setattr(
+        lck,
+        "_live_task_contract",
+        lambda *_args: {"body_sha256": "d" * 64},
+    )
+    monkeypatch.setattr(lck, "_review_identity", lambda *_args: identity)
+    checks = FakeReviewChecks()
+
+    result = lck.ReviewCompleter(
+        resolver,
+        store=store,
+        workspace=cast(Any, FakeReviewWorkspace(tmp_path / "review-root")),
+        checks_gate=cast(Any, checks),
+    ).complete(159, review_id, verdict="PASS")
+
+    assert result.status == "READY_FOR_HUMAN_MERGE"
+    assert "manual merge" in result.to_dict()["human_boundary"]
+    assert checks.calls == 1
+
+
+def test_review_workspace_seal_removes_write_bits(tmp_path: Path) -> None:
+    root = tmp_path / "review"
+    nested = root / "pkg"
+    nested.mkdir(parents=True)
+    target = nested / "file.py"
+    target.write_text("print('read only')\n", encoding="utf-8")
+
+    lck.ReviewWorkspaceManager.seal_read_only(root)
+
+    assert root.stat().st_mode & 0o222 == 0
+    assert nested.stat().st_mode & 0o222 == 0
+    assert target.stat().st_mode & 0o222 == 0
+    lck.ReviewWorkspaceManager._make_removable(root)
+
+
+def test_remediation_prepare_uses_live_head_not_review_record_identity(
+    tmp_path: Path,
+) -> None:
+    live_head = "b" * 40
+    state = _review_state(head=live_head, base=SHA)
+    resolver = cast(Any, StaticResolver(tmp_path, state))
+    store = lck.ReviewInvocationStore(tmp_path)
+    review_id = store.new_id()
+    store.write_record(
+        159,
+        review_id,
+        {
+            "task_number": 159,
+            "verdict": "FAIL",
+            "identity": _review_identity_value(head=SHA).to_dict(),
+            "findings": "[F1][Medium] Semantic repair input.",
+        },
+    )
+    store.write_latest_review(159, review_id, "FAIL")
+
+    context = lck.RemediationPreparer(resolver, store=store).prepare(159, review_id)
+
+    assert context.to_dict()["live_target"]["head_sha"] == live_head
+    assert context.findings == "[F1][Medium] Semantic repair input."
+    assert "current live state" in context.to_dict()["mechanical_authority"]
+
+
+def test_remediation_complete_requires_actual_repair_changes(
+    tmp_path: Path,
+) -> None:
+    resolver = cast(Any, StaticResolver(tmp_path, _review_state(clean=True)))
+    store = lck.ReviewInvocationStore(tmp_path)
+    review_id = store.new_id()
+    store.write_record(
+        159,
+        review_id,
+        {
+            "task_number": 159,
+            "verdict": "FAIL",
+            "identity": _review_identity_value().to_dict(),
+            "findings": "[F1][Medium] Repair required.",
+        },
+    )
+    store.write_latest_review(159, review_id, "FAIL")
+
+    with pytest.raises(
+        lck.LckStopError, match="repaired head or uncommitted repair changes"
+    ):
+        lck.RemediationCompleter(resolver, store=store).complete(
+            159,
+            review_id,
+            commit_message="Repair review finding",
+            summary="Repair finding",
+        )
+
+
+def test_reuse_existing_open_pr_never_creates_a_replacement(tmp_path: Path) -> None:
+    state = _review_state()
+    resolver = cast(Any, StaticResolver(tmp_path, state))
+
+    receipt = lck.ReuseExistingOpenPrEffect(resolver).execute(
+        159,
+        summary="ignored",
+        risks="ignored",
+        critical_outcome={"status": "valid"},
+        validation={"status": "pass"},
+        expected_base_sha=SHA,
+        expected_body_sha256="d" * 64,
+    )
+
+    assert receipt.effect == "reuse_open_pr"
+    assert receipt.action == "reused-current-open-pr"
+    assert resolver.runner.commands == []
+
+
+def test_remediation_requires_latest_failed_review(tmp_path: Path) -> None:
+    resolver = cast(Any, StaticResolver(tmp_path, _review_state()))
+    store = lck.ReviewInvocationStore(tmp_path)
+    failed_id = store.new_id()
+    newer_id = store.new_id()
+    store.write_record(
+        159,
+        failed_id,
+        {
+            "task_number": 159,
+            "verdict": "FAIL",
+            "identity": _review_identity_value().to_dict(),
+            "findings": "[F1][Medium] Old finding.",
+        },
+    )
+    store.write_latest_review(159, newer_id, "PASS")
+
+    with pytest.raises(lck.LckStopError, match="latest completed Independent Review"):
+        lck.RemediationPreparer(resolver, store=store).prepare(159, failed_id)
+
+
+def test_post_remediation_boundary_blocks_another_remediation_until_review(
+    tmp_path: Path,
+) -> None:
+    resolver = cast(Any, StaticResolver(tmp_path, _review_state(head="b" * 40)))
+    store = lck.ReviewInvocationStore(tmp_path)
+    failed_id = store.new_id()
+    store.write_record(
+        159,
+        failed_id,
+        {
+            "task_number": 159,
+            "verdict": "FAIL",
+            "identity": _review_identity_value().to_dict(),
+            "findings": "[F1][Medium] Repair required.",
+        },
+    )
+    store.write_latest_review(159, failed_id, "FAIL")
+    store.write_review_required(159, failed_id, "b" * 40)
+
+    with pytest.raises(lck.LckStopError, match="fresh Independent Review is required"):
+        lck.RemediationPreparer(resolver, store=store).prepare(159, failed_id)
+
+
+def test_accepted_fresh_review_releases_post_remediation_boundary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    identity = _review_identity_value(head="b" * 40)
+    resolver = cast(Any, StaticResolver(tmp_path, _review_state(head="b" * 40)))
+    store = lck.ReviewInvocationStore(tmp_path)
+    old_review_id = store.new_id()
+    store.write_review_required(159, old_review_id, "b" * 40)
+    review_id = store.new_id()
+    store.write_guard(
+        review_id,
+        {
+            "task_number": 159,
+            "identity": identity.to_dict(),
+            "review_root": str(tmp_path / "review-root"),
+            "checks": {"status": "pass"},
+            "validation": {"status": "pass"},
+        },
+    )
+    findings = tmp_path / "findings-new.md"
+    findings.write_text("[F2][Medium] New review finding.\n", encoding="utf-8")
+    monkeypatch.setattr(
+        lck,
+        "_live_task_contract",
+        lambda *_args: {"body_sha256": "d" * 64},
+    )
+    monkeypatch.setattr(lck, "_review_identity", lambda *_args: identity)
+
+    result = lck.ReviewCompleter(
+        resolver,
+        store=store,
+        workspace=cast(Any, FakeReviewWorkspace(tmp_path / "review-root")),
+    ).complete(159, review_id, verdict="FAIL", findings_file=findings)
+
+    assert result.status == "STOP_REQUIRED"
+    assert store.read_review_required(159) is None
+    latest = store.read_latest_review(159)
+    assert latest is not None
+    assert latest["review_id"] == review_id
+    assert latest["verdict"] == "FAIL"
+
+
+def test_remediation_complete_can_resume_committed_new_head_and_requires_re_review(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repaired_head = "b" * 40
+    state = _review_state(head=repaired_head, clean=True)
+    resolver = cast(Any, StaticResolver(tmp_path, state))
+    store = lck.ReviewInvocationStore(tmp_path)
+    review_id = store.new_id()
+    store.write_record(
+        159,
+        review_id,
+        {
+            "task_number": 159,
+            "verdict": "FAIL",
+            "identity": _review_identity_value(head=SHA).to_dict(),
+            "findings": "[F1][Medium] Repair required.",
+        },
+    )
+    store.write_latest_review(159, review_id, "FAIL")
+
+    delivery_result = lck.DeliveryCompletionResult(
+        task_number=159,
+        status="READY_FOR_REVIEW",
+        branch=state.target_branch,
+        head_sha=repaired_head,
+        critical_outcome={"status": "pass"},
+        validation={"status": "pass"},
+        checks={"status": "pass"},
+        effects=(),
+        final_state=state,
+    )
+
+    class FakeDeliveryCompleter:
+        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+            pass
+
+        def complete(self, *_args: Any, **_kwargs: Any) -> lck.DeliveryCompletionResult:
+            return delivery_result
+
+    monkeypatch.setattr(lck, "DeliveryCompleter", FakeDeliveryCompleter)
+
+    result = lck.RemediationCompleter(resolver, store=store).complete(
+        159,
+        review_id,
+        commit_message="Repair review finding",
+        summary="Repair finding",
+    )
+
+    assert result.to_dict()["status"] == "READY_FOR_NEW_REVIEW"
+    assert result.to_dict()["automatic_review"] is False
+    required = store.read_review_required(159)
+    assert required is not None
+    assert required["remediated_head"] == repaired_head
+    with pytest.raises(lck.LckStopError, match="fresh Independent Review is required"):
+        lck.RemediationPreparer(resolver, store=store).prepare(159, review_id)

--- a/tests/tools/test_lck.py
+++ b/tests/tools/test_lck.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import sys
+import tempfile
 from pathlib import Path
 from typing import Any, cast
 
@@ -922,10 +923,52 @@ class StaticResolver:
         return self.state
 
 
+class FakeWorkspaceRunner:
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.status_output = ""
+        self.configured = False
+
+    def run(
+        self,
+        argv: list[str] | tuple[str, ...],
+        *,
+        command_id: str,
+        **_: Any,
+    ) -> CommandResult:
+        command = tuple(str(item) for item in argv)
+        args = list(command[1:]) if command and command[0] == "git" else list(command)
+        stdout = ""
+        if args == ["worktree", "list", "--porcelain"]:
+            stdout = f"worktree {self.root}\n"
+        elif args == ["status", "--porcelain=v1", "--untracked-files=all"]:
+            stdout = self.status_output
+        elif args == ["rev-parse", "HEAD"]:
+            stdout = f"{SHA}\n"
+        elif args == ["config", "--worktree", "core.filemode", "false"]:
+            self.configured = True
+        else:
+            return CommandResult(
+                command_id=command_id,
+                argv=command,
+                returncode=1,
+                stdout="",
+                stderr=f"unsupported fake command: {args}",
+            )
+        return CommandResult(
+            command_id=command_id,
+            argv=command,
+            returncode=0,
+            stdout=stdout,
+            stderr="",
+        )
+
+
 class FakeReviewWorkspace:
     def __init__(self, root: Path) -> None:
         self.root = root
         self.sealed: list[Path] = []
+        self.ready_checked: list[Path] = []
         self.removed: list[Path] = []
 
     def create(self, _task: int, _head: str) -> Path:
@@ -934,6 +977,12 @@ class FakeReviewWorkspace:
 
     def seal_read_only(self, path: Path) -> None:
         self.sealed.append(path)
+
+    def seal_for_review(self, path: Path, _head: str) -> None:
+        self.seal_read_only(path)
+
+    def assert_ready_for_completion(self, path: Path, _head: str) -> None:
+        self.ready_checked.append(path)
 
     def remove(self, path: Path) -> None:
         self.removed.append(path)
@@ -1338,6 +1387,30 @@ def test_review_workspace_seal_removes_write_bits(tmp_path: Path) -> None:
     assert nested.stat().st_mode & 0o222 == 0
     assert target.stat().st_mode & 0o222 == 0
     lck.ReviewWorkspaceManager._make_removable(root)
+
+
+def test_review_workspace_seal_preserves_clean_status_and_rejects_mutation(
+    tmp_path: Path,
+) -> None:
+    with tempfile.TemporaryDirectory(prefix="tracequant-lck-review-test-") as raw:
+        root = Path(raw)
+        (root / "tracked.py").write_text("print('review')\n", encoding="utf-8")
+        resolver = cast(Any, StaticResolver(tmp_path, _review_state()))
+        runner = FakeWorkspaceRunner(root)
+        resolver.runner = runner
+        manager = lck.ReviewWorkspaceManager(resolver)
+
+        manager.seal_for_review(root, SHA)
+
+        assert runner.configured is True
+        assert root.stat().st_mode & 0o222 == 0
+        assert (root / "tracked.py").stat().st_mode & 0o222 == 0
+        manager.assert_ready_for_completion(root, SHA)
+
+        runner.status_output = " M tracked.py\n"
+        with pytest.raises(lck.LckStopError, match="changed the isolated worktree"):
+            manager.assert_ready_for_completion(root, SHA)
+        manager._make_removable(root)
 
 
 def test_review_workspace_remove_rejects_unvalidated_path(tmp_path: Path) -> None:

--- a/tests/tools/test_lck.py
+++ b/tests/tools/test_lck.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import shutil
+import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -19,7 +21,10 @@ from pr_resolve import (  # type: ignore[import-not-found]
     PrResolveError,
     resolve_open_pr,
 )  # noqa: E402
-from workflow_common import CommandResult  # type: ignore[import-not-found]  # noqa: E402
+from workflow_common import (  # type: ignore[import-not-found]  # noqa: E402
+    CommandResult,
+    CommandRunner,
+)
 
 
 SHA = "a" * 40
@@ -927,7 +932,7 @@ class FakeWorkspaceRunner:
     def __init__(self, root: Path) -> None:
         self.root = root
         self.status_output = ""
-        self.configured = False
+        self.commands: list[tuple[str, ...]] = []
 
     def run(
         self,
@@ -937,6 +942,7 @@ class FakeWorkspaceRunner:
         **_: Any,
     ) -> CommandResult:
         command = tuple(str(item) for item in argv)
+        self.commands.append(command)
         args = list(command[1:]) if command and command[0] == "git" else list(command)
         stdout = ""
         if args == ["worktree", "list", "--porcelain"]:
@@ -945,8 +951,6 @@ class FakeWorkspaceRunner:
             stdout = self.status_output
         elif args == ["rev-parse", "HEAD"]:
             stdout = f"{SHA}\n"
-        elif args == ["config", "--worktree", "core.filemode", "false"]:
-            self.configured = True
         else:
             return CommandResult(
                 command_id=command_id,
@@ -1380,12 +1384,17 @@ def test_review_workspace_seal_removes_write_bits(tmp_path: Path) -> None:
     nested.mkdir(parents=True)
     target = nested / "file.py"
     target.write_text("print('read only')\n", encoding="utf-8")
+    executable = nested / "tool.py"
+    executable.write_text("#!/usr/bin/env python3\n", encoding="utf-8")
+    executable.chmod(0o755)
 
     lck.ReviewWorkspaceManager.seal_read_only(root)
 
     assert root.stat().st_mode & 0o222 == 0
     assert nested.stat().st_mode & 0o222 == 0
     assert target.stat().st_mode & 0o222 == 0
+    assert executable.stat().st_mode & 0o222 == 0
+    assert executable.stat().st_mode & 0o111 != 0
     lck.ReviewWorkspaceManager._make_removable(root)
 
 
@@ -1402,7 +1411,10 @@ def test_review_workspace_seal_preserves_clean_status_and_rejects_mutation(
 
         manager.seal_for_review(root, SHA)
 
-        assert runner.configured is True
+        assert not any(
+            command[:3] == ("git", "config", "--worktree")
+            for command in runner.commands
+        )
         assert root.stat().st_mode & 0o222 == 0
         assert (root / "tracked.py").stat().st_mode & 0o222 == 0
         manager.assert_ready_for_completion(root, SHA)
@@ -1411,6 +1423,89 @@ def test_review_workspace_seal_preserves_clean_status_and_rejects_mutation(
         with pytest.raises(lck.LckStopError, match="changed the isolated worktree"):
             manager.assert_ready_for_completion(root, SHA)
         manager._make_removable(root)
+
+
+def test_review_workspace_seal_real_git_multi_worktree_without_worktree_config(
+    tmp_path: Path,
+) -> None:
+    if shutil.which("git") is None:
+        pytest.skip("git is required for Review worktree integration test")
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    def git(*args: str, cwd: Path = repo) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            check=True,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+
+    git("init")
+    git("config", "user.name", "TraceQuant Test")
+    git("config", "user.email", "tracequant-test@example.invalid")
+    tracked = repo / "tracked.py"
+    tracked.write_text("print('review')\n", encoding="utf-8")
+    executable = repo / "tool.py"
+    executable.write_text("#!/usr/bin/env python3\n", encoding="utf-8")
+    executable.chmod(0o755)
+    git("add", "tracked.py", "tool.py")
+    git("commit", "-m", "initial")
+    head_sha = git("rev-parse", "HEAD").stdout.strip()
+
+    unset = subprocess.run(
+        ["git", "config", "--unset-all", "extensions.worktreeConfig"],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    assert unset.returncode in {0, 5}
+
+    resolver = cast(Any, StaticResolver(repo, _review_state()))
+    resolver.runner = CommandRunner(repo)
+    manager = lck.ReviewWorkspaceManager(resolver)
+    review_root = manager.create(159, head_sha)
+    worktrees = git("worktree", "list", "--porcelain").stdout
+    assert worktrees.count("worktree ") == 2
+    config_before_seal = (repo / ".git" / "config").read_text(encoding="utf-8")
+
+    try:
+        manager.seal_for_review(review_root, head_sha)
+
+        assert (repo / ".git" / "config").read_text(
+            encoding="utf-8"
+        ) == config_before_seal
+        status = git(
+            "status",
+            "--porcelain=v1",
+            "--untracked-files=all",
+            cwd=review_root,
+        )
+        assert status.stdout.strip() == ""
+        assert git("rev-parse", "HEAD", cwd=review_root).stdout.strip() == head_sha
+        assert review_root.stat().st_mode & 0o222 == 0
+        assert (review_root / "tracked.py").stat().st_mode & 0o222 == 0
+        sealed_executable = review_root / "tool.py"
+        assert sealed_executable.stat().st_mode & 0o222 == 0
+        assert sealed_executable.stat().st_mode & 0o111 != 0
+
+        configured = subprocess.run(
+            ["git", "config", "--get", "extensions.worktreeConfig"],
+            cwd=repo,
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+        assert configured.returncode == 1
+        assert configured.stdout.strip() == ""
+    finally:
+        manager.remove(review_root)
 
 
 def test_review_workspace_remove_rejects_unvalidated_path(tmp_path: Path) -> None:

--- a/tests/tools/test_lck_delivery.py
+++ b/tests/tools/test_lck_delivery.py
@@ -112,6 +112,35 @@ def test_ensure_remote_branch_create_then_idempotent(tmp_path: Path) -> None:
     assert created.details["head_sha"] == repeated.details["remote_oid"]
 
 
+def test_ensure_remote_branch_repairs_missing_upstream_when_already_synced(
+    tmp_path: Path,
+) -> None:
+    repo, _ = _repo(tmp_path)
+    branch = "task/160-delivery"
+    _git(repo, "switch", "-c", branch)
+    (repo / "task.txt").write_text("task\n", encoding="utf-8")
+    _git(repo, "add", "task.txt")
+    _git(repo, "commit", "-m", "task")
+    effect = lck.EnsureRemoteBranchEffect(_resolver_for_repo(repo))
+    effect.execute(branch)
+    _git(repo, "branch", "--unset-upstream")
+
+    repaired = effect.execute(branch)
+
+    assert repaired.action == "already-synced"
+    assert repaired.details["upstream"] == f"origin/{branch}"
+    assert (
+        _git(
+            repo,
+            "rev-parse",
+            "--abbrev-ref",
+            "--symbolic-full-name",
+            "@{upstream}",
+        )
+        == f"origin/{branch}"
+    )
+
+
 def test_ensure_remote_branch_rejects_unvalidated_local_head(
     tmp_path: Path,
 ) -> None:
@@ -447,6 +476,7 @@ class CliDeliveryRunner:
         self.commands: list[tuple[str, ...]] = []
         self.command_ids: list[str] = []
         self.remote_oid: str | None = None
+        self.upstream: str | None = None
         self.open_pr = False
         self.project_status = "In Progress"
         self.dirty = True
@@ -575,6 +605,13 @@ Verification test: tests/tools/test_lck_delivery.py::test_task_160_critical_outc
             return self._result(command_id, command, stdout=self.tree_oid)
         if args == ["rev-parse", "FETCH_HEAD"]:
             return self._result(command_id, command, stdout=self.remote_oid or "")
+        if args == [
+            "rev-parse",
+            "--abbrev-ref",
+            "--symbolic-full-name",
+            "@{upstream}",
+        ]:
+            return self._result(command_id, command, stdout=self.upstream or "")
         if args == ["rev-parse", "refs/heads/main"]:
             return self._result(command_id, command, stdout=self.base_sha)
         if args == ["rev-parse", "refs/remotes/origin/main"]:
@@ -614,6 +651,9 @@ Verification test: tests/tools/test_lck_delivery.py::test_task_160_critical_outc
             return self._result(command_id, command)
         if args == ["diff", "--name-only"]:
             return self._result(command_id, command, stdout="candidate.py")
+        if args[:2] == ["branch", "--set-upstream-to"]:
+            self.upstream = args[2]
+            return self._result(command_id, command)
         if args == ["add", "-A", "--", ":/"]:
             return self._result(command_id, command)
         if args == ["write-tree"]:
@@ -623,6 +663,8 @@ Verification test: tests/tools/test_lck_delivery.py::test_task_160_critical_outc
             return self._result(command_id, command)
         if args[:1] == ["push"]:
             self.remote_oid = self.new_head
+            if "-u" in args:
+                self.upstream = f"origin/{self.branch}"
             return self._result(command_id, command)
         if args[:3] == ["merge-base", "--is-ancestor", self.remote_oid or ""]:
             return self._result(command_id, command)

--- a/tests/tools/test_retrieval_v2_policy.py
+++ b/tests/tools/test_retrieval_v2_policy.py
@@ -245,15 +245,15 @@ def test_review_skills_independent_and_lazy_hierarchy() -> None:
     for path in SKILLS["review"].values():
         text = _flat(path)
         assert (
-            "Independently read the current Task body, PR body and effective diff"
+            "The current Task Contract, effective diff, and necessary related code are the default semantic context"
             in text
         )
         assert (
-            "Comments, Parent/Epic bodies, and other hierarchy/history are not default review input"
+            "Comments, Parent/Epic bodies, and other hierarchy or history are not default Review input"
             in text
         )
-        assert "Expansion is bounded" in text
-        assert "Do not inherit Delivery conclusions" in text
+        assert "expand only when the current Task explicitly references them" in text
+        assert "Delivery conclusions" in text and "are not evidence" in text
         assert "fresh session" in text.casefold() or "new session" in text.casefold()
         assert "read-only" in text
 
@@ -299,7 +299,7 @@ def test_feature_audit_skills_hierarchy_aware_exception() -> None:
 def test_codex_claude_retrieval_semantics_parity() -> None:
     markers = {
         "delivery": "Do not default to reading comments, complete Parent/Epic bodies",
-        "review": "hierarchy/history are not default review input",
+        "review": "hierarchy or history are not default Review input",
         "closeout": "does not default to re-reading the complete business Issue hierarchy",
         "audit": "not a leaf-Issue-first default",
     }

--- a/tests/tools/test_workflow_skills.py
+++ b/tests/tools/test_workflow_skills.py
@@ -14,6 +14,14 @@ ACTIVE_SKILLS = {
     / ".agents/skills/feature-completion-audit/SKILL.md",
 }
 PATH_AUDIT = ROOT / "tools/agent_workflow/skill_path_audit.py"
+LCK_COMMAND_PREFIX = "uv run --frozen python tools/agent_workflow/lck.py"
+LCK_COMMAND_SOURCES = (
+    ACTIVE_SKILLS["task-delivery-runner"],
+    ACTIVE_SKILLS["task-pr-review-runner"],
+    ROOT / ".claude/skills/task-delivery-runner/SKILL.md",
+    ROOT / ".claude/skills/task-pr-review-runner/SKILL.md",
+    ROOT / "docs/development/pr-review.md",
+)
 
 
 def _dual_skill(name: str) -> tuple[str, str]:
@@ -54,6 +62,21 @@ def test_current_runner_skills_use_one_mechanical_path() -> None:
         assert ".agents/policies/workflow-evidence.md" in ACTIVE_SKILLS[name].read_text(
             encoding="utf-8"
         )
+
+
+def test_lck_commands_use_the_pinned_project_python() -> None:
+    for path in LCK_COMMAND_SOURCES:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if "tools/agent_workflow/lck.py" in line:
+                assert line.strip().startswith(LCK_COMMAND_PREFIX), (
+                    f"{path} contains a non-canonical LCK launcher: {line!r}"
+                )
+
+    profile = (ROOT / ".agents/execution-profile.example.toml").read_text(
+        encoding="utf-8"
+    )
+    assert 'executable = "python"' not in profile
+    assert 'name = "uv-toolchain"' in profile
 
 
 def test_delivery_runner_uses_lck_for_initial_delivery_and_explicit_remediation() -> (

--- a/tests/tools/test_workflow_skills.py
+++ b/tests/tools/test_workflow_skills.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import re
 import subprocess
 import sys
 from pathlib import Path
@@ -15,6 +14,13 @@ ACTIVE_SKILLS = {
     / ".agents/skills/feature-completion-audit/SKILL.md",
 }
 PATH_AUDIT = ROOT / "tools/agent_workflow/skill_path_audit.py"
+
+
+def _dual_skill(name: str) -> tuple[str, str]:
+    return (
+        (ROOT / ".agents/skills" / name / "SKILL.md").read_text(encoding="utf-8"),
+        (ROOT / ".claude/skills" / name / "SKILL.md").read_text(encoding="utf-8"),
+    )
 
 
 def test_current_runner_skills_use_one_mechanical_path() -> None:
@@ -34,37 +40,46 @@ def test_current_runner_skills_use_one_mechanical_path() -> None:
     for name, path in ACTIVE_SKILLS.items():
         text = path.read_text(encoding="utf-8")
         assert f"name: {name}" in text
-        assert ".agents/policies/workflow-evidence.md" in text
         assert len(text) < 28_000
         assert len(text.splitlines()) < 550
         for fragment in forbidden:
             assert fragment not in text
         assert "telemetry" not in text.casefold()
 
+    # Review is deliberately cut over from Evidence Runner snapshot authority.
+    review = ACTIVE_SKILLS["task-pr-review-runner"].read_text(encoding="utf-8")
+    assert ".agents/policies/command-execution.md" in review
+    assert ".agents/policies/workflow-evidence.md" not in review
+    for name in ("task-delivery-runner", "task-closeout", "feature-completion-audit"):
+        assert ".agents/policies/workflow-evidence.md" in ACTIVE_SKILLS[name].read_text(
+            encoding="utf-8"
+        )
 
-def test_delivery_runner_uses_lck_for_initial_delivery_and_keeps_remediation() -> None:
+
+def test_delivery_runner_uses_lck_for_initial_delivery_and_explicit_remediation() -> (
+    None
+):
     text = ACTIVE_SKILLS["task-delivery-runner"].read_text(encoding="utf-8")
     assert "tools/agent_workflow/lck.py delivery prepare" in text
     assert "tools/agent_workflow/lck.py delivery complete" in text
     assert "Critical Outcome" in text
     assert "READY_FOR_REVIEW" in text
     assert "Agent / Skill MUST NOT directly" in text
-    assert "branch, remote, SHA, base SHA, PR number, or refspec" in text
+    assert "branch/SHA/base/PR identity as workflow authority" in text
     assert "no alternate write route" in text
+
     assert "## Review remediation" in text
-    assert "reviewed head SHA" in text
-    assert "workflow-delivery" in text
-    assert "delivery-readiness" in text
-    assert "new commit" in text and "fresh independent review" in text
+    assert "tools/agent_workflow/lck.py remediation prepare" in text
+    assert "tools/agent_workflow/lck.py remediation complete" in text
+    assert "semantic findings" in text
+    assert "mechanical facts from the Review" in text
+    assert "reuse existing OPEN PR" in text
+    assert "READY_FOR_NEW_REVIEW" in text
+    assert "MUST NOT start\nIndependent Review automatically" in text
 
 
-def test_initial_delivery_lck_contract_is_shared_by_both_skills() -> None:
-    agent = (ROOT / ".agents/skills/task-delivery-runner/SKILL.md").read_text(
-        encoding="utf-8"
-    )
-    claude = (ROOT / ".claude/skills/task-delivery-runner/SKILL.md").read_text(
-        encoding="utf-8"
-    )
+def test_delivery_lck_contract_is_shared_by_both_skills() -> None:
+    agent, claude = _dual_skill("task-delivery-runner")
     assert agent == claude
     for phrase in (
         "LCK Delivery Prepare",
@@ -73,6 +88,9 @@ def test_initial_delivery_lck_contract_is_shared_by_both_skills() -> None:
         "ensure_remote_branch",
         "ensure_open_pr",
         "READY_FOR_REVIEW",
+        "LCK Remediation Prepare",
+        "LCK Remediation Complete",
+        "READY_FOR_NEW_REVIEW",
         "The Skill is a semantic procedure",
     ):
         assert phrase in agent
@@ -81,20 +99,71 @@ def test_initial_delivery_lck_contract_is_shared_by_both_skills() -> None:
     assert "--bootstrap-verify" not in agent
 
 
-def test_review_runner_is_read_only_and_emits_bounded_remediation_handoff() -> None:
+def test_review_runner_is_fresh_read_only_lck_review() -> None:
+    agent, claude = _dual_skill("task-pr-review-runner")
+    assert agent == claude
+    text = agent
+    for phrase in (
+        "fresh session",
+        "implementation-read-only",
+        "tools/agent_workflow/lck.py review prepare",
+        "READY_FOR_SEMANTIC_REVIEW",
+        "Inspect",
+        "Reason",
+        "Judge",
+        "Report",
+        "tools/agent_workflow/lck.py review complete",
+        "REVIEW_STALE_HEAD",
+        "REVIEW_STALE_BASE",
+        "READY_FOR_HUMAN_MERGE",
+        "STOP_REQUIRED",
+        "通过，可以人工合并",
+        "不通过，需要修复",
+    ):
+        assert phrase in text
+    assert "do not start Remediation" in text
+    assert "Task Contract" in text
+    assert "complete effective diff" in text
+
+
+def test_review_runner_does_not_restore_pre_cutover_authority() -> None:
     text = ACTIVE_SKILLS["task-pr-review-runner"].read_text(encoding="utf-8")
-    assert "workflow-review" in text
-    assert "recheck --snapshot-id" in text
-    assert "通过，可以人工合并" in text
-    assert "有条件通过，不得合并" in text
-    assert "不通过，需要修复" in text
-    assert "new session" in text.casefold()
-    assert "strictly read-only" in text
-    assert "## Remediation handoff" in text
-    assert "Required remediation:" in text
-    assert "Objective gates:" in text
-    assert "Maintainer decision required:" in text
-    assert "task-delivery-runner 修复" in text
+    for forbidden in (
+        "workflow-review",
+        "recheck --snapshot-id",
+        "--expected-head-sha",
+        "--expected-base-sha",
+        "有条件通过，不得合并",
+        "Remediation handoff",
+        "Reviewed head SHA:",
+        "Objective gates:",
+        "Maintainer decision required:",
+    ):
+        assert forbidden not in text
+    assert "Delivery handoff" in text
+    assert "MUST NOT pass PR/base/head/checks/snapshot" in text
+    assert "do not fall back to Evidence Runner snapshots" in text
+
+
+def test_review_fail_stops_and_never_auto_starts_remediation() -> None:
+    text = ACTIVE_SKILLS["task-pr-review-runner"].read_text(encoding="utf-8")
+    assert "FAIL" in text
+    assert "STOP_REQUIRED" in text
+    assert "maintainer may explicitly use for\nRemediation" in text
+    assert "Do not emit an automatic" in text and "Delivery prompt" in text
+    assert "do not start Remediation" in text
+
+
+def test_review_skill_keeps_semantic_coverage_without_mechanical_handoff_matrix() -> (
+    None
+):
+    text = ACTIVE_SKILLS["task-pr-review-runner"].read_text(encoding="utf-8")
+    assert "AC\ncoverage/evidence matrix" in text
+    assert "complete effective diff" in text
+    assert "Check correctness, failure" in text
+    assert "behavior, tests, docs/config/public interfaces" in text
+    assert "Historical Skill matches source commit blob" not in text
+    assert "All target Skills are canonical-state" not in text
 
 
 def test_closeout_and_feature_audit_keep_manual_gates() -> None:
@@ -112,7 +181,7 @@ def test_closeout_and_feature_audit_keep_manual_gates() -> None:
     assert "performs none" in audit
 
 
-def test_active_skills_have_bounded_failure_contract_without_evolution_traces() -> None:
+def test_active_skills_have_no_evolution_traces() -> None:
     forbidden_traces = (
         "trusted_runner.py",
         "--trusted-sha",
@@ -127,9 +196,6 @@ def test_active_skills_have_bounded_failure_contract_without_evolution_traces() 
     )
     for path in ACTIVE_SKILLS.values():
         text = path.read_text(encoding="utf-8").casefold()
-        assert "partial" in text
-        assert "unknown" in text
-        assert "bounded" in text or "only the named" in text
         for trace in forbidden_traces:
             assert trace not in text
 
@@ -145,6 +211,7 @@ def test_path_audit_reports_only_clean_current_skills() -> None:
     )
     assert result.returncode == 0, result.stdout + result.stderr
     value = json.loads(result.stdout)
+    assert value["schema_version"] == 5
     assert value["status"] == "pass"
     assert value["totals"]["direct_command_path_count"] == 0
     assert value["totals"]["evolution_trace_count"] == 0
@@ -159,7 +226,7 @@ def test_legacy_skill_directories_are_absent() -> None:
         assert not (ROOT / relative).exists(), relative
 
 
-def test_local_workflow_artifact_directories_are_exactly_ignored() -> None:
+def test_local_workflow_artifact_directories_are_ignored() -> None:
     patterns = {
         line.strip()
         for line in (ROOT / ".gitignore").read_text(encoding="utf-8-sig").splitlines()
@@ -167,149 +234,4 @@ def test_local_workflow_artifact_directories_are_exactly_ignored() -> None:
     }
     assert ".agents/evidence.local/" in patterns
     assert ".agents/validation.local/" in patterns
-
-
-# --- Evidence verdict matrix tests ---
-
-
-def test_review_skill_has_shared_owner_contract_and_exact_tokens() -> None:
-    text = ACTIVE_SKILLS["task-pr-review-runner"].read_text(encoding="utf-8")
-    # Shared semantic owner referenced for verdict and remediation conditions.
-    assert "docs/development/pr-review.md" in text
-    assert "§8" in text
-    assert "§9" in text
-    # Exact executable verdict output tokens are retained.
-    assert "通过，可以人工合并" in text
-    assert "有条件通过，不得合并" in text
-    assert "不通过，需要修复" in text
-    # Head-change invalidation retained as a hard guard.
-    assert "REVIEW INVALIDATED — HEAD CHANGED" in text
-    # Executable procedure retained.
-    assert "workflow-review" in text
-    assert "recheck --snapshot-id" in text
-    # The full shared verdict mapping table is no longer duplicated in the Skill.
-    assert "### Deterministic mapping" not in text
-    assert "| Evidence `status` | Permitted verdict ceiling |" not in text
-
-
-def test_review_skill_requires_remediation_handoff_for_non_pass() -> None:
-    for path in (
-        ROOT / ".agents/skills/task-pr-review-runner/SKILL.md",
-        ROOT / ".claude/skills/task-pr-review-runner/SKILL.md",
-    ):
-        text = path.read_text(encoding="utf-8")
-        section = text[
-            text.index("## Remediation handoff") : text.index(
-                "## Report and recovery", text.index("## Remediation handoff")
-            )
-        ]
-        match = re.search(
-            r"^```text\n(?P<body>.*?)\n```$", section, re.MULTILINE | re.DOTALL
-        )
-        assert match is not None
-        body = match.group("body")
-        assert len(re.findall(r"^## Remediation handoff$", section, re.MULTILINE)) == 1
-        assert len(re.findall(r"^```text$", section, re.MULTILINE)) == 1
-        assert body.startswith("请按 task-delivery-runner 修复\n")
-        for field in (
-            "Task:",
-            "PR:",
-            "Reviewed head SHA:",
-            "Verdict:",
-            "Required remediation:",
-            "Objective gates:",
-            "Maintainer decision required:",
-        ):
-            assert field in body
-        for forbidden in ("上述", "同上", "见前文"):
-            assert forbidden not in body
-        assert "Review remediation handoff:" not in section
-        assert "<上述 remediation handoff>" not in section
-        assert body.count("[F1]") == 1
-        assert "exactly one final" in section
-        assert "duplicate" in section
-        assert "A passing verdict does not emit a remediation handoff." in section
-        assert "A passing verdict emits no remediation\nsection." in section
-
-
-def test_review_skill_has_semantic_review_evidence_matrix() -> None:
-    text = ACTIVE_SKILLS["task-pr-review-runner"].read_text(encoding="utf-8")
-    assert "evidence matrix" in text.casefold()
-    assert "changed_file_groups" in text
-    assert "acceptance_criteria" in text
-    assert "effective_diff_sha256" in text
-    assert "overall" in text
-    assert "verified | partial | not_verified" in text
-
-
-def test_review_skill_requires_file_coverage_completeness() -> None:
-    text = ACTIVE_SKILLS["task-pr-review-runner"].read_text(encoding="utf-8")
-    assert "changed file" in text.casefold()
-    assert "one group" in text
-    assert "not covered" in text.casefold()
-
-
-def test_review_skill_has_mechanical_assertions_table() -> None:
-    text = ACTIVE_SKILLS["task-pr-review-runner"].read_text(encoding="utf-8")
-    assert "Mechanical assertions" in text
-    assert "Historical Skill matches source commit blob" in text
-    assert "All target Skills are canonical-state" in text
-    assert "byte-for-byte" in text.casefold()
-    assert "must not be enlarged" in text
-
-
-def test_review_skill_has_tool_discipline_section() -> None:
-    text = ACTIVE_SKILLS["task-pr-review-runner"].read_text(encoding="utf-8")
-    assert "## Tool discipline" in text
-    assert "File existence" in text
-    assert "Tool availability" in text
-    assert "Runner result independence" in text
-    assert "Search completeness" in text
-
-
-def test_review_skill_has_minimal_verdict_summary_without_duplicated_rules() -> None:
-    text = ACTIVE_SKILLS["task-pr-review-runner"].read_text(encoding="utf-8")
-    # Minimal semantic summary with authoritative reference, not a full rule set.
-    assert "pr-review.md" in text
-    assert "PASS is the only mergeable state" in text
-    assert "CONDITIONAL is never mergeable" in text
-    assert "### Verdict rules" not in text
-
-
-def test_review_skill_runner_command_includes_skill_path() -> None:
-    text = ACTIVE_SKILLS["task-pr-review-runner"].read_text(encoding="utf-8")
-    assert "--skill-path" in text
-    assert ".claude/skills/task-pr-review-runner/SKILL.md" in text
-
-
-def test_claude_skill_differs_from_agents_skill_only_in_execution_details() -> None:
-    """Both Skills share business semantics; only platform execution differs."""
-    claude_text = (ROOT / ".claude/skills/task-pr-review-runner/SKILL.md").read_text(
-        encoding="utf-8"
-    )
-    agents_text = (ROOT / ".agents/skills/task-pr-review-runner/SKILL.md").read_text(
-        encoding="utf-8"
-    )
-    # Both have the same verdict structure
-    for phrase in (
-        "通过，可以人工合并",
-        "有条件通过，不得合并",
-        "不通过，需要修复",
-        "Remediation handoff",
-        "Required remediation:",
-        "Objective gates:",
-        "Maintainer decision required:",
-        "evidence matrix",
-        "changed_file_groups",
-        "acceptance_criteria",
-        "Conditional pass",
-    ):
-        assert phrase in claude_text
-        assert phrase in agents_text
-    # Both prohibit upgrading partial/unknown to unconditional pass
-    assert "never" in claude_text.casefold()
-    assert "never" in agents_text.casefold()
-    # Claude Skill references .claude paths
-    assert ".claude/skills/task-pr-review-runner/SKILL.md" in claude_text
-    # Agents Skill references .agents paths
-    assert ".agents/skills/task-pr-review-runner/SKILL.md" in agents_text
+    assert ".workflow.local/" in patterns

--- a/tools/agent_workflow/lck.py
+++ b/tools/agent_workflow/lck.py
@@ -1528,6 +1528,12 @@ class ReviewCompleter:
                     f"Review Complete STOP for Task #{task_number}: "
                     + "; ".join(final_decision.reasons)
                 )
+            if verdict == "PASS" and not DeliveryChecksGate._checks_postcondition(
+                final_state, checks
+            ):
+                raise LckStopError(
+                    "Review Complete STOP: current PR checks are no longer passing"
+                )
             current = final_identity
             record = {
                 "schema_version": LCK_SCHEMA_VERSION,

--- a/tools/agent_workflow/lck.py
+++ b/tools/agent_workflow/lck.py
@@ -1360,6 +1360,12 @@ class ReviewPreparer:
             validation = self.validation.run(review_root, identity.base_sha)
             final_state = self.resolver.resolve(task_number)
             final_contract = _live_task_contract(self.resolver, task_number)
+            final_decision = self.eligibility.resolve(final_state, Phase.REVIEW_PREPARE)
+            if not final_decision.eligible:
+                raise LckStopError(
+                    "Review Prepare post-validation STOP: "
+                    + "; ".join(final_decision.reasons)
+                )
             final_identity = _review_identity(
                 self.resolver, final_state, final_contract
             )
@@ -1433,11 +1439,13 @@ class ReviewCompleter:
         self,
         resolver: LiveStateResolver,
         *,
+        eligibility: PhaseEligibilityResolver | None = None,
         store: ReviewInvocationStore | None = None,
         workspace: ReviewWorkspaceManager | None = None,
         checks_gate: DeliveryChecksGate | None = None,
     ) -> None:
         self.resolver = resolver
+        self.eligibility = eligibility or PhaseEligibilityResolver()
         self.store = store or ReviewInvocationStore(resolver.repo_root)
         self.workspace = workspace or ReviewWorkspaceManager(resolver)
         self.checks_gate = checks_gate or DeliveryChecksGate(
@@ -1491,6 +1499,12 @@ class ReviewCompleter:
                 )
             current = _review_identity(self.resolver, state, task_contract)
             _assert_review_applicable(start, current)
+            decision = self.eligibility.resolve(state, Phase.REVIEW_PREPARE)
+            if not decision.eligible:
+                raise LckStopError(
+                    f"Review Complete STOP for Task #{task_number}: "
+                    + "; ".join(decision.reasons)
+                )
             checks: Mapping[str, Any] = guard.get("checks", {})
             if verdict == "PASS":
                 self.checks_gate.run(task_number)

--- a/tools/agent_workflow/lck.py
+++ b/tools/agent_workflow/lck.py
@@ -1507,7 +1507,28 @@ class ReviewCompleter:
                 )
             checks: Mapping[str, Any] = guard.get("checks", {})
             if verdict == "PASS":
-                self.checks_gate.run(task_number)
+                checks = self.checks_gate.run(task_number)
+            # The checks gate re-resolves the live PR while it waits. Reacquire
+            # the complete applicability identity after that gate so a head,
+            # base, Task Contract, or effective-diff change cannot publish a
+            # verdict for the sealed Review worktree.
+            final_state = self.resolver.resolve(task_number)
+            final_contract = _live_task_contract(self.resolver, task_number)
+            if final_state.open_pr is None:
+                raise ReviewStaleError(
+                    "REVIEW_STALE_PR", "the reviewed OPEN PR no longer exists"
+                )
+            final_identity = _review_identity(
+                self.resolver, final_state, final_contract
+            )
+            _assert_review_applicable(start, final_identity)
+            final_decision = self.eligibility.resolve(final_state, Phase.REVIEW_PREPARE)
+            if not final_decision.eligible:
+                raise LckStopError(
+                    f"Review Complete STOP for Task #{task_number}: "
+                    + "; ".join(final_decision.reasons)
+                )
+            current = final_identity
             record = {
                 "schema_version": LCK_SCHEMA_VERSION,
                 "kind": "independent-review-record",

--- a/tools/agent_workflow/lck.py
+++ b/tools/agent_workflow/lck.py
@@ -653,6 +653,10 @@ class PhaseEligibilityResolver:
             pr_head = state.open_pr.get("headRefOid") if state.open_pr else None
             if not is_sha(pr_head):
                 reasons.append("current OPEN PR head OID is unavailable")
+            pr_base = state.open_pr.get("baseRefOid") if state.open_pr else None
+            origin_main = state.git.get("origin_main_sha")
+            if not is_sha(pr_base) or not is_sha(origin_main) or pr_base != origin_main:
+                reasons.append("current OPEN PR base must match current origin/main")
             if state.remote_task_oid != pr_head:
                 reasons.append("remote Task branch must match current OPEN PR head")
             if state.local_task_head is not None and state.local_task_head != pr_head:
@@ -974,6 +978,68 @@ class ReviewValidationGate:
     def __init__(self, resolver: LiveStateResolver) -> None:
         self.resolver = resolver
 
+    def _persist_validation_artifacts(
+        self, review_root: Path, payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        raw_output_dir = payload.get("output_dir")
+        if not isinstance(raw_output_dir, str) or not raw_output_dir:
+            raise LckStopError(
+                "formal Review validation did not provide an output directory"
+            )
+        output_dir = Path(raw_output_dir)
+        if output_dir.is_absolute():
+            raise LckStopError(
+                "formal Review validation output directory must be relative"
+            )
+        review_root = review_root.resolve()
+        source = (review_root / output_dir).resolve()
+        try:
+            source.relative_to(review_root)
+        except ValueError as exc:
+            raise LckStopError(
+                "formal Review validation output escaped the Review worktree"
+            ) from exc
+        if not source.is_dir():
+            raise LckStopError(
+                "formal Review validation output directory is unavailable"
+            )
+
+        durable_root = (
+            self.resolver.repo_root / ".agents" / "validation.local"
+        ).resolve()
+        durable_root.mkdir(parents=True, exist_ok=True)
+        destination = durable_root / f"lck-review-{uuid.uuid4().hex}"
+        try:
+            shutil.copytree(source, destination)
+        except OSError as exc:
+            shutil.rmtree(destination, ignore_errors=True)
+            raise LckStopError(
+                f"cannot preserve formal Review validation artifacts: {exc}"
+            ) from exc
+
+        durable_relative = destination.relative_to(
+            self.resolver.repo_root.resolve()
+        ).as_posix()
+        preserved = dict(payload)
+        preserved["output_dir"] = durable_relative
+        commands = preserved.get("commands")
+        if isinstance(commands, list):
+            for command in commands:
+                if not isinstance(command, dict):
+                    continue
+                raw_log_path = command.get("log_path")
+                if not isinstance(raw_log_path, str) or not raw_log_path:
+                    continue
+                log_path = Path(raw_log_path)
+                try:
+                    log_relative = log_path.relative_to(output_dir)
+                except ValueError as exc:
+                    raise LckStopError(
+                        "formal Review validation log path escaped its output directory"
+                    ) from exc
+                command["log_path"] = (Path(durable_relative) / log_relative).as_posix()
+        return preserved
+
     def run(self, review_root: Path, base_sha: str) -> dict[str, Any]:
         if not is_sha(base_sha):
             raise LckStopError("formal Review validation base SHA is unavailable")
@@ -1011,7 +1077,7 @@ class ReviewValidationGate:
                 "formal Review validation failed: "
                 + str(payload.get("status") or result.returncode)
             )
-        return payload
+        return self._persist_validation_artifacts(review_root, payload)
 
 
 class ReviewWorkspaceManager:
@@ -1019,6 +1085,42 @@ class ReviewWorkspaceManager:
 
     def __init__(self, resolver: LiveStateResolver) -> None:
         self.resolver = resolver
+
+    @staticmethod
+    def _validated_worktree_path(path: Path) -> Path:
+        resolved = path.resolve(strict=False)
+        temp_root = Path(tempfile.gettempdir()).resolve()
+        try:
+            relative = resolved.relative_to(temp_root)
+        except ValueError as exc:
+            raise LckStopError(
+                "Review worktree cleanup path is outside the temporary root"
+            ) from exc
+        if len(relative.parts) != 1 or not resolved.name.startswith(
+            "tracequant-lck-review-"
+        ):
+            raise LckStopError("Review worktree cleanup path is not LCK-owned")
+        return resolved
+
+    def _assert_registered_worktree(self, path: Path) -> None:
+        result = self.resolver.runner.run(
+            ["git", "worktree", "list", "--porcelain"],
+            command_id="lck-review-worktree-verify",
+        )
+        if result.returncode != 0:
+            raise LckStopError(
+                "cannot verify isolated Review worktree ownership: "
+                + (result.stderr.strip() or result.stdout.strip())
+            )
+        registered = {
+            Path(line.removeprefix("worktree ").strip()).resolve()
+            for line in result.stdout.splitlines()
+            if line.startswith("worktree ") and line.removeprefix("worktree ").strip()
+        }
+        if path not in registered:
+            raise LckStopError(
+                "Review worktree cleanup path is not a registered LCK worktree"
+            )
 
     def create(self, task_number: int, head_sha: str) -> Path:
         path = Path(
@@ -1087,6 +1189,8 @@ class ReviewWorkspaceManager:
                     os.chmod(target, 0o644)
 
     def remove(self, path: Path) -> None:
+        path = self._validated_worktree_path(path)
+        self._assert_registered_worktree(path)
         self._make_removable(path)
         result = self.resolver.runner.run(
             ["git", "worktree", "remove", "--force", str(path)],
@@ -1094,6 +1198,10 @@ class ReviewWorkspaceManager:
         )
         if result.returncode != 0:
             shutil.rmtree(path, ignore_errors=True)
+            if path.exists():
+                raise LckStopError(
+                    "failed to remove isolated Review worktree directory"
+                )
             prune = self.resolver.runner.run(
                 ["git", "worktree", "prune"],
                 command_id="lck-review-worktree-prune",
@@ -2313,6 +2421,7 @@ class DeliveryCompleter:
         pr_effect: EnsureOpenPrEffect | None = None,
         status_effect: SetReviewStatusEffect | None = None,
         checks_gate: DeliveryChecksGate | None = None,
+        require_existing_open_pr: bool = False,
     ) -> None:
         self.resolver = resolver
         self.eligibility = eligibility or PhaseEligibilityResolver()
@@ -2322,6 +2431,7 @@ class DeliveryCompleter:
         self.pr_effect = pr_effect or EnsureOpenPrEffect(resolver)
         self.status_effect = status_effect or SetReviewStatusEffect(resolver)
         self.checks_gate = checks_gate or DeliveryChecksGate(resolver)
+        self.require_existing_open_pr = require_existing_open_pr
 
     def _run_critical_outcome(self, state: LiveState) -> dict[str, Any]:
         issue = state.issue
@@ -2362,6 +2472,7 @@ class DeliveryCompleter:
         body_sha256: str,
         branch: str,
         head_sha: str | None = None,
+        expected_pr_base_sha: str | None = None,
     ) -> LiveState:
         """Reacquire the facts that must stay stable within this invocation."""
         state = self.resolver.resolve(task_number)
@@ -2379,6 +2490,15 @@ class DeliveryCompleter:
             raise LckStopError(
                 "Delivery operation guard stopped: Task branch identity changed"
             )
+        if expected_pr_base_sha is not None:
+            pr = state.open_pr
+            if (
+                not isinstance(pr, Mapping)
+                or pr.get("baseRefOid") != expected_pr_base_sha
+            ):
+                raise LckStopError(
+                    "Delivery operation guard stopped: existing OPEN PR base changed"
+                )
         if head_sha is not None and state.local_task_head != head_sha:
             raise LckStopError(
                 "Delivery operation guard stopped: local Task head changed"
@@ -2457,6 +2577,17 @@ class DeliveryCompleter:
         if not isinstance(body_sha256, str) or not body_sha256:
             raise LckStopError("current Task body identity is unavailable")
         branch = state.target_branch
+        expected_pr_base_sha = base_sha if self.require_existing_open_pr else None
+
+        if expected_pr_base_sha is not None:
+            self._operation_guard(
+                task_number,
+                base_sha=base_sha,
+                body_sha256=body_sha256,
+                branch=branch,
+                head_sha=state.local_task_head,
+                expected_pr_base_sha=expected_pr_base_sha,
+            )
 
         effects: list[EffectReceipt] = []
         if state.git.get("clean") is True:
@@ -2494,6 +2625,7 @@ class DeliveryCompleter:
                 body_sha256=body_sha256,
                 branch=branch,
                 head_sha=state.local_task_head,
+                expected_pr_base_sha=expected_pr_base_sha,
             )
             self.commit_effect.verify_tree_unchanged(
                 validated_tree,
@@ -2515,6 +2647,7 @@ class DeliveryCompleter:
             body_sha256=body_sha256,
             branch=branch,
             head_sha=str(head),
+            expected_pr_base_sha=expected_pr_base_sha,
         )
         effects.append(
             self.remote_effect.execute(
@@ -2528,6 +2661,7 @@ class DeliveryCompleter:
             body_sha256=body_sha256,
             branch=branch,
             head_sha=str(head),
+            expected_pr_base_sha=expected_pr_base_sha,
         )
         effects.append(
             self.pr_effect.execute(
@@ -2546,6 +2680,7 @@ class DeliveryCompleter:
             body_sha256=body_sha256,
             branch=branch,
             head_sha=str(head),
+            expected_pr_base_sha=expected_pr_base_sha,
         )
         checks = self.checks_gate.run(task_number)
         self._operation_guard(
@@ -2554,6 +2689,7 @@ class DeliveryCompleter:
             body_sha256=body_sha256,
             branch=branch,
             head_sha=str(head),
+            expected_pr_base_sha=expected_pr_base_sha,
         )
         checks_pr = checks.get("pr")
         if not isinstance(checks_pr, Mapping):
@@ -2824,6 +2960,7 @@ class RemediationCompleter:
             self.resolver,
             pr_effect=cast(Any, ReuseExistingOpenPrEffect(self.resolver)),
             checks_gate=self.checks_gate,
+            require_existing_open_pr=True,
         ).complete(
             task_number,
             commit_message=commit_message,

--- a/tools/agent_workflow/lck.py
+++ b/tools/agent_workflow/lck.py
@@ -1157,6 +1157,69 @@ class ReviewWorkspaceManager:
             raise LckStopError("isolated Review worktree postcondition failed")
         return path
 
+    def _assert_clean_exact(self, path: Path, expected_head_sha: str) -> None:
+        if not path.is_dir():
+            raise LckStopError("isolated Review worktree is unavailable")
+        status = self.resolver.runner.run(
+            ["git", "status", "--porcelain=v1", "--untracked-files=all"],
+            command_id="lck-review-worktree-post-validation-clean",
+            cwd=path,
+        )
+        head = self.resolver.runner.run(
+            ["git", "rev-parse", "HEAD"],
+            command_id="lck-review-worktree-post-validation-head",
+            cwd=path,
+        )
+        if status.returncode != 0 or head.returncode != 0:
+            raise LckStopError(
+                "cannot verify isolated Review worktree after validation"
+            )
+        if status.stdout.strip():
+            raise LckStopError("formal Review validation changed the isolated worktree")
+        if head.stdout.strip() != expected_head_sha:
+            raise LckStopError(
+                "isolated Review worktree HEAD changed during validation"
+            )
+
+    @staticmethod
+    def _assert_read_only(path: Path) -> None:
+        for root, dirs, files in os.walk(path, topdown=True, followlinks=False):
+            root_path = Path(root)
+            if root_path.stat().st_mode & 0o222:
+                raise LckStopError("isolated Review worktree is not read-only")
+            for name in (*dirs, *files):
+                target = root_path / name
+                if not target.is_symlink() and target.stat().st_mode & 0o222:
+                    raise LckStopError("isolated Review worktree is not read-only")
+
+    def seal_for_review(self, path: Path, expected_head_sha: str) -> None:
+        """Verify exact contents, seal files, and preserve clean Git status."""
+        path = self._validated_worktree_path(path)
+        self._assert_registered_worktree(path)
+        self._assert_clean_exact(path, expected_head_sha)
+        filemode = self.resolver.runner.run(
+            ["git", "config", "--worktree", "core.filemode", "false"],
+            command_id="lck-review-worktree-ignore-filemode",
+            cwd=path,
+        )
+        if filemode.returncode != 0:
+            raise LckStopError(
+                "cannot configure isolated Review worktree read-only sealing: "
+                + (filemode.stderr.strip() or filemode.stdout.strip())
+            )
+        self.seal_read_only(path)
+        self._assert_clean_exact(path, expected_head_sha)
+        self._assert_read_only(path)
+
+    def assert_ready_for_completion(self, path: Path, expected_head_sha: str) -> None:
+        """Fail closed unless the prepared Review context is still intact."""
+        path = self._validated_worktree_path(path)
+        if not path.is_dir():
+            raise LckStopError("prepared Review worktree is unavailable")
+        self._assert_registered_worktree(path)
+        self._assert_clean_exact(path, expected_head_sha)
+        self._assert_read_only(path)
+
     @staticmethod
     def seal_read_only(path: Path) -> None:
         for root, dirs, files in os.walk(path, topdown=False, followlinks=False):
@@ -1479,7 +1542,7 @@ class ReviewPreparer:
             )
             _assert_review_applicable(identity, final_identity)
             final_checks = self.checks_gate.run(task_number)
-            self.workspace.seal_read_only(review_root)
+            self.workspace.seal_for_review(review_root, identity.head_sha)
         except BaseException:
             self.workspace.remove(review_root)
             raise
@@ -1599,6 +1662,19 @@ class ReviewCompleter:
         review_root = Path(review_root_value)
 
         try:
+            validation = guard.get("validation")
+            if (
+                not isinstance(validation, Mapping)
+                or validation.get("status") != "pass"
+            ):
+                raise LckStopError(
+                    "Review invocation has no successful formal validation"
+                )
+            if start.task_number != task_number:
+                raise LckStopError(
+                    "Review invocation identity does not belong to this Task"
+                )
+            self.workspace.assert_ready_for_completion(review_root, start.head_sha)
             state = self.resolver.resolve(task_number)
             task_contract = _live_task_contract(self.resolver, task_number)
             if state.open_pr is None:

--- a/tools/agent_workflow/lck.py
+++ b/tools/agent_workflow/lck.py
@@ -17,6 +17,7 @@ import json
 import os
 import re
 import shutil
+import stat
 import sys
 import tempfile
 import time
@@ -1197,16 +1198,6 @@ class ReviewWorkspaceManager:
         path = self._validated_worktree_path(path)
         self._assert_registered_worktree(path)
         self._assert_clean_exact(path, expected_head_sha)
-        filemode = self.resolver.runner.run(
-            ["git", "config", "--worktree", "core.filemode", "false"],
-            command_id="lck-review-worktree-ignore-filemode",
-            cwd=path,
-        )
-        if filemode.returncode != 0:
-            raise LckStopError(
-                "cannot configure isolated Review worktree read-only sealing: "
-                + (filemode.stderr.strip() or filemode.stdout.strip())
-            )
         self.seal_read_only(path)
         self._assert_clean_exact(path, expected_head_sha)
         self._assert_read_only(path)
@@ -1221,18 +1212,23 @@ class ReviewWorkspaceManager:
         self._assert_read_only(path)
 
     @staticmethod
-    def seal_read_only(path: Path) -> None:
+    def _remove_write_bits(path: Path) -> None:
+        mode = stat.S_IMODE(path.stat().st_mode)
+        os.chmod(path, mode & ~0o222)
+
+    @classmethod
+    def seal_read_only(cls, path: Path) -> None:
         for root, dirs, files in os.walk(path, topdown=False, followlinks=False):
             root_path = Path(root)
             for name in files:
                 target = root_path / name
                 if not target.is_symlink():
-                    os.chmod(target, 0o444)
+                    cls._remove_write_bits(target)
             for name in dirs:
                 target = root_path / name
                 if not target.is_symlink():
-                    os.chmod(target, 0o555)
-        os.chmod(path, 0o555)
+                    cls._remove_write_bits(target)
+        cls._remove_write_bits(path)
 
     @staticmethod
     def _make_removable(path: Path) -> None:

--- a/tools/agent_workflow/lck.py
+++ b/tools/agent_workflow/lck.py
@@ -1868,6 +1868,57 @@ class EnsureRemoteBranchEffect:
         remote_oid = refs.get(branch)
         return head, remote_oid
 
+    def _ensure_upstream(self, branch: str) -> str:
+        expected = f"origin/{branch}"
+        upstream = self.resolver.runner.run(
+            [
+                "git",
+                "rev-parse",
+                "--abbrev-ref",
+                "--symbolic-full-name",
+                "@{upstream}",
+            ],
+            command_id="lck-task-branch-upstream",
+        )
+        current = upstream.stdout.strip() if upstream.returncode == 0 else ""
+        if current != expected:
+            set_upstream = self.resolver.runner.run(
+                [
+                    "git",
+                    "branch",
+                    "--set-upstream-to",
+                    expected,
+                    branch,
+                ],
+                command_id="lck-set-task-branch-upstream",
+            )
+            if set_upstream.returncode != 0:
+                raise LckStopError(
+                    "cannot establish Task branch upstream: "
+                    + (
+                        set_upstream.stderr.strip()
+                        or set_upstream.stdout.strip()
+                        or f"exit {set_upstream.returncode}"
+                    )
+                )
+            upstream = self.resolver.runner.run(
+                [
+                    "git",
+                    "rev-parse",
+                    "--abbrev-ref",
+                    "--symbolic-full-name",
+                    "@{upstream}",
+                ],
+                command_id="lck-verify-task-branch-upstream",
+            )
+            current = upstream.stdout.strip() if upstream.returncode == 0 else ""
+        if current != expected:
+            raise LckStopError(
+                "Task branch upstream postcondition failed: "
+                f"expected {expected!r}, observed {current or 'unavailable'!r}"
+            )
+        return current
+
     def execute(
         self,
         branch: str,
@@ -1879,10 +1930,15 @@ class EnsureRemoteBranchEffect:
             expected_head_sha=expected_head_sha,
         )
         if remote_oid == head:
+            upstream = self._ensure_upstream(branch)
             return EffectReceipt(
                 effect="ensure_remote_branch",
                 action="already-synced",
-                details={"head_sha": head, "remote_oid": remote_oid},
+                details={
+                    "head_sha": head,
+                    "remote_oid": remote_oid,
+                    "upstream": upstream,
+                },
             )
         if remote_oid is not None:
             fetch = self.resolver.runner.run(
@@ -1934,10 +1990,15 @@ class EnsureRemoteBranchEffect:
             raise LckStopError(
                 "push postcondition failed: local and remote heads differ"
             )
+        upstream = self._ensure_upstream(branch)
         return EffectReceipt(
             effect="ensure_remote_branch",
             action=action,
-            details={"head_sha": head, "remote_oid": final_remote},
+            details={
+                "head_sha": head,
+                "remote_oid": final_remote,
+                "upstream": upstream,
+            },
         )
 
 

--- a/tools/agent_workflow/lck.py
+++ b/tools/agent_workflow/lck.py
@@ -12,12 +12,16 @@ branch/PR identity is workflow authority.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
+import os
 import re
+import shutil
 import sys
 import tempfile
 import time
 import unicodedata
+import uuid
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from enum import StrEnum
@@ -42,10 +46,13 @@ from project_status import set_project_status_with_runner
 from workflow_common import (
     CommandRunner,
     WorkflowToolError,
+    atomic_write_json,
     command_warning,
     is_sha,
     print_json,
+    read_json_file,
     read_json_text,
+    sha256_json,
 )
 from workflow_evidence import (
     _git_snapshot,
@@ -72,6 +79,7 @@ class Phase(StrEnum):
     DELIVERY_COMPLETE = "Delivery Complete"
     REVIEW_PREPARE = "Review Prepare"
     REMEDIATION_PREPARE = "Remediation Prepare"
+    REMEDIATION_COMPLETE = "Remediation Complete"
     CLOSEOUT = "Closeout"
 
 
@@ -82,6 +90,14 @@ class ResolutionStatus(StrEnum):
 
 class LckStopError(WorkflowToolError):
     """A deterministic LCK gate could not identify one safe action."""
+
+
+class ReviewStaleError(LckStopError):
+    """The live PR target changed during one bounded Review invocation."""
+
+    def __init__(self, code: str, detail: str) -> None:
+        self.code = code
+        super().__init__(f"{code}: {detail}")
 
 
 def canonical_task_branch(task_number: int, title: str) -> str:
@@ -438,6 +454,57 @@ class LiveStateResolver:
         )
 
 
+def _live_task_contract(
+    resolver: LiveStateResolver, task_number: int
+) -> dict[str, Any]:
+    """Read the current Task body directly from GitHub for semantic consumers."""
+    state = resolver.resolve(task_number)
+    if state.status is not ResolutionStatus.RESOLVED or state.repository is None:
+        raise LckStopError("cannot read Task Contract from unresolved live state")
+    result = resolver.runner.run(
+        [
+            "gh",
+            "issue",
+            "view",
+            str(task_number),
+            "--repo",
+            state.repository,
+            "--json",
+            "number,title,body,state,url",
+        ],
+        command_id="lck-task-contract-live",
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        raise LckStopError(
+            "current Task Contract is unavailable: "
+            + (result.stderr.strip() or f"exit {result.returncode}")
+        )
+    value = read_json_text(result.stdout, field="lck-task-contract-live")
+    if not isinstance(value, Mapping):
+        raise LckStopError("current Task Contract result is not an object")
+    body = value.get("body")
+    if not isinstance(body, str):
+        raise LckStopError("current Task Contract body is unavailable")
+    body_sha256 = sha256_json({"body": body})
+    live_issue = state.issue
+    if (
+        not isinstance(live_issue, Mapping)
+        or live_issue.get("body_sha256") != body_sha256
+        or value.get("number") != task_number
+        or value.get("title") != live_issue.get("title")
+        or str(value.get("state", "")).upper() != "OPEN"
+    ):
+        raise LckStopError("Task Contract changed while being acquired")
+    return {
+        "number": task_number,
+        "title": value.get("title"),
+        "url": value.get("url"),
+        "body": body,
+        "body_sha256": body_sha256,
+        "critical_outcome": live_issue.get("critical_outcome"),
+    }
+
+
 @dataclass(frozen=True)
 class PhaseDecision:
     phase: Phase
@@ -499,6 +566,7 @@ class PhaseEligibilityResolver:
                 Phase.DELIVERY_COMPLETE: {"Ready", "In Progress", "Review"},
                 Phase.REVIEW_PREPARE: {"Review", "In Progress"},
                 Phase.REMEDIATION_PREPARE: {"Review"},
+                Phase.REMEDIATION_COMPLETE: {"Review"},
                 Phase.CLOSEOUT: {"In Progress", "Review", "Done"},
             }[phase]
             if project not in allowed_projects:
@@ -575,12 +643,36 @@ class PhaseEligibilityResolver:
             if state.project_status not in {"Review", "In Progress"}:
                 reasons.append("Task is not eligible for Review Prepare")
             capabilities = ("prepare_read_only_review_context",)
-        elif phase is Phase.REMEDIATION_PREPARE:
+        elif phase in {Phase.REMEDIATION_PREPARE, Phase.REMEDIATION_COMPLETE}:
             if state.open_pr is None:
                 reasons.append("no current OPEN PR")
+            elif state.open_pr.get("isDraft") is not False:
+                reasons.append("Remediation requires a non-Draft OPEN PR")
             if state.project_status != "Review":
                 reasons.append("Remediation requires Project Status Review")
-            capabilities = ("prepare_task_workspace",)
+            pr_head = state.open_pr.get("headRefOid") if state.open_pr else None
+            if not is_sha(pr_head):
+                reasons.append("current OPEN PR head OID is unavailable")
+            if state.remote_task_oid != pr_head:
+                reasons.append("remote Task branch must match current OPEN PR head")
+            if state.local_task_head is not None and state.local_task_head != pr_head:
+                reasons.append("local Task branch must match current OPEN PR head")
+            if phase is Phase.REMEDIATION_PREPARE:
+                capabilities = ("prepare_task_workspace", "load_review_findings")
+            else:
+                if state.local_task_branch is None:
+                    reasons.append("Remediation Complete requires a local Task branch")
+                if state.git.get("branch") != state.target_branch:
+                    reasons.append(
+                        "Remediation Complete requires the resolved Task branch selected"
+                    )
+                capabilities = (
+                    "verify_critical_outcome",
+                    "run_formal_validation",
+                    "commit_current_tree",
+                    "ensure_remote_branch",
+                    "reuse_open_pr",
+                )
         else:
             if state.merged is not True:
                 reasons.append("Closeout requires one current merged PR")
@@ -786,6 +878,657 @@ class FormalValidationGate:
                 + str(payload.get("status") or result.returncode)
             )
         return payload
+
+
+@dataclass(frozen=True)
+class ReviewIdentity:
+    task_number: int
+    pr_number: int
+    base_sha: str
+    head_sha: str
+    task_body_sha256: str
+    merge_base_sha: str
+    effective_diff_sha256: str
+    changed_files: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "task_number": self.task_number,
+            "pr_number": self.pr_number,
+            "base_sha": self.base_sha,
+            "head_sha": self.head_sha,
+            "task_body_sha256": self.task_body_sha256,
+            "merge_base_sha": self.merge_base_sha,
+            "effective_diff_sha256": self.effective_diff_sha256,
+            "changed_files": list(self.changed_files),
+        }
+
+
+def _review_identity(
+    resolver: LiveStateResolver,
+    state: LiveState,
+    task_contract: Mapping[str, Any],
+) -> ReviewIdentity:
+    """Bind one Review invocation to the live PR object without cross-phase input."""
+    pr = state.open_pr
+    if not isinstance(pr, Mapping):
+        raise LckStopError("Review target has no current OPEN PR")
+    pr_number = pr.get("number")
+    base_sha = pr.get("baseRefOid")
+    head_sha = pr.get("headRefOid")
+    task_body_sha256 = task_contract.get("body_sha256")
+    if not isinstance(pr_number, int) or isinstance(pr_number, bool) or pr_number <= 0:
+        raise LckStopError("Review target PR number is unavailable")
+    if not is_sha(base_sha) or not is_sha(head_sha):
+        raise LckStopError("Review target base/head identity is unavailable")
+    if not isinstance(task_body_sha256, str) or not task_body_sha256:
+        raise LckStopError("Review target Task Contract identity is unavailable")
+
+    merge_base = resolver.runner.run(
+        ["git", "merge-base", str(base_sha), str(head_sha)],
+        command_id="lck-review-merge-base",
+    )
+    if merge_base.returncode != 0 or not is_sha(merge_base.stdout.strip()):
+        raise LckStopError("Review effective-diff merge base is unavailable")
+    diff = resolver.runner.run(
+        [
+            "git",
+            "diff",
+            "--binary",
+            "--full-index",
+            "--no-ext-diff",
+            "--no-textconv",
+            f"{base_sha}...{head_sha}",
+        ],
+        command_id="lck-review-effective-diff",
+    )
+    if diff.returncode != 0:
+        raise LckStopError(
+            "Review effective diff is unavailable: "
+            + (diff.stderr.strip() or f"exit {diff.returncode}")
+        )
+    names = resolver.runner.run(
+        ["git", "diff", "--name-only", f"{base_sha}...{head_sha}"],
+        command_id="lck-review-changed-files",
+    )
+    if names.returncode != 0:
+        raise LckStopError("Review changed-file inventory is unavailable")
+    changed_files = tuple(line for line in names.stdout.splitlines() if line)
+    return ReviewIdentity(
+        task_number=state.task_number,
+        pr_number=pr_number,
+        base_sha=str(base_sha),
+        head_sha=str(head_sha),
+        task_body_sha256=task_body_sha256,
+        merge_base_sha=merge_base.stdout.strip(),
+        effective_diff_sha256=hashlib.sha256(
+            diff.stdout.encode("utf-8", errors="replace")
+        ).hexdigest(),
+        changed_files=changed_files,
+    )
+
+
+class ReviewValidationGate:
+    """Run current Review validation inside the isolated reviewed worktree."""
+
+    def __init__(self, resolver: LiveStateResolver) -> None:
+        self.resolver = resolver
+
+    def run(self, review_root: Path, base_sha: str) -> dict[str, Any]:
+        if not is_sha(base_sha):
+            raise LckStopError("formal Review validation base SHA is unavailable")
+        tool = review_root / "tools" / "agent_workflow" / "workflow_validation.py"
+        if not tool.is_file():
+            raise LckStopError("reviewed head does not contain workflow_validation.py")
+        result = self.resolver.runner.run(
+            [
+                sys.executable,
+                str(tool),
+                "run",
+                "--repo-root",
+                str(review_root),
+                "--phase",
+                "review",
+                "--base-sha",
+                base_sha,
+                "--include-skill-validators",
+                "--require-skill-validator",
+            ],
+            command_id="lck-formal-review-validation",
+            cwd=review_root,
+            validation=True,
+        )
+        if not result.stdout.strip():
+            raise LckStopError(
+                "formal Review validation produced no structured result: "
+                + (result.stderr.strip() or f"exit {result.returncode}")
+            )
+        payload = read_json_text(result.stdout, field="lck-formal-review-validation")
+        if not isinstance(payload, dict):
+            raise LckStopError("formal Review validation result is not an object")
+        if result.returncode != 0 or payload.get("status") != "pass":
+            raise LckStopError(
+                "formal Review validation failed: "
+                + str(payload.get("status") or result.returncode)
+            )
+        return payload
+
+
+class ReviewWorkspaceManager:
+    """Create and later remove one isolated, implementation-read-only worktree."""
+
+    def __init__(self, resolver: LiveStateResolver) -> None:
+        self.resolver = resolver
+
+    def create(self, task_number: int, head_sha: str) -> Path:
+        path = Path(
+            tempfile.mkdtemp(prefix=f"tracequant-lck-review-{task_number}-")
+        ).resolve()
+        # mkdtemp creates the path, while git worktree requires an absent target.
+        path.rmdir()
+        result = self.resolver.runner.run(
+            ["git", "worktree", "add", "--detach", str(path), head_sha],
+            command_id="lck-review-worktree-add",
+        )
+        if result.returncode != 0:
+            shutil.rmtree(path, ignore_errors=True)
+            raise LckStopError(
+                "cannot create isolated Review worktree: "
+                + (result.stderr.strip() or result.stdout.strip())
+            )
+        status = self.resolver.runner.run(
+            ["git", "status", "--porcelain=v1", "--untracked-files=all"],
+            command_id="lck-review-worktree-clean",
+            cwd=path,
+        )
+        head = self.resolver.runner.run(
+            ["git", "rev-parse", "HEAD"],
+            command_id="lck-review-worktree-head",
+            cwd=path,
+        )
+        if (
+            status.returncode != 0
+            or status.stdout.strip()
+            or head.stdout.strip() != head_sha
+        ):
+            self.remove(path)
+            raise LckStopError("isolated Review worktree postcondition failed")
+        return path
+
+    @staticmethod
+    def seal_read_only(path: Path) -> None:
+        for root, dirs, files in os.walk(path, topdown=False, followlinks=False):
+            root_path = Path(root)
+            for name in files:
+                target = root_path / name
+                if not target.is_symlink():
+                    os.chmod(target, 0o444)
+            for name in dirs:
+                target = root_path / name
+                if not target.is_symlink():
+                    os.chmod(target, 0o555)
+        os.chmod(path, 0o555)
+
+    @staticmethod
+    def _make_removable(path: Path) -> None:
+        if not path.exists():
+            return
+        os.chmod(path, 0o755)
+        for root, dirs, files in os.walk(path, topdown=True, followlinks=False):
+            root_path = Path(root)
+            os.chmod(root_path, 0o755)
+            for name in dirs:
+                target = root_path / name
+                if not target.is_symlink():
+                    os.chmod(target, 0o755)
+            for name in files:
+                target = root_path / name
+                if not target.is_symlink():
+                    os.chmod(target, 0o644)
+
+    def remove(self, path: Path) -> None:
+        self._make_removable(path)
+        result = self.resolver.runner.run(
+            ["git", "worktree", "remove", "--force", str(path)],
+            command_id="lck-review-worktree-remove",
+        )
+        if result.returncode != 0:
+            shutil.rmtree(path, ignore_errors=True)
+            prune = self.resolver.runner.run(
+                ["git", "worktree", "prune"],
+                command_id="lck-review-worktree-prune",
+            )
+            if prune.returncode != 0:
+                raise LckStopError("failed to remove isolated Review worktree")
+
+
+class ReviewInvocationStore:
+    """Persist invocation-local guards and diagnostic review records only."""
+
+    _ID = re.compile(r"^[0-9a-f]{32}$")
+
+    def __init__(self, repo_root: Path) -> None:
+        self.root = repo_root / ".workflow.local" / "lck"
+
+    def new_id(self) -> str:
+        return uuid.uuid4().hex
+
+    def _validate_id(self, review_id: str) -> None:
+        if self._ID.fullmatch(review_id) is None:
+            raise LckStopError("invalid Review invocation id")
+
+    def guard_path(self, review_id: str) -> Path:
+        self._validate_id(review_id)
+        return self.root / "review-invocations" / f"{review_id}.json"
+
+    def record_path(self, task_number: int, review_id: str) -> Path:
+        self._validate_id(review_id)
+        return self.root / "reviews" / f"task-{task_number}" / f"{review_id}.json"
+
+    def latest_review_path(self, task_number: int) -> Path:
+        return self.root / "review-state" / f"task-{task_number}-latest.json"
+
+    def review_required_path(self, task_number: int) -> Path:
+        return self.root / "review-state" / f"task-{task_number}-required.json"
+
+    def write_guard(self, review_id: str, payload: Mapping[str, Any]) -> None:
+        atomic_write_json(self.guard_path(review_id), payload)
+
+    def read_guard(self, review_id: str) -> dict[str, Any]:
+        value = read_json_file(self.guard_path(review_id))
+        if not isinstance(value, dict):
+            raise LckStopError("Review invocation guard is not an object")
+        return value
+
+    def delete_guard(self, review_id: str) -> None:
+        try:
+            self.guard_path(review_id).unlink()
+        except FileNotFoundError:
+            pass
+
+    def write_record(
+        self, task_number: int, review_id: str, payload: Mapping[str, Any]
+    ) -> Path:
+        path = self.record_path(task_number, review_id)
+        atomic_write_json(path, payload)
+        return path
+
+    def read_record(self, task_number: int, review_id: str) -> dict[str, Any]:
+        value = read_json_file(self.record_path(task_number, review_id))
+        if not isinstance(value, dict):
+            raise LckStopError("Review record is not an object")
+        return value
+
+    def write_latest_review(
+        self, task_number: int, review_id: str, verdict: str
+    ) -> None:
+        self._validate_id(review_id)
+        atomic_write_json(
+            self.latest_review_path(task_number),
+            {
+                "schema_version": LCK_SCHEMA_VERSION,
+                "kind": "latest-independent-review",
+                "task_number": task_number,
+                "review_id": review_id,
+                "verdict": verdict,
+                "authority": "semantic predecessor only; never mechanical target authority",
+            },
+        )
+
+    def read_latest_review(self, task_number: int) -> dict[str, Any] | None:
+        path = self.latest_review_path(task_number)
+        if not path.exists():
+            return None
+        value = read_json_file(path)
+        if not isinstance(value, dict) or value.get("task_number") != task_number:
+            raise LckStopError("latest Review state is invalid")
+        return value
+
+    def write_review_required(
+        self, task_number: int, review_id: str, head_sha: str
+    ) -> None:
+        self._validate_id(review_id)
+        if not is_sha(head_sha):
+            raise LckStopError("review-required state needs a valid remediation head")
+        atomic_write_json(
+            self.review_required_path(task_number),
+            {
+                "schema_version": LCK_SCHEMA_VERSION,
+                "kind": "fresh-review-required",
+                "task_number": task_number,
+                "source_review_id": review_id,
+                "remediated_head": head_sha,
+                "authority": "negative lifecycle boundary only; current target remains live-resolved",
+            },
+        )
+
+    def read_review_required(self, task_number: int) -> dict[str, Any] | None:
+        path = self.review_required_path(task_number)
+        if not path.exists():
+            return None
+        value = read_json_file(path)
+        if not isinstance(value, dict) or value.get("task_number") != task_number:
+            raise LckStopError("review-required state is invalid")
+        return value
+
+    def clear_review_required(self, task_number: int) -> None:
+        try:
+            self.review_required_path(task_number).unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _identity_from_mapping(value: Mapping[str, Any]) -> ReviewIdentity:
+    changed = value.get("changed_files")
+    if not isinstance(changed, list) or not all(
+        isinstance(item, str) for item in changed
+    ):
+        raise LckStopError("Review invocation identity has invalid changed-files data")
+    fields = {
+        "task_number": value.get("task_number"),
+        "pr_number": value.get("pr_number"),
+        "base_sha": value.get("base_sha"),
+        "head_sha": value.get("head_sha"),
+        "task_body_sha256": value.get("task_body_sha256"),
+        "merge_base_sha": value.get("merge_base_sha"),
+        "effective_diff_sha256": value.get("effective_diff_sha256"),
+    }
+    if not isinstance(fields["task_number"], int) or not isinstance(
+        fields["pr_number"], int
+    ):
+        raise LckStopError("Review invocation identity is incomplete")
+    for name in ("base_sha", "head_sha", "merge_base_sha"):
+        if not is_sha(fields[name]):
+            raise LckStopError(f"Review invocation identity has invalid {name}")
+    for name in ("task_body_sha256", "effective_diff_sha256"):
+        item = fields[name]
+        if not isinstance(item, str) or re.fullmatch(r"[0-9a-f]{64}", item) is None:
+            raise LckStopError(f"Review invocation identity has invalid {name}")
+    return ReviewIdentity(
+        task_number=cast(int, fields["task_number"]),
+        pr_number=cast(int, fields["pr_number"]),
+        base_sha=cast(str, fields["base_sha"]),
+        head_sha=cast(str, fields["head_sha"]),
+        task_body_sha256=cast(str, fields["task_body_sha256"]),
+        merge_base_sha=cast(str, fields["merge_base_sha"]),
+        effective_diff_sha256=cast(str, fields["effective_diff_sha256"]),
+        changed_files=tuple(changed),
+    )
+
+
+def _assert_review_applicable(start: ReviewIdentity, current: ReviewIdentity) -> None:
+    """Apply only invocation-local stale guards; this is not a drift framework."""
+    if current.pr_number != start.pr_number:
+        raise ReviewStaleError(
+            "REVIEW_STALE_PR",
+            f"OPEN PR changed from #{start.pr_number} to #{current.pr_number}",
+        )
+    if current.head_sha != start.head_sha:
+        raise ReviewStaleError(
+            "REVIEW_STALE_HEAD",
+            f"PR head changed from {start.head_sha} to {current.head_sha}",
+        )
+    if current.base_sha != start.base_sha:
+        raise ReviewStaleError(
+            "REVIEW_STALE_BASE",
+            f"PR base changed from {start.base_sha} to {current.base_sha}",
+        )
+    if current.task_body_sha256 != start.task_body_sha256:
+        raise ReviewStaleError(
+            "REVIEW_STALE_TASK",
+            "Task Contract changed during this Review invocation",
+        )
+    if (
+        current.merge_base_sha != start.merge_base_sha
+        or current.effective_diff_sha256 != start.effective_diff_sha256
+        or current.changed_files != start.changed_files
+    ):
+        raise ReviewStaleError(
+            "REVIEW_STALE_DIFF",
+            "effective diff changed during this Review invocation",
+        )
+
+
+@dataclass(frozen=True)
+class ReviewContext:
+    review_id: str
+    task_contract: Mapping[str, Any]
+    identity: ReviewIdentity
+    checks: Mapping[str, Any]
+    validation: Mapping[str, Any]
+    review_root: Path
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": LCK_SCHEMA_VERSION,
+            "operation": "review-prepare",
+            "status": "READY_FOR_SEMANTIC_REVIEW",
+            "review_id": self.review_id,
+            "task_contract": _jsonable(self.task_contract),
+            "review_target": self.identity.to_dict(),
+            "checks": _jsonable(self.checks),
+            "validation": _jsonable(self.validation),
+            "review_root": str(self.review_root),
+            "workspace_mode": "implementation-read-only",
+            "agent_role": ["Inspect", "Reason", "Judge", "Report"],
+            "mechanical_authority": "live Git/GitHub state resolved by LCK",
+            "forbidden_handoff_authority": [
+                "Delivery SHA",
+                "Delivery base SHA",
+                "Delivery PR identity",
+                "Delivery checks snapshot",
+                "Delivery validation snapshot",
+            ],
+        }
+
+
+class ReviewPreparer:
+    """Resolve a fresh review target and construct one bounded read-only context."""
+
+    def __init__(
+        self,
+        resolver: LiveStateResolver,
+        *,
+        eligibility: PhaseEligibilityResolver | None = None,
+        validation: ReviewValidationGate | None = None,
+        checks_gate: DeliveryChecksGate | None = None,
+        workspace: ReviewWorkspaceManager | None = None,
+        store: ReviewInvocationStore | None = None,
+    ) -> None:
+        self.resolver = resolver
+        self.eligibility = eligibility or PhaseEligibilityResolver()
+        self.validation = validation or ReviewValidationGate(resolver)
+        self.checks_gate = checks_gate or DeliveryChecksGate(
+            resolver, timeout_seconds=0.0, poll_seconds=0.0
+        )
+        self.workspace = workspace or ReviewWorkspaceManager(resolver)
+        self.store = store or ReviewInvocationStore(resolver.repo_root)
+
+    def prepare(self, task_number: int) -> ReviewContext:
+        state = self.resolver.resolve(task_number)
+        decision = self.eligibility.resolve(state, Phase.REVIEW_PREPARE)
+        if not decision.eligible:
+            raise LckStopError(
+                f"Review Prepare STOP for Task #{task_number}: "
+                + "; ".join(decision.reasons)
+            )
+        task_contract = _live_task_contract(self.resolver, task_number)
+        identity = _review_identity(self.resolver, state, task_contract)
+        self.checks_gate.run(task_number)
+        review_root = self.workspace.create(task_number, identity.head_sha)
+        try:
+            validation = self.validation.run(review_root, identity.base_sha)
+            final_state = self.resolver.resolve(task_number)
+            final_contract = _live_task_contract(self.resolver, task_number)
+            final_identity = _review_identity(
+                self.resolver, final_state, final_contract
+            )
+            _assert_review_applicable(identity, final_identity)
+            final_checks = self.checks_gate.run(task_number)
+            self.workspace.seal_read_only(review_root)
+        except BaseException:
+            self.workspace.remove(review_root)
+            raise
+
+        review_id = self.store.new_id()
+        guard = {
+            "schema_version": LCK_SCHEMA_VERSION,
+            "kind": "review-invocation-guard",
+            "review_id": review_id,
+            "task_number": task_number,
+            "identity": identity.to_dict(),
+            "review_root": str(review_root),
+            "validation": validation,
+            "checks": final_checks,
+            "authority": "ephemeral applicability guard only",
+        }
+        try:
+            self.store.write_guard(review_id, guard)
+        except BaseException:
+            self.workspace.remove(review_root)
+            raise
+        return ReviewContext(
+            review_id=review_id,
+            task_contract=task_contract,
+            identity=identity,
+            checks=final_checks,
+            validation=validation,
+            review_root=review_root,
+        )
+
+
+@dataclass(frozen=True)
+class ReviewCompletionResult:
+    review_id: str
+    task_number: int
+    verdict: str
+    status: str
+    identity: ReviewIdentity
+    record_path: Path
+
+    def to_dict(self) -> dict[str, Any]:
+        human_boundary = (
+            "Maintainer manual merge decision"
+            if self.verdict == "PASS"
+            else "STOP; Human must explicitly choose remediation, redesign, or abandon"
+        )
+        return {
+            "schema_version": LCK_SCHEMA_VERSION,
+            "operation": "review-complete",
+            "review_id": self.review_id,
+            "task_number": self.task_number,
+            "verdict": self.verdict,
+            "status": self.status,
+            "review_target": self.identity.to_dict(),
+            "record_path": str(self.record_path),
+            "human_boundary": human_boundary,
+            "automatic_remediation": False,
+        }
+
+
+class ReviewCompleter:
+    """Accept one semantic verdict only while the invocation target is still live."""
+
+    def __init__(
+        self,
+        resolver: LiveStateResolver,
+        *,
+        store: ReviewInvocationStore | None = None,
+        workspace: ReviewWorkspaceManager | None = None,
+        checks_gate: DeliveryChecksGate | None = None,
+    ) -> None:
+        self.resolver = resolver
+        self.store = store or ReviewInvocationStore(resolver.repo_root)
+        self.workspace = workspace or ReviewWorkspaceManager(resolver)
+        self.checks_gate = checks_gate or DeliveryChecksGate(
+            resolver, timeout_seconds=0.0, poll_seconds=0.0
+        )
+
+    @staticmethod
+    def _read_findings(path: Path | None, verdict: str) -> str:
+        if path is None:
+            if verdict == "FAIL":
+                raise LckStopError("FAIL verdict requires --findings-file")
+            return ""
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise LckStopError(f"cannot read findings file: {exc}") from exc
+        if verdict == "FAIL" and not text.strip():
+            raise LckStopError("FAIL verdict requires non-empty findings")
+        return text
+
+    def complete(
+        self,
+        task_number: int,
+        review_id: str,
+        *,
+        verdict: str,
+        findings_file: Path | None = None,
+    ) -> ReviewCompletionResult:
+        verdict = verdict.upper()
+        if verdict not in {"PASS", "FAIL"}:
+            raise LckStopError("Review verdict must be PASS or FAIL")
+        findings = self._read_findings(findings_file, verdict)
+        guard = self.store.read_guard(review_id)
+        if guard.get("task_number") != task_number:
+            raise LckStopError("Review invocation does not belong to this Task")
+        raw_identity = guard.get("identity")
+        if not isinstance(raw_identity, Mapping):
+            raise LckStopError("Review invocation guard has no identity")
+        start = _identity_from_mapping(raw_identity)
+        review_root_value = guard.get("review_root")
+        if not isinstance(review_root_value, str) or not review_root_value:
+            raise LckStopError("Review invocation guard has no review root")
+        review_root = Path(review_root_value)
+
+        try:
+            state = self.resolver.resolve(task_number)
+            task_contract = _live_task_contract(self.resolver, task_number)
+            if state.open_pr is None:
+                raise ReviewStaleError(
+                    "REVIEW_STALE_PR", "the reviewed OPEN PR no longer exists"
+                )
+            current = _review_identity(self.resolver, state, task_contract)
+            _assert_review_applicable(start, current)
+            checks: Mapping[str, Any] = guard.get("checks", {})
+            if verdict == "PASS":
+                self.checks_gate.run(task_number)
+            record = {
+                "schema_version": LCK_SCHEMA_VERSION,
+                "kind": "independent-review-record",
+                "review_id": review_id,
+                "task_number": task_number,
+                "verdict": verdict,
+                "status": (
+                    "READY_FOR_HUMAN_MERGE" if verdict == "PASS" else "STOP_REQUIRED"
+                ),
+                "identity": current.to_dict(),
+                "findings": findings,
+                "findings_sha256": hashlib.sha256(findings.encode("utf-8")).hexdigest(),
+                "validation": guard.get("validation"),
+                "checks": checks,
+                "authority_note": (
+                    "record is diagnostic/audit evidence; later lifecycle mechanics "
+                    "must reacquire live Git/GitHub state"
+                ),
+            }
+            record_path = self.store.write_record(task_number, review_id, record)
+            self.store.write_latest_review(task_number, review_id, verdict)
+            # A successfully accepted fresh Review is the only operation that
+            # releases the post-remediation "new Review required" boundary.
+            self.store.clear_review_required(task_number)
+            return ReviewCompletionResult(
+                review_id=review_id,
+                task_number=task_number,
+                verdict=verdict,
+                status=cast(str, record["status"]),
+                identity=current,
+                record_path=record_path,
+            )
+        finally:
+            self.workspace.remove(review_root)
+            self.store.delete_guard(review_id)
 
 
 class CommitCurrentTreeEffect:
@@ -1141,6 +1884,64 @@ class EnsureOpenPrEffect:
                 "head_sha": result.get("head_sha"),
                 "base_sha": result.get("base_sha"),
                 "warnings": warnings,
+            },
+        )
+
+
+class ReuseExistingOpenPrEffect:
+    """Verify the pushed repair is attached to the already-existing OPEN PR."""
+
+    def __init__(self, resolver: LiveStateResolver) -> None:
+        self.resolver = resolver
+
+    def execute(
+        self,
+        task_number: int,
+        *,
+        summary: str,
+        risks: str,
+        critical_outcome: Mapping[str, Any],
+        validation: Mapping[str, Any],
+        expected_base_sha: str,
+        expected_body_sha256: str,
+    ) -> EffectReceipt:
+        del summary, risks, critical_outcome, validation
+        state = self.resolver.resolve(task_number)
+        if state.status is not ResolutionStatus.RESOLVED:
+            raise LckStopError("cannot reuse OPEN PR from unresolved live state")
+        pr = state.open_pr
+        issue = state.issue
+        if not isinstance(pr, Mapping) or pr.get("isDraft") is not False:
+            raise LckStopError("Remediation requires the existing non-Draft OPEN PR")
+        if state.git.get("origin_main_sha") != expected_base_sha:
+            raise LckStopError(
+                "Remediation PR precondition failed: origin/main changed"
+            )
+        if (
+            not isinstance(issue, Mapping)
+            or issue.get("body_sha256") != expected_body_sha256
+        ):
+            raise LckStopError("Remediation PR precondition failed: Task body changed")
+        head = state.local_task_head
+        if (
+            not is_sha(head)
+            or state.remote_task_oid != head
+            or pr.get("headRefOid") != head
+            or pr.get("baseRefOid") != expected_base_sha
+            or pr.get("headRefName") != state.target_branch
+            or pr.get("baseRefName") != BASE_BRANCH
+        ):
+            raise LckStopError(
+                "Remediation PR postcondition failed: existing PR is not on the pushed head"
+            )
+        return EffectReceipt(
+            effect="reuse_open_pr",
+            action="reused-current-open-pr",
+            details={
+                "number": pr.get("number"),
+                "url": pr.get("url"),
+                "head_sha": head,
+                "base_sha": expected_base_sha,
             },
         )
 
@@ -1747,6 +2548,259 @@ class DeliveryCompleter:
         )
 
 
+@dataclass(frozen=True)
+class RemediationContext:
+    task_number: int
+    review_id: str
+    findings: str
+    state: LiveState
+    action: str
+
+    def to_dict(self) -> dict[str, Any]:
+        pr = self.state.open_pr or {}
+        return {
+            "schema_version": LCK_SCHEMA_VERSION,
+            "operation": "remediation-prepare",
+            "status": "READY_FOR_REMEDIATION",
+            "task_number": self.task_number,
+            "review_id": self.review_id,
+            "action": self.action,
+            "findings": self.findings,
+            "live_target": {
+                "pr_number": pr.get("number"),
+                "base_sha": pr.get("baseRefOid"),
+                "head_sha": pr.get("headRefOid"),
+                "branch": self.state.target_branch,
+                "task_body_sha256": (
+                    self.state.issue.get("body_sha256")
+                    if isinstance(self.state.issue, Mapping)
+                    else None
+                ),
+            },
+            "mechanical_authority": "current live state; Review record supplies findings only",
+        }
+
+
+def _failed_review_record(
+    store: ReviewInvocationStore, task_number: int, review_id: str
+) -> dict[str, Any]:
+    record = store.read_record(task_number, review_id)
+    if record.get("task_number") != task_number or record.get("verdict") != "FAIL":
+        raise LckStopError("Remediation requires a failed Independent Review record")
+    latest = store.read_latest_review(task_number)
+    if (
+        not isinstance(latest, Mapping)
+        or latest.get("review_id") != review_id
+        or latest.get("verdict") != "FAIL"
+    ):
+        raise LckStopError(
+            "Remediation requires the latest completed Independent Review to be this FAIL"
+        )
+    findings = record.get("findings")
+    if not isinstance(findings, str) or not findings.strip():
+        raise LckStopError(
+            "failed Independent Review record has no remediation findings"
+        )
+    identity = record.get("identity")
+    if not isinstance(identity, Mapping):
+        raise LckStopError("failed Independent Review record has no reviewed identity")
+    _identity_from_mapping(identity)
+    return record
+
+
+def _failed_review_findings(
+    store: ReviewInvocationStore, task_number: int, review_id: str
+) -> str:
+    record = _failed_review_record(store, task_number, review_id)
+    return cast(str, record["findings"])
+
+
+class RemediationPreparer:
+    """Explicitly enter repair using live mechanics plus semantic Review findings."""
+
+    def __init__(
+        self,
+        resolver: LiveStateResolver,
+        *,
+        eligibility: PhaseEligibilityResolver | None = None,
+        store: ReviewInvocationStore | None = None,
+    ) -> None:
+        self.resolver = resolver
+        self.eligibility = eligibility or PhaseEligibilityResolver()
+        self.store = store or ReviewInvocationStore(resolver.repo_root)
+
+    def _run_git(self, args: Sequence[str], command_id: str) -> None:
+        result = self.resolver.runner.run(["git", *args], command_id=command_id)
+        if result.returncode != 0:
+            raise LckStopError(
+                f"{command_id} failed with exit code {result.returncode}: "
+                f"{result.stderr.strip() or result.stdout.strip()}"
+            )
+
+    def prepare(self, task_number: int, review_id: str) -> RemediationContext:
+        required = self.store.read_review_required(task_number)
+        if required is not None:
+            raise LckStopError(
+                "Remediation STOP: a fresh Independent Review is required after the previous remediation"
+            )
+        findings = _failed_review_findings(self.store, task_number, review_id)
+        state = self.resolver.resolve(task_number)
+        decision = self.eligibility.resolve(state, Phase.REMEDIATION_PREPARE)
+        if not decision.eligible:
+            raise LckStopError(
+                f"Remediation Prepare STOP for Task #{task_number}: "
+                + "; ".join(decision.reasons)
+            )
+
+        branch = state.target_branch
+        current = state.git.get("branch")
+        clean = state.git.get("clean") is True
+        action = "already-prepared"
+        if state.local_task_branch is None:
+            if not clean:
+                raise LckStopError(
+                    "restoring Remediation workspace requires a clean current worktree"
+                )
+            if state.remote_task_branch != branch:
+                raise LckStopError(
+                    "current OPEN PR has no restorable remote Task branch"
+                )
+            self._run_git(
+                ["switch", "-c", branch, "--track", f"origin/{branch}"],
+                "lck-remediation-restore-branch",
+            )
+            action = "restored-remote-branch"
+        elif current != branch:
+            if not clean:
+                raise LckStopError(
+                    "cannot switch to Remediation branch with a dirty unrelated worktree"
+                )
+            self._run_git(["switch", branch], "lck-remediation-switch-branch")
+            action = "selected-existing-branch"
+        elif not clean:
+            action = "resumed-dirty-remediation"
+
+        final = self.resolver.resolve(task_number)
+        final_decision = self.eligibility.resolve(final, Phase.REMEDIATION_PREPARE)
+        pr_head = final.open_pr.get("headRefOid") if final.open_pr else None
+        if (
+            not final_decision.eligible
+            or final.git.get("branch") != branch
+            or final.local_task_head != pr_head
+            or final.remote_task_oid != pr_head
+        ):
+            raise LckStopError(
+                "Remediation Prepare postcondition failed: workspace is not on current PR head"
+            )
+        return RemediationContext(
+            task_number=task_number,
+            review_id=review_id,
+            findings=findings,
+            state=final,
+            action=action,
+        )
+
+
+@dataclass(frozen=True)
+class RemediationCompletionResult:
+    task_number: int
+    review_id: str
+    delivery: DeliveryCompletionResult
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = self.delivery.to_dict()
+        return {
+            "schema_version": LCK_SCHEMA_VERSION,
+            "operation": "remediation-complete",
+            "task_number": self.task_number,
+            "review_id": self.review_id,
+            "status": "READY_FOR_NEW_REVIEW",
+            "head_sha": self.delivery.head_sha,
+            "critical_outcome": payload["critical_outcome"],
+            "validation": payload["validation"],
+            "checks": payload["checks"],
+            "effects": payload["effects"],
+            "final_state": payload["final_state"],
+            "human_boundary": (
+                "STOP — a new Independent Review must be started explicitly in a fresh invocation"
+            ),
+            "automatic_review": False,
+        }
+
+
+class RemediationCompleter:
+    """Reuse Task-2 Delivery effects for one explicitly started repair."""
+
+    def __init__(
+        self,
+        resolver: LiveStateResolver,
+        *,
+        eligibility: PhaseEligibilityResolver | None = None,
+        store: ReviewInvocationStore | None = None,
+        checks_gate: DeliveryChecksGate | None = None,
+    ) -> None:
+        self.resolver = resolver
+        self.eligibility = eligibility or PhaseEligibilityResolver()
+        self.store = store or ReviewInvocationStore(resolver.repo_root)
+        self.checks_gate = checks_gate or DeliveryChecksGate(resolver)
+
+    def complete(
+        self,
+        task_number: int,
+        review_id: str,
+        *,
+        commit_message: str,
+        summary: str,
+        risks: str = "",
+    ) -> RemediationCompletionResult:
+        if self.store.read_review_required(task_number) is not None:
+            raise LckStopError(
+                "Remediation STOP: a fresh Independent Review is required after the previous remediation"
+            )
+        record = _failed_review_record(self.store, task_number, review_id)
+        reviewed_identity = _identity_from_mapping(
+            cast(Mapping[str, Any], record["identity"])
+        )
+        state = self.resolver.resolve(task_number)
+        decision = self.eligibility.resolve(state, Phase.REMEDIATION_COMPLETE)
+        if not decision.eligible:
+            raise LckStopError(
+                f"Remediation Complete STOP for Task #{task_number}: "
+                + "; ".join(decision.reasons)
+            )
+        if (
+            state.git.get("clean") is True
+            and state.local_task_head == reviewed_identity.head_sha
+        ):
+            raise LckStopError(
+                "Remediation Complete requires a repaired head or uncommitted repair changes"
+            )
+
+        # Initial Delivery already owns the bounded validate/commit/push/check
+        # mechanics.  Remediation deliberately reuses those effects while
+        # replacing PR create/resolve with a strict existing-PR postcondition.
+        delivery = DeliveryCompleter(
+            self.resolver,
+            pr_effect=cast(Any, ReuseExistingOpenPrEffect(self.resolver)),
+            checks_gate=self.checks_gate,
+        ).complete(
+            task_number,
+            commit_message=commit_message,
+            summary=summary,
+            risks=risks,
+        )
+        if delivery.head_sha == reviewed_identity.head_sha:
+            raise LckStopError(
+                "Remediation Complete did not produce a new head; fresh Review boundary cannot advance"
+            )
+        self.store.write_review_required(task_number, review_id, delivery.head_sha)
+        return RemediationCompletionResult(
+            task_number=task_number,
+            review_id=review_id,
+            delivery=delivery,
+        )
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="LCK v1 live state operations")
     parser.add_argument("--repo-root", type=Path, default=Path.cwd())
@@ -1766,6 +2820,33 @@ def _build_parser() -> argparse.ArgumentParser:
     complete.add_argument("--summary", required=True)
     complete.add_argument("--risks", default="")
     complete.add_argument("--check-timeout-seconds", type=float, default=600.0)
+
+    review = commands.add_parser("review")
+    review_commands = review.add_subparsers(dest="review_command", required=True)
+    review_prepare = review_commands.add_parser("prepare")
+    review_prepare.add_argument("task", type=int)
+    review_complete = review_commands.add_parser("complete")
+    review_complete.add_argument("task", type=int)
+    review_complete.add_argument("--review-id", required=True)
+    review_complete.add_argument("--verdict", required=True, choices=("PASS", "FAIL"))
+    review_complete.add_argument("--findings-file", type=Path)
+
+    remediation = commands.add_parser("remediation")
+    remediation_commands = remediation.add_subparsers(
+        dest="remediation_command", required=True
+    )
+    remediation_prepare = remediation_commands.add_parser("prepare")
+    remediation_prepare.add_argument("task", type=int)
+    remediation_prepare.add_argument("--review-id", required=True)
+    remediation_complete = remediation_commands.add_parser("complete")
+    remediation_complete.add_argument("task", type=int)
+    remediation_complete.add_argument("--review-id", required=True)
+    remediation_complete.add_argument("--commit-message", required=True)
+    remediation_complete.add_argument("--summary", required=True)
+    remediation_complete.add_argument("--risks", default="")
+    remediation_complete.add_argument(
+        "--check-timeout-seconds", type=float, default=600.0
+    )
     return parser
 
 
@@ -1780,11 +2861,11 @@ def main(argv: Sequence[str] | None = None) -> int:
             state = resolver.resolve(args.task)
             print_json(state.to_dict(), pretty=True)
             return 0 if state.status is ResolutionStatus.RESOLVED else 2
-        if args.delivery_command == "prepare":
+        if args.command == "delivery" and args.delivery_command == "prepare":
             context = DeliveryPreparer(resolver).prepare(args.task)
             print_json(context.to_dict(), pretty=True)
             return 0
-        if args.delivery_command == "complete":
+        if args.command == "delivery" and args.delivery_command == "complete":
             result = DeliveryCompleter(
                 resolver,
                 checks_gate=DeliveryChecksGate(
@@ -1798,7 +2879,47 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
             print_json(result.to_dict(), pretty=True)
             return 0
+        if args.command == "review" and args.review_command == "prepare":
+            context = ReviewPreparer(resolver).prepare(args.task)
+            print_json(context.to_dict(), pretty=True)
+            return 0
+        if args.command == "review" and args.review_command == "complete":
+            result = ReviewCompleter(resolver).complete(
+                args.task,
+                args.review_id,
+                verdict=args.verdict,
+                findings_file=args.findings_file,
+            )
+            print_json(result.to_dict(), pretty=True)
+            return 0
+        if args.command == "remediation" and args.remediation_command == "prepare":
+            context = RemediationPreparer(resolver).prepare(args.task, args.review_id)
+            print_json(context.to_dict(), pretty=True)
+            return 0
+        if args.command == "remediation" and args.remediation_command == "complete":
+            result = RemediationCompleter(
+                resolver,
+                checks_gate=DeliveryChecksGate(
+                    resolver, timeout_seconds=args.check_timeout_seconds
+                ),
+            ).complete(
+                args.task,
+                args.review_id,
+                commit_message=args.commit_message,
+                summary=args.summary,
+                risks=args.risks,
+            )
+            print_json(result.to_dict(), pretty=True)
+            return 0
         raise LckStopError("unsupported LCK command")
+    except ReviewStaleError as exc:
+        print(
+            json.dumps(
+                {"status": "stale", "code": exc.code, "error": str(exc)},
+                ensure_ascii=False,
+            )
+        )
+        return 3
     except WorkflowToolError as exc:
         print(json.dumps({"status": "stop", "error": str(exc)}, ensure_ascii=False))
         return 2

--- a/tools/agent_workflow/skill_path_audit.py
+++ b/tools/agent_workflow/skill_path_audit.py
@@ -8,7 +8,7 @@ import json
 from pathlib import Path
 from typing import Final
 
-SCHEMA_VERSION: Final = 4
+SCHEMA_VERSION: Final = 5
 ACTIVE_SKILLS: Final = {
     "task-delivery-runner": Path(".agents/skills/task-delivery-runner/SKILL.md"),
     "task-pr-review-runner": Path(".agents/skills/task-pr-review-runner/SKILL.md"),
@@ -31,16 +31,18 @@ REQUIRED: Final = {
         "delivery prepare",
         "delivery complete",
         "Critical Outcome",
-        "wsl2_github_evidence_runner.py",
-        "wsl2_validation_runner.py",
-        "Review remediation",
+        "remediation prepare",
+        "remediation complete",
+        "READY_FOR_NEW_REVIEW",
     ),
     "task-pr-review-runner": (
-        "wsl2_github_evidence_runner.py",
-        "wsl2_validation_runner.py",
-        "workflow-review",
-        "recheck",
-        "Remediation handoff",
+        "tools/agent_workflow/lck.py",
+        "review prepare",
+        "review complete",
+        "READY_FOR_SEMANTIC_REVIEW",
+        "REVIEW_STALE_HEAD",
+        "REVIEW_STALE_BASE",
+        "STOP_REQUIRED",
     ),
     "task-closeout": (
         "wsl2_github_evidence_runner.py",


### PR DESCRIPTION
Closes #161

## Summary
Move Independent Review target resolution, read-only context, invocation-local stale guards, explicit remediation boundaries, and dual-agent workflow contracts under LCK live-state control.

## Validation
- Critical Outcome: pass
- Formal Delivery validation: pass

## Risks / limitations
Independent Review and merge remain explicit human-boundary actions; historical Evidence Runner review/recheck paths remain compatibility/audit only.
