### PR TITLE
[Task] 去除 Delivery 实现阶段的重复完整验证

### DIFF
--- a/.agents/skills/task-delivery-runner/SKILL.md
+++ b/.agents/skills/task-delivery-runner/SKILL.md
@@ -161,6 +161,26 @@ Read the current Task body and implement the smallest complete change that
 satisfies Objective, Requirements, Critical Outcome, Acceptance Criteria, and
 explicit scope boundaries.
 
+#### Development validation boundary
+
+Normal implementation validation is development feedback, not Delivery
+authorization. Before LCK Delivery Complete, choose the smallest check that
+matches the changed surface: a named targeted profile, a focused pytest node,
+or a scoped static check. Rerun the relevant target after a change when useful.
+
+For a normal Task, do not proactively run a full `current-ci-equivalent`, full
+`workflow-delivery`, or equivalent full-repository validation before LCK
+Delivery Complete merely as a precaution or to "confirm" the candidate. The
+formal full Delivery validation is intentionally reserved for LCK Delivery
+Complete.
+
+A broader or full validation run is allowed only for a concrete diagnostic
+reason, such as a targeted failure indicating a cross-module regression, a
+change that spans global infrastructure, or an explicit maintainer request.
+Record and treat that run as diagnostic information only: it does not replace
+LCK's Critical Outcome verifier or formal validation, authorize commit/push/PR
+effects, or advance lifecycle state.
+
 During implementation, use a matching targeted Validation profile when useful:
 
 ```bash
@@ -169,7 +189,10 @@ tools/agent_workflow/wsl2_validation_runner.py targeted:workflow-tests
 ```
 
 Targeted validation is development feedback only. Do not treat it as final
-Delivery authorization and do not weaken tests to obtain a pass.
+Delivery authorization and do not weaken tests to obtain a pass. Any full
+validation performed for diagnosis remains non-authoritative; LCK Delivery
+Complete must still run its own Critical Outcome and formal Delivery validation
+and bind the exact validated tree before commit.
 
 Before completion, inspect the complete workspace diff semantically. Remove or
 repair unrelated, generated, secret-bearing, or prohibited changes. The

--- a/.claude/skills/task-delivery-runner/SKILL.md
+++ b/.claude/skills/task-delivery-runner/SKILL.md
@@ -143,6 +143,26 @@ Read the current Task body and implement the smallest complete change that
 satisfies Objective, Requirements, Critical Outcome, Acceptance Criteria, and
 explicit scope boundaries.
 
+#### Development validation boundary
+
+Normal implementation validation is development feedback, not Delivery
+authorization. Before LCK Delivery Complete, choose the smallest check that
+matches the changed surface: a named targeted profile, a focused pytest node,
+or a scoped static check. Rerun the relevant target after a change when useful.
+
+For a normal Task, do not proactively run a full `current-ci-equivalent`, full
+`workflow-delivery`, or equivalent full-repository validation before LCK
+Delivery Complete merely as a precaution or to "confirm" the candidate. The
+formal full Delivery validation is intentionally reserved for LCK Delivery
+Complete.
+
+A broader or full validation run is allowed only for a concrete diagnostic
+reason, such as a targeted failure indicating a cross-module regression, a
+change that spans global infrastructure, or an explicit maintainer request.
+Record and treat that run as diagnostic information only: it does not replace
+LCK's Critical Outcome verifier or formal validation, authorize commit/push/PR
+effects, or advance lifecycle state.
+
 During implementation, use a matching targeted Validation profile when useful:
 
 ```bash
@@ -151,7 +171,10 @@ tools/agent_workflow/wsl2_validation_runner.py targeted:workflow-tests
 ```
 
 Targeted validation is development feedback only. Do not treat it as final
-Delivery authorization and do not weaken tests to obtain a pass.
+Delivery authorization and do not weaken tests to obtain a pass. Any full
+validation performed for diagnosis remains non-authoritative; LCK Delivery
+Complete must still run its own Critical Outcome and formal Delivery validation
+and bind the exact validated tree before commit.
 
 Before completion, inspect the complete workspace diff semantically. Remove or
 repair unrelated, generated, secret-bearing, or prohibited changes. The

--- a/tests/tools/test_workflow_skills.py
+++ b/tests/tools/test_workflow_skills.py
@@ -218,6 +218,37 @@ def test_delivery_runner_uses_lck_for_initial_delivery_and_explicit_remediation(
     assert "MUST NOT start\nIndependent Review automatically" in text
 
 
+def test_delivery_skill_reserves_full_validation_for_lck_complete() -> None:
+    for path in (
+        ROOT / ".agents/skills/task-delivery-runner/SKILL.md",
+        ROOT / ".claude/skills/task-delivery-runner/SKILL.md",
+    ):
+        text = path.read_text(encoding="utf-8")
+        implementation = " ".join(
+            text.split("### 2. Semantic implementation", 1)[1]
+            .split("### 3. LCK Delivery Complete", 1)[0]
+            .split()
+        )
+        completion = " ".join(text.split("### 3. LCK Delivery Complete", 1)[1].split())
+
+        assert "Development validation boundary" in implementation
+        assert "development feedback, not Delivery authorization" in implementation
+        assert "smallest check that" in implementation
+        assert "current-ci-equivalent" in implementation
+        assert "workflow-delivery" in implementation
+        assert "merely as a precaution" in implementation
+        assert "concrete diagnostic" in implementation
+        assert "explicit maintainer request" in implementation
+        assert "does not replace" in implementation
+        assert "Critical Outcome verifier" in implementation
+        assert "Critical Outcome and formal Delivery validation" in implementation
+        assert "authorize commit/push/PR effects" in implementation
+
+        assert "run formal Delivery validation" in completion
+        assert "prove validated staged tree is unchanged" in completion
+        assert "commit_current_tree" in completion
+
+
 def test_delivery_lck_contract_is_shared_by_both_skills() -> None:
     agent, claude = _dual_skill("task-delivery-runner")
     assert _without_route_contract(agent) == claude


### PR DESCRIPTION
Closes #177

## Summary
Clarified targeted development validation, diagnostic full-run exceptions, and LCK-owned formal Delivery validation in both active Delivery Skills with regression coverage.

## Validation
- Critical Outcome: pass
- Formal Delivery validation: pass

## Risks / limitations
No known risks; LCK formal validation and validated-tree binding remain authoritative.
