### PR TITLE
[Task] 定义初始公共领域模型与共享测试 Fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ Pull requests targeting `main` and pushes to `main` automatically run CI. The wo
 
 Internal datetimes must be timezone-aware and use UTC as the standard timezone. Naive datetimes are explicitly rejected. Time utilities are provided by `tracequant.core.time`.
 
+The initial Research MVP domain models are documented in
+[Domain models](docs/architecture/domain-models.md) and are imported from
+`tracequant.domain`.
+
 ## Configuration
 
 Application configuration is loaded explicitly with `tracequant.config.load_settings`.

--- a/docs/architecture/domain-models.md
+++ b/docs/architecture/domain-models.md
@@ -1,0 +1,38 @@
+# Initial domain models
+
+TraceQuant's Research MVP currently exposes the following small internal domain
+models through the formal public import path:
+
+```python
+from tracequant.domain import InstrumentId, OHLCVBar, TimeRange
+```
+
+`InstrumentId` trims surrounding whitespace, normalizes ASCII letters to upper
+case, and accepts only ASCII letters and digits. It is a single normalized
+instrument identifier; venue, exchange, market type, and symbol decomposition
+are intentionally outside its boundary.
+
+`TimeRange` is an immutable UTC half-open interval, `[start, end)`. Inputs must
+be timezone-aware and are normalized with the existing `tracequant.core.time`
+UTC utilities. Naive datetimes are rejected, and `start` must be earlier than
+`end`.
+
+`OHLCVBar` contains an `InstrumentId`, a UTC half-open interval, and Python
+`float` OHLCV values. Values must be finite, volume must be non-negative, and
+the high/low values must enclose open and close. Prices of zero and negative
+values are currently allowed; no positive-price market assumption is added yet.
+
+All three models are immutable, comparable value objects with explicit
+`to_dict()` / `from_dict()` APIs. Their output is JSON-compatible and uses the
+repository's UTC ISO 8601 format. This is the initial internal Research MVP
+model set, not a long-term externally versioned serialization protocol.
+
+Shared tests use deterministic factories in `tests/fixtures/domain.py` only
+when multiple test modules need the same construction. Fixtures default to
+function scope, expose important values, and do not use current time, random
+data, environment variables, network access, or filesystem access. Single-test
+data stays in its test module.
+
+The models do not define orders, trades, accounts, positions, strategies,
+factors, backtest events, exchange adapters, storage schemas, timeframes,
+calendars, precision systems, API DTOs, or a fixture platform.

--- a/src/tracequant/domain.py
+++ b/src/tracequant/domain.py
@@ -1,0 +1,209 @@
+"""Initial Research MVP domain models.
+
+The models in this module are deliberately small, immutable value objects.  They
+contain no exchange, storage, configuration, or application orchestration
+concerns.
+"""
+
+import math
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import ClassVar, Self, cast
+
+from tracequant.core.time import format_utc, parse_utc, to_utc
+
+__all__ = ["DomainValidationError", "InstrumentId", "OHLCVBar", "TimeRange"]
+
+
+class DomainValidationError(ValueError):
+    """Raised when input violates a public domain model invariant."""
+
+
+_INSTRUMENT_PATTERN = re.compile(r"[A-Z0-9]+\Z")
+_TIME_RANGE_FIELDS = frozenset({"start", "end"})
+_OHLCV_FIELDS = frozenset(
+    {"instrument", "start", "end", "open", "high", "low", "close", "volume"}
+)
+
+
+def _require_mapping(
+    value: object, fields: frozenset[str], model: str
+) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise DomainValidationError(f"{model} data must be a mapping")
+    if set(value) != fields:
+        raise DomainValidationError(
+            f"{model} data must contain exactly: {', '.join(sorted(fields))}"
+        )
+    return cast(Mapping[str, object], value)
+
+
+def _require_datetime(value: object, field: str) -> datetime:
+    if not isinstance(value, datetime):
+        raise DomainValidationError(f"{field} must be a datetime")
+    return value
+
+
+def _require_float(value: object, field: str) -> float:
+    if type(value) is not float:
+        raise DomainValidationError(f"{field} must be a float")
+    if not math.isfinite(value):
+        raise DomainValidationError(f"{field} must be finite")
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class InstrumentId:
+    """A normalized single-market instrument identifier."""
+
+    value: str
+    MAX_LENGTH: ClassVar[int] = 32
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.value, str):
+            raise DomainValidationError("instrument must be a string")
+
+        trimmed = self.value.strip()
+        if not trimmed:
+            raise DomainValidationError("instrument must not be empty")
+        if not trimmed.isascii():
+            raise DomainValidationError("instrument must contain ASCII characters only")
+
+        normalized = trimmed.upper()
+        if len(normalized) > self.MAX_LENGTH:
+            raise DomainValidationError(
+                f"instrument must be at most {self.MAX_LENGTH} characters"
+            )
+        if _INSTRUMENT_PATTERN.fullmatch(normalized) is None:
+            raise DomainValidationError(
+                "instrument must contain only ASCII letters and digits"
+            )
+        object.__setattr__(self, "value", normalized)
+
+    def __str__(self) -> str:
+        return self.value
+
+    def to_dict(self) -> str:
+        """Return the JSON-compatible normalized identifier."""
+        return self.value
+
+    @classmethod
+    def from_dict(cls, value: object) -> Self:
+        """Build an identifier from its JSON-compatible string form."""
+        if not isinstance(value, str):
+            raise DomainValidationError("instrument data must be a string")
+        return cls(value)
+
+
+@dataclass(frozen=True, slots=True)
+class TimeRange:
+    """A UTC half-open interval ``[start, end)``."""
+
+    start: datetime
+    end: datetime
+
+    def __post_init__(self) -> None:
+        start = to_utc(_require_datetime(self.start, "start"))
+        end = to_utc(_require_datetime(self.end, "end"))
+        if start >= end:
+            raise DomainValidationError("start must be earlier than end")
+        object.__setattr__(self, "start", start)
+        object.__setattr__(self, "end", end)
+
+    @property
+    def duration(self) -> timedelta:
+        """Return the interval duration."""
+        return self.end - self.start
+
+    def __contains__(self, value: object) -> bool:
+        if not isinstance(value, datetime):
+            return False
+        value_utc = to_utc(value)
+        return self.start <= value_utc < self.end
+
+    def to_dict(self) -> dict[str, str]:
+        """Return the stable JSON-compatible interval representation."""
+        return {"start": format_utc(self.start), "end": format_utc(self.end)}
+
+    @classmethod
+    def from_dict(cls, value: object) -> Self:
+        """Build an interval from its stable UTC ISO 8601 representation."""
+        data = _require_mapping(value, _TIME_RANGE_FIELDS, "TimeRange")
+        start = data["start"]
+        end = data["end"]
+        if not isinstance(start, str) or not isinstance(end, str):
+            raise DomainValidationError("TimeRange datetimes must be strings")
+        return cls(parse_utc(start), parse_utc(end))
+
+
+@dataclass(frozen=True, slots=True)
+class OHLCVBar:
+    """One validated OHLCV bar over a UTC half-open interval."""
+
+    instrument: InstrumentId
+    start: datetime
+    end: datetime
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.instrument, InstrumentId):
+            raise DomainValidationError("instrument must be an InstrumentId")
+
+        interval = TimeRange(self.start, self.end)
+        object.__setattr__(self, "start", interval.start)
+        object.__setattr__(self, "end", interval.end)
+
+        open_price = _require_float(self.open, "open")
+        high_price = _require_float(self.high, "high")
+        low_price = _require_float(self.low, "low")
+        close_price = _require_float(self.close, "close")
+        volume = _require_float(self.volume, "volume")
+        if volume < 0:
+            raise DomainValidationError("volume must be non-negative")
+        if (
+            high_price < open_price
+            or high_price < low_price
+            or high_price < close_price
+        ):
+            raise DomainValidationError("high must not be lower than OHLC prices")
+        if low_price > open_price or low_price > high_price or low_price > close_price:
+            raise DomainValidationError("low must not be higher than OHLC prices")
+
+    def to_dict(self) -> dict[str, str | float]:
+        """Return the stable JSON-compatible bar representation."""
+        return {
+            "instrument": self.instrument.to_dict(),
+            "start": format_utc(self.start),
+            "end": format_utc(self.end),
+            "open": _require_float(self.open, "open"),
+            "high": _require_float(self.high, "high"),
+            "low": _require_float(self.low, "low"),
+            "close": _require_float(self.close, "close"),
+            "volume": _require_float(self.volume, "volume"),
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> Self:
+        """Build a bar from its stable JSON-compatible representation."""
+        data = _require_mapping(value, _OHLCV_FIELDS, "OHLCVBar")
+        instrument = InstrumentId.from_dict(data["instrument"])
+        start = data["start"]
+        end = data["end"]
+        if not isinstance(start, str) or not isinstance(end, str):
+            raise DomainValidationError("OHLCVBar datetimes must be strings")
+        return cls(
+            instrument=instrument,
+            start=parse_utc(start),
+            end=parse_utc(end),
+            open=_require_float(data["open"], "open"),
+            high=_require_float(data["high"], "high"),
+            low=_require_float(data["low"], "low"),
+            close=_require_float(data["close"], "close"),
+            volume=_require_float(data["volume"], "volume"),
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+"""Shared fixtures used by multiple domain test modules."""
+
+import pytest
+from fixtures.domain import make_instrument, make_ohlcv_bar, make_time_range
+
+from tracequant.domain import InstrumentId, OHLCVBar, TimeRange
+
+
+@pytest.fixture(scope="function")
+def sample_instrument() -> InstrumentId:
+    return make_instrument()
+
+
+@pytest.fixture(scope="function")
+def sample_time_range() -> TimeRange:
+    return make_time_range()
+
+
+@pytest.fixture(scope="function")
+def sample_ohlcv_bar() -> OHLCVBar:
+    return make_ohlcv_bar()

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,0 +1,1 @@
+"""Deterministic shared test factories."""

--- a/tests/fixtures/domain.py
+++ b/tests/fixtures/domain.py
@@ -1,0 +1,44 @@
+"""Deterministic factories for tests that exercise public domain models."""
+
+from datetime import UTC, datetime, timedelta
+
+from tracequant.domain import InstrumentId, OHLCVBar, TimeRange
+
+DEFAULT_START = datetime(2024, 2, 28, 23, 45, tzinfo=UTC)
+DEFAULT_END = DEFAULT_START + timedelta(minutes=15)
+
+
+def make_instrument(value: str = "BTCUSDT") -> InstrumentId:
+    """Create an instrument with an explicit, easy-to-see default."""
+    return InstrumentId(value)
+
+
+def make_time_range(
+    start: datetime = DEFAULT_START, end: datetime = DEFAULT_END
+) -> TimeRange:
+    """Create a deterministic UTC interval with explicit field overrides."""
+    return TimeRange(start=start, end=end)
+
+
+def make_ohlcv_bar(
+    *,
+    instrument: InstrumentId | None = None,
+    start: datetime = DEFAULT_START,
+    end: datetime = DEFAULT_END,
+    open: float = 50_000.0,
+    high: float = 50_025.0,
+    low: float = 49_975.0,
+    close: float = 50_010.0,
+    volume: float = 12.5,
+) -> OHLCVBar:
+    """Create a fresh deterministic bar; every field can be overridden."""
+    return OHLCVBar(
+        instrument=instrument if instrument is not None else make_instrument(),
+        start=start,
+        end=end,
+        open=open,
+        high=high,
+        low=low,
+        close=close,
+        volume=volume,
+    )

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -1,0 +1,229 @@
+"""Unit and boundary tests for the initial public domain models."""
+
+import json
+import math
+from dataclasses import FrozenInstanceError
+from datetime import UTC, datetime, timedelta, timezone
+
+import pytest
+from fixtures.domain import make_instrument, make_ohlcv_bar, make_time_range
+
+from tracequant.domain import DomainValidationError, InstrumentId, OHLCVBar, TimeRange
+
+
+@pytest.mark.parametrize("value", ["", "   ", "BTC-USDT", "BTC_USDT", "比特币"])
+def test_instrument_rejects_empty_non_ascii_and_separators(value: str) -> None:
+    with pytest.raises(DomainValidationError):
+        InstrumentId(value)
+
+
+def test_instrument_normalizes_and_is_immutable_hashable() -> None:
+    value = InstrumentId("  ethusdt ")
+
+    assert value.value == "ETHUSDT"
+    assert str(value) == "ETHUSDT"
+    assert value == InstrumentId("ETHUSDT")
+    assert hash(value) == hash(InstrumentId("ETHUSDT"))
+    assert {value} == {InstrumentId("ETHUSDT")}
+    with pytest.raises((AttributeError, TypeError, FrozenInstanceError)):
+        value.value = "BTCUSDT"  # type: ignore[misc]
+
+
+def test_instrument_rejects_long_values() -> None:
+    with pytest.raises(DomainValidationError):
+        InstrumentId("A" * (InstrumentId.MAX_LENGTH + 1))
+
+
+def test_time_range_normalizes_offsets_and_uses_half_open_semantics() -> None:
+    start = datetime(2024, 2, 29, 8, 0, tzinfo=timezone(timedelta(hours=8)))
+    end = datetime(2024, 2, 29, 9, 0, tzinfo=timezone(timedelta(hours=8)))
+    value = TimeRange(start=start, end=end)
+
+    assert value.start == datetime(2024, 2, 29, 0, 0, tzinfo=UTC)
+    assert value.end == datetime(2024, 2, 29, 1, 0, tzinfo=UTC)
+    assert value.duration == timedelta(hours=1)
+    assert value.start in value
+    assert datetime(2024, 2, 29, 1, 0, tzinfo=UTC) not in value
+
+
+@pytest.mark.parametrize(
+    ("start", "end"),
+    [
+        (datetime(2024, 2, 29, 0, 0), datetime(2024, 2, 29, 1, 0, tzinfo=UTC)),
+        (
+            datetime(2024, 2, 29, 1, 0, tzinfo=UTC),
+            datetime(2024, 2, 29, 0, 0, tzinfo=UTC),
+        ),
+        (
+            datetime(2024, 2, 29, 1, 0, tzinfo=UTC),
+            datetime(2024, 2, 29, 1, 0, tzinfo=UTC),
+        ),
+    ],
+)
+def test_time_range_rejects_naive_or_non_positive_intervals(
+    start: datetime, end: datetime
+) -> None:
+    with pytest.raises(ValueError):
+        TimeRange(start=start, end=end)
+
+
+def test_time_range_supports_cross_month_and_leap_day() -> None:
+    value = make_time_range(
+        start=datetime(2024, 2, 29, 23, 59, tzinfo=UTC),
+        end=datetime(2024, 3, 1, 0, 1, tzinfo=UTC),
+    )
+
+    assert value.duration == timedelta(minutes=2)
+
+
+@pytest.mark.parametrize(
+    ("open", "high", "low", "close", "volume"),
+    [
+        (math.nan, 50_025.0, 49_975.0, 50_010.0, 12.5),
+        (50_000.0, math.inf, 49_975.0, 50_010.0, 12.5),
+        (50_000.0, 50_025.0, -math.inf, 50_010.0, 12.5),
+        (50_000.0, 50_025.0, 49_975.0, math.nan, 12.5),
+        (50_000.0, 50_025.0, 49_975.0, 50_010.0, math.inf),
+        (50_000.0, 50_025.0, 49_975.0, 50_010.0, -1.0),
+    ],
+)
+def test_ohlcv_rejects_non_finite_prices_and_negative_volume(
+    open: float, high: float, low: float, close: float, volume: float
+) -> None:
+    with pytest.raises(DomainValidationError):
+        make_ohlcv_bar(
+            open=open,
+            high=high,
+            low=low,
+            close=close,
+            volume=volume,
+        )
+
+
+@pytest.mark.parametrize(
+    ("open", "high", "low", "close"),
+    [
+        (50_000.0, 49_999.0, 49_975.0, 50_010.0),
+        (50_000.0, 50_025.0, 50_001.0, 50_010.0),
+        (50_000.0, 50_050.0, 49_975.0, 50_100.0),
+    ],
+)
+def test_ohlcv_rejects_invalid_high_low_relationships(
+    open: float, high: float, low: float, close: float
+) -> None:
+    with pytest.raises(DomainValidationError):
+        make_ohlcv_bar(open=open, high=high, low=low, close=close)
+
+
+def test_ohlcv_allows_zero_and_negative_prices() -> None:
+    value = make_ohlcv_bar(open=-2.0, high=-1.0, low=-3.0, close=-2.5)
+    zero_value = make_ohlcv_bar(open=0.0, high=0.0, low=0.0, close=0.0)
+
+    assert value.open == -2.0
+    assert zero_value.close == 0.0
+
+
+def test_ohlcv_is_immutable_and_has_fixed_public_fields() -> None:
+    value = make_ohlcv_bar()
+
+    assert tuple(value.__dataclass_fields__) == (
+        "instrument",
+        "start",
+        "end",
+        "open",
+        "high",
+        "low",
+        "close",
+        "volume",
+    )
+    with pytest.raises((AttributeError, TypeError, FrozenInstanceError)):
+        value.volume = 1.0  # type: ignore[misc]
+
+
+def test_serialization_is_stable_json_compatible_and_round_trips() -> None:
+    value = make_ohlcv_bar()
+    encoded = value.to_dict()
+
+    assert tuple(encoded) == (
+        "instrument",
+        "start",
+        "end",
+        "open",
+        "high",
+        "low",
+        "close",
+        "volume",
+    )
+    assert json.loads(json.dumps(encoded)) == encoded
+    assert OHLCVBar.from_dict(encoded) == value
+    assert TimeRange.from_dict(
+        {"start": encoded["start"], "end": encoded["end"]}
+    ) == TimeRange(start=value.start, end=value.end)
+
+
+@pytest.mark.parametrize(
+    "malformed",
+    [
+        {},
+        {"instrument": "BTCUSDT"},
+        {
+            "instrument": "BTCUSDT",
+            "start": "2024-02-28T23:45:00Z",
+            "end": "2024-02-29T00:00:00Z",
+            "open": 50_000.0,
+            "high": 50_025.0,
+            "low": 49_975.0,
+            "close": 50_010.0,
+            "volume": 12.5,
+            "extra": "not allowed",
+        },
+        {
+            "instrument": "BTCUSDT",
+            "start": "2024-02-28T23:45:00",
+            "end": "2024-02-29T00:00:00Z",
+            "open": 50_000.0,
+            "high": 50_025.0,
+            "low": 49_975.0,
+            "close": 50_010.0,
+            "volume": 12.5,
+        },
+        {
+            "instrument": "BTCUSDT",
+            "start": "2024-02-28T23:45:00Z",
+            "end": "2024-02-29T00:00:00Z",
+            "open": "50000",
+            "high": 50_025.0,
+            "low": 49_975.0,
+            "close": 50_010.0,
+            "volume": 12.5,
+        },
+    ],
+)
+def test_ohlcv_from_dict_rejects_malformed_data(
+    malformed: object,
+) -> None:
+    with pytest.raises(ValueError):
+        OHLCVBar.from_dict(malformed)
+
+
+def test_factories_return_isolated_objects_and_allow_overrides(
+    sample_instrument: InstrumentId,
+    sample_time_range: TimeRange,
+    sample_ohlcv_bar: OHLCVBar,
+) -> None:
+    other_instrument = make_instrument("ETHUSDT")
+    other_range = make_time_range(
+        start=datetime(2024, 3, 1, 0, 0, tzinfo=UTC),
+        end=datetime(2024, 3, 1, 0, 15, tzinfo=UTC),
+    )
+    other_bar = make_ohlcv_bar(
+        instrument=other_instrument,
+        start=other_range.start,
+        end=other_range.end,
+    )
+
+    assert sample_instrument != other_instrument
+    assert sample_time_range != other_range
+    assert sample_ohlcv_bar.instrument == InstrumentId("BTCUSDT")
+    assert other_bar.instrument == other_instrument
+    assert other_bar.start == other_range.start

--- a/tests/test_domain_acceptance.py
+++ b/tests/test_domain_acceptance.py
@@ -1,0 +1,56 @@
+"""Critical Outcome coverage for the public domain API."""
+
+import json
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from tracequant.domain import InstrumentId, OHLCVBar, TimeRange
+
+
+def test_public_domain_models_support_validated_json_round_trip() -> None:
+    start = datetime(2024, 2, 29, 0, 0, tzinfo=UTC)
+    end = start + timedelta(minutes=15)
+    instrument = InstrumentId("  btcusdt ")
+    time_range = TimeRange(start=start, end=end)
+    bar = OHLCVBar(
+        instrument=instrument,
+        start=time_range.start,
+        end=time_range.end,
+        open=50_000.0,
+        high=50_025.0,
+        low=49_975.0,
+        close=50_010.0,
+        volume=12.5,
+    )
+
+    instrument_data = instrument.to_dict()
+    time_range_data = time_range.to_dict()
+    bar_data = bar.to_dict()
+    json.dumps(instrument_data)
+    json.dumps(time_range_data)
+    json.dumps(bar_data)
+
+    assert InstrumentId.from_dict(instrument_data) == instrument
+    assert TimeRange.from_dict(time_range_data) == time_range
+    assert OHLCVBar.from_dict(bar_data) == bar
+
+    with pytest.raises(ValueError):
+        InstrumentId("BTC-USDT")
+    with pytest.raises(ValueError):
+        TimeRange(start=end, end=start)
+    with pytest.raises(ValueError):
+        OHLCVBar(
+            instrument=instrument,
+            start=start,
+            end=end,
+            open=50_000.0,
+            high=49_000.0,
+            low=49_500.0,
+            close=49_750.0,
+            volume=12.5,
+        )
+
+
+def test_acceptance_uses_shared_bar_fixture(sample_ohlcv_bar: OHLCVBar) -> None:
+    assert sample_ohlcv_bar.instrument == InstrumentId("BTCUSDT")


### PR DESCRIPTION
Closes #169

## Summary
实现不可变的 InstrumentId、TimeRange 和 OHLCVBar，复用现有 UTC 工具，提供稳定 JSON-compatible 序列化，并加入跨测试模块复用的确定性 domain fixtures、完整边界测试和 Research MVP 文档。

## Validation
- Critical Outcome: pass
- Formal Delivery validation: pass

## Risks / limitations
当前模型仅为 Research MVP 内部公共模型；价格允许零值和负值，InstrumentId 不包含交易所/市场类型，且尚未提供长期版本化外部 schema。
