### PR TITLE
[Task] 将 Merge Preflight、Closeout 与 Recovery 迁移至 LCK

### DIFF
--- a/.agents/skills/task-closeout/SKILL.md
+++ b/.agents/skills/task-closeout/SKILL.md
@@ -1,212 +1,99 @@
 ---
 name: task-closeout
-description: Close out one maintainer-specified Task after maintainer manual merge. Verify the exact merge, synchronize main, run post-merge validation, converge final Task metadata, and delete only the verified Task branch. Never merge, manually close an Issue, repair code, clean unrelated branches, or assess Feature completion.
+description: Close out one maintainer-specified Task after maintainer manual Squash Merge through LCK live-state recovery. Never merge, manually close an Issue, repair code, clean unrelated branches, or assess Feature completion.
 ---
 
 # Task closeout
 
-Use this Skill only after the maintainer states that a specific PR was manually
-merged and requests closeout for its exact Task. The statement authorizes
-verification; it is not proof of merge. This Skill never merges a PR.
+Use this Skill only after the maintainer states that a specific PR was
+manually Squash Merged and requests closeout for its exact Task. The statement
+authorizes verification; it is not proof of merge. This Skill never merges.
 
 ## Standard invocation
 
-```text
+~~~text
 PR #<PR编号> 已由我人工 Squash Merge。
 
 请使用 task-closeout，完成
-[Task] <当前完整标题> #<Task编号>
-及 PR #<PR编号> 的合并后核验与分支清理。
-```
+[Task] <当前完整标题> #<Task编号> 的合并后核验与分支清理。
+~~~
 
 Task and PR numbers are primary keys; the current Issue title is canonical.
-A request may limit execution to one named Phase or to the documented
-cleanup-only path.
-
-## Policies and Runner interface
-
-Read applicable agent rules and:
-
-```text
-.agents/policies/command-execution.md
-.agents/policies/workflow-evidence.md
-```
-
-Shared lifecycle semantics are owned by `docs/development/issue-workflow.md`
-(§11 manual Squash Merge boundary, §13 Closeout). Read the minimal needed
-section for the current phase; do not duplicate closeout-semantic prose in this
-Skill.
-
-Use the current repository Runner interfaces:
-
-```bash
-tools/agent_workflow/wsl2_github_evidence_runner.py closeout-readonly \
-  --task <TASK> \
-  --pr <PR> \
-  --expected-head-sha <REVIEWED_PR_HEAD_SHA> \
-  --expected-merge-sha <MERGE_SHA>
-
-tools/agent_workflow/wsl2_validation_runner.py workflow-closeout \
-  --base-sha <PR_BASE_SHA>
-
-tools/agent_workflow/wsl2_github_evidence_runner.py \
-  recheck --snapshot-id <CLOSEOUT_PLAN_SNAPSHOT_ID>
-```
-
-The first snapshot is the read-only closeout plan. `workflow-closeout` validates
-the synchronized merged result. `recheck` verifies stability after metadata and
-cleanup operations.
-
-For `partial`, `unknown`, `fail`, truncation, schema mismatch, or drift, inspect
-only the named facts or failed commands and preserve the original status.
-
-A recognized Required-Checks plan-limit `403` keeps
-`required_checks_configuration = unknown` and Evidence status `partial`.
-Branch cleanup may still use the separate
-`cleanup_eligibility.status = eligible-under-capability-limited-policy`; that
-field authorizes only exact branch cleanup under the conditions below.
+The LCK resolver reacquires the PR from current Git/GitHub facts. Do not pass
+an old PR, branch, SHA, or snapshot as lifecycle authority.
 
 ## Default context
 
-Normal closeout verifies: Task/PR identity, reviewed head, merge identity,
-CI/review status, Issue/Project lifecycle state, local/origin main, branch
-state, and post-merge validation requirements. It does not default to
-re-reading the complete business Issue hierarchy (Parent/Epic bodies),
-business comments, or full implementation context. Those are read only when
-an explicit anomaly trigger requires it — for example a linkage, closure, or
-merge-identity conflict that the deterministic facts cannot resolve.
+It does not default to re-reading the complete business Issue hierarchy
+(Parent/Epic bodies), business comments, or full implementation context. Read
+additional business context only when an explicit anomaly trigger requires it,
+such as an unresolved linkage, closure, or merge-identity conflict.
 
-## Permission boundary
+## Policies and lifecycle owner
 
-After all prerequisite gates pass, this Skill may fetch refs, fast-forward local
-`main` to `origin/main`, run post-merge validation, set this Task's Project
-Status to `Done`, restore lifecycle label `codex:ready`, remove
-`codex:blocked`, and delete only the exact verified Task branch.
+Read the applicable AGENTS.md,
+.agents/policies/command-execution.md, and
+.agents/policies/workflow-evidence.md. Shared semantics are owned by
+docs/development/issue-workflow.md (§11 and §13).
 
-It does not authorize merge, manual Issue close, repair commits, code push,
-hierarchy/Relationship changes, unrelated cleanup, Feature completion, force
-push, `--admin`, protection bypass, destructive reset, or `git clean`.
+The lifecycle entry point is:
 
-## Entry gates
+~~~bash
+uv run --frozen python tools/agent_workflow/lck.py closeout <TASK>
+~~~
 
-Generate `closeout-readonly`. Verify repository, Task/PR/title, exact closing
-linkage, actual `MERGED` state, reviewed head, merge SHA/method/time, automatic
-Issue closure, Project/label facts, workspace/worktrees, exact branches, and
-checks.
+Before the maintainer merge, the deterministic merge gate is:
 
-If the intended PR did not automatically close the Task, stop. Do not close the
-Issue manually.
+~~~bash
+uv run --frozen python tools/agent_workflow/lck.py merge preflight <TASK>
+~~~
 
-## Phase 1: synchronize the merged result
+Merge Preflight verifies the unique current PR, head/base, required checks,
+current Review PASS, blockers, and mergeability. It returns
+READY_FOR_HUMAN_MERGE; it has no automatic merge path. The maintainer must
+perform the manual Squash Merge.
 
-Start from a clean workspace. Fetch refs, switch to local `main`, and
-fast-forward only. Stop on divergence, changes, worktree conflict, or any need
-for reset, force, or bypass.
+closeout-readonly and workflow-closeout remain bounded validation/evidence
+interfaces where the repository runtime requires them; they are not a
+substitute for LCK live-state resolution or write authority. The historical
+eligible-under-capability-limited-policy state remains a reported limitation,
+not permission to broaden cleanup. The compatibility interfaces are backed by
+wsl2_github_evidence_runner.py, wsl2_validation_runner.py, and recheck.
 
-Verify:
+## LCK closeout contract
 
-```text
-local main == origin/main
-merge SHA is reachable
-merged tree and scope match the reviewed change
-no tracked or staged execution artifacts exist
-```
+LCK resolves the current state on every invocation and fail-closes on
+ambiguous identity, multiple merged PRs, open PR conflicts, remote divergence,
+unknown merge identity, or unsafe worktree ownership. It does not require a
+previous Kernel process or authoritative snapshot lineage.
 
-For Squash Merge, use merge facts, linkage, reviewed head, changed-file scope,
-and tree comparison rather than ancestry assumptions.
+The result separates:
 
-## Phase 2: post-merge validation
+~~~text
+Business Delivery: COMPLETE | NOT_COMPLETE
+Cleanup: COMPLETE | PENDING
+~~~
 
-Run `workflow-closeout` after synchronization. Read remote-main checks and
-Required-Checks classification. Preserve none-configured, plan-limit `403`,
-pending, failed, cancelled, skipped, stale, and unavailable states. A real
-failure or unresolved required gate blocks metadata convergence and cleanup.
+A verified merged PR makes Business Delivery COMPLETE. Cleanup may remain
+PENDING after an interrupted or failed idempotent effect and can be retried
+with the same LCK command. A GitHub-deleted remote branch is recognized as a
+normal post-merge state.
 
-## Phase 3: final Task metadata
+The bounded effects may synchronize main by fast-forward, converge Project
+Status and lifecycle labels only when authoritative Issue closure is present,
+and clean only the verified Task branch after head/tree/worktree proof. LCK
+never manually closes the Issue, uses force push, resets, deletes unrelated
+branches, or assesses Feature completion.
 
-The expected final state is:
+## Recovery and reporting
 
-```text
-Issue: CLOSED by the verified PR
-Project Status: Done
-Codex label: codex:ready
-codex:blocked: absent
-```
+The same closeout command is the cleanup-only recovery entry when only the
+exact verified Task refs remain. Reacquire live facts; do not reconstruct state
+from an old report. Stop and surface facts when the unique safe action cannot
+be proved.
 
-Verify existing automation first. Apply only missing exact Project/lifecycle
-convergence and re-read it. Do not change any other field or infer Feature
-completion.
-
-## Phase 4: exact branch cleanup
-
-Resolve the exact branch from verified PR facts. Before deletion confirm branch
-ownership, expected head, no worktree use, merged result, Issue closure,
-synchronized main, validation/checks, final metadata, and an unambiguous,
-non-default, non-protected target.
-
-Complete Issue-side proof that the locked merged PR closed the Task is required.
-Unknown, partial, or conflicting closure evidence blocks cleanup.
-
-When Required-Checks configuration is unknown only because of a recognized
-plan-limit `403`, cleanup may proceed only when all of the following hold:
-
-- `cleanup_eligibility.status` is exactly
-  `eligible-under-capability-limited-policy`;
-- observed check runs include at least one quality gate and all are successful
-  terminal states;
-- the final recheck is stable;
-- `local main == origin/main == merge SHA`;
-- local Task branch tip equals the reviewed PR head;
-- if the remote Task branch still exists, its tip equals the reviewed PR head;
-- if GitHub already deleted the remote branch, the Evidence Runner records
-  `remote_branch_state = ALREADY_DELETED` only after the same PR/head/merge,
-  effective-diff, squash-tree, and synchronized-main identity proof;
-- PR-head tree equals merge tree;
-- no worktree uses the branch;
-- the cleanup plan contains no other branch.
-
-Authentication, scope, permission, rate-limit, network, schema, service, or
-other unknown failures keep cleanup blocked.
-
-Delete only the exact remote branch when it still exists and verify absence. A
-remote ref already absent after the recorded identity proof is not a failed
-gate. For local cleanup, use `git branch -d` first. Exact `-D` is allowed only
-after verified Squash Merge, remote presence/absence proof, local tip equal to
-reviewed head, tree equality with main, no worktree use, and all other gates
-pass.
-
-## Cleanup-only recovery
-
-When lifecycle closeout is complete and only the exact Task branch remains, the
-maintainer may request `cleanup-only` with Task, PR, PR base SHA, reviewed head
-SHA, merge SHA, and exact branch name.
-
-Re-run the same identity, validation, recheck, and cleanup gates. This path may
-delete only the exact Task branch; it may not merge, close an Issue, edit
-metadata, commit, push, repair files, change lifecycle state, delete another
-branch, or assess Feature completion.
-
-## Stability and report
-
-Run `recheck` after synchronization, metadata convergence, and cleanup. Any
-merge, state, main, check, or branch drift blocks success.
-
-On clean success, report Task/PR URLs, PR base/head/reviewed head, merge
-method/SHA, Issue/Project/label state, local/origin main, post-merge validation
-and checks, exact branch actions, Parent/sub-issue facts without Feature
-judgment, limitations, and actions not performed.
-
-When cleanup uses the capability-limited policy, report:
-
-```text
-closeout = completed-with-capability-limitation
-evidence = stable / partial
-required_checks_configuration = unknown
-cleanup = completed-under-capability-limited-policy
-```
-
-Other terminal states are `completed`, `partial-cleanup-deferred`, `blocked`,
-and `invalidated-by-drift`. Use a detailed report for any fallback,
-`partial`/`unknown`, failure, drift, conflict, or maintainer decision. Explicitly
-state that no merge, manual Issue close, repair commit, unrelated cleanup, or
-Feature completion action occurred.
+Report the canonical Task/PR, merge identity, Business Delivery, Cleanup,
+metadata, main synchronization, exact branch/worktree actions, preserved
+limitations, and actions not performed. Explicitly state that no merge,
+manual Issue close, repair commit, unrelated cleanup, or Feature completion
+occurred.

--- a/.claude/skills/task-closeout/SKILL.md
+++ b/.claude/skills/task-closeout/SKILL.md
@@ -1,255 +1,99 @@
 ---
 name: task-closeout
-description: Close out one maintainer-specified Task after maintainer manual merge. Verify the exact merge, synchronize main, run post-merge validation, converge final Task metadata, and delete only the verified Task branch. Never merge, manually close an Issue, repair code, clean unrelated branches, or assess Feature completion.
+description: Close out one maintainer-specified Task after maintainer manual Squash Merge through LCK live-state recovery. Never merge, manually close an Issue, repair code, clean unrelated branches, or assess Feature completion.
 ---
 
 # Task closeout
 
-Use this Skill only after the maintainer states that a specific PR was manually
-merged and requests closeout for its exact Task. The statement authorizes
-verification; it is not proof of merge. This Skill never merges a PR.
+Use this Skill only after the maintainer states that a specific PR was
+manually Squash Merged and requests closeout for its exact Task. The statement
+authorizes verification; it is not proof of merge. This Skill never merges.
 
 ## Standard invocation
 
-```text
+~~~text
 PR #<PR编号> 已由我人工 Squash Merge。
 
 请使用 task-closeout，完成
-[Task] <当前完整标题> #<Task编号>
-及 PR #<PR编号> 的合并后核验与分支清理。
-```
+[Task] <当前完整标题> #<Task编号> 的合并后核验与分支清理。
+~~~
 
 Task and PR numbers are primary keys; the current Issue title is canonical.
-A request may limit execution to one named Phase or to the documented
-cleanup-only path. Verify prior Phase facts using the Evidence Runner snapshot
-that Phase would have produced (`closeout-readonly` for entry gates, `recheck`
-for stability) — do not substitute direct `gh` or `git` queries for Runner
-snapshots — and stop at the requested boundary.
-
-## Policies and Runner interface
-
-Read applicable `AGENTS.md` and:
-
-```text
-.agents/policies/workflow-evidence.md
-```
-
-Shared lifecycle semantics are owned by `docs/development/issue-workflow.md`
-(§11 manual Squash Merge boundary, §13 Closeout). Read the minimal needed
-section for the current phase; do not duplicate closeout-semantic prose in this
-Skill.
-
-Use the current repository Runner interfaces:
-
-```bash
-tools/agent_workflow/wsl2_github_evidence_runner.py closeout-readonly \
-  --task <TASK> \
-  --pr <PR> \
-  --expected-head-sha <REVIEWED_PR_HEAD_SHA> \
-  --expected-merge-sha <MERGE_SHA>
-
-tools/agent_workflow/wsl2_validation_runner.py workflow-closeout \
-  --base-sha <PR_BASE_SHA>
-
-tools/agent_workflow/wsl2_github_evidence_runner.py \
-  recheck --snapshot-id <CLOSEOUT_PLAN_SNAPSHOT_ID>
-```
-
-The first snapshot is the read-only closeout plan. `workflow-closeout` validates
-the synchronized merged result. `recheck` verifies stability after metadata and
-cleanup operations.
-
-For `partial`, `unknown`, `fail`, truncation, schema mismatch, or drift, inspect
-only the named facts or failed commands and preserve the original status.
-
-A recognized Required-Checks plan-limit `403` keeps
-`required_checks_configuration = unknown` and Evidence status `partial`.
-Branch cleanup may still use the separate
-`cleanup_eligibility.status = eligible-under-capability-limited-policy`; that
-field authorizes only exact branch cleanup under the conditions below.
-
-## Execution model
-
-Claude Code executes commands directly in the user's shell environment — there
-is no sandbox isolation layer. Git, `gh`, Python, subprocess, network, and
-filesystem access all work natively. The Codex Guardian sandbox/elevated routing
-model does not apply.
-
-Runner commands are deterministic Python CLI tools invoked from the repository
-root on the WSL2 Linux filesystem. Each Runner call is a single Bash tool
-invocation.
-
-The Bash tool itself may prompt for user approval on first use. To suppress
-these prompts for the documented Runner invocations, pre-authorize in
-`.claude/settings.json`:
-
-```json
-{
-  "permissions": {
-    "allow": [
-      "Bash(tools/agent_workflow/wsl2_github_evidence_runner.py *)",
-      "Bash(tools/agent_workflow/wsl2_validation_runner.py *)"
-    ]
-  }
-}
-```
-
-Runner commands can fail, but not because of sandbox restrictions. Read the
-Runner's own output to classify:
-
-- `pass`: all commands succeeded, inspect the compact digest.
-- `fail`: one or more commands returned non-zero. Read the named failure
-  artifact before deciding how to proceed.
-- `blocked`: a Runner precondition failed (e.g. unclean worktree, wrong branch,
-  wrong cwd, identity mismatch). Fix the precondition; do not retry with
-  different arguments.
-- `partial` / `unknown`: bounded diagnostics in the artifact — inspect only the
-  named gates.
-
-Never fall back to an equivalent direct command chain after a Runner result.
-Never retry a Runner command with modified arguments to work around a failure.
+The LCK resolver reacquires the PR from current Git/GitHub facts. Do not pass
+an old PR, branch, SHA, or snapshot as lifecycle authority.
 
 ## Default context
 
-Normal closeout verifies: Task/PR identity, reviewed head, merge identity,
-CI/review status, Issue/Project lifecycle state, local/origin main, branch
-state, and post-merge validation requirements. It does not default to
-re-reading the complete business Issue hierarchy (Parent/Epic bodies),
-business comments, or full implementation context. Those are read only when
-an explicit anomaly trigger requires it — for example a linkage, closure, or
-merge-identity conflict that the deterministic facts cannot resolve.
+It does not default to re-reading the complete business Issue hierarchy
+(Parent/Epic bodies), business comments, or full implementation context. Read
+additional business context only when an explicit anomaly trigger requires it,
+such as an unresolved linkage, closure, or merge-identity conflict.
 
-## Permission boundary
+## Policies and lifecycle owner
 
-After all prerequisite gates pass, this Skill may fetch refs, fast-forward local
-`main` to `origin/main`, run post-merge validation, set this Task's Project
-Status to `Done`, restore lifecycle label `codex:ready`, remove
-`codex:blocked`, and delete only the exact verified Task branch.
+Read the applicable AGENTS.md,
+.agents/policies/command-execution.md, and
+.agents/policies/workflow-evidence.md. Shared semantics are owned by
+docs/development/issue-workflow.md (§11 and §13).
 
-It does not authorize merge, manual Issue close, repair commits, code push,
-hierarchy/Relationship changes, unrelated cleanup, Feature completion, force
-push, `--admin`, protection bypass, destructive reset, or `git clean`.
+The lifecycle entry point is:
 
-## Entry gates
+~~~bash
+uv run --frozen python tools/agent_workflow/lck.py closeout <TASK>
+~~~
 
-Generate `closeout-readonly`. Verify repository, Task/PR/title, exact closing
-linkage, actual `MERGED` state, reviewed head, merge SHA/method/time, automatic
-Issue closure, Project/label facts, workspace/worktrees, exact branches, and
-checks.
+Before the maintainer merge, the deterministic merge gate is:
 
-If the intended PR did not automatically close the Task, stop. Do not close the
-Issue manually.
+~~~bash
+uv run --frozen python tools/agent_workflow/lck.py merge preflight <TASK>
+~~~
 
-## Phase 1: synchronize the merged result
+Merge Preflight verifies the unique current PR, head/base, required checks,
+current Review PASS, blockers, and mergeability. It returns
+READY_FOR_HUMAN_MERGE; it has no automatic merge path. The maintainer must
+perform the manual Squash Merge.
 
-Start from a clean workspace. Fetch refs, switch to local `main`, and
-fast-forward only. Stop on divergence, changes, worktree conflict, or any need
-for reset, force, or bypass.
+closeout-readonly and workflow-closeout remain bounded validation/evidence
+interfaces where the repository runtime requires them; they are not a
+substitute for LCK live-state resolution or write authority. The historical
+eligible-under-capability-limited-policy state remains a reported limitation,
+not permission to broaden cleanup. The compatibility interfaces are backed by
+wsl2_github_evidence_runner.py, wsl2_validation_runner.py, and recheck.
 
-Verify:
+## LCK closeout contract
 
-```text
-local main == origin/main
-merge SHA is reachable
-merged tree and scope match the reviewed change
-no tracked or staged execution artifacts exist
-```
+LCK resolves the current state on every invocation and fail-closes on
+ambiguous identity, multiple merged PRs, open PR conflicts, remote divergence,
+unknown merge identity, or unsafe worktree ownership. It does not require a
+previous Kernel process or authoritative snapshot lineage.
 
-For Squash Merge, use merge facts, linkage, reviewed head, changed-file scope,
-and tree comparison rather than ancestry assumptions.
+The result separates:
 
-## Phase 2: post-merge validation
+~~~text
+Business Delivery: COMPLETE | NOT_COMPLETE
+Cleanup: COMPLETE | PENDING
+~~~
 
-Run `workflow-closeout` after synchronization. Read remote-main checks and
-Required-Checks classification. Preserve none-configured, plan-limit `403`,
-pending, failed, cancelled, skipped, stale, and unavailable states. A real
-failure or unresolved required gate blocks metadata convergence and cleanup.
+A verified merged PR makes Business Delivery COMPLETE. Cleanup may remain
+PENDING after an interrupted or failed idempotent effect and can be retried
+with the same LCK command. A GitHub-deleted remote branch is recognized as a
+normal post-merge state.
 
-## Phase 3: final Task metadata
+The bounded effects may synchronize main by fast-forward, converge Project
+Status and lifecycle labels only when authoritative Issue closure is present,
+and clean only the verified Task branch after head/tree/worktree proof. LCK
+never manually closes the Issue, uses force push, resets, deletes unrelated
+branches, or assesses Feature completion.
 
-The expected final state is:
+## Recovery and reporting
 
-```text
-Issue: CLOSED by the verified PR
-Project Status: Done
-Codex label: codex:ready
-codex:blocked: absent
-```
+The same closeout command is the cleanup-only recovery entry when only the
+exact verified Task refs remain. Reacquire live facts; do not reconstruct state
+from an old report. Stop and surface facts when the unique safe action cannot
+be proved.
 
-Verify existing automation first. Apply only missing exact Project/lifecycle
-convergence and re-read it. Do not change any other field or infer Feature
-completion.
-
-## Phase 4: exact branch cleanup
-
-Resolve the exact branch from verified PR facts. Before deletion confirm branch
-ownership, expected head, no worktree use, merged result, Issue closure,
-synchronized main, validation/checks, final metadata, and an unambiguous,
-non-default, non-protected target.
-
-Complete Issue-side proof that the locked merged PR closed the Task is required.
-Unknown, partial, or conflicting closure evidence blocks cleanup.
-
-When Required-Checks configuration is unknown only because of a recognized
-plan-limit `403`, cleanup may proceed only when all of the following hold:
-
-- `cleanup_eligibility.status` is exactly
-  `eligible-under-capability-limited-policy`;
-- observed check runs include at least one quality gate and all are successful
-  terminal states;
-- the final recheck is stable;
-- `local main == origin/main == merge SHA`;
-- local Task branch tip equals the reviewed PR head;
-- if the remote Task branch still exists, its tip equals the reviewed PR head;
-- if GitHub already deleted the remote branch, the Evidence Runner records
-  `remote_branch_state = ALREADY_DELETED` only after the same PR/head/merge,
-  effective-diff, squash-tree, and synchronized-main identity proof;
-- PR-head tree equals merge tree;
-- no worktree uses the branch;
-- the cleanup plan contains no other branch.
-
-Authentication, scope, permission, rate-limit, network, schema, service, or
-other unknown failures keep cleanup blocked.
-
-Delete only the exact remote branch when it still exists and verify absence. A
-remote ref already absent after the recorded identity proof is not a failed
-gate. For local cleanup, use `git branch -d` first. Exact `-D` is allowed only
-after verified Squash Merge, remote presence/absence proof, local tip equal to
-reviewed head, tree equality with main, no worktree use, and all other gates
-pass.
-
-## Cleanup-only recovery
-
-When lifecycle closeout is complete and only the exact Task branch remains, the
-maintainer may request `cleanup-only` with Task, PR, PR base SHA, reviewed head
-SHA, merge SHA, and exact branch name.
-
-Re-run the same identity, validation, recheck, and cleanup gates. This path may
-delete only the exact Task branch; it may not merge, close an Issue, edit
-metadata, commit, push, repair files, change lifecycle state, delete another
-branch, or assess Feature completion.
-
-## Stability and report
-
-Run `recheck` after synchronization, metadata convergence, and cleanup. Any
-merge, state, main, check, or branch drift blocks success.
-
-On clean success, report Task/PR URLs, PR base/head/reviewed head, merge
-method/SHA, Issue/Project/label state, local/origin main, post-merge validation
-and checks, exact branch actions, Parent/sub-issue facts without Feature
-judgment, limitations, and actions not performed.
-
-When cleanup uses the capability-limited policy, report:
-
-```text
-closeout = completed-with-capability-limitation
-evidence = stable / partial
-required_checks_configuration = unknown
-cleanup = completed-under-capability-limited-policy
-```
-
-Other terminal states are `completed`, `partial-cleanup-deferred`, `blocked`,
-and `invalidated-by-drift`. Use a detailed report for any fallback,
-`partial`/`unknown`, failure, drift, conflict, or maintainer decision. Explicitly
-state that no merge, manual Issue close, repair commit, unrelated cleanup, or
-Feature completion action occurred.
+Report the canonical Task/PR, merge identity, Business Delivery, Cleanup,
+metadata, main synchronization, exact branch/worktree actions, preserved
+limitations, and actions not performed. Explicitly state that no merge,
+manual Issue close, repair commit, unrelated cleanup, or Feature completion
+occurred.

--- a/docs/development/issue-workflow.md
+++ b/docs/development/issue-workflow.md
@@ -156,6 +156,9 @@ override remains supported.
 - PR 关联 `Closes #N` 仅当 maintainer 预期 merge 后 close。
 - merge 决策：passing Independent Review for current PR head
   + maintainer manual Squash Merge。
+- merge 前由 LCK 执行 deterministic preflight：
+  uv run --frozen python tools/agent_workflow/lck.py merge preflight <TASK>；
+  LCK 只返回人工合并就绪，不执行 merge。
 
 ## 8. Independent Review
 
@@ -218,11 +221,16 @@ Issue comments（Retrieval v2 comments default-off 仍适用）。
 
 Closeout 仅在 maintainer 已人工 Squash Merge 后执行：
 
-1. 验证 merge identity：reviewed head == 实际 merged head；
-2. Issue / Project lifecycle 收敛（state、Status、labels）；
-3. canonical `main` 同步与验证；
-4. branch lifecycle：仅删除已验证的 Task branch；
-5. post-merge validation。
+1. 由
+   uv run --frozen python tools/agent_workflow/lck.py closeout <TASK>
+   从当前 Git / GitHub facts 重新求解 merge identity（reviewed head == 实际 merged head）；
+2. 将 Business Delivery 与 Cleanup 分离：merged PR 可立即得到
+   Business Delivery = COMPLETE，cleanup 失败只产生 Cleanup = PENDING；
+3. 收敛 Issue / Project lifecycle（state、Status、labels）并同步 canonical
+   `main`；
+4. 仅在 head/tree/worktree proof 完整时删除已验证的 Task branch，识别
+   GitHub 已删除的 remote branch，并允许安全重试；
+5. 不依赖旧 Kernel session 或 authoritative snapshot lineage。
 
 Closeout 不 repair 代码、不手动 close Issue、不清理无关 branch、
 不评估 Feature completion。

--- a/tests/tools/test_lck_closeout.py
+++ b/tests/tools/test_lck_closeout.py
@@ -1,0 +1,232 @@
+# ruff: noqa: E402, I001
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+AGENT_WORKFLOW = str(Path(__file__).parents[2] / "tools" / "agent_workflow")
+if AGENT_WORKFLOW not in sys.path:
+    sys.path.insert(0, AGENT_WORKFLOW)
+
+import lck  # type: ignore[import-not-found]  # noqa: E402
+
+
+SHA = "a" * 40
+MERGE_SHA = "b" * 40
+BRANCH = "task/162-closeout"
+
+
+def _state(
+    *,
+    local_branch: str | None = None,
+    remote_branch: str | None = None,
+    remote_oid: str | None = None,
+    merged_head: str = SHA,
+    issue_state: str = "CLOSED",
+) -> lck.LiveState:
+    issue = {
+        "number": 162,
+        "title": "[Task] closeout",
+        "state": issue_state,
+        "labels": {"items": ["type:task", "codex:ready"]},
+        "project_status": "Done",
+    }
+    merged_pr = {
+        "number": 262,
+        "state": "MERGED",
+        "baseRefName": "main",
+        "baseRefOid": SHA,
+        "headRefName": BRANCH,
+        "headRefOid": merged_head,
+        "mergeCommit": {"oid": MERGE_SHA},
+    }
+    return lck.LiveState(
+        task_number=162,
+        repository="owner/repo",
+        issue=issue,
+        relationships={
+            "available": True,
+            "blocked_by": {"items": [], "count": 0, "truncated": False},
+        },
+        git={
+            "branch": "main",
+            "head_sha": MERGE_SHA,
+            "local_main_sha": MERGE_SHA,
+            "origin_main_sha": MERGE_SHA,
+            "origin_fetch": "pass",
+            "clean": True,
+            "worktree_branches": {"items": ["main"], "count": 1},
+        },
+        target_branch=BRANCH,
+        local_task_branch=local_branch,
+        local_task_head=merged_head if local_branch else None,
+        remote_task_branch=remote_branch,
+        remote_task_oid=remote_oid,
+        open_pr=None,
+        merged_pr_numbers=(262,),
+        merged=True,
+        merged_pr=merged_pr,
+        checks={},
+        cleanup={
+            "business_delivery": "complete",
+            "cleanup": "pending",
+        },
+    )
+
+
+class StaticResolver:
+    def __init__(self, state: lck.LiveState) -> None:
+        self.repo_root = Path.cwd()
+        self.state = state
+        self.runner = cast(Any, object())
+
+    def resolve(self, _task_number: int) -> lck.LiveState:
+        return self.state
+
+
+class FixedEffect:
+    def __init__(self, receipt: lck.EffectReceipt) -> None:
+        self.receipt = receipt
+
+    def execute(self, *_args: Any, **_kwargs: Any) -> lck.EffectReceipt:
+        return self.receipt
+
+
+def _receipt(effect: str, action: str) -> lck.EffectReceipt:
+    return lck.EffectReceipt(effect=effect, action=action, details={})
+
+
+def test_closeout_resolves_business_delivery_and_cleanup_from_live_state() -> None:
+    resolver = StaticResolver(_state())
+    result = lck.CloseoutCompleter(
+        cast(Any, resolver),
+        main_effect=cast(
+            Any, FixedEffect(_receipt("synchronize_main", "synchronized"))
+        ),
+        metadata_effect=cast(
+            Any,
+            FixedEffect(_receipt("converge_task_metadata", "already-converged")),
+        ),
+        cleanup_effect=cast(
+            Any,
+            FixedEffect(_receipt("cleanup_task_refs", "already-clean")),
+        ),
+    ).complete(162)
+
+    assert result.business_delivery == "COMPLETE"
+    assert result.cleanup == "COMPLETE"
+    assert result.status == "BUSINESS_DELIVERY_COMPLETE"
+
+
+def test_closeout_keeps_business_complete_when_cleanup_is_pending() -> None:
+    resolver = StaticResolver(_state())
+    result = lck.CloseoutCompleter(
+        cast(Any, resolver),
+        main_effect=cast(Any, FixedEffect(_receipt("synchronize_main", "pending"))),
+        metadata_effect=cast(
+            Any,
+            FixedEffect(_receipt("converge_task_metadata", "pending")),
+        ),
+        cleanup_effect=cast(
+            Any,
+            FixedEffect(_receipt("cleanup_task_refs", "pending")),
+        ),
+    ).complete(162)
+
+    assert result.business_delivery == "COMPLETE"
+    assert result.cleanup == "PENDING"
+
+
+def test_closeout_stops_on_remote_divergence() -> None:
+    state = _state(
+        remote_branch=BRANCH,
+        remote_oid="c" * 40,
+    )
+    with pytest.raises(lck.LckStopError, match="remote Task branch diverges"):
+        lck.CloseoutCompleter(
+            cast(Any, StaticResolver(state)),
+            main_effect=cast(
+                Any,
+                FixedEffect(_receipt("synchronize_main", "synchronized")),
+            ),
+            metadata_effect=cast(
+                Any,
+                FixedEffect(_receipt("converge_task_metadata", "already-converged")),
+            ),
+            cleanup_effect=cast(
+                Any,
+                FixedEffect(_receipt("cleanup_task_refs", "already-clean")),
+            ),
+        ).complete(162)
+
+
+def test_merge_preflight_has_manual_merge_boundary() -> None:
+    pr = {
+        "number": 262,
+        "state": "OPEN",
+        "isDraft": False,
+        "baseRefName": "main",
+        "baseRefOid": SHA,
+        "headRefName": BRANCH,
+        "headRefOid": SHA,
+        "mergeable": "MERGEABLE",
+    }
+    issue = {
+        "number": 162,
+        "title": "[Task] closeout",
+        "state": "OPEN",
+        "labels": {"items": ["type:task", "codex:ready"]},
+        "project_status": "Review",
+        "body_sha256": "d" * 64,
+    }
+    state = lck.LiveState(
+        task_number=162,
+        repository="owner/repo",
+        issue=issue,
+        relationships={
+            "available": True,
+            "blocked_by": {"items": [], "count": 0, "truncated": False},
+        },
+        git={
+            "branch": BRANCH,
+            "head_sha": SHA,
+            "local_main_sha": SHA,
+            "origin_main_sha": SHA,
+            "origin_fetch": "pass",
+            "clean": True,
+        },
+        target_branch=BRANCH,
+        local_task_branch=BRANCH,
+        local_task_head=SHA,
+        remote_task_branch=BRANCH,
+        remote_task_oid=SHA,
+        open_pr=pr,
+        merged_pr_numbers=(),
+        merged=False,
+        checks={},
+        cleanup={},
+    )
+
+    class Review:
+        def run(self, _task: int, _state: lck.LiveState) -> dict[str, Any]:
+            return {"status": "pass", "review_id": "review"}
+
+    class Checks:
+        def run(self, _task: int) -> dict[str, Any]:
+            return {
+                "status": "pass",
+                "pr": {"number": 262, "head_sha": SHA, "base_sha": SHA},
+            }
+
+    result = lck.MergePreflight(
+        cast(Any, StaticResolver(state)),
+        review_gate=cast(Any, Review()),
+        checks_gate=cast(Any, Checks()),
+    ).run(162)
+
+    assert result.status == "READY_FOR_HUMAN_MERGE"
+    assert result.to_dict()["automatic_merge"] is False

--- a/tests/tools/test_lck_closeout.py
+++ b/tests/tools/test_lck_closeout.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import sys
+from dataclasses import replace
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
@@ -34,6 +36,12 @@ def _state(
         "state": issue_state,
         "labels": {"items": ["type:task", "codex:ready"]},
         "project_status": "Done",
+        "issue_closure": {
+            "evidence_status": "complete",
+            "status": "closed-by-pr",
+            "closer_repository": "owner/repo",
+            "closer_number": 262,
+        },
     }
     merged_pr = {
         "number": 262,
@@ -43,6 +51,8 @@ def _state(
         "headRefName": BRANCH,
         "headRefOid": merged_head,
         "mergeCommit": {"oid": MERGE_SHA},
+        "mergedAt": "2026-08-23T00:00:00Z",
+        "closingIssuesReferences": [{"number": 162}],
     }
     return lck.LiveState(
         task_number=162,
@@ -70,7 +80,13 @@ def _state(
         merged_pr_numbers=(262,),
         merged=True,
         merged_pr=merged_pr,
-        checks={},
+        checks={
+            "count": 0,
+            "failed": 0,
+            "pending": 0,
+            "skipped_or_unknown": 0,
+            "all_success": True,
+        },
         cleanup={
             "business_delivery": "complete",
             "cleanup": "pending",
@@ -86,6 +102,56 @@ class StaticResolver:
 
     def resolve(self, _task_number: int) -> lck.LiveState:
         return self.state
+
+
+class SequenceResolver:
+    def __init__(self, *states: lck.LiveState) -> None:
+        self.repo_root = Path.cwd()
+        self.states = states
+        self.index = 0
+        self.runner = cast(Any, object())
+
+    def resolve(self, _task_number: int) -> lck.LiveState:
+        state = self.states[min(self.index, len(self.states) - 1)]
+        self.index += 1
+        return state
+
+
+class StaticReviewStore:
+    def __init__(self, *, head_sha: str = SHA) -> None:
+        self.latest = {"task_number": 162, "review_id": "review", "verdict": "PASS"}
+        self.record = {
+            "task_number": 162,
+            "review_id": "review",
+            "verdict": "PASS",
+            "status": "READY_FOR_HUMAN_MERGE",
+            "identity": {
+                "task_number": 162,
+                "pr_number": 262,
+                "base_sha": SHA,
+                "head_sha": head_sha,
+                "task_body_sha256": "d" * 64,
+                "merge_base_sha": SHA,
+                "effective_diff_sha256": "e" * 64,
+                "changed_files": [],
+            },
+        }
+
+    def read_latest_review(self, _task_number: int) -> dict[str, Any]:
+        return self.latest
+
+    def read_record(self, _task_number: int, _review_id: str) -> dict[str, Any]:
+        return self.record
+
+
+class RecordingRunner:
+    def __init__(self, returncode: int = 0) -> None:
+        self.returncode = returncode
+        self.calls: list[tuple[str, ...]] = []
+
+    def run(self, argv: list[str], **_kwargs: Any) -> Any:
+        self.calls.append(tuple(argv))
+        return SimpleNamespace(returncode=self.returncode, stdout="", stderr="")
 
 
 class FixedEffect:
@@ -115,6 +181,7 @@ def test_closeout_resolves_business_delivery_and_cleanup_from_live_state() -> No
             Any,
             FixedEffect(_receipt("cleanup_task_refs", "already-clean")),
         ),
+        review_store=cast(Any, StaticReviewStore()),
     ).complete(162)
 
     assert result.business_delivery == "COMPLETE"
@@ -135,6 +202,7 @@ def test_closeout_keeps_business_complete_when_cleanup_is_pending() -> None:
             Any,
             FixedEffect(_receipt("cleanup_task_refs", "pending")),
         ),
+        review_store=cast(Any, StaticReviewStore()),
     ).complete(162)
 
     assert result.business_delivery == "COMPLETE"
@@ -161,6 +229,7 @@ def test_closeout_stops_on_remote_divergence() -> None:
                 Any,
                 FixedEffect(_receipt("cleanup_task_refs", "already-clean")),
             ),
+            review_store=cast(Any, StaticReviewStore()),
         ).complete(162)
 
 
@@ -207,7 +276,13 @@ def test_merge_preflight_has_manual_merge_boundary() -> None:
         open_pr=pr,
         merged_pr_numbers=(),
         merged=False,
-        checks={},
+        checks={
+            "count": 0,
+            "failed": 0,
+            "pending": 0,
+            "skipped_or_unknown": 0,
+            "all_success": True,
+        },
         cleanup={},
     )
 
@@ -219,6 +294,9 @@ def test_merge_preflight_has_manual_merge_boundary() -> None:
         def run(self, _task: int) -> dict[str, Any]:
             return {
                 "status": "pass",
+                "configuration": "not-configured",
+                "required": [],
+                "observed": {},
                 "pr": {"number": 262, "head_sha": SHA, "base_sha": SHA},
             }
 
@@ -230,3 +308,105 @@ def test_merge_preflight_has_manual_merge_boundary() -> None:
 
     assert result.status == "READY_FOR_HUMAN_MERGE"
     assert result.to_dict()["automatic_merge"] is False
+
+
+def test_merge_preflight_rechecks_project_status_after_checks() -> None:
+    pr = {
+        "number": 262,
+        "state": "OPEN",
+        "isDraft": False,
+        "baseRefName": "main",
+        "baseRefOid": SHA,
+        "headRefName": BRANCH,
+        "headRefOid": SHA,
+        "mergeable": "MERGEABLE",
+    }
+    issue = {
+        "number": 162,
+        "title": "[Task] closeout",
+        "state": "OPEN",
+        "labels": {"items": ["type:task", "codex:ready"]},
+        "project_status": "Review",
+    }
+    state = lck.LiveState(
+        task_number=162,
+        repository="owner/repo",
+        issue=issue,
+        relationships={
+            "available": True,
+            "blocked_by": {"items": [], "count": 0, "truncated": False},
+        },
+        git={"branch": BRANCH, "clean": True},
+        target_branch=BRANCH,
+        local_task_branch=BRANCH,
+        local_task_head=SHA,
+        remote_task_branch=BRANCH,
+        remote_task_oid=SHA,
+        open_pr=pr,
+        merged_pr_numbers=(),
+        merged=False,
+        checks={
+            "count": 0,
+            "failed": 0,
+            "pending": 0,
+            "skipped_or_unknown": 0,
+            "all_success": True,
+        },
+        cleanup={},
+    )
+    changed = replace(state, issue={**issue, "project_status": "In Progress"})
+
+    class Review:
+        def run(self, _task: int, _state: lck.LiveState) -> dict[str, Any]:
+            return {"status": "pass", "review_id": "review"}
+
+    class Checks:
+        def run(self, _task: int) -> dict[str, Any]:
+            return {
+                "status": "pass",
+                "configuration": "not-configured",
+                "required": [],
+                "observed": {},
+                "pr": {"number": 262, "head_sha": SHA, "base_sha": SHA},
+            }
+
+    with pytest.raises(lck.LckStopError, match="PR identity changed"):
+        lck.MergePreflight(
+            cast(Any, SequenceResolver(state, changed)),
+            review_gate=cast(Any, Review()),
+            checks_gate=cast(Any, Checks()),
+        ).run(162)
+
+
+def test_closeout_requires_reviewed_head_identity() -> None:
+    state = _state()
+    with pytest.raises(lck.LckStopError, match="does not match the latest Review PASS"):
+        lck.CloseoutCompleter(
+            cast(Any, StaticResolver(state)),
+            review_store=cast(Any, StaticReviewStore(head_sha="c" * 40)),
+        ).complete(162)
+
+
+def test_closeout_stops_on_incomplete_merge_identity() -> None:
+    state = _state()
+    incomplete = dict(cast(dict[str, Any], state.merged_pr))
+    incomplete.pop("mergeCommit")
+    with pytest.raises(lck.LckStopError, match="identity is incomplete"):
+        lck.CloseoutCompleter(
+            cast(Any, StaticResolver(replace(state, merged_pr=incomplete))),
+            review_store=cast(Any, StaticReviewStore()),
+        ).complete(162)
+
+
+def test_cleanup_proves_squash_tree_when_refs_are_already_deleted() -> None:
+    runner = RecordingRunner()
+    resolver = StaticResolver(_state())
+    resolver.runner = cast(Any, runner)
+    result = lck.CleanupTaskRefsEffect(cast(Any, resolver)).execute(
+        _state(),
+        expected_head_sha=SHA,
+        merge_sha=MERGE_SHA,
+    )
+
+    assert result.action == "already-clean"
+    assert ("git", "diff", "--quiet", SHA, MERGE_SHA) in runner.calls

--- a/tests/tools/test_lck_closeout.py
+++ b/tests/tools/test_lck_closeout.py
@@ -146,14 +146,26 @@ class StaticReviewStore:
 
 
 class RecordingRunner:
-    def __init__(self, returncode: int = 0, *, pr_view: str = "") -> None:
+    def __init__(
+        self,
+        returncode: int = 0,
+        *,
+        pr_view: str = "",
+        remote_outputs: list[str] | None = None,
+    ) -> None:
         self.returncode = returncode
         self.pr_view = pr_view
+        self.remote_outputs = list(remote_outputs or [])
         self.calls: list[tuple[str, ...]] = []
 
     def run(self, argv: list[str], **_kwargs: Any) -> Any:
         self.calls.append(tuple(argv))
-        stdout = self.pr_view if argv[:3] == ["gh", "pr", "view"] else ""
+        if argv[:3] == ["gh", "pr", "view"]:
+            stdout = self.pr_view
+        elif argv[:3] == ["git", "ls-remote", "--heads"] and self.remote_outputs:
+            stdout = self.remote_outputs.pop(0)
+        else:
+            stdout = ""
         return SimpleNamespace(returncode=self.returncode, stdout=stdout, stderr="")
 
 
@@ -415,8 +427,10 @@ def test_cleanup_proves_squash_tree_when_refs_are_already_deleted() -> None:
     assert ("git", "diff", "--quiet", SHA, MERGE_SHA) in runner.calls
 
 
-def test_cleanup_uses_an_expected_tip_lease_for_remote_deletion() -> None:
-    runner = RecordingRunner()
+def test_cleanup_rechecks_tip_before_non_force_remote_deletion() -> None:
+    runner = RecordingRunner(
+        remote_outputs=[f"{SHA}\trefs/heads/{BRANCH}\n", ""],
+    )
     resolver = StaticResolver(_state(remote_branch=BRANCH, remote_oid=SHA))
     resolver.runner = cast(Any, runner)
 
@@ -428,7 +442,36 @@ def test_cleanup_uses_an_expected_tip_lease_for_remote_deletion() -> None:
 
     assert result.action == "cleaned"
     delete_call = next(call for call in runner.calls if "--delete" in call)
-    assert f"--force-with-lease=refs/heads/{BRANCH}:{SHA}" in delete_call
+    assert delete_call == ("git", "push", "origin", "--delete", BRANCH)
+    assert all("force" not in item for item in delete_call)
+
+
+def test_cleanup_stops_when_final_live_state_is_unresolved() -> None:
+    state = _state()
+    unresolved = replace(
+        state,
+        status=lck.ResolutionStatus.STOP,
+        stop_reasons=("ambiguous recovery",),
+    )
+    resolver = SequenceResolver(state, state, state, unresolved)
+
+    with pytest.raises(lck.LckStopError, match="final live state is unresolved"):
+        lck.CloseoutCompleter(
+            cast(Any, resolver),
+            main_effect=cast(
+                Any,
+                FixedEffect(_receipt("synchronize_main", "synchronized")),
+            ),
+            metadata_effect=cast(
+                Any,
+                FixedEffect(_receipt("converge_task_metadata", "already-converged")),
+            ),
+            cleanup_effect=cast(
+                Any,
+                FixedEffect(_receipt("cleanup_task_refs", "already-clean")),
+            ),
+            review_store=cast(Any, StaticReviewStore()),
+        ).complete(162)
 
 
 def test_resolver_recovers_deleted_noncanonical_branch_from_closing_pr(

--- a/tests/tools/test_lck_closeout.py
+++ b/tests/tools/test_lck_closeout.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import sys
 from dataclasses import replace
 from pathlib import Path
@@ -145,13 +146,15 @@ class StaticReviewStore:
 
 
 class RecordingRunner:
-    def __init__(self, returncode: int = 0) -> None:
+    def __init__(self, returncode: int = 0, *, pr_view: str = "") -> None:
         self.returncode = returncode
+        self.pr_view = pr_view
         self.calls: list[tuple[str, ...]] = []
 
     def run(self, argv: list[str], **_kwargs: Any) -> Any:
         self.calls.append(tuple(argv))
-        return SimpleNamespace(returncode=self.returncode, stdout="", stderr="")
+        stdout = self.pr_view if argv[:3] == ["gh", "pr", "view"] else ""
+        return SimpleNamespace(returncode=self.returncode, stdout=stdout, stderr="")
 
 
 class FixedEffect:
@@ -410,3 +413,127 @@ def test_cleanup_proves_squash_tree_when_refs_are_already_deleted() -> None:
 
     assert result.action == "already-clean"
     assert ("git", "diff", "--quiet", SHA, MERGE_SHA) in runner.calls
+
+
+def test_cleanup_uses_an_expected_tip_lease_for_remote_deletion() -> None:
+    runner = RecordingRunner()
+    resolver = StaticResolver(_state(remote_branch=BRANCH, remote_oid=SHA))
+    resolver.runner = cast(Any, runner)
+
+    result = lck.CleanupTaskRefsEffect(cast(Any, resolver)).execute(
+        _state(remote_branch=BRANCH, remote_oid=SHA),
+        expected_head_sha=SHA,
+        merge_sha=MERGE_SHA,
+    )
+
+    assert result.action == "cleaned"
+    delete_call = next(call for call in runner.calls if "--delete" in call)
+    assert f"--force-with-lease=refs/heads/{BRANCH}:{SHA}" in delete_call
+
+
+def test_resolver_recovers_deleted_noncanonical_branch_from_closing_pr(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = "PhoenixSss/tracequant"
+    branch = "task/162-merge-preflightcloseout-recovery-lck"
+    pr = {
+        "number": 167,
+        "url": f"https://github.com/{repository}/pull/167",
+        "state": "MERGED",
+        "isDraft": False,
+        "baseRefName": "main",
+        "baseRefOid": SHA,
+        "headRefName": branch,
+        "headRefOid": SHA,
+        "mergeCommit": {"oid": MERGE_SHA},
+        "mergedAt": "2026-08-23T00:00:00Z",
+        "headRepository": {"nameWithOwner": repository},
+        "closingIssuesReferences": [{"number": 162}],
+    }
+    issue = {
+        "number": 162,
+        "title": "[Task] 将 Merge Preflight、Closeout 与 Recovery 迁移至 LCK",
+        "state": "CLOSED",
+        "issue_closure": {
+            "evidence_status": "complete",
+            "closed_by_pull_requests": {
+                "items": [
+                    {
+                        "number": 167,
+                        "state": "MERGED",
+                        "merged": True,
+                        "url": pr["url"],
+                        "repository": repository,
+                    }
+                ],
+                "count": 1,
+                "truncated": False,
+            },
+        },
+    }
+    runner = RecordingRunner(pr_view=json.dumps(pr))
+    resolver = lck.LiveStateResolver(
+        Path.cwd(), runner=cast(Any, runner), repository=repository
+    )
+
+    monkeypatch.setattr(lck, "_issue_view", lambda *_args: issue)
+    monkeypatch.setattr(
+        lck,
+        "_relationship_snapshot",
+        lambda *_args: {
+            "available": True,
+            "blocked_by": {"items": [], "count": 0, "truncated": False},
+        },
+    )
+    monkeypatch.setattr(
+        lck,
+        "_git_snapshot",
+        lambda *_args: {
+            "origin_fetch": "pass",
+            "branch": "main",
+            "head_sha": MERGE_SHA,
+            "local_main_sha": MERGE_SHA,
+            "origin_main_sha": MERGE_SHA,
+            "clean": True,
+            "worktree_branches": {"items": ["main"], "count": 1},
+        },
+    )
+    monkeypatch.setattr(
+        resolver,
+        "_task_branches",
+        lambda *_args: (set(), {}, True),
+    )
+    open_pr_branches: list[str] = []
+    history_branches: list[str] = []
+
+    def resolve_open(
+        _runner: Any,
+        _repository: str,
+        current_branch: str,
+        _base_branch: str,
+        _warnings: list[dict[str, Any]],
+    ) -> None:
+        open_pr_branches.append(current_branch)
+        return None
+
+    def list_history(
+        _runner: Any,
+        _repository: str,
+        current_branch: str,
+        _base_branch: str,
+        _warnings: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        history_branches.append(current_branch)
+        return [pr]
+
+    monkeypatch.setattr(lck, "resolve_open_pr", resolve_open)
+    monkeypatch.setattr(lck, "list_matching_prs", list_history)
+
+    state = resolver.resolve(162)
+
+    assert state.status is lck.ResolutionStatus.RESOLVED
+    assert state.target_branch == branch
+    assert state.merged is True
+    assert state.merged_pr == pr
+    assert open_pr_branches == [branch]
+    assert history_branches == [branch]

--- a/tests/tools/test_workflow_common.py
+++ b/tests/tools/test_workflow_common.py
@@ -104,7 +104,6 @@ def test_command_runner_retries_only_when_requested(tmp_path: Path) -> None:
     result = CommandRunner(tmp_path).run(
         [str(flaky)],
         command_id="test-retry",
-        timeout_seconds=1,
         retries=1,
     )
 

--- a/tests/tools/test_workflow_common.py
+++ b/tests/tools/test_workflow_common.py
@@ -13,6 +13,7 @@ if AGENT_WORKFLOW not in sys.path:
 from workflow_common import (  # type: ignore[import-not-found]  # noqa: E402
     CommandRunner,
     build_workflow_env,
+    command_warning,
 )
 
 
@@ -63,3 +64,49 @@ def test_command_runner_passes_repo_local_uv_cache_to_subprocess(
     assert marker.read_text(encoding="utf-8") == str(
         tmp_path / ".workflow.local" / "uv-cache"
     )
+
+
+def test_command_runner_times_out_and_reports_bounded_diagnostic(
+    tmp_path: Path,
+) -> None:
+    result = CommandRunner(tmp_path).run(
+        [sys.executable, "-c", "import time; time.sleep(60)"],
+        command_id="test-timeout",
+        timeout_seconds=0.2,
+    )
+
+    assert result.returncode == 124
+    assert result.stdout == ""
+    assert result.timed_out is True
+    assert result.timeout_seconds == 0.2
+    warning = command_warning(result)
+    assert warning["timed_out"] is True
+    assert warning["timeout_seconds"] == 0.2
+    assert "timed out after 0.2 seconds" in warning["error"]
+
+
+def test_command_runner_retries_only_when_requested(tmp_path: Path) -> None:
+    marker = tmp_path / "attempted"
+    flaky = tmp_path / "flaky-command"
+    flaky.write_text(
+        f"#!{sys.executable}\n"
+        "from pathlib import Path\n"
+        f"marker = Path({str(marker)!r})\n"
+        "if marker.exists():\n"
+        "    print('recovered')\n"
+        "else:\n"
+        "    marker.write_text('1', encoding='utf-8')\n"
+        "    raise SystemExit(1)\n",
+        encoding="utf-8",
+    )
+    flaky.chmod(0o755)
+
+    result = CommandRunner(tmp_path).run(
+        [str(flaky)],
+        command_id="test-retry",
+        timeout_seconds=1,
+        retries=1,
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == "recovered"

--- a/tools/agent_workflow/lck.py
+++ b/tools/agent_workflow/lck.py
@@ -71,6 +71,11 @@ LCK_SCHEMA_VERSION: Final = 1
 TASK_BRANCH_PATTERN: Final = re.compile(
     r"^(?:task/(?P<slash>\d+)(?:-.+)?|task-(?P<dash>\d+)(?:-.+)?|(?P<legacy>\d+)-.+)$"
 )
+RECOVERY_PR_FIELDS: Final = (
+    "number,url,state,isDraft,baseRefName,baseRefOid,headRefName,headRefOid,"
+    "mergeCommit,mergedAt,mergeable,reviewDecision,headRepository,"
+    "closingIssuesReferences"
+)
 
 
 class Phase(StrEnum):
@@ -326,6 +331,156 @@ class LiveStateResolver:
         }
         return local, remote, True
 
+    def _recover_merged_pr_branch(
+        self,
+        task_number: int,
+        repository: str,
+        issue: Mapping[str, Any] | None,
+        warnings: list[dict[str, Any]],
+    ) -> tuple[str | None, Mapping[str, Any] | None, str | None]:
+        """Recover a deleted Task ref from authoritative closing-PR facts."""
+        if not isinstance(issue, Mapping):
+            return None, None, None
+        if str(issue.get("state", "")).upper() != "CLOSED":
+            return None, None, None
+
+        closure = issue.get("issue_closure")
+        if not isinstance(closure, Mapping):
+            return (
+                None,
+                None,
+                "Task branch identity unavailable after ref deletion: "
+                "Issue closure facts are unavailable",
+            )
+        if closure.get("evidence_status") != "complete":
+            return (
+                None,
+                None,
+                "Task branch identity unavailable after ref deletion: "
+                "Issue closure facts are incomplete",
+            )
+        refs = closure.get("closed_by_pull_requests")
+        if not isinstance(refs, Mapping) or refs.get("truncated") is True:
+            return (
+                None,
+                None,
+                "Task branch identity unavailable after ref deletion: "
+                "closing PR references are incomplete",
+            )
+        items = refs.get("items")
+        if not isinstance(items, list):
+            return (
+                None,
+                None,
+                "Task branch identity unavailable after ref deletion: "
+                "closing PR references are malformed",
+            )
+        merged_refs = [
+            item
+            for item in items
+            if isinstance(item, Mapping)
+            and item.get("repository") == repository
+            and item.get("merged") is True
+            and str(item.get("state", "")).upper() == "MERGED"
+            and isinstance(item.get("number"), int)
+            and not isinstance(item.get("number"), bool)
+        ]
+        if len(merged_refs) != 1:
+            return (
+                None,
+                None,
+                "Task branch identity unavailable after ref deletion: "
+                f"expected one merged closing PR, found {len(merged_refs)}",
+            )
+
+        pr_number = merged_refs[0]["number"]
+        result = self.runner.run(
+            [
+                "gh",
+                "pr",
+                "view",
+                str(pr_number),
+                "--repo",
+                repository,
+                "--json",
+                RECOVERY_PR_FIELDS,
+            ],
+            command_id="lck-recover-merged-pr",
+        )
+        if result.returncode != 0 or not result.stdout.strip():
+            warnings.append(command_warning(result))
+            return (
+                None,
+                None,
+                "Task branch identity unavailable after ref deletion: "
+                "merged PR identity cannot be read",
+            )
+        try:
+            value = read_json_text(result.stdout, field="lck-recover-merged-pr")
+        except WorkflowToolError as exc:
+            warnings.append(
+                {
+                    "command_id": result.command_id,
+                    "exit_code": result.returncode,
+                    "error": str(exc),
+                }
+            )
+            return (
+                None,
+                None,
+                "Task branch identity unavailable after ref deletion: "
+                "merged PR identity is malformed",
+            )
+        if not isinstance(value, Mapping):
+            return (
+                None,
+                None,
+                "Task branch identity unavailable after ref deletion: "
+                "merged PR identity is not an object",
+            )
+        if (
+            value.get("number") != pr_number
+            or str(value.get("state", "")).upper() != "MERGED"
+            or value.get("baseRefName") != BASE_BRANCH
+            or not _branch_matches_task(str(value.get("headRefName", "")), task_number)
+        ):
+            return (
+                None,
+                None,
+                "Task branch identity unavailable after ref deletion: "
+                "merged PR identity does not match this Task",
+            )
+        head_repository = value.get("headRepository")
+        if (
+            not isinstance(head_repository, Mapping)
+            or head_repository.get("nameWithOwner") != repository
+        ):
+            return (
+                None,
+                None,
+                "Task branch identity unavailable after ref deletion: "
+                "merged PR head repository is not this repository",
+            )
+        closing = value.get("closingIssuesReferences")
+        closing_numbers = (
+            [
+                item.get("number")
+                for item in closing
+                if isinstance(item, Mapping) and isinstance(item.get("number"), int)
+            ]
+            if isinstance(closing, list)
+            else []
+        )
+        if task_number not in closing_numbers:
+            return (
+                None,
+                None,
+                "Task branch identity unavailable after ref deletion: "
+                "merged PR does not close this Task",
+            )
+        head_branch = value.get("headRefName")
+        return str(head_branch), dict(value), None
+
     def resolve(self, task_number: int) -> LiveState:
         if task_number <= 0:
             raise LckStopError(f"Task number must be positive: {task_number}")
@@ -371,7 +526,23 @@ class LiveStateResolver:
         candidates = sorted(local_branches | set(remote_branches))
         if len(candidates) > 1:
             reasons.append(f"multiple Task branch candidates: {candidates}")
-        target_branch = candidates[0] if len(candidates) == 1 else canonical
+        recovered_branch: str | None = None
+        recovered_pr: Mapping[str, Any] | None = None
+        if not candidates and repository is not None:
+            recovery_reason: str | None
+            recovered_branch, recovered_pr, recovery_reason = (
+                self._recover_merged_pr_branch(
+                    task_number,
+                    repository,
+                    issue,
+                    warnings,
+                )
+            )
+            if recovery_reason:
+                reasons.append(recovery_reason)
+        target_branch = (
+            candidates[0] if len(candidates) == 1 else recovered_branch or canonical
+        )
         local_branch = target_branch if target_branch in local_branches else None
         remote_branch = target_branch if target_branch in remote_branches else None
 
@@ -413,6 +584,8 @@ class LiveStateResolver:
                     BASE_BRANCH,
                     warnings,
                 )
+                if not history and recovered_pr is not None:
+                    history = [dict(recovered_pr)]
                 merged_items = [
                     item
                     for item in history
@@ -3029,7 +3202,14 @@ class CleanupTaskRefsEffect:
                     "Cleanup STOP: remote Task branch diverges from merged PR head"
                 )
             removed = self.resolver.runner.run(
-                ["git", "push", "origin", "--delete", branch],
+                [
+                    "git",
+                    "push",
+                    "origin",
+                    f"--force-with-lease=refs/heads/{branch}:{expected_head_sha}",
+                    "--delete",
+                    branch,
+                ],
                 command_id="lck-closeout-remote-branch-delete",
             )
             if removed.returncode != 0:

--- a/tools/agent_workflow/lck.py
+++ b/tools/agent_workflow/lck.py
@@ -2701,16 +2701,39 @@ class MergePreflight:
                 + str(checks["limitation"])
             )
         current = self.resolver.resolve(task_number)
+        current_pr = current.open_pr
         if (
             current.status is not ResolutionStatus.RESOLVED
-            or not isinstance(current.open_pr, Mapping)
-            or _pr_head_sha(current.open_pr) != head_sha
-            or _pr_base_sha(current.open_pr) != base_sha
+            or not isinstance(current_pr, Mapping)
+            or current.target_branch != state.target_branch
+            or current.project_status != "Review"
+            or current_pr.get("isDraft") is not False
+            or str(current_pr.get("state", "")).upper() != "OPEN"
+            or current_pr.get("baseRefName") != BASE_BRANCH
+            or current_pr.get("headRefName") != current.target_branch
+            or _pr_head_sha(current_pr) != head_sha
+            or _pr_base_sha(current_pr) != base_sha
+            or current.remote_task_oid != head_sha
+            or (
+                current.local_task_head is not None
+                and current.local_task_head != head_sha
+            )
         ):
             raise LckStopError(
                 "Merge Preflight PR identity changed while evaluating merge gates"
             )
-        mergeability_value = current.open_pr.get("mergeable")
+        blockers = _formal_blockers_gate(current.relationships)
+        if blockers.get("status") != "pass":
+            raise LckStopError(
+                "Merge Preflight unresolved blockers changed while evaluating gates: "
+                + str(blockers.get("detail") or blockers.get("status"))
+            )
+        review = self.review_gate.run(task_number, current)
+        if not DeliveryChecksGate._checks_postcondition(current, checks):
+            raise LckStopError(
+                "Merge Preflight checks changed or are no longer passing"
+            )
+        mergeability_value = current_pr.get("mergeable")
         mergeability = str(mergeability_value or "").upper()
         if mergeability not in {"MERGEABLE", "TRUE"}:
             raise LckStopError(
@@ -2720,7 +2743,7 @@ class MergePreflight:
         return MergePreflightResult(
             task_number=task_number,
             status="READY_FOR_HUMAN_MERGE",
-            pr=current.open_pr,
+            pr=current_pr,
             review=review,
             checks=checks,
             blockers=blockers,
@@ -2956,17 +2979,24 @@ class CleanupTaskRefsEffect:
                 reason="verified Task branch is still used by a worktree",
             )
 
+        if not is_sha(expected_head_sha) or not is_sha(merge_sha):
+            raise LckStopError(
+                "Cleanup STOP: merged PR head and squash merge identities are required"
+            )
+        tree_result = self.resolver.runner.run(
+            ["git", "diff", "--quiet", expected_head_sha, merge_sha],
+            command_id="lck-closeout-squash-tree-equality",
+        )
+        if tree_result.returncode != 0:
+            raise LckStopError(
+                "Cleanup STOP: PR head tree does not equal squash merge tree"
+            )
+
         if state.local_task_branch is None and state.remote_task_branch is None:
             return EffectReceipt(
                 effect="cleanup_task_refs",
                 action="already-clean",
                 details={"branch": branch, "remote_branch": "already-deleted"},
-            )
-        if expected_head_sha is None:
-            return _pending_receipt(
-                "cleanup_task_refs",
-                "pending",
-                reason="merged PR head identity is unavailable",
             )
         if state.local_task_branch is not None:
             local_result = self.resolver.runner.run(
@@ -2978,15 +3008,6 @@ class CleanupTaskRefsEffect:
                 raise LckStopError(
                     "Cleanup STOP: local Task branch diverges from merged PR head"
                 )
-            if is_sha(merge_sha):
-                tree_result = self.resolver.runner.run(
-                    ["git", "diff", "--quiet", expected_head_sha, merge_sha],
-                    command_id="lck-closeout-squash-tree-equality",
-                )
-                if tree_result.returncode != 0:
-                    raise LckStopError(
-                        "Cleanup STOP: PR head tree does not equal squash merge tree"
-                    )
             deleted = self.resolver.runner.run(
                 ["git", "branch", "-d", branch],
                 command_id="lck-closeout-local-branch-delete",
@@ -3069,48 +3090,115 @@ class CloseoutCompleter:
         main_effect: MainSynchronizationEffect | None = None,
         metadata_effect: CloseoutMetadataEffect | None = None,
         cleanup_effect: CleanupTaskRefsEffect | None = None,
+        review_store: ReviewInvocationStore | None = None,
     ) -> None:
         self.resolver = resolver
         self.eligibility = eligibility or PhaseEligibilityResolver()
         self.main_effect = main_effect or MainSynchronizationEffect(resolver)
         self.metadata_effect = metadata_effect or CloseoutMetadataEffect(resolver)
         self.cleanup_effect = cleanup_effect or CleanupTaskRefsEffect(resolver)
+        self.review_store = review_store or ReviewInvocationStore(resolver.repo_root)
 
     @staticmethod
-    def _validate_merged_identity(state: LiveState) -> tuple[str | None, str | None]:
+    def _validate_merged_identity(state: LiveState) -> tuple[str, str]:
         pr = state.merged_pr
-        if isinstance(pr, Mapping):
+        if not isinstance(pr, Mapping):
+            raise LckStopError("Closeout STOP: merged PR identity is unavailable")
+        if str(pr.get("state", "")).upper() != "MERGED":
+            raise LckStopError("Closeout STOP: merged PR state is not MERGED")
+        number = pr.get("number")
+        if not isinstance(number, int) or isinstance(number, bool) or number <= 0:
+            raise LckStopError("Closeout STOP: merged PR number is unavailable")
+        if pr.get("baseRefName") != BASE_BRANCH:
+            raise LckStopError("Closeout STOP: merged PR base branch is not main")
+        if pr.get("headRefName") != state.target_branch:
+            raise LckStopError(
+                "Closeout STOP: merged PR head branch is not the resolved Task branch"
+            )
+        expected_head = _pr_head_sha(pr)
+        base_sha = _pr_base_sha(pr)
+        merge_sha = _merge_commit_sha(pr)
+        merged_at = pr.get("mergedAt", pr.get("merged_at"))
+        if (
+            expected_head is None
+            or base_sha is None
+            or merge_sha is None
+            or not isinstance(merged_at, str)
+            or not merged_at
+        ):
+            raise LckStopError("Closeout STOP: merged PR identity is incomplete")
+        closing = pr.get("closingIssuesReferences")
+        if not isinstance(closing, list):
+            raise LckStopError(
+                "Closeout STOP: merged PR closing-Task linkage is unavailable"
+            )
+        closing_numbers = [
+            item.get("number")
+            for item in closing
+            if isinstance(item, Mapping) and isinstance(item.get("number"), int)
+        ]
+        if len(closing_numbers) != 1 or closing_numbers[0] != state.task_number:
+            raise LckStopError(
+                "Closeout STOP: merged PR does not close exactly this Task"
+            )
+        if state.issue_state == "CLOSED":
+            closure = (
+                state.issue.get("issue_closure")
+                if isinstance(state.issue, Mapping)
+                else None
+            )
             if (
-                pr.get("baseRefName") is not None
-                and pr.get("baseRefName") != BASE_BRANCH
-            ):
-                raise LckStopError("Closeout STOP: merged PR base branch is not main")
-            if (
-                pr.get("headRefName") is not None
-                and pr.get("headRefName") != state.target_branch
+                not isinstance(closure, Mapping)
+                or closure.get("evidence_status") != "complete"
+                or closure.get("status") != "closed-by-pr"
+                or closure.get("closer_repository") != state.repository
+                or closure.get("closer_number") != number
             ):
                 raise LckStopError(
-                    "Closeout STOP: merged PR head branch is not the resolved Task branch"
+                    "Closeout STOP: closed Task is not proven closed by the merged PR"
                 )
-            expected_head = _pr_head_sha(pr)
-            if (
-                expected_head is not None
-                and state.local_task_head is not None
-                and state.local_task_head != expected_head
-            ):
-                raise LckStopError(
-                    "Closeout STOP: local Task branch diverges from merged PR head"
-                )
-            if (
-                expected_head is not None
-                and state.remote_task_oid is not None
-                and state.remote_task_oid != expected_head
-            ):
-                raise LckStopError(
-                    "Closeout STOP: remote Task branch diverges from merged PR head"
-                )
-            return expected_head, _merge_commit_sha(pr)
-        return None, None
+        if state.local_task_head is not None and state.local_task_head != expected_head:
+            raise LckStopError(
+                "Closeout STOP: local Task branch diverges from merged PR head"
+            )
+        if state.remote_task_oid is not None and state.remote_task_oid != expected_head:
+            raise LckStopError(
+                "Closeout STOP: remote Task branch diverges from merged PR head"
+            )
+        return expected_head, merge_sha
+
+    def _validate_reviewed_identity(
+        self, state: LiveState, merged_pr: Mapping[str, Any]
+    ) -> None:
+        latest = self.review_store.read_latest_review(state.task_number)
+        if not isinstance(latest, Mapping) or latest.get("verdict") != "PASS":
+            raise LckStopError(
+                "Closeout STOP: latest Independent Review PASS is unavailable"
+            )
+        review_id = latest.get("review_id")
+        if not isinstance(review_id, str):
+            raise LckStopError("Closeout STOP: latest Review PASS has no review id")
+        record = self.review_store.read_record(state.task_number, review_id)
+        if (
+            record.get("task_number") != state.task_number
+            or record.get("review_id") != review_id
+            or record.get("verdict") != "PASS"
+            or record.get("status") != "READY_FOR_HUMAN_MERGE"
+        ):
+            raise LckStopError("Closeout STOP: latest Review PASS record is invalid")
+        raw_identity = record.get("identity")
+        if not isinstance(raw_identity, Mapping):
+            raise LckStopError("Closeout STOP: Review PASS identity is unavailable")
+        reviewed = _identity_from_mapping(raw_identity)
+        if (
+            reviewed.task_number != state.task_number
+            or reviewed.pr_number != merged_pr.get("number")
+            or reviewed.base_sha != _pr_base_sha(merged_pr)
+            or reviewed.head_sha != _pr_head_sha(merged_pr)
+        ):
+            raise LckStopError(
+                "Closeout STOP: merged PR/head does not match the latest Review PASS"
+            )
 
     def complete(self, task_number: int) -> CloseoutResult:
         state = self.resolver.resolve(task_number)
@@ -3120,6 +3208,9 @@ class CloseoutCompleter:
                 f"Closeout STOP for Task #{task_number}: " + "; ".join(decision.reasons)
             )
         expected_head, merge_sha = self._validate_merged_identity(state)
+        if not isinstance(state.merged_pr, Mapping):
+            raise LckStopError("Closeout STOP: merged PR identity is unavailable")
+        self._validate_reviewed_identity(state, state.merged_pr)
         effects: list[EffectReceipt] = []
         main = self.main_effect.execute(state, merge_sha=merge_sha)
         effects.append(main)

--- a/tools/agent_workflow/lck.py
+++ b/tools/agent_workflow/lck.py
@@ -170,6 +170,32 @@ def _remote_refs(stdout: str) -> dict[str, str]:
     return refs
 
 
+def _merge_commit_sha(pr: Mapping[str, Any] | None) -> str | None:
+    """Return a normalized squash-merge commit identity from a PR fact."""
+    if not isinstance(pr, Mapping):
+        return None
+    value = pr.get("mergeCommit")
+    if isinstance(value, Mapping):
+        value = value.get("oid")
+    if not is_sha(value):
+        value = pr.get("merge_commit_sha")
+    return value if is_sha(value) else None
+
+
+def _pr_head_sha(pr: Mapping[str, Any] | None) -> str | None:
+    if not isinstance(pr, Mapping):
+        return None
+    value = pr.get("headRefOid", pr.get("head_sha"))
+    return value if is_sha(value) else None
+
+
+def _pr_base_sha(pr: Mapping[str, Any] | None) -> str | None:
+    if not isinstance(pr, Mapping):
+        return None
+    value = pr.get("baseRefOid", pr.get("base_sha"))
+    return value if is_sha(value) else None
+
+
 @dataclass(frozen=True)
 class LiveState:
     """Current mechanical facts acquired from Git and GitHub."""
@@ -192,6 +218,7 @@ class LiveState:
     status: ResolutionStatus = ResolutionStatus.RESOLVED
     stop_reasons: tuple[str, ...] = ()
     warnings: tuple[Mapping[str, Any], ...] = ()
+    merged_pr: Mapping[str, Any] | None = None
 
     @property
     def project_status(self) -> str | None:
@@ -235,6 +262,7 @@ class LiveState:
                     "status": self.status,
                     "stop_reasons": self.stop_reasons,
                     "warnings": self.warnings,
+                    "merged_pr": self.merged_pr,
                 }
             ),
         )
@@ -363,6 +391,7 @@ class LiveStateResolver:
         # observe a local validated commit that is not pushed yet.
 
         open_pr: Mapping[str, Any] | None = None
+        merged_pr: Mapping[str, Any] | None = None
         merged_numbers: tuple[int, ...] = ()
         if repository is not None:
             try:
@@ -383,14 +412,17 @@ class LiveStateResolver:
                     BASE_BRANCH,
                     warnings,
                 )
+                merged_items = [
+                    item
+                    for item in history
+                    if str(item.get("state", "")).upper() == "MERGED"
+                    and isinstance(item.get("number"), int)
+                ]
                 merged_numbers = tuple(
-                    sorted(
-                        int(item["number"])
-                        for item in history
-                        if str(item.get("state", "")).upper() == "MERGED"
-                        and isinstance(item.get("number"), int)
-                    )
+                    sorted(int(item["number"]) for item in merged_items)
                 )
+                if len(merged_items) == 1:
+                    merged_pr = dict(merged_items[0])
             except PrResolveError as exc:
                 reasons.append(str(exc))
 
@@ -431,6 +463,9 @@ class LiveStateResolver:
                 open_pr.get("number") if isinstance(open_pr, Mapping) else None
             ),
             "merged_pr_numbers": merged_numbers,
+            "merged_pr_number": (
+                merged_pr.get("number") if isinstance(merged_pr, Mapping) else None
+            ),
         }
         status = ResolutionStatus.STOP if reasons else ResolutionStatus.RESOLVED
         return LiveState(
@@ -452,6 +487,7 @@ class LiveStateResolver:
             status=status,
             stop_reasons=tuple(reasons),
             warnings=tuple(warnings),
+            merged_pr=merged_pr,
         )
 
 
@@ -568,7 +604,15 @@ class PhaseEligibilityResolver:
                 Phase.REVIEW_PREPARE: {"Review", "In Progress"},
                 Phase.REMEDIATION_PREPARE: {"Review"},
                 Phase.REMEDIATION_COMPLETE: {"Review"},
-                Phase.CLOSEOUT: {"In Progress", "Review", "Done"},
+                Phase.CLOSEOUT: {
+                    "Inbox",
+                    "Specifying",
+                    "Ready",
+                    "In Progress",
+                    "Review",
+                    "Blocked",
+                    "Done",
+                },
             }[phase]
             if project not in allowed_projects:
                 reasons.append("Project Status is unavailable or unknown")
@@ -2511,6 +2555,610 @@ class DeliveryChecksGate:
             time.sleep(self.poll_seconds)
 
 
+class ReviewPassGate:
+    """Prove that the latest accepted Review PASS still matches live facts."""
+
+    def __init__(
+        self,
+        resolver: LiveStateResolver,
+        *,
+        store: ReviewInvocationStore | None = None,
+    ) -> None:
+        self.resolver = resolver
+        self.store = store or ReviewInvocationStore(resolver.repo_root)
+
+    def run(self, task_number: int, state: LiveState) -> dict[str, Any]:
+        latest = self.store.read_latest_review(task_number)
+        if not isinstance(latest, Mapping) or latest.get("verdict") != "PASS":
+            raise LckStopError(
+                "Merge Preflight requires the latest Independent Review PASS"
+            )
+        review_id = latest.get("review_id")
+        if not isinstance(review_id, str):
+            raise LckStopError("latest Independent Review PASS has no review id")
+        record = self.store.read_record(task_number, review_id)
+        if (
+            record.get("task_number") != task_number
+            or record.get("review_id") != review_id
+            or record.get("verdict") != "PASS"
+            or record.get("status") != "READY_FOR_HUMAN_MERGE"
+        ):
+            raise LckStopError("latest Independent Review PASS record is invalid")
+        raw_identity = record.get("identity")
+        if not isinstance(raw_identity, Mapping):
+            raise LckStopError("Independent Review PASS has no identity")
+        recorded = _identity_from_mapping(raw_identity)
+        issue = state.issue
+        body_sha256 = issue.get("body_sha256") if isinstance(issue, Mapping) else None
+        if not isinstance(body_sha256, str):
+            raise LckStopError("current Task body identity is unavailable")
+        current = _review_identity(
+            self.resolver,
+            state,
+            {"body_sha256": body_sha256},
+        )
+        try:
+            _assert_review_applicable(recorded, current)
+        except ReviewStaleError as exc:
+            raise LckStopError(f"Review PASS is stale: {exc}") from exc
+        return {
+            "status": "pass",
+            "review_id": review_id,
+            "identity": current.to_dict(),
+            "recorded_identity": recorded.to_dict(),
+        }
+
+
+@dataclass(frozen=True)
+class MergePreflightResult:
+    task_number: int
+    status: str
+    pr: Mapping[str, Any]
+    review: Mapping[str, Any]
+    checks: Mapping[str, Any]
+    blockers: Mapping[str, Any]
+    mergeability: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": LCK_SCHEMA_VERSION,
+            "operation": "merge-preflight",
+            "task_number": self.task_number,
+            "status": self.status,
+            "pr": _jsonable(self.pr),
+            "review": _jsonable(self.review),
+            "checks": _jsonable(self.checks),
+            "blockers": _jsonable(self.blockers),
+            "mergeability": self.mergeability,
+            "human_boundary": (
+                "STOP — maintainer must perform the manual Squash Merge; "
+                "LCK has no auto-merge path"
+            ),
+            "automatic_merge": False,
+        }
+
+
+class MergePreflight:
+    """Run deterministic merge gates without mutating GitHub."""
+
+    def __init__(
+        self,
+        resolver: LiveStateResolver,
+        *,
+        review_gate: ReviewPassGate | None = None,
+        checks_gate: DeliveryChecksGate | None = None,
+    ) -> None:
+        self.resolver = resolver
+        self.review_gate = review_gate or ReviewPassGate(resolver)
+        self.checks_gate = checks_gate or DeliveryChecksGate(
+            resolver, timeout_seconds=0.0, poll_seconds=0.0
+        )
+
+    def run(self, task_number: int) -> MergePreflightResult:
+        state = self.resolver.resolve(task_number)
+        if state.status is not ResolutionStatus.RESOLVED:
+            raise LckStopError("Merge Preflight STOP: " + "; ".join(state.stop_reasons))
+        pr = state.open_pr
+        if not isinstance(pr, Mapping):
+            raise LckStopError("Merge Preflight requires one current OPEN PR")
+        if pr.get("isDraft") is not False:
+            raise LckStopError("Merge Preflight requires a non-Draft OPEN PR")
+        if str(pr.get("state", "")).upper() != "OPEN":
+            raise LckStopError("Merge Preflight requires an OPEN PR")
+        if pr.get("baseRefName") != BASE_BRANCH:
+            raise LckStopError("Merge Preflight PR base branch is not main")
+        if pr.get("headRefName") != state.target_branch:
+            raise LckStopError(
+                "Merge Preflight PR head branch is not the resolved Task branch"
+            )
+        head_sha = _pr_head_sha(pr)
+        base_sha = _pr_base_sha(pr)
+        if head_sha is None or base_sha is None:
+            raise LckStopError("Merge Preflight PR head/base identity is unavailable")
+        if state.remote_task_oid != head_sha:
+            raise LckStopError(
+                "Merge Preflight remote Task branch diverges from PR head"
+            )
+        if state.local_task_head is not None and state.local_task_head != head_sha:
+            raise LckStopError(
+                "Merge Preflight local Task branch diverges from PR head"
+            )
+        if state.project_status != "Review":
+            raise LckStopError("Merge Preflight requires Project Status Review")
+
+        blockers = _formal_blockers_gate(state.relationships)
+        if blockers.get("status") != "pass":
+            raise LckStopError(
+                "Merge Preflight unresolved blockers: "
+                + str(blockers.get("detail") or blockers.get("status"))
+            )
+        review = self.review_gate.run(task_number, state)
+        checks = self.checks_gate.run(task_number)
+        if checks.get("limitation"):
+            raise LckStopError(
+                "Merge Preflight cannot prove required checks: "
+                + str(checks["limitation"])
+            )
+        current = self.resolver.resolve(task_number)
+        if (
+            current.status is not ResolutionStatus.RESOLVED
+            or not isinstance(current.open_pr, Mapping)
+            or _pr_head_sha(current.open_pr) != head_sha
+            or _pr_base_sha(current.open_pr) != base_sha
+        ):
+            raise LckStopError(
+                "Merge Preflight PR identity changed while evaluating merge gates"
+            )
+        mergeability_value = current.open_pr.get("mergeable")
+        mergeability = str(mergeability_value or "").upper()
+        if mergeability not in {"MERGEABLE", "TRUE"}:
+            raise LckStopError(
+                "Merge Preflight mergeability is not proven: "
+                + (mergeability or "UNKNOWN")
+            )
+        return MergePreflightResult(
+            task_number=task_number,
+            status="READY_FOR_HUMAN_MERGE",
+            pr=current.open_pr,
+            review=review,
+            checks=checks,
+            blockers=blockers,
+            mergeability=mergeability,
+        )
+
+
+MergePreflightRunner = MergePreflight
+
+
+def _label_names(issue: Mapping[str, Any] | None) -> set[str]:
+    if not isinstance(issue, Mapping):
+        return set()
+    raw = issue.get("labels")
+    if isinstance(raw, Mapping):
+        raw = raw.get("items")
+    if not isinstance(raw, list):
+        return set()
+    return {item for item in raw if isinstance(item, str)}
+
+
+def _pending_receipt(
+    effect: str,
+    action: str,
+    *,
+    reason: str,
+    details: Mapping[str, Any] | None = None,
+) -> EffectReceipt:
+    payload = {"reason": reason}
+    if details:
+        payload.update(details)
+    return EffectReceipt(effect=effect, action=action, details=payload)
+
+
+class MainSynchronizationEffect:
+    """Fast-forward the local main to origin/main and prove merge reachability."""
+
+    def __init__(self, resolver: LiveStateResolver) -> None:
+        self.resolver = resolver
+
+    def execute(
+        self,
+        state: LiveState,
+        *,
+        merge_sha: str | None,
+    ) -> EffectReceipt:
+        if not is_sha(merge_sha):
+            return _pending_receipt(
+                "synchronize_main",
+                "pending",
+                reason="merged PR merge commit identity is unavailable",
+            )
+        if state.git.get("clean") is not True:
+            return _pending_receipt(
+                "synchronize_main",
+                "pending",
+                reason="current worktree is not clean",
+            )
+        if state.git.get("branch") != BASE_BRANCH:
+            switched = self.resolver.runner.run(
+                ["git", "switch", BASE_BRANCH],
+                command_id="lck-closeout-switch-main",
+            )
+            if switched.returncode != 0:
+                return _pending_receipt(
+                    "synchronize_main",
+                    "pending",
+                    reason="cannot switch to main",
+                )
+        fetched = self.resolver.runner.run(
+            ["git", "fetch", "--prune", "origin"],
+            command_id="lck-closeout-fetch-origin",
+        )
+        if fetched.returncode != 0:
+            return _pending_receipt(
+                "synchronize_main",
+                "pending",
+                reason="cannot refresh origin/main",
+            )
+        merged = self.resolver.runner.run(
+            ["git", "merge", "--ff-only", f"refs/remotes/origin/{BASE_BRANCH}"],
+            command_id="lck-closeout-fast-forward-main",
+        )
+        if merged.returncode != 0:
+            return _pending_receipt(
+                "synchronize_main",
+                "pending",
+                reason="local main cannot fast-forward to origin/main",
+            )
+        head = self.resolver.runner.run(
+            ["git", "rev-parse", "HEAD"],
+            command_id="lck-closeout-main-head",
+        )
+        origin = self.resolver.runner.run(
+            ["git", "rev-parse", f"refs/remotes/origin/{BASE_BRANCH}"],
+            command_id="lck-closeout-origin-main-head",
+        )
+        ancestry = self.resolver.runner.run(
+            [
+                "git",
+                "merge-base",
+                "--is-ancestor",
+                merge_sha,
+                f"refs/remotes/origin/{BASE_BRANCH}",
+            ],
+            command_id="lck-closeout-merge-reachable",
+        )
+        if (
+            head.returncode != 0
+            or origin.returncode != 0
+            or not is_sha(head.stdout.strip())
+            or head.stdout.strip() != origin.stdout.strip()
+            or ancestry.returncode != 0
+        ):
+            return _pending_receipt(
+                "synchronize_main",
+                "pending",
+                reason="main synchronization postcondition is not proven",
+            )
+        return EffectReceipt(
+            effect="synchronize_main",
+            action="synchronized",
+            details={"main_sha": head.stdout.strip(), "merge_sha": merge_sha},
+        )
+
+
+class CloseoutMetadataEffect:
+    """Converge only the exact closed Task's Project status and lifecycle labels."""
+
+    def __init__(self, resolver: LiveStateResolver) -> None:
+        self.resolver = resolver
+
+    def execute(self, state: LiveState) -> EffectReceipt:
+        if state.issue_state != "CLOSED":
+            return _pending_receipt(
+                "converge_task_metadata",
+                "pending",
+                reason="Issue is not closed by authoritative GitHub state",
+            )
+        if state.repository is None:
+            return _pending_receipt(
+                "converge_task_metadata",
+                "pending",
+                reason="repository identity is unavailable",
+            )
+        actions: list[str] = []
+        try:
+            if state.project_status != "Done":
+                set_project_status_with_runner(
+                    self.resolver.runner,
+                    state.repository,
+                    state.task_number,
+                    value="Done",
+                )
+                actions.append("project-status-done")
+            labels = _label_names(state.issue)
+            if "codex:ready" not in labels or "codex:blocked" in labels:
+                label_result = self.resolver.runner.run(
+                    [
+                        "gh",
+                        "issue",
+                        "edit",
+                        str(state.task_number),
+                        "--repo",
+                        state.repository,
+                        "--add-label",
+                        "codex:ready",
+                        "--remove-label",
+                        "codex:blocked",
+                    ],
+                    command_id="lck-closeout-lifecycle-labels",
+                )
+                if label_result.returncode != 0:
+                    return _pending_receipt(
+                        "converge_task_metadata",
+                        "pending",
+                        reason="lifecycle label convergence failed",
+                        details={"actions": actions},
+                    )
+                actions.append("lifecycle-labels-converged")
+        except WorkflowToolError:
+            return _pending_receipt(
+                "converge_task_metadata",
+                "pending",
+                reason="Project Status convergence failed",
+                details={"actions": actions},
+            )
+        final = self.resolver.resolve(state.task_number)
+        if (
+            final.project_status != "Done"
+            or "codex:ready" not in _label_names(final.issue)
+            or "codex:blocked" in _label_names(final.issue)
+        ):
+            return _pending_receipt(
+                "converge_task_metadata",
+                "pending",
+                reason="metadata convergence postcondition is not proven",
+                details={"actions": actions},
+            )
+        return EffectReceipt(
+            effect="converge_task_metadata",
+            action="already-converged" if not actions else "updated",
+            details={"actions": actions},
+        )
+
+
+class CleanupTaskRefsEffect:
+    """Clean only the verified Task branch and recognize GitHub auto-deletion."""
+
+    def __init__(self, resolver: LiveStateResolver) -> None:
+        self.resolver = resolver
+
+    def execute(
+        self,
+        state: LiveState,
+        *,
+        expected_head_sha: str | None,
+        merge_sha: str | None,
+    ) -> EffectReceipt:
+        branch = state.target_branch
+        if branch == BASE_BRANCH or not _branch_matches_task(branch, state.task_number):
+            raise LckStopError("Cleanup target is not the verified Task branch")
+        worktree_branches = state.git.get("worktree_branches")
+        worktree_items = (
+            worktree_branches.get("items")
+            if isinstance(worktree_branches, Mapping)
+            else []
+        )
+        if isinstance(worktree_items, list) and branch in worktree_items:
+            return _pending_receipt(
+                "cleanup_task_refs",
+                "pending",
+                reason="verified Task branch is still used by a worktree",
+            )
+
+        if state.local_task_branch is None and state.remote_task_branch is None:
+            return EffectReceipt(
+                effect="cleanup_task_refs",
+                action="already-clean",
+                details={"branch": branch, "remote_branch": "already-deleted"},
+            )
+        if expected_head_sha is None:
+            return _pending_receipt(
+                "cleanup_task_refs",
+                "pending",
+                reason="merged PR head identity is unavailable",
+            )
+        if state.local_task_branch is not None:
+            local_result = self.resolver.runner.run(
+                ["git", "rev-parse", f"refs/heads/{branch}"],
+                command_id="lck-closeout-local-branch-tip",
+            )
+            local_tip = local_result.stdout.strip()
+            if local_result.returncode != 0 or local_tip != expected_head_sha:
+                raise LckStopError(
+                    "Cleanup STOP: local Task branch diverges from merged PR head"
+                )
+            if is_sha(merge_sha):
+                tree_result = self.resolver.runner.run(
+                    ["git", "diff", "--quiet", expected_head_sha, merge_sha],
+                    command_id="lck-closeout-squash-tree-equality",
+                )
+                if tree_result.returncode != 0:
+                    raise LckStopError(
+                        "Cleanup STOP: PR head tree does not equal squash merge tree"
+                    )
+            deleted = self.resolver.runner.run(
+                ["git", "branch", "-d", branch],
+                command_id="lck-closeout-local-branch-delete",
+            )
+            if deleted.returncode != 0:
+                deleted = self.resolver.runner.run(
+                    ["git", "branch", "-D", branch],
+                    command_id="lck-closeout-local-branch-force-delete-after-proof",
+                )
+            if deleted.returncode != 0:
+                return _pending_receipt(
+                    "cleanup_task_refs",
+                    "pending",
+                    reason="verified local Task branch could not be deleted",
+                )
+        if state.remote_task_branch is not None:
+            if state.remote_task_oid != expected_head_sha:
+                raise LckStopError(
+                    "Cleanup STOP: remote Task branch diverges from merged PR head"
+                )
+            removed = self.resolver.runner.run(
+                ["git", "push", "origin", "--delete", branch],
+                command_id="lck-closeout-remote-branch-delete",
+            )
+            if removed.returncode != 0:
+                return _pending_receipt(
+                    "cleanup_task_refs",
+                    "pending",
+                    reason="verified remote Task branch could not be deleted",
+                )
+            verified = self.resolver.runner.run(
+                ["git", "ls-remote", "--heads", "origin", branch],
+                command_id="lck-closeout-remote-branch-verify",
+            )
+            if verified.returncode != 0 or verified.stdout.strip():
+                return _pending_receipt(
+                    "cleanup_task_refs",
+                    "pending",
+                    reason="remote Task branch deletion postcondition is not proven",
+                )
+        return EffectReceipt(
+            effect="cleanup_task_refs",
+            action="cleaned",
+            details={"branch": branch, "expected_head_sha": expected_head_sha},
+        )
+
+
+@dataclass(frozen=True)
+class CloseoutResult:
+    task_number: int
+    status: str
+    business_delivery: str
+    cleanup: str
+    effects: tuple[EffectReceipt, ...]
+    final_state: LiveState
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": LCK_SCHEMA_VERSION,
+            "operation": "closeout",
+            "task_number": self.task_number,
+            "status": self.status,
+            "business_delivery": self.business_delivery,
+            "cleanup": self.cleanup,
+            "effects": [item.to_dict() for item in self.effects],
+            "final_state": self.final_state.to_dict(),
+            "automatic_merge": False,
+            "manual_issue_close": False,
+        }
+
+
+class CloseoutCompleter:
+    """Resolve and converge post-merge state without trusting prior snapshots."""
+
+    def __init__(
+        self,
+        resolver: LiveStateResolver,
+        *,
+        eligibility: PhaseEligibilityResolver | None = None,
+        main_effect: MainSynchronizationEffect | None = None,
+        metadata_effect: CloseoutMetadataEffect | None = None,
+        cleanup_effect: CleanupTaskRefsEffect | None = None,
+    ) -> None:
+        self.resolver = resolver
+        self.eligibility = eligibility or PhaseEligibilityResolver()
+        self.main_effect = main_effect or MainSynchronizationEffect(resolver)
+        self.metadata_effect = metadata_effect or CloseoutMetadataEffect(resolver)
+        self.cleanup_effect = cleanup_effect or CleanupTaskRefsEffect(resolver)
+
+    @staticmethod
+    def _validate_merged_identity(state: LiveState) -> tuple[str | None, str | None]:
+        pr = state.merged_pr
+        if isinstance(pr, Mapping):
+            if (
+                pr.get("baseRefName") is not None
+                and pr.get("baseRefName") != BASE_BRANCH
+            ):
+                raise LckStopError("Closeout STOP: merged PR base branch is not main")
+            if (
+                pr.get("headRefName") is not None
+                and pr.get("headRefName") != state.target_branch
+            ):
+                raise LckStopError(
+                    "Closeout STOP: merged PR head branch is not the resolved Task branch"
+                )
+            expected_head = _pr_head_sha(pr)
+            if (
+                expected_head is not None
+                and state.local_task_head is not None
+                and state.local_task_head != expected_head
+            ):
+                raise LckStopError(
+                    "Closeout STOP: local Task branch diverges from merged PR head"
+                )
+            if (
+                expected_head is not None
+                and state.remote_task_oid is not None
+                and state.remote_task_oid != expected_head
+            ):
+                raise LckStopError(
+                    "Closeout STOP: remote Task branch diverges from merged PR head"
+                )
+            return expected_head, _merge_commit_sha(pr)
+        return None, None
+
+    def complete(self, task_number: int) -> CloseoutResult:
+        state = self.resolver.resolve(task_number)
+        decision = self.eligibility.resolve(state, Phase.CLOSEOUT)
+        if not decision.eligible:
+            raise LckStopError(
+                f"Closeout STOP for Task #{task_number}: " + "; ".join(decision.reasons)
+            )
+        expected_head, merge_sha = self._validate_merged_identity(state)
+        effects: list[EffectReceipt] = []
+        main = self.main_effect.execute(state, merge_sha=merge_sha)
+        effects.append(main)
+
+        current = self.resolver.resolve(task_number)
+        metadata = self.metadata_effect.execute(current)
+        effects.append(metadata)
+
+        current = self.resolver.resolve(task_number)
+        if main.action in {"synchronized", "already-synced"}:
+            cleanup = self.cleanup_effect.execute(
+                current,
+                expected_head_sha=expected_head,
+                merge_sha=merge_sha,
+            )
+        else:
+            cleanup = _pending_receipt(
+                "cleanup_task_refs",
+                "pending",
+                reason="main synchronization is incomplete",
+            )
+        effects.append(cleanup)
+        final = self.resolver.resolve(task_number)
+        cleanup_complete = (
+            main.action in {"synchronized", "already-synced"}
+            and metadata.action in {"updated", "already-converged"}
+            and cleanup.action in {"cleaned", "already-clean"}
+            and final.local_task_branch is None
+            and final.remote_task_branch is None
+        )
+        return CloseoutResult(
+            task_number=task_number,
+            status="BUSINESS_DELIVERY_COMPLETE",
+            business_delivery="COMPLETE",
+            cleanup="COMPLETE" if cleanup_complete else "PENDING",
+            effects=tuple(effects),
+            final_state=final,
+        )
+
+
 @dataclass(frozen=True)
 class DeliveryCompletionResult:
     task_number: int
@@ -3158,6 +3806,17 @@ def _build_parser() -> argparse.ArgumentParser:
     remediation_complete.add_argument(
         "--check-timeout-seconds", type=float, default=600.0
     )
+
+    merge = commands.add_parser("merge")
+    merge_commands = merge.add_subparsers(dest="merge_command", required=True)
+    merge_preflight = merge_commands.add_parser("preflight")
+    merge_preflight.add_argument("task", type=int)
+
+    merge_preflight_alias = commands.add_parser("merge-preflight")
+    merge_preflight_alias.add_argument("task", type=int)
+
+    closeout = commands.add_parser("closeout")
+    closeout.add_argument("task", type=int)
     return parser
 
 
@@ -3220,6 +3879,16 @@ def main(argv: Sequence[str] | None = None) -> int:
                 summary=args.summary,
                 risks=args.risks,
             )
+            print_json(result.to_dict(), pretty=True)
+            return 0
+        if (
+            args.command == "merge" and args.merge_command == "preflight"
+        ) or args.command == "merge-preflight":
+            result = MergePreflight(resolver).run(args.task)
+            print_json(result.to_dict(), pretty=True)
+            return 0
+        if args.command == "closeout":
+            result = CloseoutCompleter(resolver).complete(args.task)
             print_json(result.to_dict(), pretty=True)
             return 0
         raise LckStopError("unsupported LCK command")

--- a/tools/agent_workflow/lck.py
+++ b/tools/agent_workflow/lck.py
@@ -3201,12 +3201,37 @@ class CleanupTaskRefsEffect:
                 raise LckStopError(
                     "Cleanup STOP: remote Task branch diverges from merged PR head"
                 )
+            remote_ref = self.resolver.runner.run(
+                ["git", "ls-remote", "--heads", "origin", branch],
+                command_id="lck-closeout-remote-branch-precondition",
+            )
+            if remote_ref.returncode != 0:
+                return _pending_receipt(
+                    "cleanup_task_refs",
+                    "pending",
+                    reason="remote Task branch precondition could not be verified",
+                )
+            remote_refs = _remote_refs(remote_ref.stdout)
+            observed_remote_oid = remote_refs.get(branch)
+            if observed_remote_oid is None:
+                if remote_ref.stdout.strip():
+                    raise LckStopError(
+                        "Cleanup STOP: remote Task branch identity is malformed"
+                    )
+                return EffectReceipt(
+                    effect="cleanup_task_refs",
+                    action="already-clean",
+                    details={"branch": branch, "remote_branch": "already-deleted"},
+                )
+            if observed_remote_oid != expected_head_sha:
+                raise LckStopError(
+                    "Cleanup STOP: remote Task branch diverges from merged PR head"
+                )
             removed = self.resolver.runner.run(
                 [
                     "git",
                     "push",
                     "origin",
-                    f"--force-with-lease=refs/heads/{branch}:{expected_head_sha}",
                     "--delete",
                     branch,
                 ],
@@ -3414,6 +3439,15 @@ class CloseoutCompleter:
             )
         effects.append(cleanup)
         final = self.resolver.resolve(task_number)
+        if final.status is not ResolutionStatus.RESOLVED:
+            raise LckStopError(
+                "Closeout STOP: final live state is unresolved: "
+                + "; ".join(final.stop_reasons)
+            )
+        if final.merged is not True or final.open_pr is not None:
+            raise LckStopError(
+                "Closeout STOP: final merged PR state changed or an OPEN PR exists"
+            )
         cleanup_complete = (
             main.action in {"synchronized", "already-synced"}
             and metadata.action in {"updated", "already-converged"}

--- a/tools/agent_workflow/lck.py
+++ b/tools/agent_workflow/lck.py
@@ -313,6 +313,7 @@ class LiveStateResolver:
         remote_result = self.runner.run(
             ["git", "ls-remote", "--heads", "origin"],
             command_id="lck-remote-task-branches",
+            retries=1,
         )
         if remote_result.returncode != 0:
             warnings.append(command_warning(remote_result))

--- a/tools/agent_workflow/pr_resolve.py
+++ b/tools/agent_workflow/pr_resolve.py
@@ -33,11 +33,13 @@ _PR_URL_PATTERN: Final = re.compile(
 )
 _PR_LIST_FIELDS: Final = (
     "number,url,state,isDraft,baseRefName,baseRefOid,headRefName,headRefOid,"
-    "mergeCommit,mergedAt,mergeable,reviewDecision,headRepository,statusCheckRollup"
+    "mergeCommit,mergedAt,mergeable,reviewDecision,headRepository,statusCheckRollup,"
+    "closingIssuesReferences"
 )
 _PR_VIEW_FIELDS: Final = (
     "number,url,state,isDraft,baseRefName,baseRefOid,headRefName,headRefOid,"
-    "mergeCommit,mergedAt,mergeable,reviewDecision,headRepository,statusCheckRollup"
+    "mergeCommit,mergedAt,mergeable,reviewDecision,headRepository,statusCheckRollup,"
+    "closingIssuesReferences"
 )
 _REQUIRED_PR_FIELDS: Final = (
     "number",

--- a/tools/agent_workflow/pr_resolve.py
+++ b/tools/agent_workflow/pr_resolve.py
@@ -31,10 +31,13 @@ from workflow_common import (
 _PR_URL_PATTERN: Final = re.compile(
     r"https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/pull/\d+"
 )
-_PR_LIST_FIELDS: Final = "number,url,state,isDraft,baseRefName,headRefName,headRefOid"
+_PR_LIST_FIELDS: Final = (
+    "number,url,state,isDraft,baseRefName,baseRefOid,headRefName,headRefOid,"
+    "mergeCommit,mergedAt,mergeable,reviewDecision,headRepository,statusCheckRollup"
+)
 _PR_VIEW_FIELDS: Final = (
     "number,url,state,isDraft,baseRefName,baseRefOid,headRefName,headRefOid,"
-    "statusCheckRollup"
+    "mergeCommit,mergedAt,mergeable,reviewDecision,headRepository,statusCheckRollup"
 )
 _REQUIRED_PR_FIELDS: Final = (
     "number",

--- a/tools/agent_workflow/workflow_common.py
+++ b/tools/agent_workflow/workflow_common.py
@@ -8,7 +8,9 @@ import json
 import os
 import re
 import shutil
+import signal
 import subprocess
+import time
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -18,6 +20,12 @@ MAX_STRING: Final = 512
 MAX_LIST_ITEMS: Final = 50
 MAX_STDERR_TAIL: Final = 2000
 MAX_LOG_BYTES: Final = 1_000_000
+DEFAULT_COMMAND_TIMEOUT_SECONDS: Final = 30.0
+NETWORK_COMMAND_TIMEOUT_SECONDS: Final = 60.0
+VALIDATION_COMMAND_TIMEOUT_SECONDS: Final = 1200.0
+PROCESS_TERM_GRACE_SECONDS: Final = 2.0
+RETRY_DELAY_SECONDS: Final = 0.5
+TIMEOUT_EXIT_CODE: Final = 124
 SHA_PATTERN: Final = re.compile(r"^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$")
 WINDOWS_ABSOLUTE_PATH: Final = re.compile(r"^[A-Za-z]:[\\/]")
 WINDOWS_ABSOLUTE_PATH_IN_TEXT: Final = re.compile(
@@ -60,6 +68,68 @@ class CommandResult:
     returncode: int
     stdout: str
     stderr: str
+    timed_out: bool = False
+    timeout_seconds: float | None = None
+
+
+def _command_timeout(
+    argv: Sequence[str], *, executable: str, validation: bool
+) -> float:
+    """Choose a bounded timeout appropriate for the command class."""
+    if validation:
+        return VALIDATION_COMMAND_TIMEOUT_SECONDS
+    if executable in {"gh", "gh.exe", "gh.cmd"}:
+        return DEFAULT_COMMAND_TIMEOUT_SECONDS
+    if executable in {"git", "git.exe", "git.cmd"} and any(
+        item in {"fetch", "ls-remote", "push", "pull", "clone"} for item in argv[1:]
+    ):
+        return NETWORK_COMMAND_TIMEOUT_SECONDS
+    return DEFAULT_COMMAND_TIMEOUT_SECONDS
+
+
+def _signal_process_group(process: subprocess.Popen[str], sig: signal.Signals) -> None:
+    """Terminate a bounded command and its descendants when possible."""
+    try:
+        if os.name == "posix":
+            os.killpg(process.pid, sig)
+        else:
+            process.send_signal(sig)
+    except ProcessLookupError:
+        pass
+
+
+def _run_process(
+    resolved_argv: Sequence[str],
+    *,
+    cwd: Path,
+    env: Mapping[str, str],
+    timeout_seconds: float,
+) -> tuple[int, str, str, bool]:
+    """Run one command with a timeout and process-group cleanup."""
+    process = subprocess.Popen(
+        resolved_argv,
+        cwd=cwd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=env,
+        start_new_session=os.name == "posix",
+    )
+    try:
+        stdout, stderr = process.communicate(timeout=timeout_seconds)
+    except subprocess.TimeoutExpired:
+        _signal_process_group(process, signal.SIGTERM)
+        try:
+            stdout, stderr = process.communicate(timeout=PROCESS_TERM_GRACE_SECONDS)
+        except subprocess.TimeoutExpired:
+            _signal_process_group(process, signal.SIGKILL)
+            stdout, stderr = process.communicate()
+        timeout_message = f"command timed out after {timeout_seconds:g} seconds"
+        stderr = f"{stderr.rstrip()}\n{timeout_message}" if stderr else timeout_message
+        return TIMEOUT_EXIT_CODE, stdout, stderr, True
+    return process.returncode, stdout, stderr, False
 
 
 class CommandRunner:
@@ -80,9 +150,13 @@ class CommandRunner:
         cwd: Path | None = None,
         validation: bool = False,
         env: Mapping[str, str] | None = None,
+        timeout_seconds: float | None = None,
+        retries: int = 0,
     ) -> CommandResult:
         if not argv:
             raise WorkflowToolError("command argv cannot be empty")
+        if retries < 0 or retries > 2:
+            raise WorkflowToolError("command retries must be between 0 and 2")
         process_env = build_workflow_env(self.repo_root)
         process_env.setdefault("PYTHONUTF8", "1")
         process_env.setdefault("PYTHONIOENCODING", "utf-8")
@@ -101,31 +175,44 @@ class CommandRunner:
             self.github_queries += 1
         if validation:
             self.validation_commands += 1
-        try:
-            completed = subprocess.run(
+        effective_timeout = (
+            _command_timeout(
                 resolved_argv,
-                cwd=cwd or self.repo_root,
-                check=False,
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-                env=process_env,
+                executable=executable,
+                validation=validation,
             )
-        except FileNotFoundError:
-            return CommandResult(
-                command_id=command_id,
-                argv=tuple(resolved_argv),
-                returncode=127,
-                stdout="",
-                stderr=f"executable not found: {Path(argv[0]).name}",
-            )
+            if timeout_seconds is None
+            else timeout_seconds
+        )
+        if effective_timeout <= 0:
+            raise WorkflowToolError("command timeout must be positive")
+        for attempt in range(retries + 1):
+            try:
+                returncode, stdout, stderr, timed_out = _run_process(
+                    resolved_argv,
+                    cwd=cwd or self.repo_root,
+                    env=process_env,
+                    timeout_seconds=effective_timeout,
+                )
+            except FileNotFoundError:
+                return CommandResult(
+                    command_id=command_id,
+                    argv=tuple(resolved_argv),
+                    returncode=127,
+                    stdout="",
+                    stderr=f"executable not found: {Path(argv[0]).name}",
+                )
+            if returncode == 0 or returncode == 127 or attempt == retries:
+                break
+            time.sleep(RETRY_DELAY_SECONDS)
         return CommandResult(
             command_id=command_id,
             argv=tuple(resolved_argv),
-            returncode=completed.returncode,
-            stdout=completed.stdout,
-            stderr=completed.stderr,
+            returncode=returncode,
+            stdout=stdout,
+            stderr=stderr,
+            timed_out=timed_out,
+            timeout_seconds=effective_timeout if timed_out else None,
         )
 
     def counters(self) -> dict[str, int]:
@@ -305,8 +392,12 @@ def parse_repository_slug(remote: str) -> str | None:
 
 
 def command_warning(result: CommandResult) -> dict[str, Any]:
-    return {
+    warning: dict[str, Any] = {
         "command_id": result.command_id,
         "exit_code": result.returncode,
         "error": stderr_tail(result.stderr or result.stdout),
     }
+    if result.timed_out:
+        warning["timed_out"] = True
+        warning["timeout_seconds"] = result.timeout_seconds
+    return warning

--- a/tools/agent_workflow/workflow_evidence.py
+++ b/tools/agent_workflow/workflow_evidence.py
@@ -260,6 +260,7 @@ def _repository_slug(
     result = runner.run(
         ["gh", "repo", "view", "--json", "nameWithOwner"],
         command_id="gh-repo-view",
+        retries=1,
     )
     if result.returncode != 0:
         warnings.append(command_warning(result))
@@ -280,6 +281,7 @@ def _git_snapshot(
         fetch = runner.run(
             ["git", "fetch", "--prune", "origin"],
             command_id="git-fetch-origin",
+            retries=1,
         )
         if fetch.returncode != 0:
             warnings.append(command_warning(fetch))
@@ -382,6 +384,7 @@ def _issue_view(
             fields,
         ],
         command_id=f"gh-issue-view-{number}",
+        retries=1,
     )
     if result.returncode != 0:
         fallback = runner.run(
@@ -522,6 +525,7 @@ def _graphql(
             f"number={number}",
         ],
         command_id=command_id,
+        retries=1,
     )
     if result.returncode != 0:
         warnings.append(command_warning(result))


### PR DESCRIPTION
Closes #162

## Summary
Add live-state merge preflight, separated Business Delivery/Cleanup closeout effects, and idempotent recovery for Task lifecycle state.

## Validation
- Critical Outcome: pass
- Formal Delivery validation: pass

## Risks / limitations
Closeout metadata and exact branch cleanup remain bounded and fail closed when merge identity, issue closure, worktree ownership, or remote state cannot be proven.
