### PR TITLE
[Task] 将 required-check gate 从 Initial Delivery 移出

### DIFF
--- a/.agents/skills/task-delivery-runner/SKILL.md
+++ b/.agents/skills/task-delivery-runner/SKILL.md
@@ -201,7 +201,7 @@ reacquire live Task/Git/GitHub facts
 → commit_current_tree
 → ensure_remote_branch
 → ensure_open_pr
-→ wait for applicable checks
+→ observe current checks without making CI completion a Delivery gate
 → set Project Status Review
 → reacquire live facts
 → prove local HEAD == remote HEAD == PR head
@@ -214,9 +214,12 @@ trust a previous receipt as authority. It reacquires current facts and reruns
 the applicable Critical Outcome / formal validation gates before continuing.
 
 `Critical Outcome FAIL`, formal validation failure, remote divergence,
-ambiguous PR identity, failed/unknown checks, stale lifecycle facts, or failed
-postconditions are terminal for that invocation. LCK does not rebase, force
-push, guess an identity, or route itself into repair.
+ambiguous PR identity, stale lifecycle facts, or failed postconditions are
+terminal for that invocation. Pending, failed, missing, or otherwise unresolved
+PR checks may be reported as a non-authoritative observation, but do not veto
+Initial Delivery. Required-check success remains a Review Complete / Merge
+Preflight gate. LCK does not rebase, force push, guess an identity, or route
+itself into repair.
 
 ### 4. Initial Delivery reporting
 
@@ -227,7 +230,7 @@ On `READY_FOR_REVIEW`, report:
 - Critical Outcome result;
 - formal Delivery validation result;
 - LCK effect receipts at summary level;
-- checks result and preserved limitations;
+- non-blocking checks observation and preserved limitations;
 - current lifecycle state;
 - remaining semantic risks or limitations;
 - exact fresh-session `task-pr-review-runner` prompt.
@@ -328,9 +331,9 @@ uv run --frozen python tools/agent_workflow/lck.py remediation complete <TASK> \
 ```
 
 LCK reuses the Task-2 Delivery effects for Critical Outcome, formal validation, exact
-validated-tree commit, remote synchronization, checks, and final local/remote/PR head
-verification. Unlike Initial Delivery, Remediation must reuse existing OPEN PR state; it never
-creates a replacement PR.
+validated-tree commit, remote synchronization, non-blocking check observation, and final
+local/remote/PR head verification. Unlike Initial Delivery, Remediation must reuse existing OPEN PR
+state; it never creates a replacement PR.
 
 `remediation complete` gates the repaired implementation and the mechanics needed to create
 a stable new candidate head. It MUST NOT require provider-attributed implementation receipts,

--- a/.agents/skills/task-pr-review-runner/SKILL.md
+++ b/.agents/skills/task-pr-review-runner/SKILL.md
@@ -72,6 +72,8 @@ Task Contract, current review target, validation/check state, and `review_root`.
 The `review_root` is a detached, clean, implementation-read-only standalone temporary
 clone for the live-resolved head. The source tracked tree and source Git metadata remain
 read-only; only ignored LCK operation/evidence state may be written outside the clone.
+Review Prepare may begin while CI checks are pending or have failed; check success
+is revalidated as a fresh gate by Review Complete and Merge Preflight.
 
 If LCK returns STOP or stale, do not fall back to archived evidence snapshots,
 expected SHAs, direct `gh` selection, or a Delivery handoff.
@@ -132,8 +134,10 @@ explicit stale result such as `REVIEW_STALE_HEAD`, `REVIEW_STALE_BASE`,
 `REVIEW_STALE_TASK`, or `REVIEW_STALE_DIFF`. A stale semantic verdict is not accepted as
 the current Review result; start a fresh Review Prepare for the new target.
 
-Current applicable PR checks must also still pass. Review Complete itself performs no
-nested/full-state refresh after its operation snapshot is frozen.
+For a PASS, current applicable PR checks must also still pass. For a FAIL, current
+checks are only observed so a semantic finding is not delayed by pending or failed
+CI. Review Complete itself performs no nested/full-state refresh after its operation
+snapshot is frozen.
 
 A valid PASS returns `READY_FOR_MERGE_PREFLIGHT`, not direct merge readiness. FAIL returns
 `STOP_REQUIRED` and stops; do not start Remediation automatically.

--- a/.claude/skills/task-delivery-runner/SKILL.md
+++ b/.claude/skills/task-delivery-runner/SKILL.md
@@ -183,7 +183,7 @@ reacquire live Task/Git/GitHub facts
 → commit_current_tree
 → ensure_remote_branch
 → ensure_open_pr
-→ wait for applicable checks
+→ observe current checks without making CI completion a Delivery gate
 → set Project Status Review
 → reacquire live facts
 → prove local HEAD == remote HEAD == PR head
@@ -196,9 +196,12 @@ trust a previous receipt as authority. It reacquires current facts and reruns
 the applicable Critical Outcome / formal validation gates before continuing.
 
 `Critical Outcome FAIL`, formal validation failure, remote divergence,
-ambiguous PR identity, failed/unknown checks, stale lifecycle facts, or failed
-postconditions are terminal for that invocation. LCK does not rebase, force
-push, guess an identity, or route itself into repair.
+ambiguous PR identity, stale lifecycle facts, or failed postconditions are
+terminal for that invocation. Pending, failed, missing, or otherwise unresolved
+PR checks may be reported as a non-authoritative observation, but do not veto
+Initial Delivery. Required-check success remains a Review Complete / Merge
+Preflight gate. LCK does not rebase, force push, guess an identity, or route
+itself into repair.
 
 ### 4. Initial Delivery reporting
 
@@ -209,7 +212,7 @@ On `READY_FOR_REVIEW`, report:
 - Critical Outcome result;
 - formal Delivery validation result;
 - LCK effect receipts at summary level;
-- checks result and preserved limitations;
+- non-blocking checks observation and preserved limitations;
 - current lifecycle state;
 - remaining semantic risks or limitations;
 - exact fresh-session `task-pr-review-runner` prompt.
@@ -310,9 +313,9 @@ uv run --frozen python tools/agent_workflow/lck.py remediation complete <TASK> \
 ```
 
 LCK reuses the Task-2 Delivery effects for Critical Outcome, formal validation, exact
-validated-tree commit, remote synchronization, checks, and final local/remote/PR head
-verification. Unlike Initial Delivery, Remediation must reuse existing OPEN PR state; it never
-creates a replacement PR.
+validated-tree commit, remote synchronization, non-blocking check observation, and final
+local/remote/PR head verification. Unlike Initial Delivery, Remediation must reuse existing OPEN PR
+state; it never creates a replacement PR.
 
 `remediation complete` gates the repaired implementation and the mechanics needed to create
 a stable new candidate head. It MUST NOT require provider-attributed implementation receipts,

--- a/.claude/skills/task-pr-review-runner/SKILL.md
+++ b/.claude/skills/task-pr-review-runner/SKILL.md
@@ -58,6 +58,8 @@ Task Contract, current review target, validation/check state, and `review_root`.
 The `review_root` is a detached, clean, implementation-read-only standalone temporary
 clone for the live-resolved head. The source tracked tree and source Git metadata remain
 read-only; only ignored LCK operation/evidence state may be written outside the clone.
+Review Prepare may begin while CI checks are pending or have failed; check success
+is revalidated as a fresh gate by Review Complete and Merge Preflight.
 
 If LCK returns STOP or stale, do not fall back to archived evidence snapshots,
 expected SHAs, direct `gh` selection, or a Delivery handoff.
@@ -118,8 +120,10 @@ explicit stale result such as `REVIEW_STALE_HEAD`, `REVIEW_STALE_BASE`,
 `REVIEW_STALE_TASK`, or `REVIEW_STALE_DIFF`. A stale semantic verdict is not accepted as
 the current Review result; start a fresh Review Prepare for the new target.
 
-Current applicable PR checks must also still pass. Review Complete itself performs no
-nested/full-state refresh after its operation snapshot is frozen.
+For a PASS, current applicable PR checks must also still pass. For a FAIL, current
+checks are only observed so a semantic finding is not delayed by pending or failed
+CI. Review Complete itself performs no nested/full-state refresh after its operation
+snapshot is frozen.
 
 A valid PASS returns `READY_FOR_MERGE_PREFLIGHT`, not direct merge readiness. FAIL returns
 `STOP_REQUIRED` and stops; do not start Remediation automatically.

--- a/docs/development/issue-workflow.md
+++ b/docs/development/issue-workflow.md
@@ -21,8 +21,7 @@ Codex 与 Claude Code 的 workflow Skills 引用本文件作为生命周期语�
 Issue (Specifying)
   → Ready（codex:ready + Project Ready + 无 blocker）
   → Delivery（branch → implementation/tests → commit/push → PR）
-  → CI checks
-  → Independent Review（fresh session，read-only）
+  → Independent Review（fresh session，read-only；可与 CI 并行）
   → maintainer manual Squash Merge
   → Closeout（merge identity / state convergence / branch cleanup）
   → Feature completion（hierarchy-aware audit）
@@ -126,8 +125,8 @@ subprocesses continue to receive the same path through `build_workflow_env()`.
   deterministic control 执行；Agent/Skill 不提供 branch/SHA/PR/refspec authority。
 - 一次 Initial Delivery 覆盖：LCK Delivery Prepare → semantic implementation / targeted
   development validation → LCK Delivery Complete → Critical Outcome → formal validation →
-  commit validated tree → ensure remote branch → ensure OPEN PR → CI checks → Project
-  Status `Review` → final live verification → `READY_FOR_REVIEW`。
+  commit validated tree → ensure remote branch → ensure OPEN PR → observe current CI checks
+  （non-blocking）→ Project Status `Review` → final live verification → `READY_FOR_REVIEW`。
 - 一个 Task 通常产生一个 PR（base = `main`）。
 - Initial Task branch bootstrap is LCK-owned. An existing branch is reusable only when
   Task identity, ownership, base, and the required worktree state are mechanically proven.
@@ -156,10 +155,10 @@ subprocesses continue to receive the same path through `build_workflow_env()`.
   check 名称由 canonical CI workflow 中的静态 job 定义，并从 **exact trusted
   base commit** 读取；不能读取调用者当前 checkout、未提交修改或 candidate
   head 上的未来 workflow policy。LCK v1 对 dynamic job name / matrix job
-  fail closed。Delivery Complete 由当前 authoritative `main` policy 约束；
-  已有 PR 的 Review / Remediation / Merge
-  Preflight 由 exact PR base policy 约束。候选 head 对该配置的修改只在 merge
-  后成为后续 operation 的新 policy，不能降低它自身的验收门禁。GitHub
+  fail closed。Initial Delivery / Remediation 只观察当前 PR checks，不以 required
+  check success 作为完成条件；Review Complete / Merge Preflight 由 exact PR base
+  policy 约束。候选 head 对该配置的修改只在 merge 后成为后续 operation 的新
+  policy，不能降低它自身的验收门禁。GitHub
   `statusCheckRollup` 只提供 exact PR head 上这些 check 的 live result。
   GitHub Ruleset 可继续作为平台侧独立强制层，但 plan/permission-dependent
   Required-Checks discovery API 不作为 LCK lifecycle authority。
@@ -177,9 +176,10 @@ fresh session、strict read-only、head lock、independent judgement、
 no Delivery mechanical authority inheritance、LCK live target resolution、
 Review Prepare/Complete operation-boundary stale guard、PASS / FAIL、new head → fresh re-review。
 
-本文件只声明其在 lifecycle 中的位置：Review 在 CI checks 通过后、
-maintainer merge 前执行；Review FAIL 必须先 STOP，只有 Human 显式发起后
-才进入 remediation（§10）。
+本文件只声明其在 lifecycle 中的位置：Review 可在 CI checks 运行期间与其并行，
+但 Review Complete 的 PASS 与 maintainer merge 前的 Merge Preflight 都必须
+基于各自 fresh authority 验证 checks 通过；Review FAIL 必须先 STOP，只有
+Human 显式发起后才进入 remediation（§10）。
 
 ## 9. Human Gate
 

--- a/docs/development/pr-review.md
+++ b/docs/development/pr-review.md
@@ -90,6 +90,9 @@ remediation rationale 或 persuasive framing 当作 evidence。
 Review Agent 可以读取完整 effective diff、相关 unchanged code、tests、docs、config
 和 public interfaces；必须逐项判断 Acceptance Criteria、正确性、failure paths、
 安全边界与回归风险。
+Review Prepare 不等待 CI checks 进入终态；semantic Review 可以与 CI 并行。Checks
+success 只在 Review Complete 与后续 Merge Preflight 的 fresh gate 中决定是否可进入
+人工合并边界。
 
 ## 5. Review Complete：fresh applicability snapshot
 
@@ -129,9 +132,10 @@ Task Contract changed → REVIEW_STALE_TASK
 effective diff changed→ REVIEW_STALE_DIFF
 ```
 
-current applicable checks 也必须仍然满足 completion gate。若 PR/base/head/Task identity
-仍一致，effective diff applicability 从仍受 LCK ownership 保护的 sealed Review clone
-重新机械推导；Review Complete 不要求 source repository materialize reviewed commits。
+PASS 的 current applicable checks 也必须仍然满足 completion gate；FAIL 只观察 current
+checks，从而不会因 pending 或 failed CI 延迟 semantic finding。若 PR/base/head/Task
+identity 仍一致，effective diff applicability 从仍受 LCK ownership 保护的 sealed Review
+clone 重新机械推导；Review Complete 不要求 source repository materialize reviewed commits。
 
 任何 stale result 都不会把 semantic verdict 发布成当前有效 Review PASS/FAIL，也不会
 解除 fresh-review requirement；必须重新执行新的 Review Prepare。Review Complete

--- a/tests/tools/test_lck.py
+++ b/tests/tools/test_lck.py
@@ -1276,6 +1276,21 @@ class FakeReviewChecks:
             "checks": snapshot.state.checks,
         }
 
+    def observe(self, snapshot: lck.OperationSnapshot) -> dict[str, Any]:
+        self.calls += 1
+        pr = snapshot.state.open_pr or {}
+        return {
+            "status": "observed",
+            "gate": "non-blocking",
+            "check_state": "pending",
+            "pr": {
+                "number": pr.get("number", 200),
+                "head_sha": pr.get("headRefOid", SHA),
+                "base_sha": pr.get("baseRefOid", SHA),
+            },
+            "checks": snapshot.state.checks,
+        }
+
 
 class FakeReviewValidation:
     def run(self, _root: Path, _base: str, _head: str) -> dict[str, Any]:
@@ -1341,6 +1356,33 @@ def test_review_prepare_builds_context_only_from_live_resolution(
     )
     assert inflight["state"] == "handed-off"
     assert inflight["review_id"] == context.review_id
+    assert checks.calls == 1
+
+
+def test_review_prepare_allows_pending_checks_for_parallel_semantic_review(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = _review_state()
+    resolver = cast(Any, StaticResolver(tmp_path, state))
+    identity = _review_identity_value()
+    monkeypatch.setattr(lck, "_review_identity", lambda *_args, **_kwargs: identity)
+
+    class PendingChecks(FakeReviewChecks):
+        def evaluate(self, _snapshot: lck.OperationSnapshot) -> dict[str, Any]:
+            raise AssertionError("Review Prepare must not require passing checks")
+
+    checks = PendingChecks()
+    context = lck.ReviewPreparer(
+        resolver,
+        validation=cast(Any, FakeReviewValidation()),
+        checks_gate=cast(Any, checks),
+        workspace=cast(Any, FakeReviewWorkspace(tmp_path / "review-root")),
+        store=lck.ReviewInvocationStore(tmp_path),
+    ).prepare(159)
+
+    assert context.checks["status"] == "observed"
+    assert context.checks["check_state"] == "pending"
     assert checks.calls == 1
 
 
@@ -1694,6 +1736,37 @@ def test_review_complete_revalidates_current_checks(
 
     assert resolver.calls == 1
     assert store.read_latest_review(159) is None
+
+
+def test_review_fail_is_not_delayed_by_pending_checks(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    identity = _review_identity_value()
+    resolver = cast(Any, StaticResolver(tmp_path, _review_state()))
+    monkeypatch.setattr(lck, "_review_identity", lambda *_args, **_kwargs: identity)
+    store = lck.ReviewInvocationStore(tmp_path)
+    review_id = store.new_id()
+    review_root = tmp_path / "review-root"
+    review_root.mkdir()
+    store.write_guard(review_id, _review_guard(identity, review_root=review_root))
+    findings = tmp_path / "findings.txt"
+    findings.write_text(
+        "[F1][Medium] CI-independent semantic finding.\n", encoding="utf-8"
+    )
+
+    class PendingChecks(FakeReviewChecks):
+        def evaluate(self, _snapshot: lck.OperationSnapshot) -> dict[str, Any]:
+            raise lck.LckStopError("PR checks are pending")
+
+    result = lck.ReviewCompleter(
+        resolver,
+        checks_gate=cast(Any, PendingChecks()),
+        store=store,
+        workspace=cast(Any, FakeReviewWorkspace(review_root)),
+    ).complete(159, review_id, verdict="FAIL", findings_file=findings)
+
+    assert result.status == "STOP_REQUIRED"
 
 
 def test_review_workspace_seal_removes_write_bits(tmp_path: Path) -> None:

--- a/tests/tools/test_lck_delivery.py
+++ b/tests/tools/test_lck_delivery.py
@@ -527,6 +527,34 @@ class StubChecks:
             str(pr.get("baseRefOid", SHA)),
         )
 
+    def observe(self, snapshot: lck.OperationSnapshot) -> dict[str, Any]:
+        self.calls += 1
+        pr = snapshot.state.open_pr or {}
+        result = self._result(
+            int(pr.get("number", 10)),
+            str(pr.get("headRefOid", "b" * 40)),
+            str(pr.get("baseRefOid", SHA)),
+        )
+        result["status"] = "observed"
+        result["gate"] = "non-blocking"
+        result["check_state"] = "pass"
+        return result
+
+    def observe_exact_pr(
+        self,
+        _repository: str,
+        pr_number: int,
+        *,
+        expected_head_sha: str,
+        expected_base_sha: str,
+    ) -> dict[str, Any]:
+        self.calls += 1
+        result = self._result(pr_number, expected_head_sha, expected_base_sha)
+        result["status"] = "observed"
+        result["gate"] = "non-blocking"
+        result["check_state"] = "pass"
+        return result
+
     def query_exact_pr(
         self,
         _repository: str,
@@ -1273,9 +1301,12 @@ def test_review_required_checks_policy_is_governed_by_pr_base_not_candidate_head
     assert "self-approved" in _git(repo, "show", f"{head_sha}:.github/workflows/ci.yml")
 
 
-def test_delivery_rejects_unresolved_required_check_policy_before_effects(
+def test_delivery_does_not_require_required_check_policy_before_effects(
     tmp_path: Path,
 ) -> None:
+    target = tmp_path / "tests" / "test_critical_path.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("def test_critical_path(): pass\n", encoding="utf-8")
     head = "b" * 40
     state = _live_state(
         head=head,
@@ -1298,29 +1329,29 @@ def test_delivery_rejects_unresolved_required_check_policy_before_effects(
     pr = StubEffect("ensure_open_pr", "created")
     status = StubEffect("set_review_status", "updated")
 
-    with pytest.raises(lck.LckStopError, match="canonical-CI check contract"):
-        lck.DeliveryCompleter(
-            cast(Any, resolver),
-            formal_validation=cast(Any, StubValidation()),
-            commit_effect=cast(Any, commit),
-            remote_effect=cast(Any, remote),
-            pr_effect=cast(Any, pr),
-            status_effect=cast(Any, status),
-            checks_gate=cast(Any, StubChecks()),
-        ).complete(
-            160,
-            commit_message="candidate",
-            summary="candidate",
-            operation_snapshot=snapshot,
-        )
+    result = lck.DeliveryCompleter(
+        cast(Any, resolver),
+        formal_validation=cast(Any, StubValidation()),
+        commit_effect=cast(Any, commit),
+        remote_effect=cast(Any, remote),
+        pr_effect=cast(Any, pr),
+        status_effect=cast(Any, status),
+        checks_gate=cast(Any, StubChecks()),
+    ).complete(
+        160,
+        commit_message="candidate",
+        summary="candidate",
+        operation_snapshot=snapshot,
+    )
 
-    assert commit.calls == []
-    assert remote.calls == 0
-    assert pr.calls == 0
-    assert status.calls == 0
+    assert result.status == "READY_FOR_REVIEW"
+    assert commit.calls == ["current_head_tree", "verify_tree_unchanged"]
+    assert remote.calls == 1
+    assert pr.calls == 1
+    assert status.calls == 1
 
 
-def test_delivery_checks_gate_requires_named_required_check_success(
+def test_strict_checks_gate_requires_named_required_check_success(
     tmp_path: Path,
 ) -> None:
     head = "b" * 40
@@ -1353,7 +1384,7 @@ def test_delivery_checks_gate_requires_named_required_check_success(
     assert resolver.calls == 0
 
 
-def test_delivery_checks_gate_stops_on_failed_check(tmp_path: Path) -> None:
+def test_strict_checks_gate_stops_on_failed_check(tmp_path: Path) -> None:
     head = "b" * 40
     base = _live_state(
         head=head,
@@ -1383,7 +1414,7 @@ def test_delivery_checks_gate_stops_on_failed_check(tmp_path: Path) -> None:
     assert resolver.calls == 0
 
 
-def test_delivery_checks_gate_pending_stops_without_polling(tmp_path: Path) -> None:
+def test_strict_checks_gate_pending_stops_without_polling(tmp_path: Path) -> None:
     head = "b" * 40
     base = _live_state(
         head=head,
@@ -1401,7 +1432,7 @@ def test_delivery_checks_gate_pending_stops_without_polling(tmp_path: Path) -> N
     state = _with_checks(base, _checks(category="pending", state_name="IN_PROGRESS"))
     resolver = SequenceResolver(tmp_path, CompletionRunner(), [state])
 
-    with pytest.raises(lck.LckStopError, match="start a new lifecycle operation"):
+    with pytest.raises(lck.LckStopError, match="strict check gate"):
         lck.DeliveryChecksGate(cast(Any, resolver)).evaluate(
             _snapshot(
                 state,
@@ -1413,7 +1444,7 @@ def test_delivery_checks_gate_pending_stops_without_polling(tmp_path: Path) -> N
     assert resolver.calls == 0
 
 
-def test_delivery_checks_gate_rejects_legacy_plan_limited_policy(
+def test_strict_checks_gate_rejects_legacy_plan_limited_policy(
     tmp_path: Path,
 ) -> None:
     head = "b" * 40
@@ -1447,6 +1478,31 @@ def test_delivery_checks_gate_rejects_legacy_plan_limited_policy(
 
 
 class FailingChecks:
+    def observe(self, snapshot: lck.OperationSnapshot) -> dict[str, Any]:
+        pr = snapshot.state.open_pr or {}
+        return {
+            "status": "observed",
+            "gate": "non-blocking",
+            "check_state": "failed",
+            "pr": {
+                "number": pr.get("number", 10),
+                "head_sha": pr.get("headRefOid", "b" * 40),
+                "base_sha": pr.get("baseRefOid", SHA),
+            },
+        }
+
+    def observe_exact_pr(self, *_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        return {
+            "status": "observed",
+            "gate": "non-blocking",
+            "check_state": "failed",
+            "pr": {
+                "number": 10,
+                "head_sha": "b" * 40,
+                "base_sha": SHA,
+            },
+        }
+
     def evaluate(self, _snapshot: lck.OperationSnapshot) -> dict[str, Any]:
         raise lck.LckStopError("checks failed")
 
@@ -1537,7 +1593,9 @@ def test_delivery_complete_freezes_authority_for_the_operation(tmp_path: Path) -
     assert resolver.calls == 1
 
 
-def test_failed_checks_do_not_move_project_status_to_review(tmp_path: Path) -> None:
+def test_failed_checks_do_not_block_delivery_project_status_transition(
+    tmp_path: Path,
+) -> None:
     target = tmp_path / "tests" / "test_critical_path.py"
     target.parent.mkdir(parents=True)
     target.write_text(
@@ -1578,22 +1636,69 @@ def test_failed_checks_do_not_move_project_status_to_review(tmp_path: Path) -> N
     resolver = SequenceResolver(tmp_path, runner, [pre, pre, remote, with_pr])
     status = StubEffect("set_review_status", "updated")
 
-    with pytest.raises(lck.LckStopError, match="checks failed"):
-        lck.DeliveryCompleter(
-            cast(Any, resolver),
-            formal_validation=cast(Any, StubValidation()),
-            commit_effect=cast(Any, StubCommit(dirty=False)),
-            remote_effect=cast(Any, StubEffect("ensure_remote_branch", "created")),
-            pr_effect=cast(Any, StubEffect("ensure_open_pr", "created")),
-            status_effect=cast(Any, status),
-            checks_gate=cast(Any, FailingChecks()),
-        ).complete(
-            160,
-            commit_message="Implement LCK Delivery cutover",
-            summary="Move initial Delivery mechanics into LCK.",
-        )
+    result = lck.DeliveryCompleter(
+        cast(Any, resolver),
+        formal_validation=cast(Any, StubValidation()),
+        commit_effect=cast(Any, StubCommit(dirty=False)),
+        remote_effect=cast(Any, StubEffect("ensure_remote_branch", "created")),
+        pr_effect=cast(Any, StubEffect("ensure_open_pr", "created")),
+        status_effect=cast(Any, status),
+        checks_gate=cast(Any, FailingChecks()),
+    ).complete(
+        160,
+        commit_message="Implement LCK Delivery cutover",
+        summary="Move initial Delivery mechanics into LCK.",
+    )
 
-    assert status.calls == 0
+    assert result.status == "READY_FOR_REVIEW"
+    assert status.calls == 1
+
+
+def test_initial_delivery_reaches_ready_for_review_with_pending_checks(
+    tmp_path: Path,
+) -> None:
+    """Critical Outcome: pending CI is observed but is not a Delivery veto."""
+    target = tmp_path / "tests" / "test_critical_path.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("def test_critical_path(): pass\n", encoding="utf-8")
+    head = "b" * 40
+    pr = {
+        "number": 10,
+        "state": "OPEN",
+        "isDraft": False,
+        "headRefOid": head,
+        "baseRefOid": SHA,
+        "statusCheckRollup": [
+            {"name": "quality", "status": "IN_PROGRESS", "conclusion": None}
+        ],
+    }
+    state = _live_state(
+        head=head,
+        clean=True,
+        project_status="In Progress",
+        open_pr=pr,
+        remote_oid=head,
+    )
+    resolver = SequenceResolver(tmp_path, CompletionRunner(), [state])
+    status = StubEffect("set_review_status", "updated")
+
+    result = lck.DeliveryCompleter(
+        cast(Any, resolver),
+        formal_validation=cast(Any, StubValidation()),
+        commit_effect=cast(Any, StubCommit(dirty=False)),
+        remote_effect=cast(Any, StubEffect("ensure_remote_branch", "already-present")),
+        pr_effect=cast(Any, StubEffect("ensure_open_pr", "already-present")),
+        status_effect=cast(Any, status),
+    ).complete(
+        160,
+        commit_message="Move required checks to Review and Merge gates",
+        summary="Publish the validated candidate without waiting for CI.",
+    )
+
+    assert result.status == "READY_FOR_REVIEW"
+    assert result.checks["status"] == "observed"
+    assert result.checks["check_state"] == "pending"
+    assert status.calls == 1
 
 
 def test_delivery_complete_does_not_requery_checks_after_gate(tmp_path: Path) -> None:
@@ -1689,7 +1794,7 @@ def test_set_review_status_rejects_failed_checks_receipt_before_mutation(
     resolver = SequenceResolver(tmp_path, runner, [state])
     identity = {"number": 10, "head_sha": head, "base_sha": SHA}
 
-    with pytest.raises(lck.LckStopError, match="PR checks are not passing"):
+    with pytest.raises(lck.LckStopError, match="PR checks receipt is invalid"):
         lck.SetReviewStatusEffect(cast(Any, resolver)).execute(
             state,
             expected_pr=identity,
@@ -1698,3 +1803,31 @@ def test_set_review_status_rejects_failed_checks_receipt_before_mutation(
 
     assert not any(command[:2] == ("gh", "project") for command in runner.commands)
     assert resolver.calls == 0
+
+
+def test_set_review_status_accepts_nonblocking_checks_observation(
+    tmp_path: Path,
+) -> None:
+    head = "b" * 40
+    state = _live_state(
+        head=head,
+        clean=True,
+        project_status="Review",
+        open_pr=None,
+        remote_oid=head,
+    )
+    resolver = SequenceResolver(tmp_path, CompletionRunner(), [state])
+    identity = {"number": 10, "head_sha": head, "base_sha": SHA}
+
+    receipt = lck.SetReviewStatusEffect(cast(Any, resolver)).execute(
+        state,
+        expected_pr=identity,
+        checks_result={
+            "status": "observed",
+            "gate": "non-blocking",
+            "check_state": "pending",
+            "pr": identity,
+        },
+    )
+
+    assert receipt.action == "already-review"

--- a/tools/agent_workflow/lck.py
+++ b/tools/agent_workflow/lck.py
@@ -863,9 +863,9 @@ def _required_checks_policy_source_sha(
 ) -> str:
     """Return the immutable base commit that governs required-check policy.
 
-    Candidate heads cannot authorize their own checks.  Delivery is governed by
-    current authoritative main; operations on an existing PR are governed by the
-    exact PR base commit.
+    Candidate heads cannot authorize their own checks. Operations on an existing
+    PR are governed by the exact PR base commit; the legacy Delivery branch is
+    retained for callers that still request that policy source explicitly.
     """
 
     if operation == Phase.DELIVERY_COMPLETE.value:
@@ -2746,15 +2746,11 @@ class ReviewPreparer:
                 target=target.to_dict(),
                 review_root=str(review_root),
             )
-            snapshot = self.snapshots.bind_required_checks(
-                snapshot, repo_root=review_root
-            )
             mark(
                 "checking-current-pr",
                 target=target.to_dict(),
-                required_checks=snapshot.required_checks,
             )
-            checks = self.checks_gate.evaluate(snapshot)
+            checks = self.checks_gate.observe(snapshot)
             identity = _review_identity(
                 self.resolver,
                 state,
@@ -2944,11 +2940,8 @@ class ReviewCompleter:
                     "Review invocation identity does not belong to this Task"
                 )
             prepared_checks = guard.get("checks")
-            if (
-                not isinstance(prepared_checks, Mapping)
-                or prepared_checks.get("status") != "pass"
-            ):
-                raise LckStopError("Review invocation has no successful PR check gate")
+            if not isinstance(prepared_checks, Mapping):
+                raise LckStopError("Review invocation has no PR check observation")
             prepared_snapshot = guard.get("snapshot")
             if not isinstance(prepared_snapshot, Mapping):
                 raise LckStopError("Review invocation has no sealed operation snapshot")
@@ -2975,9 +2968,6 @@ class ReviewCompleter:
             self.workspace.assert_ready_for_completion(
                 review_root, reviewed_identity.head_sha
             )
-            completion_snapshot = self.snapshots.bind_required_checks(
-                completion_snapshot, repo_root=review_root
-            )
             current_identity = _review_identity(
                 self.resolver,
                 state,
@@ -2985,7 +2975,13 @@ class ReviewCompleter:
                 repo_root=review_root,
             )
             _assert_review_applicable(reviewed_identity, current_identity)
-            completion_checks = self.checks_gate.evaluate(completion_snapshot)
+            if verdict == "PASS":
+                completion_snapshot = self.snapshots.bind_required_checks(
+                    completion_snapshot, repo_root=review_root
+                )
+                completion_checks = self.checks_gate.evaluate(completion_snapshot)
+            else:
+                completion_checks = self.checks_gate.observe(completion_snapshot)
             record = {
                 "schema_version": LCK_SCHEMA_VERSION,
                 "kind": "independent-review-record",
@@ -3591,7 +3587,7 @@ class SetReviewStatusEffect:
             raise LckStopError("cannot set Review status without repository identity")
         if expected_pr is None or checks_result is None:
             raise LckStopError(
-                "Project Status Review requires the exact checks-gated PR receipt"
+                "Project Status Review requires the exact PR checks observation"
             )
         gated_pr = checks_result.get("pr")
         expected_identity = {
@@ -3611,9 +3607,9 @@ class SetReviewStatusEffect:
             raise LckStopError(
                 "Project Status precondition failed: checks receipt PR identity mismatch"
             )
-        if checks_result.get("status") != "pass":
+        if checks_result.get("status") not in {"pass", "observed"}:
             raise LckStopError(
-                "Project Status precondition failed: PR checks are not passing"
+                "Project Status precondition failed: PR checks receipt is invalid"
             )
         if state.project_status == "Review":
             return EffectReceipt(
@@ -3663,11 +3659,11 @@ class SetReviewStatusEffect:
 
 
 class DeliveryChecksGate:
-    """Evaluate PR checks from one operation snapshot or one exact PR query.
+    """Observe or strictly evaluate PR checks from an operation snapshot/query.
 
-    This gate never resolves lifecycle state and never polls.  If checks are
-    pending, the current operation stops and a later lifecycle invocation
-    acquires a fresh snapshot.
+    This gate never resolves lifecycle state and never polls.  Delivery and
+    Review Prepare use the non-blocking observation path; Review Complete and
+    Merge Preflight use the strict evaluation path.
     """
 
     PR_FIELDS: Final = (
@@ -3719,11 +3715,15 @@ class DeliveryChecksGate:
     def _evaluate_pr_checks(
         cls,
         pr: Mapping[str, Any],
-        required: Mapping[str, Any],
+        required: Mapping[str, Any] | None,
+        *,
+        require_success: bool = True,
     ) -> dict[str, Any]:
         checks = _normalize_checks(pr.get("statusCheckRollup"))
-        required_names = cls._required_names(required)
-        config = required.get("configuration")
+        required_names = (
+            cls._required_names(required) if required is not None else set()
+        )
+        config = required.get("configuration") if required is not None else None
         observed = cls._observed_categories(checks)
         try:
             failed = int(checks.get("failed", 0) or 0)
@@ -3732,37 +3732,55 @@ class DeliveryChecksGate:
         except (TypeError, ValueError) as exc:
             raise LckStopError("PR check summary is malformed") from exc
 
-        if failed > 0 or unknown > 0:
-            raise LckStopError("PR checks failed, cancelled, skipped, or unknown")
-        if pending > 0:
-            raise LckStopError(
-                "PR checks are pending; start a new lifecycle operation after CI completes"
-            )
-
-        if required_names:
-            failed_required = {
-                name
-                for name in required_names
-                if observed.get(name) not in {None, "success"}
-            }
+        failed_required = {
+            name
+            for name in required_names
+            if observed.get(name) not in {None, "success"}
+        }
+        missing = required_names - set(observed)
+        if require_success:
+            if failed > 0 or unknown > 0:
+                raise LckStopError("PR checks failed, cancelled, skipped, or unknown")
+            if pending > 0:
+                raise LckStopError(
+                    "PR checks are pending; strict check gate is not satisfied"
+                )
             if failed_required:
                 raise LckStopError(
                     "required PR checks are not successful: "
                     + ", ".join(sorted(failed_required))
                 )
-            missing = required_names - set(observed)
             if missing:
                 raise LckStopError(
                     "required PR checks are not present: " + ", ".join(sorted(missing))
                 )
 
-        return {
-            "status": "pass",
+        if failed > 0 or failed_required:
+            check_state = "failed"
+        elif unknown > 0:
+            check_state = "unknown"
+        elif pending > 0:
+            check_state = "pending"
+        elif missing:
+            check_state = "missing"
+        else:
+            check_state = "pass"
+
+        result = {
+            "status": "pass" if require_success else "observed",
             "configuration": config,
             "required": sorted(required_names),
             "pr": cls._pr_identity_from_pr(pr),
             "checks": checks,
         }
+        if not require_success:
+            result.update(
+                {
+                    "gate": "non-blocking",
+                    "check_state": check_state,
+                }
+            )
+        return result
 
     def evaluate(self, snapshot: OperationSnapshot) -> dict[str, Any]:
         state = snapshot.state
@@ -3778,7 +3796,20 @@ class DeliveryChecksGate:
         if not isinstance(required, Mapping):
             raise LckStopError("required PR check configuration was not acquired")
         _required_check_contract_for_snapshot(snapshot)
-        return self._evaluate_pr_checks(pr, required)
+        return self._evaluate_pr_checks(pr, required, require_success=True)
+
+    def observe(self, snapshot: OperationSnapshot) -> dict[str, Any]:
+        """Return a bounded check observation without requiring CI success."""
+        state = snapshot.state
+        if state.status is not ResolutionStatus.RESOLVED:
+            raise LckStopError(
+                "cannot observe checks from unresolved operation snapshot: "
+                + "; ".join(state.stop_reasons)
+            )
+        pr = state.open_pr
+        if not isinstance(pr, Mapping):
+            raise LckStopError("PR checks require one OPEN PR in operation snapshot")
+        return self._evaluate_pr_checks(pr, None, require_success=False)
 
     def query_exact_pr(
         self,
@@ -3789,7 +3820,26 @@ class DeliveryChecksGate:
         expected_base_sha: str,
         required_checks: Mapping[str, Any],
     ) -> dict[str, Any]:
-        """Targeted post-effect query for a PR created/updated by this operation."""
+        """Targeted strict query for a PR created/updated by this operation."""
+        return self._query_exact_pr(
+            repository,
+            pr_number,
+            expected_head_sha=expected_head_sha,
+            expected_base_sha=expected_base_sha,
+            required_checks=required_checks,
+            require_success=True,
+        )
+
+    def _query_exact_pr(
+        self,
+        repository: str,
+        pr_number: int,
+        *,
+        expected_head_sha: str,
+        expected_base_sha: str,
+        required_checks: Mapping[str, Any] | None,
+        require_success: bool,
+    ) -> dict[str, Any]:
         result = self.runner.run(
             [
                 "gh",
@@ -3819,7 +3869,29 @@ class DeliveryChecksGate:
             or value.get("baseRefOid") != expected_base_sha
         ):
             raise LckStopError("exact PR identity changed after the PR effect")
-        return self._evaluate_pr_checks(value, required_checks)
+        return self._evaluate_pr_checks(
+            value,
+            required_checks,
+            require_success=require_success,
+        )
+
+    def observe_exact_pr(
+        self,
+        repository: str,
+        pr_number: int,
+        *,
+        expected_head_sha: str,
+        expected_base_sha: str,
+    ) -> dict[str, Any]:
+        """Observe a post-effect PR without making CI success a Delivery gate."""
+        return self._query_exact_pr(
+            repository,
+            pr_number,
+            expected_head_sha=expected_head_sha,
+            expected_base_sha=expected_base_sha,
+            required_checks=None,
+            require_success=False,
+        )
 
     @staticmethod
     def _checks_postcondition(
@@ -4739,9 +4811,6 @@ class DeliveryCompleter:
     ) -> DeliveryCompletionResult:
         state = snapshot.state
         task_number = state.task_number
-        required_checks = snapshot.required_checks
-        _required_check_contract_for_snapshot(snapshot)
-        required_checks_mapping = cast(Mapping[str, Any], required_checks)
         decision = self.eligibility.resolve(state, phase)
         if not decision.eligible:
             raise LckStopError(
@@ -4852,16 +4921,15 @@ class DeliveryCompleter:
             and snapshot_pr.get("headRefOid") == head
             and snapshot_pr.get("baseRefOid") == base_sha
         ):
-            checks = self.checks_gate.evaluate(snapshot)
+            checks = self.checks_gate.observe(snapshot)
         else:
             if not isinstance(state.repository, str):
                 raise LckStopError("repository identity is unavailable for PR checks")
-            checks = self.checks_gate.query_exact_pr(
+            checks = self.checks_gate.observe_exact_pr(
                 state.repository,
                 pr_number,
                 expected_head_sha=str(head),
                 expected_base_sha=base_sha,
-                required_checks=required_checks_mapping,
             )
 
         checks_pr = checks.get("pr")
@@ -4914,7 +4982,6 @@ class DeliveryCompleter:
             snapshot = operation_snapshot or self.snapshots.acquire(
                 task_number,
                 operation=phase.value,
-                include_required_checks=True,
             )
             if snapshot.state.task_number != task_number:
                 raise LckStopError("operation snapshot belongs to another Task")
@@ -5470,7 +5537,6 @@ class RemediationCompleter:
         snapshot = self.snapshots.acquire(
             task_number,
             operation=Phase.REMEDIATION_COMPLETE.value,
-            include_required_checks=True,
         )
         state = snapshot.state
         decision = self.eligibility.resolve(state, Phase.REMEDIATION_COMPLETE)

--- a/tools/agent_workflow/lck.py
+++ b/tools/agent_workflow/lck.py
@@ -4697,9 +4697,10 @@ class DeliveryCompleter:
     """Complete Delivery from one immutable operation-start snapshot.
 
     Lifecycle authority is acquired once.  Local/remote/PR/metadata mutations
-    then prove only their own exact postconditions.  If asynchronous PR checks
-    are pending, the operation stops after the durable commit/push/PR effects;
-    a later invocation acquires a fresh snapshot and continues idempotently.
+    then prove only their own exact postconditions.  Asynchronous PR checks are
+    observed without blocking Delivery; pending checks are reported while the
+    operation continues through Project Status and final identity verification.
+    Strict check evaluation remains owned by Review Complete and Merge Preflight.
     """
 
     def __init__(


### PR DESCRIPTION
Closes #176

## Summary
Initial Delivery now publishes the validated candidate and records non-blocking check observations; strict required-check validation remains at Review Complete and Merge Preflight.

## Validation
- Critical Outcome: pass
- Formal Delivery validation: pass

## Risks / limitations
CI pending, failed, missing, or unresolved statuses no longer veto Initial Delivery or semantic Review FAIL; Review Complete PASS and Merge Preflight still fail closed on current required checks and policy.
