### PR TITLE
[Task] 标准化 LCK 长操作等待与阶段进度输出

### DIFF
--- a/.agents/policies/command-execution.md
+++ b/.agents/policies/command-execution.md
@@ -23,6 +23,13 @@ Run them from the current repository root on the WSL2 Linux filesystem. Do not
 wrap them in `bash -c`, `sh -c`, command substitution, pipelines, redirection,
 or a generic shell string.
 
+Known heavyweight LCK operations (`delivery complete`, `review prepare`, and
+formal workflow validation) use a fixed 30-second wait window for the first
+wait and every subsequent still-running poll. A process that exits earlier is
+returned immediately; the 30-second value is a maximum wait window, not a
+minimum runtime. Adaptive polling intervals are not part of the workflow
+contract.
+
 The local profile may choose:
 
 ```text

--- a/.agents/skills/task-delivery-runner/SKILL.md
+++ b/.agents/skills/task-delivery-runner/SKILL.md
@@ -98,6 +98,22 @@ Verification test: tests/.../test_*.py::test_*
 The verification target is data, not an arbitrary command. LCK executes only
 the bounded pytest verifier defined by the repository runtime.
 
+## Long-operation wait and progress contract
+
+For known heavyweight operations — `delivery complete`, `review prepare`, and
+formal workflow validation — use a fixed 30-second wait window for the first
+wait and every subsequent still-running poll (for example,
+`write_stdin`/`yield_time_ms=30000`). Do not use adaptive 1-second, 10-second,
+20-second, or 30-second polling. If the process exits earlier, return its
+output immediately; 30 seconds is the maximum wait window, not a minimum
+runtime.
+
+During these operations, structured progress may appear on stderr. It is
+bounded, non-authoritative observability only: use it to identify the current
+operation and stage, never as evidence for eligibility, freshness, verdicts,
+retry, Merge, Closeout, or any lifecycle result. The final stdout JSON remains
+the only machine-parseable lifecycle result.
+
 ## Initial Delivery authority boundary
 
 For **initial Delivery**, the Agent / Skill MAY:

--- a/.agents/skills/task-pr-review-runner/SKILL.md
+++ b/.agents/skills/task-pr-review-runner/SKILL.md
@@ -45,6 +45,22 @@ uv run --frozen python --version
 If this preflight fails, report an environment/launcher failure. It is not a
 Review verdict, and must not be converted into `STOP_REQUIRED`.
 
+## Long-operation wait and progress contract
+
+For known heavyweight operations — `delivery complete`, `review prepare`, and
+formal workflow validation — use a fixed 30-second wait window for the first
+wait and every subsequent still-running poll (for example,
+`write_stdin`/`yield_time_ms=30000`). Do not use adaptive 1-second, 10-second,
+20-second, or 30-second polling. If the process exits earlier, return its
+output immediately; 30 seconds is the maximum wait window, not a minimum
+runtime.
+
+During these operations, structured progress may appear on stderr. It is
+bounded, non-authoritative observability only: use it to identify the current
+operation and stage, never as evidence for eligibility, freshness, verdicts,
+retry, Merge, Closeout, or any lifecycle result. The final stdout JSON remains
+the only machine-parseable lifecycle result.
+
 ## 1. LCK Review Prepare
 
 ```bash

--- a/.claude/skills/task-delivery-runner/SKILL.md
+++ b/.claude/skills/task-delivery-runner/SKILL.md
@@ -80,6 +80,22 @@ Verification test: tests/.../test_*.py::test_*
 The verification target is data, not an arbitrary command. LCK executes only
 the bounded pytest verifier defined by the repository runtime.
 
+## Long-operation wait and progress contract
+
+For known heavyweight operations — `delivery complete`, `review prepare`, and
+formal workflow validation — use a fixed 30-second wait window for the first
+wait and every subsequent still-running poll (for example,
+`write_stdin`/`yield_time_ms=30000`). Do not use adaptive 1-second, 10-second,
+20-second, or 30-second polling. If the process exits earlier, return its
+output immediately; 30 seconds is the maximum wait window, not a minimum
+runtime.
+
+During these operations, structured progress may appear on stderr. It is
+bounded, non-authoritative observability only: use it to identify the current
+operation and stage, never as evidence for eligibility, freshness, verdicts,
+retry, Merge, Closeout, or any lifecycle result. The final stdout JSON remains
+the only machine-parseable lifecycle result.
+
 ## Initial Delivery authority boundary
 
 For **initial Delivery**, the Agent / Skill MAY:

--- a/.claude/skills/task-pr-review-runner/SKILL.md
+++ b/.claude/skills/task-pr-review-runner/SKILL.md
@@ -31,6 +31,22 @@ uv run --frozen python --version
 If this preflight fails, report an environment/launcher failure. It is not a
 Review verdict, and must not be converted into `STOP_REQUIRED`.
 
+## Long-operation wait and progress contract
+
+For known heavyweight operations — `delivery complete`, `review prepare`, and
+formal workflow validation — use a fixed 30-second wait window for the first
+wait and every subsequent still-running poll (for example,
+`write_stdin`/`yield_time_ms=30000`). Do not use adaptive 1-second, 10-second,
+20-second, or 30-second polling. If the process exits earlier, return its
+output immediately; 30 seconds is the maximum wait window, not a minimum
+runtime.
+
+During these operations, structured progress may appear on stderr. It is
+bounded, non-authoritative observability only: use it to identify the current
+operation and stage, never as evidence for eligibility, freshness, verdicts,
+retry, Merge, Closeout, or any lifecycle result. The final stdout JSON remains
+the only machine-parseable lifecycle result.
+
 ## 1. LCK Review Prepare
 
 ```bash

--- a/tests/tools/test_lck.py
+++ b/tests/tools/test_lck.py
@@ -1344,6 +1344,51 @@ def test_review_prepare_builds_context_only_from_live_resolution(
     assert checks.calls == 1
 
 
+def test_review_prepare_emits_bounded_progress_without_changing_final_result(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    state = _review_state()
+    resolver = cast(Any, StaticResolver(tmp_path, state))
+    identity = _review_identity_value()
+    monkeypatch.setattr(lck, "_review_identity", lambda *_args, **_kwargs: identity)
+    store = lck.ReviewInvocationStore(tmp_path)
+    context = lck.ReviewPreparer(
+        resolver,
+        validation=cast(Any, FakeReviewValidation()),
+        checks_gate=cast(Any, FakeReviewChecks()),
+        workspace=cast(Any, FakeReviewWorkspace(tmp_path / "review-root")),
+        store=store,
+    ).prepare(159)
+
+    lck.print_json(context.to_dict())
+    captured = capsys.readouterr()
+    final_result = json.loads(captured.out)
+    progress = [json.loads(line) for line in captured.err.splitlines() if line.strip()]
+
+    assert final_result == context.to_dict()
+    assert progress
+    assert progress[0]["event"] == "started"
+    assert any(item["event"] == "completed" for item in progress)
+    assert {item["operation"] for item in progress} == {"review-prepare"}
+    assert {item["stage"] for item in progress} >= {
+        "initializing",
+        "formal-validation",
+        "handoff",
+    }
+    assert all(
+        item["kind"] == "workflow-progress"
+        and item["authority"] == "non-authoritative observability only"
+        for item in progress
+    )
+    assert all("Task Contract" not in line for line in captured.err.splitlines())
+    assert all(
+        "snapshot" not in line and "diff" not in line
+        for line in captured.err.splitlines()
+    )
+
+
 def test_review_prepare_freezes_authority_before_validation(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/tools/test_workflow_common.py
+++ b/tests/tools/test_workflow_common.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -13,7 +14,8 @@ ROOT = Path(__file__).parents[2]
 if AGENT_WORKFLOW not in sys.path:
     sys.path.insert(0, AGENT_WORKFLOW)
 
-from workflow_common import (  # type: ignore[import-not-found]  # noqa: E402
+import workflow_common  # type: ignore[import-not-found]  # noqa: E402
+from workflow_common import (  # noqa: E402
     CommandRunner,
     build_workflow_env,
     command_warning,
@@ -109,6 +111,41 @@ def test_command_runner_times_out_and_reports_bounded_diagnostic(
     assert warning["timed_out"] is True
     assert warning["timeout_seconds"] == 0.2
     assert "timed out after 0.2 seconds" in warning["error"]
+
+
+def test_command_runner_returns_immediately_when_process_finishes_before_heartbeat(
+    tmp_path: Path,
+) -> None:
+    started = time.monotonic()
+    result = CommandRunner(tmp_path).run(
+        [sys.executable, "-c", "print('finished')"],
+        command_id="test-early-finish",
+        timeout_seconds=1.0,
+        progress=lambda: pytest.fail("early completion must not wait for heartbeat"),
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == "finished"
+    assert time.monotonic() - started < 0.8
+
+
+def test_command_runner_emits_low_frequency_heartbeat_without_changing_result(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(workflow_common, "PROGRESS_HEARTBEAT_INTERVAL_SECONDS", 0.02)
+    heartbeats: list[int] = []
+
+    result = CommandRunner(tmp_path).run(
+        [sys.executable, "-c", "import time; time.sleep(0.07); print('finished')"],
+        command_id="test-heartbeat",
+        timeout_seconds=1.0,
+        progress=lambda: heartbeats.append(1),
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == "finished"
+    assert heartbeats
 
 
 def test_command_runner_retries_only_when_requested(tmp_path: Path) -> None:

--- a/tests/tools/test_workflow_validation.py
+++ b/tests/tools/test_workflow_validation.py
@@ -137,6 +137,39 @@ def test_success_output_is_compact_and_logs_are_ignored(tmp_path: Path) -> None:
         assert command["log_path"].startswith(".agents/validation.local/")
 
 
+def test_progress_is_bounded_stderr_and_does_not_change_final_result(
+    tmp_path: Path,
+) -> None:
+    repo = _write_repo(tmp_path)
+    bin_dir = _write_fake_tools(tmp_path)
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+
+    result = _run(repo, env, "--phase", "delivery")
+
+    assert result.returncode == 0, result.stderr
+    final_result = json.loads(result.stdout)
+    progress = [json.loads(line) for line in result.stderr.splitlines() if line.strip()]
+    assert final_result["status"] == "pass"
+    assert progress[0] == {
+        "authority": "non-authoritative observability only",
+        "event": "started",
+        "kind": "workflow-progress",
+        "operation": "workflow-validation",
+        "schema_version": 1,
+        "stage": "validation",
+    }
+    assert progress[-1]["event"] == "completed"
+    assert progress[-1]["stage"] == "validation"
+    assert all(len(line.encode("utf-8")) < 512 for line in result.stderr.splitlines())
+    assert all(
+        "commands" not in line
+        and "output_dir" not in line
+        and "Task Contract" not in line
+        for line in result.stderr.splitlines()
+    )
+
+
 def test_failure_has_bounded_diagnostic_and_nonzero_exit(tmp_path: Path) -> None:
     repo = _write_repo(tmp_path)
     bin_dir = _write_fake_tools(tmp_path)

--- a/tools/agent_workflow/critical_outcome.py
+++ b/tools/agent_workflow/critical_outcome.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Final
 
-from workflow_common import CommandRunner, safe_text
+from workflow_common import CommandRunner, ProgressReporter, safe_text
 
 _SECTION_HEADING: Final = re.compile(r"^###\s+Critical Outcome\s*$", re.IGNORECASE)
 _NEXT_HEADING: Final = re.compile(r"^#{1,6}\s+")
@@ -167,6 +167,8 @@ def verify_critical_outcome(
     repo_root: Path,
     runner: CommandRunner,
     contract: CriticalOutcomeContract,
+    *,
+    progress: ProgressReporter | None = None,
 ) -> CriticalOutcomeResult:
     """Run the bounded Task-specific Critical Outcome verifier."""
     file_part = contract.verification_test.split("::", 1)[0]
@@ -182,18 +184,31 @@ def verify_critical_outcome(
             f"Critical Outcome verification test does not exist: {file_part}"
         )
 
-    result = runner.run(
-        [
-            "uv",
-            "run",
-            "--frozen",
-            "pytest",
-            "-q",
-            contract.verification_test,
-        ],
-        command_id="lck-critical-outcome",
-        validation=True,
-    )
+    reporter = progress or ProgressReporter("critical-outcome")
+    reporter.started("critical-outcome")
+    try:
+        result = runner.run(
+            [
+                "uv",
+                "run",
+                "--frozen",
+                "pytest",
+                "-q",
+                contract.verification_test,
+            ],
+            command_id="lck-critical-outcome",
+            validation=True,
+            progress=lambda: reporter.heartbeat(
+                "critical-outcome", command_id="lck-critical-outcome"
+            ),
+        )
+    except BaseException:
+        reporter.failed("critical-outcome")
+        raise
+    if result.returncode != 0:
+        reporter.failed("critical-outcome")
+    else:
+        reporter.completed("critical-outcome")
     combined = [line.strip() for line in result.stdout.splitlines() if line.strip()]
     summary = safe_text(combined[-1], limit=240) if combined else None
     return CriticalOutcomeResult(

--- a/tools/agent_workflow/lck.py
+++ b/tools/agent_workflow/lck.py
@@ -49,6 +49,7 @@ from pr_resolve import (
 from project_status import set_project_status_with_runner
 from workflow_common import (
     CommandRunner,
+    ProgressReporter,
     WorkflowToolError,
     atomic_write_json,
     command_warning,
@@ -1413,41 +1414,52 @@ class FormalValidationGate:
             / "agent_workflow"
             / "workflow_validation.py"
         )
-        result = self.resolver.runner.run(
-            [
-                sys.executable,
-                str(tool),
-                "run",
-                "--repo-root",
-                str(self.resolver.repo_root),
-                "--phase",
-                "delivery",
-                "--base-sha",
-                base_sha,
-                "--include-skill-validators",
-                "--require-skill-validator",
-            ],
-            command_id="lck-formal-delivery-validation",
-            validation=True,
-        )
-        if not result.stdout.strip():
-            raise LckStopError(
-                "formal Delivery validation produced no structured result: "
-                + (result.stderr.strip() or f"exit {result.returncode}")
-            )
+        reporter = ProgressReporter("workflow-validation")
+        reporter.started("formal-validation")
         try:
-            payload = read_json_text(
-                result.stdout, field="lck-formal-delivery-validation"
+            result = self.resolver.runner.run(
+                [
+                    sys.executable,
+                    str(tool),
+                    "run",
+                    "--repo-root",
+                    str(self.resolver.repo_root),
+                    "--phase",
+                    "delivery",
+                    "--base-sha",
+                    base_sha,
+                    "--include-skill-validators",
+                    "--require-skill-validator",
+                ],
+                command_id="lck-formal-delivery-validation",
+                validation=True,
+                progress=lambda: reporter.heartbeat(
+                    "formal-validation",
+                    command_id="lck-formal-delivery-validation",
+                ),
             )
-        except WorkflowToolError as exc:
-            raise LckStopError(str(exc)) from exc
-        if not isinstance(payload, dict):
-            raise LckStopError("formal Delivery validation result is not an object")
-        if result.returncode != 0 or payload.get("status") != "pass":
-            raise LckStopError(
-                "formal Delivery validation failed: "
-                + str(payload.get("status") or result.returncode)
-            )
+            if not result.stdout.strip():
+                raise LckStopError(
+                    "formal Delivery validation produced no structured result: "
+                    + (result.stderr.strip() or f"exit {result.returncode}")
+                )
+            try:
+                payload = read_json_text(
+                    result.stdout, field="lck-formal-delivery-validation"
+                )
+            except WorkflowToolError as exc:
+                raise LckStopError(str(exc)) from exc
+            if not isinstance(payload, dict):
+                raise LckStopError("formal Delivery validation result is not an object")
+            if result.returncode != 0 or payload.get("status") != "pass":
+                raise LckStopError(
+                    "formal Delivery validation failed: "
+                    + str(payload.get("status") or result.returncode)
+                )
+        except BaseException:
+            reporter.failed("formal-validation")
+            raise
+        reporter.completed("formal-validation")
         return payload
 
 
@@ -1715,54 +1727,71 @@ class ReviewValidationGate:
         tool = review_root / "tools" / "agent_workflow" / "workflow_validation.py"
         if not tool.is_file():
             raise LckStopError("reviewed head does not contain workflow_validation.py")
-        result = self.resolver.runner.run(
-            [
-                sys.executable,
-                str(tool),
-                "run",
-                "--repo-root",
-                str(review_root),
-                "--phase",
-                "review",
-                "--base-sha",
-                base_sha,
-                "--include-skill-validators",
-                "--require-skill-validator",
-            ],
-            command_id="lck-formal-review-validation",
-            cwd=review_root,
-            validation=True,
-        )
-        if not result.stdout.strip():
-            return self._persist_unstructured_failure(
-                result, base_sha=base_sha, head_sha=head_sha
-            )
+        reporter = ProgressReporter("review-prepare")
+        reporter.started("formal-validation")
         try:
-            parsed = read_json_text(result.stdout, field="lck-formal-review-validation")
-        except WorkflowToolError:
-            return self._persist_unstructured_failure(
-                result, base_sha=base_sha, head_sha=head_sha
+            result = self.resolver.runner.run(
+                [
+                    sys.executable,
+                    str(tool),
+                    "run",
+                    "--repo-root",
+                    str(review_root),
+                    "--phase",
+                    "review",
+                    "--base-sha",
+                    base_sha,
+                    "--include-skill-validators",
+                    "--require-skill-validator",
+                ],
+                command_id="lck-formal-review-validation",
+                cwd=review_root,
+                validation=True,
+                progress=lambda: reporter.heartbeat(
+                    "formal-validation",
+                    command_id="lck-formal-review-validation",
+                ),
             )
-        if not isinstance(parsed, dict):
-            return self._persist_unstructured_failure(
-                result, base_sha=base_sha, head_sha=head_sha
-            )
-        payload = dict(parsed)
-        if result.returncode != 0 and payload.get("status") == "pass":
-            payload["status"] = "fail"
-        try:
-            return self._persist_validation_artifacts(
-                review_root,
-                payload,
-                base_sha=base_sha,
-                head_sha=head_sha,
-            )
-        except LckStopError:
-            if payload.get("status") != "fail" and result.returncode == 0:
-                raise
-            return self._persist_unstructured_failure(
-                result, base_sha=base_sha, head_sha=head_sha
-            )
+            if not result.stdout.strip():
+                payload = self._persist_unstructured_failure(
+                    result, base_sha=base_sha, head_sha=head_sha
+                )
+            else:
+                try:
+                    parsed = read_json_text(
+                        result.stdout, field="lck-formal-review-validation"
+                    )
+                except WorkflowToolError:
+                    parsed = None
+                if not isinstance(parsed, dict):
+                    payload = self._persist_unstructured_failure(
+                        result, base_sha=base_sha, head_sha=head_sha
+                    )
+                else:
+                    candidate = dict(parsed)
+                    if result.returncode != 0 and candidate.get("status") == "pass":
+                        candidate["status"] = "fail"
+                    try:
+                        payload = self._persist_validation_artifacts(
+                            review_root,
+                            candidate,
+                            base_sha=base_sha,
+                            head_sha=head_sha,
+                        )
+                    except LckStopError:
+                        if candidate.get("status") != "fail" and result.returncode == 0:
+                            raise
+                        payload = self._persist_unstructured_failure(
+                            result, base_sha=base_sha, head_sha=head_sha
+                        )
+        except BaseException:
+            reporter.failed()
+            raise
+        if payload.get("status") == "pass":
+            reporter.completed("formal-validation")
+        else:
+            reporter.failed("formal-validation")
+        return payload
 
 
 class ReviewWorkspaceManager:
@@ -2646,8 +2675,11 @@ class ReviewPreparer:
             )
         invocation = self.store.begin_review_prepare(task_number)
         review_root: Path | None = None
+        progress = ProgressReporter("review-prepare")
+        last_stage = "initializing"
 
         def mark(state: str, **fields: Any) -> None:
+            nonlocal last_stage
             payload: dict[str, Any] = {
                 "schema_version": LCK_SCHEMA_VERSION,
                 "kind": "review-prepare-in-flight",
@@ -2660,8 +2692,18 @@ class ReviewPreparer:
             }
             payload.update(fields)
             invocation.update(payload)
+            if state == "failed":
+                progress.failed(last_stage)
+            elif state == "handed-off":
+                progress.completed("handoff")
+            elif state == "started":
+                progress.started("initializing")
+            else:
+                progress.running(state)
+            last_stage = state
 
         try:
+            mark("started")
             recovered = invocation.recovered
             if recovered is not None:
                 previous_root = recovered.get("review_root")
@@ -4612,7 +4654,12 @@ class DeliveryCompleter:
         self.checks_gate = checks_gate or DeliveryChecksGate(resolver)
         self.require_existing_open_pr = require_existing_open_pr
 
-    def _run_critical_outcome(self, state: LiveState) -> dict[str, Any]:
+    def _run_critical_outcome(
+        self,
+        state: LiveState,
+        *,
+        progress: ProgressReporter | None = None,
+    ) -> dict[str, Any]:
         issue = state.issue
         contract_snapshot = (
             issue.get("critical_outcome") if isinstance(issue, Mapping) else None
@@ -4623,6 +4670,7 @@ class DeliveryCompleter:
                 self.resolver.repo_root,
                 self.resolver.runner,
                 contract,
+                progress=progress,
             )
         except CriticalOutcomeError as exc:
             raise LckStopError(f"Critical Outcome contract invalid: {exc}") from exc
@@ -4687,6 +4735,7 @@ class DeliveryCompleter:
         commit_message: str,
         summary: str,
         risks: str,
+        progress: ProgressReporter,
     ) -> DeliveryCompletionResult:
         state = snapshot.state
         task_number = state.task_number
@@ -4722,12 +4771,15 @@ class DeliveryCompleter:
 
         effects: list[EffectReceipt] = []
         if state.git.get("clean") is True:
+            progress.running("revalidating-candidate")
             if not self._has_task_diff(base_sha):
                 raise LckStopError(
                     "Delivery Complete found no Task diff against operation base"
                 )
             validated_tree = self.commit_effect.current_head_tree()
-            critical = self._run_critical_outcome(state)
+            progress.running("critical-outcome")
+            critical = self._run_critical_outcome(state, progress=progress)
+            progress.running("formal-validation")
             validation = self.formal_validation.run(base_sha)
             validated_head = state.local_task_head
             if not is_sha(validated_head):
@@ -4745,8 +4797,11 @@ class DeliveryCompleter:
                 )
             )
         else:
+            progress.running("staging-candidate")
             validated_tree = self.commit_effect.stage_candidate_tree()
-            critical = self._run_critical_outcome(state)
+            progress.running("critical-outcome")
+            critical = self._run_critical_outcome(state, progress=progress)
+            progress.running("formal-validation")
             validation = self.formal_validation.run(base_sha)
             self.commit_effect.verify_tree_unchanged(
                 validated_tree,
@@ -4762,11 +4817,13 @@ class DeliveryCompleter:
             if not is_sha(head):
                 raise LckStopError("commit receipt did not contain a valid head SHA")
 
+        progress.running("remote-branch")
         remote = self.remote_effect.execute(branch, expected_head_sha=str(head))
         effects.append(remote)
         if remote.details.get("remote_oid") != head:
             raise LckStopError("remote branch effect did not prove the validated head")
 
+        progress.running("open-pr")
         pr_receipt = self.pr_effect.execute(
             state,
             head_sha=str(head),
@@ -4787,6 +4844,7 @@ class DeliveryCompleter:
         ):
             raise LckStopError("PR effect did not prove the validated head/base")
 
+        progress.running("checks")
         snapshot_pr = state.open_pr
         if (
             isinstance(snapshot_pr, Mapping)
@@ -4809,6 +4867,7 @@ class DeliveryCompleter:
         checks_pr = checks.get("pr")
         if not isinstance(checks_pr, Mapping):
             raise LckStopError("checks result did not contain PR identity")
+        progress.running("project-status")
         status_receipt = self.status_effect.execute(
             state,
             expected_pr=checks_pr,
@@ -4843,20 +4902,35 @@ class DeliveryCompleter:
     ) -> DeliveryCompletionResult:
         if not summary.strip():
             raise LckStopError("Delivery summary must be non-empty")
-        snapshot = operation_snapshot or self.snapshots.acquire(
-            task_number,
-            operation=phase.value,
-            include_required_checks=True,
+        operation = (
+            "remediation-complete"
+            if phase is Phase.REMEDIATION_COMPLETE
+            else "delivery-complete"
         )
-        if snapshot.state.task_number != task_number:
-            raise LckStopError("operation snapshot belongs to another Task")
-        return self._complete_from_snapshot(
-            snapshot,
-            phase=phase,
-            commit_message=commit_message,
-            summary=summary,
-            risks=risks,
-        )
+        progress = ProgressReporter(operation)
+        progress.started("initializing")
+        try:
+            progress.running("resolving-live-state")
+            snapshot = operation_snapshot or self.snapshots.acquire(
+                task_number,
+                operation=phase.value,
+                include_required_checks=True,
+            )
+            if snapshot.state.task_number != task_number:
+                raise LckStopError("operation snapshot belongs to another Task")
+            result = self._complete_from_snapshot(
+                snapshot,
+                phase=phase,
+                commit_message=commit_message,
+                summary=summary,
+                risks=risks,
+                progress=progress,
+            )
+        except BaseException:
+            progress.failed()
+            raise
+        progress.completed("handoff")
+        return result
 
 
 @dataclass(frozen=True)

--- a/tools/agent_workflow/workflow_common.py
+++ b/tools/agent_workflow/workflow_common.py
@@ -10,8 +10,10 @@ import re
 import shutil
 import signal
 import subprocess
+import sys
+import threading
 import time
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Final
@@ -25,6 +27,7 @@ NETWORK_COMMAND_TIMEOUT_SECONDS: Final = 60.0
 VALIDATION_COMMAND_TIMEOUT_SECONDS: Final = 1200.0
 PROCESS_TERM_GRACE_SECONDS: Final = 2.0
 RETRY_DELAY_SECONDS: Final = 0.5
+PROGRESS_HEARTBEAT_INTERVAL_SECONDS: Final = 30.0
 TIMEOUT_EXIT_CODE: Final = 124
 SHA_PATTERN: Final = re.compile(r"^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$")
 WINDOWS_ABSOLUTE_PATH: Final = re.compile(r"^[A-Za-z]:[\\/]")
@@ -44,6 +47,74 @@ SENSITIVE_VALUE_PATTERNS: Final = (
 
 class WorkflowToolError(RuntimeError):
     """Expected user-facing workflow tooling error."""
+
+
+ProgressCallback = Callable[[], None]
+
+
+class ProgressReporter:
+    """Write bounded, non-authoritative workflow progress to stderr."""
+
+    _EVENTS: Final = frozenset(
+        {"started", "running", "heartbeat", "completed", "failed"}
+    )
+
+    def __init__(self, operation: str) -> None:
+        self.operation = operation
+        self._enabled = True
+        self._last_stage = "initializing"
+
+    @staticmethod
+    def _value(value: str) -> str:
+        # Progress values are internal identifiers, but keep the output safe if
+        # a future caller derives one from a command or error path.
+        normalized = " ".join(value.replace("\x00", "").split())
+        return safe_text(normalized, limit=96) or "unknown"
+
+    def emit(
+        self,
+        event: str,
+        stage: str,
+        *,
+        command_id: str | None = None,
+    ) -> None:
+        """Emit one small JSONL event without affecting lifecycle execution."""
+        if not self._enabled or event not in self._EVENTS:
+            return
+        if event != "failed":
+            self._last_stage = stage
+        payload: dict[str, str | int] = {
+            "schema_version": 1,
+            "kind": "workflow-progress",
+            "operation": self._value(self.operation),
+            "stage": self._value(stage),
+            "event": event,
+            "authority": "non-authoritative observability only",
+        }
+        if command_id is not None:
+            payload["command_id"] = self._value(command_id)
+        try:
+            print(json_dumps(payload), end="", file=sys.stderr, flush=True)
+        except Exception:
+            # Progress is deliberately outside the lifecycle result contract.
+            # A closed or unavailable diagnostic stream must not change the
+            # command's exit status or suppress its final machine result.
+            self._enabled = False
+
+    def started(self, stage: str) -> None:
+        self.emit("started", stage)
+
+    def running(self, stage: str, *, command_id: str | None = None) -> None:
+        self.emit("running", stage, command_id=command_id)
+
+    def heartbeat(self, stage: str, *, command_id: str | None = None) -> None:
+        self.emit("heartbeat", stage, command_id=command_id)
+
+    def completed(self, stage: str) -> None:
+        self.emit("completed", stage)
+
+    def failed(self, stage: str | None = None) -> None:
+        self.emit("failed", stage or self._last_stage)
 
 
 def build_workflow_env(repo_root: Path) -> dict[str, str]:
@@ -104,8 +175,9 @@ def _run_process(
     cwd: Path,
     env: Mapping[str, str],
     timeout_seconds: float,
+    on_heartbeat: ProgressCallback | None = None,
 ) -> tuple[int, str, str, bool]:
-    """Run one command with a timeout and process-group cleanup."""
+    """Run one command with a timeout and bounded heartbeat cadence."""
     process = subprocess.Popen(
         resolved_argv,
         cwd=cwd,
@@ -117,19 +189,70 @@ def _run_process(
         env=env,
         start_new_session=os.name == "posix",
     )
-    try:
-        stdout, stderr = process.communicate(timeout=timeout_seconds)
-    except subprocess.TimeoutExpired:
+
+    stdout_parts: list[str] = []
+    stderr_parts: list[str] = []
+
+    def drain(pipe: Any, parts: list[str]) -> None:
+        try:
+            value = pipe.read()
+            if value:
+                parts.append(value)
+        finally:
+            pipe.close()
+
+    readers = (
+        threading.Thread(
+            target=drain,
+            args=(process.stdout, stdout_parts),
+            daemon=True,
+        ),
+        threading.Thread(
+            target=drain,
+            args=(process.stderr, stderr_parts),
+            daemon=True,
+        ),
+    )
+    for reader in readers:
+        reader.start()
+
+    timed_out = False
+    deadline = time.monotonic() + timeout_seconds
+    while process.poll() is None:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            timed_out = True
+            break
+        wait_window = min(remaining, PROGRESS_HEARTBEAT_INTERVAL_SECONDS)
+        try:
+            process.wait(timeout=wait_window)
+        except subprocess.TimeoutExpired:
+            if on_heartbeat is not None:
+                try:
+                    on_heartbeat()
+                except Exception:
+                    # The progress channel is not allowed to affect command
+                    # execution or its final result.
+                    pass
+
+    if timed_out:
         _signal_process_group(process, signal.SIGTERM)
         try:
-            stdout, stderr = process.communicate(timeout=PROCESS_TERM_GRACE_SECONDS)
+            process.wait(timeout=PROCESS_TERM_GRACE_SECONDS)
         except subprocess.TimeoutExpired:
             _signal_process_group(process, signal.SIGKILL)
-            stdout, stderr = process.communicate()
+            process.wait()
         timeout_message = f"command timed out after {timeout_seconds:g} seconds"
-        stderr = f"{stderr.rstrip()}\n{timeout_message}" if stderr else timeout_message
-        return TIMEOUT_EXIT_CODE, stdout, stderr, True
-    return process.returncode, stdout, stderr, False
+        stderr_parts.append(timeout_message)
+
+    for reader in readers:
+        reader.join()
+    return (
+        TIMEOUT_EXIT_CODE if timed_out else int(process.returncode),
+        "".join(stdout_parts),
+        "\n".join(stderr_parts),
+        timed_out,
+    )
 
 
 class CommandRunner:
@@ -152,6 +275,7 @@ class CommandRunner:
         env: Mapping[str, str] | None = None,
         timeout_seconds: float | None = None,
         retries: int = 0,
+        progress: ProgressCallback | None = None,
     ) -> CommandResult:
         if not argv:
             raise WorkflowToolError("command argv cannot be empty")
@@ -193,6 +317,7 @@ class CommandRunner:
                     cwd=cwd or self.repo_root,
                     env=process_env,
                     timeout_seconds=effective_timeout,
+                    on_heartbeat=progress,
                 )
             except FileNotFoundError:
                 return CommandResult(

--- a/tools/agent_workflow/workflow_validation.py
+++ b/tools/agent_workflow/workflow_validation.py
@@ -17,6 +17,7 @@ from typing import Any, Final
 from workflow_common import (
     MAX_LOG_BYTES,
     CommandRunner,
+    ProgressReporter,
     WorkflowToolError,
     is_sha,
     print_json,
@@ -228,16 +229,25 @@ def _run_validation(
 
     results: list[dict[str, Any]] = []
     overall = True
+    progress = ProgressReporter("workflow-validation")
+    progress.started("validation")
     for command in plan:
         started = time.monotonic()
+        stage = f"command:{command.command_id}"
+        progress.running(stage, command_id=command.command_id)
         result = runner.run(
             command.argv,
             command_id=command.command_id,
             validation=True,
+            progress=lambda: progress.heartbeat(stage, command_id=command.command_id),
         )
         duration_ms = max(0, round((time.monotonic() - started) * 1000))
         status = "pass" if result.returncode == 0 else "fail"
         overall = overall and result.returncode == 0
+        if result.returncode == 0:
+            progress.completed(stage)
+        else:
+            progress.failed(stage)
         log_text = _sanitize_log(
             f"$ {' '.join(command.argv)}\n\n[stdout]\n{result.stdout}\n\n[stderr]\n{result.stderr}",
             repo_root,
@@ -263,6 +273,11 @@ def _run_validation(
                 limit=2000,
             )
         results.append(entry)
+
+    if overall:
+        progress.completed("validation")
+    else:
+        progress.failed("validation")
 
     output: dict[str, Any] = {
         "schema_version": SCHEMA_VERSION,


### PR DESCRIPTION
Closes #175

## Summary
为 LCK 长操作和正式 workflow validation 增加固定等待语义、低频非权威 stderr 进度事件及 Codex/Claude 一致 guidance。

## Validation
- Critical Outcome: pass
- Formal Delivery validation: pass

## Risks / limitations
进度事件仅用于 observability；最终 lifecycle authority 与 validation gates 保持不变。
