### PR TITLE
[Task] 将 LCK LiveState 获取收敛为阶段最小事实集

### DIFF
--- a/docs/development/issue-workflow.md
+++ b/docs/development/issue-workflow.md
@@ -120,6 +120,9 @@ subprocesses continue to receive the same path through `build_workflow_env()`.
 - Task `Critical Outcome` 是正式 Delivery gate：LCK 从当前 Task body 读取结构化
   contract，使用固定 pytest verifier 执行真实 supported path。缺失、malformed、unsafe
   target 或 verifier failure 均 fail closed；不得用普通 unit/static check 替代。
+- 每个 authoritative operation 在入口绑定一个稳定的 fact profile，并在 operation snapshot
+  中记录 profile 与 acquired facts。Delivery Prepare 直接返回同一次 fresh acquisition 绑定的
+  完整 Task Contract；semantic caller 不应为同一 operation 再查询 Task body。
 - Initial Delivery 的 lifecycle mechanics（workspace prepare、commit validated tree、
   remote synchronization、OPEN PR resolve/create、Project Status → Review）由 LCK
   deterministic control 执行；Agent/Skill 不提供 branch/SHA/PR/refspec authority。

--- a/docs/development/pr-review.md
+++ b/docs/development/pr-review.md
@@ -124,6 +124,12 @@ workspace ownership；这些是“审查了什么”的历史证据，不是 Rev
 Review Complete 在 operation 入口只获取一次 fresh `ReviewCompleteSnapshot`，并与
 Prepare 时封存的 target 比较：
 
+该 snapshot 使用 review-complete fact profile：读取当前 Task Contract、关系/阻塞、
+OPEN PR identity 与当前 checks，但不读取 Issue comments、closure timeline、source
+Delivery workspace staged/changed/worktree inventory 或完整 PR history。PASS 所需的
+exact-base required-check policy 绑定在同一个 bounded operation-start window 内，不触发
+第二次 full live-state resolve。
+
 ```text
 PR changed            → REVIEW_STALE_PR
 PR head changed       → REVIEW_STALE_HEAD

--- a/tests/tools/test_lck.py
+++ b/tests/tools/test_lck.py
@@ -3274,12 +3274,15 @@ def _write_owned_candidate_session(
 
 class OwnedCandidateRunner(FakeRunner):
     def __init__(self, *, head_sha: str, tree_oid: str) -> None:
+        branch = "task/159-lck-core-live-state-resolution"
+        open_pr = _open_pr(branch)
         super().__init__(
-            branch="task/159-lck-core-live-state-resolution",
-            local_branches={"task/159-lck-core-live-state-resolution"},
-            remote_branches={"task/159-lck-core-live-state-resolution": SHA},
+            branch=branch,
+            local_branches={branch},
+            remote_branches={branch: SHA},
             clean=True,
             head_sha=head_sha,
+            open_pr=open_pr,
         )
         self.tree_oid = tree_oid
 
@@ -3294,9 +3297,44 @@ class OwnedCandidateRunner(FakeRunner):
         if command == ("git", "rev-parse", "HEAD^{tree}"):
             self.commands.append(command)
             return CommandResult(command_id, command, 0, f"{self.tree_oid}\n", "")
+        if command == ("git", "diff", "--quiet"):
+            self.commands.append(command)
+            return CommandResult(command_id, command, 0, "", "")
+        if command[:3] == ("git", "diff", "--quiet"):
+            self.commands.append(command)
+            return CommandResult(command_id, command, 1, "", "")
+        if command == (
+            "git",
+            "status",
+            "--porcelain=v1",
+            "--untracked-files=all",
+        ):
+            self.commands.append(command)
+            return CommandResult(command_id, command, 0, "", "")
+        if command == ("git", "write-tree"):
+            self.commands.append(command)
+            return CommandResult(command_id, command, 0, f"{self.tree_oid}\n", "")
+        if command[:3] == ("git", "cat-file", "-e"):
+            self.commands.append(command)
+            return CommandResult(command_id, command, 0, "", "")
         if command[:3] == ("git", "merge-base", "--is-ancestor"):
             self.commands.append(command)
             return CommandResult(command_id, command, 0, "", "")
+        if command[:3] == ("git", "push", "-u"):
+            self.commands.append(command)
+            self.remote_branches[self.branch] = self.head_sha
+            assert self.open_pr is not None
+            self.open_pr["headRefOid"] = self.head_sha
+            return CommandResult(command_id, command, 0, "", "")
+        if command == (
+            "git",
+            "rev-parse",
+            "--abbrev-ref",
+            "--symbolic-full-name",
+            "@{upstream}",
+        ):
+            self.commands.append(command)
+            return CommandResult(command_id, command, 0, f"origin/{self.branch}\n", "")
         return super().run(argv, command_id=command_id, **kwargs)
 
 
@@ -3307,88 +3345,100 @@ def test_remediation_complete_recovers_exact_owned_partial_effect_candidate(
     start_head = SHA
     candidate_head = "b" * 40
     candidate_tree = "c" * 40
-    initial = _review_state(head=start_head, clean=False)
-    resolver = cast(Any, StaticResolver(tmp_path, initial))
-    store = lck.ReviewInvocationStore(tmp_path)
-    review_id = store.new_id()
-    operation_id = store.new_id()
-    store.write_remediation_session(
-        159,
-        {
-            "schema_version": lck.LCK_SCHEMA_VERSION,
-            "kind": "remediation-session",
-            "task_number": 159,
-            "review_id": review_id,
-            "operation_id": operation_id,
-            "start_head_sha": start_head,
-            "pr_number": 200,
-            "base_sha": SHA,
-            "findings_sha256": "f" * 64,
-            "findings_source": "local-review-record",
-            "authority": "test",
-        },
-    )
-    calls = {"completion": 0, "critical": 0, "validation": 0}
-
-    class PartialEffectDeliveryCompleter:
-        def __init__(self, *_args: Any, **kwargs: Any) -> None:
-            self.recorder = kwargs["candidate_recorder"]
-
-        def complete(
-            self, task_number: int, **kwargs: Any
-        ) -> lck.DeliveryCompletionResult:
-            calls["completion"] += 1
-            calls["critical"] += 1
-            calls["validation"] += 1
-            if calls["completion"] == 1:
-                self.recorder(candidate_head, candidate_tree)
-                raise lck.LckStopError("REMOTE_PUSH_REJECTED: simulated interruption")
-            return lck.DeliveryCompletionResult(
-                task_number=task_number,
-                status="READY_FOR_REVIEW",
-                branch=initial.target_branch,
-                head_sha=candidate_head,
-                critical_outcome={"status": "pass"},
-                validation={"status": "pass"},
-                checks={"status": "pass"},
-                effects=(),
-                operation_snapshot=kwargs["operation_snapshot"],
-            )
-
-    monkeypatch.setattr(lck, "DeliveryCompleter", PartialEffectDeliveryCompleter)
-    completer = lck.RemediationCompleter(resolver, store=store)
-
-    with pytest.raises(lck.LckStopError, match="REMOTE_PUSH_REJECTED"):
-        completer.complete(159, review_id, commit_message="repair", summary="repair")
-
-    session = store.read_remediation_session(159)
-    assert session is not None
-    assert session["candidate"] == {
-        "operation_id": operation_id,
-        "start_head_sha": start_head,
-        "head_sha": candidate_head,
-        "tree_oid": candidate_tree,
-    }
-
+    initial = _review_state(head=start_head, clean=True)
     partial = replace(
         initial,
-        git={**initial.git, "head_sha": candidate_head, "clean": True},
+        git={**initial.git, "head_sha": candidate_head},
         local_task_head=candidate_head,
     )
-    resolver.state = partial
-    resolver.runner = OwnedCandidateRunner(
-        head_sha=candidate_head, tree_oid=candidate_tree
+    resolver = cast(Any, StaticResolver(tmp_path, partial))
+    runner = OwnedCandidateRunner(head_sha=candidate_head, tree_oid=candidate_tree)
+    resolver.runner = runner
+    store = lck.ReviewInvocationStore(tmp_path)
+    review_id = store.new_id()
+    _write_owned_candidate_session(
+        store,
+        review_id,
+        start_head=start_head,
+        candidate_head=candidate_head,
+        candidate_tree=candidate_tree,
     )
-    result = completer.complete(
+    calls = {"critical": 0, "validation": 0}
+
+    def critical_outcome(
+        _self: lck.DeliveryCompleter,
+        _state: lck.LiveState,
+        *,
+        progress: lck.ProgressReporter | None = None,
+    ) -> dict[str, Any]:
+        del progress
+        calls["critical"] += 1
+        return {"status": "pass"}
+
+    def formal_validation(
+        _self: lck.FormalValidationGate, base_sha: str
+    ) -> dict[str, Any]:
+        assert base_sha == SHA
+        calls["validation"] += 1
+        return {"status": "pass"}
+
+    monkeypatch.setattr(
+        lck.DeliveryCompleter, "_run_critical_outcome", critical_outcome
+    )
+    monkeypatch.setattr(lck.FormalValidationGate, "run", formal_validation)
+
+    result = lck.RemediationCompleter(resolver, store=store).complete(
         159, review_id, commit_message="repair", summary="repair"
     )
 
     assert result.to_dict()["status"] == "READY_FOR_NEW_REVIEW"
-    assert calls == {"completion": 2, "critical": 2, "validation": 2}
+    assert calls == {"critical": 1, "validation": 1}
+    assert resolver.calls == 1
+    assert [effect.action for effect in result.delivery.effects] == [
+        "already-committed-revalidated",
+        "fast-forwarded",
+        "reused-current-open-pr",
+        "already-review",
+    ]
+    assert not any(command[:2] == ("git", "commit") for command in runner.commands)
+    assert any(command[:3] == ("git", "push", "-u") for command in runner.commands)
     assert store.read_remediation_session(159) is None
     required = store.read_review_required(159)
     assert required is not None
     assert required["remediated_head"] == candidate_head
+
+
+def test_real_delivery_completer_rejects_unowned_local_ahead_remediation_candidate(
+    tmp_path: Path,
+) -> None:
+    candidate_head = "b" * 40
+    state = _review_state(head=SHA, clean=True)
+    state = replace(
+        state,
+        git={**state.git, "head_sha": candidate_head},
+        local_task_head=candidate_head,
+    )
+    resolver = cast(Any, StaticResolver(tmp_path, state))
+    snapshot = lck.OperationSnapshot(
+        operation=lck.Phase.REMEDIATION_COMPLETE.value,
+        state=state,
+    )
+
+    with pytest.raises(
+        lck.LckStopError, match="local Task branch must match current OPEN PR head"
+    ):
+        lck.DeliveryCompleter(
+            resolver,
+            require_existing_open_pr=True,
+        ).complete(
+            159,
+            commit_message="repair",
+            summary="repair",
+            operation_snapshot=snapshot,
+            phase=lck.Phase.REMEDIATION_COMPLETE,
+        )
+
+    assert resolver.calls == 0
 
 
 def test_remediation_owned_candidate_recovery_rejects_replaced_local_head(

--- a/tests/tools/test_lck.py
+++ b/tests/tools/test_lck.py
@@ -1695,6 +1695,60 @@ def test_review_complete_acquires_only_review_complete_fact_profile(
             },
         ),
         (
+            "Remediation Prepare",
+            {
+                "issue": (False, False, True),
+                "git": {
+                    "read_only_local_refs": True,
+                    "include_workspace_inventory": False,
+                },
+                "branches": (True, True),
+                "pr": (False, False, False),
+                "history": None,
+                "included": {
+                    "task_contract",
+                    "git",
+                    "local_task_branches",
+                    "remote_task_branches",
+                    "open_pr",
+                },
+                "excluded": {
+                    "comments",
+                    "issue_closure",
+                    "workspace_inventory",
+                    "checks",
+                    "pr_history",
+                },
+            },
+        ),
+        (
+            "Remediation No Change",
+            {
+                "issue": (False, False, False),
+                "git": {
+                    "read_only_local_refs": True,
+                    "include_workspace_inventory": False,
+                },
+                "branches": (True, True),
+                "pr": (False, False, False),
+                "history": None,
+                "included": {
+                    "git",
+                    "local_task_branches",
+                    "remote_task_branches",
+                    "open_pr",
+                },
+                "excluded": {
+                    "comments",
+                    "issue_closure",
+                    "task_contract",
+                    "workspace_inventory",
+                    "checks",
+                    "pr_history",
+                },
+            },
+        ),
+        (
             "merge-preflight",
             {
                 "issue": (False, False, True),
@@ -1864,6 +1918,11 @@ def test_authoritative_operation_resolver_queries_only_its_fact_profile(
             "Remediation Prepare",
             {"task_contract", "git", "local_task_branches", "open_pr"},
             {"comments", "issue_closure", "checks", "pr_history"},
+        ),
+        (
+            "Remediation No Change",
+            {"git", "local_task_branches", "open_pr"},
+            {"comments", "issue_closure", "task_contract", "checks", "pr_history"},
         ),
         (
             "Remediation Complete",
@@ -2715,6 +2774,8 @@ def test_remediation_prepare_uses_live_head_not_review_record_identity(
     context = lck.RemediationPreparer(resolver, store=store).prepare(159, review_id)
 
     assert context.to_dict()["live_target"]["head_sha"] == live_head
+    assert context.task_contract["body"] == "Task Contract"
+    assert context.to_dict()["task_contract"]["body"] == "Task Contract"
     assert context.findings == "[F1][Medium] Semantic repair input."
     assert (
         "operation snapshot acquired at Remediation entry"

--- a/tests/tools/test_lck.py
+++ b/tests/tools/test_lck.py
@@ -964,6 +964,7 @@ def test_delivery_prepare_creates_then_reuses_workspace(
 
     assert created.action == "created-from-main"
     assert reused.action == "already-prepared"
+    assert created.to_dict()["task_contract"]["body"] == "Task Contract"
     assert fake.branch == "task/159-lck-core-live-state-resolution"
     assert sum(command[:2] == ("git", "switch") for command in fake.commands) == 1
     assert not any(
@@ -1492,6 +1493,140 @@ def test_review_complete_acquires_one_fresh_snapshot_and_accepts_unchanged_targe
     assert "fresh Review Complete snapshot matched" in record["authority_note"]
     assert workspace.ready_checked == [review_root]
     assert workspace.removed == [review_root]
+
+
+def test_review_complete_acquires_only_review_complete_fact_profile(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    branch = "task/159-lck-core-live-state-resolution"
+    issue = _issue()
+    issue.update({"project_status": "Review", "body_sha256": "d" * 64})
+    contract = _task_contract(issue)
+    contract["body_sha256"] = "d" * 64
+    pr = _open_pr(branch)
+    pr["statusCheckRollup"] = [{"name": "quality", "conclusion": "SUCCESS"}]
+    observations: dict[str, list[Any]] = {
+        "issue": [],
+        "branches": [],
+        "pr": [],
+    }
+
+    monkeypatch.setattr(lck, "_repository_slug", lambda *_args: "owner/repo")
+
+    def issue_query(*args: Any) -> tuple[dict[str, Any], dict[str, Any]]:
+        observations["issue"].append(tuple(args[-3:]))
+        return issue, contract
+
+    def task_branches(
+        _self: Any,
+        _task: int,
+        _warnings: list[dict[str, Any]],
+        *,
+        include_local: bool,
+        include_remote: bool,
+    ) -> tuple[set[str], dict[str, str], bool]:
+        observations["branches"].append((include_local, include_remote))
+        return set(), {branch: SHA}, True
+
+    def open_pr_query(*args: Any) -> dict[str, Any]:
+        observations["pr"].append(tuple(args[-3:]))
+        return pr
+
+    monkeypatch.setattr(lck, "_issue_view_with_contract", issue_query)
+    monkeypatch.setattr(lck, "_relationship_snapshot", lambda *_args: _relationships())
+    monkeypatch.setattr(lck.LiveStateResolver, "_task_branches", task_branches)
+    monkeypatch.setattr(lck, "resolve_open_pr", open_pr_query)
+    monkeypatch.setattr(
+        lck,
+        "list_matching_prs",
+        lambda *_args, **_kwargs: pytest.fail("Review Complete queried PR history"),
+    )
+    monkeypatch.setattr(
+        lck,
+        "_git_snapshot",
+        lambda *_args, **_kwargs: pytest.fail(
+            "Review Complete queried source workspace Git facts"
+        ),
+    )
+
+    snapshot = lck.OperationSnapshotBuilder(
+        lck.LiveStateResolver(tmp_path, runner=cast(Any, FakeRunner()))
+    ).acquire(159, operation="review-complete")
+
+    assert snapshot.state.status is lck.ResolutionStatus.RESOLVED
+    assert snapshot.fact_profile == "review-complete"
+    assert observations == {
+        "issue": [(False, False, True)],
+        "branches": [(False, True)],
+        "pr": [(True, False, False)],
+    }
+    assert "task_contract" in snapshot.acquired_facts
+    assert "checks" in snapshot.acquired_facts
+    assert {
+        "comments",
+        "issue_closure",
+        "git",
+        "workspace_inventory",
+        "local_task_branches",
+        "pr_history",
+    }.isdisjoint(snapshot.acquired_facts)
+
+
+@pytest.mark.parametrize(
+    ("operation", "included", "excluded"),
+    [
+        (
+            "Delivery Prepare",
+            {"task_contract", "git", "workspace_inventory", "pr_history"},
+            {"comments", "issue_closure", "checks"},
+        ),
+        (
+            "Delivery Complete",
+            {"task_contract", "git", "checks", "pr_history"},
+            {"comments", "issue_closure", "workspace_inventory"},
+        ),
+        (
+            "review-prepare",
+            {"task_contract", "remote_task_branches", "open_pr", "checks"},
+            {"comments", "issue_closure", "git", "pr_history"},
+        ),
+        (
+            "review-complete",
+            {"task_contract", "remote_task_branches", "open_pr", "checks"},
+            {"comments", "issue_closure", "git", "pr_history"},
+        ),
+        (
+            "Remediation Prepare",
+            {"task_contract", "git", "local_task_branches", "open_pr"},
+            {"comments", "issue_closure", "checks", "pr_history"},
+        ),
+        (
+            "Remediation Complete",
+            {"task_contract", "git", "local_task_branches", "checks"},
+            {"comments", "issue_closure", "workspace_inventory", "pr_history"},
+        ),
+        (
+            "merge-preflight",
+            {"task_contract", "remote_task_branches", "checks", "mergeability"},
+            {"comments", "issue_closure", "git", "pr_history"},
+        ),
+        (
+            "closeout",
+            {"issue_closure", "git", "workspace_inventory", "pr_history"},
+            {"comments", "task_contract", "checks"},
+        ),
+    ],
+)
+def test_authoritative_operations_bind_stable_fact_profiles(
+    operation: str,
+    included: set[str],
+    excluded: set[str],
+) -> None:
+    facts = set(lck.fact_profile_for_operation(operation).facts())
+
+    assert included <= facts
+    assert excluded.isdisjoint(facts)
 
 
 def test_review_complete_can_retry_after_transient_live_resolution_failure(

--- a/tests/tools/test_lck.py
+++ b/tests/tools/test_lck.py
@@ -21,6 +21,7 @@ if AGENT_WORKFLOW not in sys.path:
 import lck  # type: ignore[import-not-found]  # noqa: E402
 from pr_resolve import (  # type: ignore[import-not-found]
     PrResolveError,
+    list_matching_prs,
     resolve_open_pr,
 )  # noqa: E402
 from workflow_common import (  # type: ignore[import-not-found]  # noqa: E402
@@ -1133,6 +1134,51 @@ def _review_state(
     )
 
 
+def test_closeout_cleanup_keeps_exact_worktree_safety_precondition(
+    tmp_path: Path,
+) -> None:
+    state = _review_state()
+
+    class WorktreeInUseRunner:
+        def __init__(self) -> None:
+            self.commands: list[tuple[str, ...]] = []
+
+        def run(
+            self,
+            argv: list[str] | tuple[str, ...],
+            *,
+            command_id: str,
+            **_: Any,
+        ) -> CommandResult:
+            command = tuple(str(item) for item in argv)
+            self.commands.append(command)
+            assert command_id == "lck-closeout-worktree-precondition"
+            assert command == ("git", "worktree", "list", "--porcelain")
+            return CommandResult(
+                command_id,
+                command,
+                0,
+                f"worktree /tmp/task\nbranch refs/heads/{state.target_branch}\n",
+                "",
+            )
+
+    resolver = cast(Any, StaticResolver(tmp_path, state))
+    runner = WorktreeInUseRunner()
+    resolver.runner = runner
+
+    receipt = lck.CleanupTaskRefsEffect(resolver).execute(
+        state,
+        expected_head_sha=SHA,
+        merge_sha="b" * 40,
+    )
+
+    assert receipt.action == "pending"
+    assert (
+        receipt.details["reason"] == "verified Task branch is still used by a worktree"
+    )
+    assert runner.commands == [("git", "worktree", "list", "--porcelain")]
+
+
 def _review_identity_value(*, head: str = SHA, base: str = SHA) -> lck.ReviewIdentity:
     return lck.ReviewIdentity(
         task_number=159,
@@ -1581,20 +1627,28 @@ def test_review_complete_acquires_only_review_complete_fact_profile(
             "Delivery Prepare",
             {
                 "issue": (False, False, True),
-                "git": {"read_only_local_refs": True},
+                "git": {
+                    "read_only_local_refs": True,
+                    "include_workspace_inventory": False,
+                },
                 "branches": (True, True),
                 "pr": (False, False, False),
                 "history": {
                     "include_checks": False,
                     "include_mergeability": False,
+                    "include_history_details": False,
                 },
                 "included": {
                     "task_contract",
                     "git",
-                    "workspace_inventory",
                     "pr_history",
                 },
-                "excluded": {"comments", "issue_closure", "checks"},
+                "excluded": {
+                    "comments",
+                    "issue_closure",
+                    "workspace_inventory",
+                    "checks",
+                },
             },
         ),
         (
@@ -1610,6 +1664,7 @@ def test_review_complete_acquires_only_review_complete_fact_profile(
                 "history": {
                     "include_checks": False,
                     "include_mergeability": False,
+                    "include_history_details": False,
                 },
                 "included": {"task_contract", "git", "checks", "pr_history"},
                 "excluded": {"comments", "issue_closure", "workspace_inventory"},
@@ -1668,20 +1723,28 @@ def test_review_complete_acquires_only_review_complete_fact_profile(
             "closeout",
             {
                 "issue": (False, True, False),
-                "git": {"read_only_local_refs": True},
+                "git": {
+                    "read_only_local_refs": True,
+                    "include_workspace_inventory": False,
+                },
                 "branches": (True, True),
                 "pr": (False, False, False),
                 "history": {
                     "include_checks": False,
                     "include_mergeability": False,
+                    "include_history_details": True,
                 },
                 "included": {
                     "issue_closure",
                     "git",
-                    "workspace_inventory",
                     "pr_history",
                 },
-                "excluded": {"comments", "task_contract", "checks"},
+                "excluded": {
+                    "comments",
+                    "task_contract",
+                    "workspace_inventory",
+                    "checks",
+                },
             },
         ),
     ],
@@ -1719,6 +1782,12 @@ def test_authoritative_operation_resolver_queries_only_its_fact_profile(
     def git_query(*_args: Any, **kwargs: Any) -> dict[str, Any]:
         if expected["git"] is None:
             pytest.fail(f"{operation} queried source workspace Git facts")
+        if operation in {"Delivery Prepare", "closeout"} and (
+            kwargs.get("include_workspace_inventory") is not False
+        ):
+            pytest.fail(
+                f"{operation} queried forbidden staged/changed/worktree inventory"
+            )
         observations["git"].append(kwargs)
         return _git_snapshot(FakeRunner(branch=branch))
 
@@ -1773,8 +1842,8 @@ def test_authoritative_operation_resolver_queries_only_its_fact_profile(
     [
         (
             "Delivery Prepare",
-            {"task_contract", "git", "workspace_inventory", "pr_history"},
-            {"comments", "issue_closure", "checks"},
+            {"task_contract", "git", "pr_history"},
+            {"comments", "issue_closure", "workspace_inventory", "checks"},
         ),
         (
             "Delivery Complete",
@@ -1808,8 +1877,8 @@ def test_authoritative_operation_resolver_queries_only_its_fact_profile(
         ),
         (
             "closeout",
-            {"issue_closure", "git", "workspace_inventory", "pr_history"},
-            {"comments", "task_contract", "checks"},
+            {"issue_closure", "git", "pr_history"},
+            {"comments", "task_contract", "workspace_inventory", "checks"},
         ),
     ],
 )
@@ -1822,6 +1891,60 @@ def test_authoritative_operations_bind_stable_fact_profiles(
 
     assert included <= facts
     assert excluded.isdisjoint(facts)
+
+
+def test_delivery_history_query_requests_only_merged_detection_fields() -> None:
+    fake = FakeRunner()
+
+    assert (
+        list_matching_prs(
+            cast(Any, fake),
+            "owner/repo",
+            "task/159-lck-core-live-state-resolution",
+            "main",
+            [],
+            include_checks=False,
+            include_mergeability=False,
+            include_history_details=False,
+        )
+        == []
+    )
+
+    command = fake.commands[-1]
+    assert command[command.index("--json") + 1] == "number,state"
+
+
+def test_closeout_history_query_retains_required_identity_details() -> None:
+    fake = FakeRunner()
+
+    assert (
+        list_matching_prs(
+            cast(Any, fake),
+            "owner/repo",
+            "task/159-lck-core-live-state-resolution",
+            "main",
+            [],
+            include_checks=False,
+            include_mergeability=False,
+            include_history_details=True,
+        )
+        == []
+    )
+
+    command = fake.commands[-1]
+    fields = set(command[command.index("--json") + 1].split(","))
+    assert {
+        "number",
+        "state",
+        "baseRefName",
+        "baseRefOid",
+        "headRefName",
+        "headRefOid",
+        "mergeCommit",
+        "mergedAt",
+        "closingIssuesReferences",
+    } <= fields
+    assert {"statusCheckRollup", "mergeable"}.isdisjoint(fields)
 
 
 def test_review_complete_can_retry_after_transient_live_resolution_failure(

--- a/tests/tools/test_lck.py
+++ b/tests/tools/test_lck.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 import tempfile
 import uuid
+from dataclasses import replace
 from pathlib import Path
 from typing import Any, cast
 
@@ -1574,6 +1575,200 @@ def test_review_complete_acquires_only_review_complete_fact_profile(
 
 
 @pytest.mark.parametrize(
+    ("operation", "expected"),
+    [
+        (
+            "Delivery Prepare",
+            {
+                "issue": (False, False, True),
+                "git": {"read_only_local_refs": True},
+                "branches": (True, True),
+                "pr": (False, False, False),
+                "history": {
+                    "include_checks": False,
+                    "include_mergeability": False,
+                },
+                "included": {
+                    "task_contract",
+                    "git",
+                    "workspace_inventory",
+                    "pr_history",
+                },
+                "excluded": {"comments", "issue_closure", "checks"},
+            },
+        ),
+        (
+            "Delivery Complete",
+            {
+                "issue": (False, False, True),
+                "git": {
+                    "read_only_local_refs": True,
+                    "include_workspace_inventory": False,
+                },
+                "branches": (True, True),
+                "pr": (True, False, False),
+                "history": {
+                    "include_checks": False,
+                    "include_mergeability": False,
+                },
+                "included": {"task_contract", "git", "checks", "pr_history"},
+                "excluded": {"comments", "issue_closure", "workspace_inventory"},
+            },
+        ),
+        (
+            "review-prepare",
+            {
+                "issue": (False, False, True),
+                "git": None,
+                "branches": (False, True),
+                "pr": (True, False, False),
+                "history": None,
+                "included": {
+                    "task_contract",
+                    "remote_task_branches",
+                    "open_pr",
+                    "checks",
+                },
+                "excluded": {
+                    "comments",
+                    "issue_closure",
+                    "git",
+                    "workspace_inventory",
+                    "local_task_branches",
+                    "pr_history",
+                },
+            },
+        ),
+        (
+            "merge-preflight",
+            {
+                "issue": (False, False, True),
+                "git": None,
+                "branches": (False, True),
+                "pr": (True, True, False),
+                "history": None,
+                "included": {
+                    "task_contract",
+                    "remote_task_branches",
+                    "open_pr",
+                    "checks",
+                    "mergeability",
+                },
+                "excluded": {
+                    "comments",
+                    "issue_closure",
+                    "git",
+                    "workspace_inventory",
+                    "local_task_branches",
+                    "pr_history",
+                },
+            },
+        ),
+        (
+            "closeout",
+            {
+                "issue": (False, True, False),
+                "git": {"read_only_local_refs": True},
+                "branches": (True, True),
+                "pr": (False, False, False),
+                "history": {
+                    "include_checks": False,
+                    "include_mergeability": False,
+                },
+                "included": {
+                    "issue_closure",
+                    "git",
+                    "workspace_inventory",
+                    "pr_history",
+                },
+                "excluded": {"comments", "task_contract", "checks"},
+            },
+        ),
+    ],
+)
+def test_authoritative_operation_resolver_queries_only_its_fact_profile(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    operation: str,
+    expected: dict[str, Any],
+) -> None:
+    branch = "task/159-lck-core-live-state-resolution"
+    issue = _issue()
+    contract = _task_contract(issue)
+    pr = _open_pr(branch)
+    pr["statusCheckRollup"] = [{"name": "quality", "conclusion": "SUCCESS"}]
+    observations: dict[str, list[Any]] = {
+        "issue": [],
+        "relationships": [],
+        "git": [],
+        "branches": [],
+        "pr": [],
+        "history": [],
+    }
+
+    monkeypatch.setattr(lck, "_repository_slug", lambda *_args: "owner/repo")
+
+    def issue_query(*args: Any) -> tuple[dict[str, Any], dict[str, Any]]:
+        observations["issue"].append(tuple(args[-3:]))
+        return issue, contract
+
+    def relationship_query(*_args: Any) -> dict[str, Any]:
+        observations["relationships"].append(True)
+        return _relationships()
+
+    def git_query(*_args: Any, **kwargs: Any) -> dict[str, Any]:
+        if expected["git"] is None:
+            pytest.fail(f"{operation} queried source workspace Git facts")
+        observations["git"].append(kwargs)
+        return _git_snapshot(FakeRunner(branch=branch))
+
+    def task_branches(
+        _self: Any,
+        _task: int,
+        _warnings: list[dict[str, Any]],
+        *,
+        include_local: bool = True,
+        include_remote: bool = True,
+    ) -> tuple[set[str], dict[str, str], bool]:
+        observations["branches"].append((include_local, include_remote))
+        return set(), {branch: SHA} if include_remote else {}, True
+
+    def open_pr_query(*args: Any) -> dict[str, Any]:
+        observations["pr"].append(tuple(args[-3:]))
+        return pr
+
+    def history_query(*_args: Any, **kwargs: Any) -> list[dict[str, Any]]:
+        if expected["history"] is None:
+            pytest.fail(f"{operation} queried PR history")
+        observations["history"].append(kwargs)
+        return []
+
+    monkeypatch.setattr(lck, "_issue_view_with_contract", issue_query)
+    monkeypatch.setattr(lck, "_relationship_snapshot", relationship_query)
+    monkeypatch.setattr(lck, "_git_snapshot", git_query)
+    monkeypatch.setattr(lck.LiveStateResolver, "_task_branches", task_branches)
+    monkeypatch.setattr(lck, "resolve_open_pr", open_pr_query)
+    monkeypatch.setattr(lck, "list_matching_prs", history_query)
+
+    snapshot = lck.OperationSnapshotBuilder(
+        lck.LiveStateResolver(tmp_path, runner=cast(Any, FakeRunner()))
+    ).acquire(159, operation=operation)
+
+    assert snapshot.state.status is lck.ResolutionStatus.RESOLVED
+    assert observations["issue"] == [expected["issue"]]
+    assert observations["relationships"] == [True]
+    assert observations["git"] == ([] if expected["git"] is None else [expected["git"]])
+    assert observations["branches"] == [expected["branches"]]
+    assert observations["pr"] == [expected["pr"]]
+    assert observations["history"] == (
+        [] if expected["history"] is None else [expected["history"]]
+    )
+    facts = set(snapshot.acquired_facts)
+    assert expected["included"] <= facts
+    assert expected["excluded"].isdisjoint(facts)
+
+
+@pytest.mark.parametrize(
     ("operation", "included", "excluded"),
     [
         (
@@ -2919,3 +3114,206 @@ def test_remediation_complete_can_resume_committed_new_head_and_requires_re_revi
     assert required["remediated_head"] == repaired_head
     with pytest.raises(lck.LckStopError, match="fresh Independent Review is required"):
         lck.RemediationPreparer(resolver, store=store).prepare(159, review_id)
+
+
+def _write_owned_candidate_session(
+    store: lck.ReviewInvocationStore,
+    review_id: str,
+    *,
+    start_head: str = SHA,
+    candidate_head: str = "b" * 40,
+    candidate_tree: str = "c" * 40,
+) -> None:
+    operation_id = store.new_id()
+    store.write_remediation_session(
+        159,
+        {
+            "schema_version": lck.LCK_SCHEMA_VERSION,
+            "kind": "remediation-session",
+            "task_number": 159,
+            "review_id": review_id,
+            "operation_id": operation_id,
+            "start_head_sha": start_head,
+            "pr_number": 200,
+            "base_sha": SHA,
+            "findings_sha256": "f" * 64,
+            "findings_source": "local-review-record",
+            "candidate": {
+                "operation_id": operation_id,
+                "start_head_sha": start_head,
+                "head_sha": candidate_head,
+                "tree_oid": candidate_tree,
+            },
+            "authority": "test",
+        },
+    )
+
+
+class OwnedCandidateRunner(FakeRunner):
+    def __init__(self, *, head_sha: str, tree_oid: str) -> None:
+        super().__init__(
+            branch="task/159-lck-core-live-state-resolution",
+            local_branches={"task/159-lck-core-live-state-resolution"},
+            remote_branches={"task/159-lck-core-live-state-resolution": SHA},
+            clean=True,
+            head_sha=head_sha,
+        )
+        self.tree_oid = tree_oid
+
+    def run(
+        self,
+        argv: list[str] | tuple[str, ...],
+        *,
+        command_id: str,
+        **kwargs: Any,
+    ) -> CommandResult:
+        command = tuple(str(item) for item in argv)
+        if command == ("git", "rev-parse", "HEAD^{tree}"):
+            self.commands.append(command)
+            return CommandResult(command_id, command, 0, f"{self.tree_oid}\n", "")
+        if command[:3] == ("git", "merge-base", "--is-ancestor"):
+            self.commands.append(command)
+            return CommandResult(command_id, command, 0, "", "")
+        return super().run(argv, command_id=command_id, **kwargs)
+
+
+def test_remediation_complete_recovers_exact_owned_partial_effect_candidate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    start_head = SHA
+    candidate_head = "b" * 40
+    candidate_tree = "c" * 40
+    initial = _review_state(head=start_head, clean=False)
+    resolver = cast(Any, StaticResolver(tmp_path, initial))
+    store = lck.ReviewInvocationStore(tmp_path)
+    review_id = store.new_id()
+    operation_id = store.new_id()
+    store.write_remediation_session(
+        159,
+        {
+            "schema_version": lck.LCK_SCHEMA_VERSION,
+            "kind": "remediation-session",
+            "task_number": 159,
+            "review_id": review_id,
+            "operation_id": operation_id,
+            "start_head_sha": start_head,
+            "pr_number": 200,
+            "base_sha": SHA,
+            "findings_sha256": "f" * 64,
+            "findings_source": "local-review-record",
+            "authority": "test",
+        },
+    )
+    calls = {"completion": 0, "critical": 0, "validation": 0}
+
+    class PartialEffectDeliveryCompleter:
+        def __init__(self, *_args: Any, **kwargs: Any) -> None:
+            self.recorder = kwargs["candidate_recorder"]
+
+        def complete(
+            self, task_number: int, **kwargs: Any
+        ) -> lck.DeliveryCompletionResult:
+            calls["completion"] += 1
+            calls["critical"] += 1
+            calls["validation"] += 1
+            if calls["completion"] == 1:
+                self.recorder(candidate_head, candidate_tree)
+                raise lck.LckStopError("REMOTE_PUSH_REJECTED: simulated interruption")
+            return lck.DeliveryCompletionResult(
+                task_number=task_number,
+                status="READY_FOR_REVIEW",
+                branch=initial.target_branch,
+                head_sha=candidate_head,
+                critical_outcome={"status": "pass"},
+                validation={"status": "pass"},
+                checks={"status": "pass"},
+                effects=(),
+                operation_snapshot=kwargs["operation_snapshot"],
+            )
+
+    monkeypatch.setattr(lck, "DeliveryCompleter", PartialEffectDeliveryCompleter)
+    completer = lck.RemediationCompleter(resolver, store=store)
+
+    with pytest.raises(lck.LckStopError, match="REMOTE_PUSH_REJECTED"):
+        completer.complete(159, review_id, commit_message="repair", summary="repair")
+
+    session = store.read_remediation_session(159)
+    assert session is not None
+    assert session["candidate"] == {
+        "operation_id": operation_id,
+        "start_head_sha": start_head,
+        "head_sha": candidate_head,
+        "tree_oid": candidate_tree,
+    }
+
+    partial = replace(
+        initial,
+        git={**initial.git, "head_sha": candidate_head, "clean": True},
+        local_task_head=candidate_head,
+    )
+    resolver.state = partial
+    resolver.runner = OwnedCandidateRunner(
+        head_sha=candidate_head, tree_oid=candidate_tree
+    )
+    result = completer.complete(
+        159, review_id, commit_message="repair", summary="repair"
+    )
+
+    assert result.to_dict()["status"] == "READY_FOR_NEW_REVIEW"
+    assert calls == {"completion": 2, "critical": 2, "validation": 2}
+    assert store.read_remediation_session(159) is None
+    required = store.read_review_required(159)
+    assert required is not None
+    assert required["remediated_head"] == candidate_head
+
+
+def test_remediation_owned_candidate_recovery_rejects_replaced_local_head(
+    tmp_path: Path,
+) -> None:
+    candidate_head = "b" * 40
+    replacement_head = "d" * 40
+    state = _review_state(head=SHA, clean=True)
+    state = replace(
+        state,
+        git={**state.git, "head_sha": replacement_head},
+        local_task_head=replacement_head,
+    )
+    resolver = cast(Any, StaticResolver(tmp_path, state))
+    store = lck.ReviewInvocationStore(tmp_path)
+    review_id = store.new_id()
+    _write_owned_candidate_session(store, review_id, candidate_head=candidate_head)
+
+    with pytest.raises(lck.LckStopError, match="exactly match its owned session"):
+        lck.RemediationCompleter(resolver, store=store).complete(
+            159, review_id, commit_message="repair", summary="repair"
+        )
+
+
+@pytest.mark.parametrize("moved", ["pr", "remote"])
+def test_remediation_owned_candidate_recovery_rejects_moved_remote_or_pr(
+    tmp_path: Path,
+    moved: str,
+) -> None:
+    candidate_head = "b" * 40
+    moved_head = "d" * 40
+    original = _review_state(head=SHA, clean=True)
+    pr = dict(original.open_pr or {})
+    if moved == "pr":
+        pr["headRefOid"] = moved_head
+    state = replace(
+        original,
+        git={**original.git, "head_sha": candidate_head},
+        local_task_head=candidate_head,
+        remote_task_oid=moved_head if moved == "remote" else SHA,
+        open_pr=pr,
+    )
+    resolver = cast(Any, StaticResolver(tmp_path, state))
+    store = lck.ReviewInvocationStore(tmp_path)
+    review_id = store.new_id()
+    _write_owned_candidate_session(store, review_id, candidate_head=candidate_head)
+
+    with pytest.raises(lck.LckStopError, match="exactly match its owned session"):
+        lck.RemediationCompleter(resolver, store=store).complete(
+            159, review_id, commit_message="repair", summary="repair"
+        )

--- a/tests/tools/test_lck_closeout.py
+++ b/tests/tools/test_lck_closeout.py
@@ -619,7 +619,10 @@ def test_resolver_recovers_deleted_noncanonical_branch_from_closing_pr(
         current_branch: str,
         _base_branch: str,
         _warnings: list[dict[str, Any]],
+        *,
+        include_history_details: bool,
     ) -> list[dict[str, Any]]:
+        assert include_history_details is True
         history_branches.append(current_branch)
         return [pr]
 

--- a/tests/tools/test_lck_delivery.py
+++ b/tests/tools/test_lck_delivery.py
@@ -260,8 +260,128 @@ def test_ensure_remote_branch_stops_on_divergence(tmp_path: Path) -> None:
     _git(repo, "add", "local.txt")
     _git(repo, "commit", "-m", "local")
 
-    with pytest.raises(lck.LckStopError, match="ahead/diverged"):
+    with pytest.raises(lck.LckStopError, match="REMOTE_BRANCH_DIVERGED"):
         effect.execute("task/160-delivery")
+
+
+class RecordingGitRunner:
+    def __init__(
+        self,
+        repo: Path,
+        *,
+        fail_fetch: bool = False,
+        force_missing_object: bool = False,
+    ) -> None:
+        self.delegate = CommandRunner(repo)
+        self.commands: list[tuple[str, ...]] = []
+        self.fail_fetch = fail_fetch
+        self.force_missing_object = force_missing_object
+
+    def run(
+        self,
+        argv: list[str] | tuple[str, ...],
+        *,
+        command_id: str,
+        **kwargs: Any,
+    ) -> CommandResult:
+        command = tuple(str(item) for item in argv)
+        self.commands.append(command)
+        if self.force_missing_object and command[:3] == ("git", "cat-file", "-e"):
+            return CommandResult(
+                command_id=command_id,
+                argv=command,
+                returncode=1,
+                stdout="",
+                stderr="object unavailable",
+            )
+        if self.fail_fetch and command[:3] == ("git", "fetch", "--no-tags"):
+            return CommandResult(
+                command_id=command_id,
+                argv=command,
+                returncode=23,
+                stdout="",
+                stderr="fetch failed\n" + ("x" * 4000),
+            )
+        return self.delegate.run(argv, command_id=command_id, **kwargs)
+
+
+def test_ensure_remote_branch_uses_local_exact_remote_oid_without_fetch(
+    tmp_path: Path,
+) -> None:
+    repo, _ = _repo(tmp_path)
+    branch = "task/160-delivery"
+    _git(repo, "switch", "-c", branch)
+    (repo / "task.txt").write_text("one\n", encoding="utf-8")
+    _git(repo, "add", "task.txt")
+    _git(repo, "commit", "-m", "one")
+    _git(repo, "push", "-u", "origin", branch)
+    (repo / "task.txt").write_text("two\n", encoding="utf-8")
+    _git(repo, "commit", "-am", "two")
+    runner = RecordingGitRunner(repo)
+    resolver = lck.LiveStateResolver(repo, runner=runner, repository="owner/repo")
+
+    receipt = lck.EnsureRemoteBranchEffect(resolver).execute(branch)
+
+    assert receipt.action == "fast-forwarded"
+    assert not any(command[:2] == ("git", "fetch") for command in runner.commands)
+
+
+def test_ensure_remote_branch_fetches_only_when_exact_remote_oid_is_missing(
+    tmp_path: Path,
+) -> None:
+    repo, origin = _repo(tmp_path)
+    branch = "task/160-delivery"
+    _git(repo, "switch", "-c", branch)
+    (repo / "task.txt").write_text("candidate\n", encoding="utf-8")
+    _git(repo, "add", "task.txt")
+    _git(repo, "commit", "-m", "candidate")
+
+    other = tmp_path / "other-missing-object"
+    subprocess.run(
+        ["git", "clone", str(origin), str(other)], check=True, capture_output=True
+    )
+    _git(other, "config", "user.name", "Other")
+    _git(other, "config", "user.email", "other@example.invalid")
+    _git(other, "switch", "-c", branch, "origin/main")
+    _git(other, "push", "-u", "origin", branch)
+
+    runner = RecordingGitRunner(repo, force_missing_object=True)
+    resolver = lck.LiveStateResolver(repo, runner=runner, repository="owner/repo")
+    receipt = lck.EnsureRemoteBranchEffect(resolver).execute(branch)
+
+    assert receipt.action == "fast-forwarded"
+    assert any(command[:2] == ("git", "fetch") for command in runner.commands)
+
+
+def test_ensure_remote_branch_fetch_failure_has_bounded_classified_diagnostic(
+    tmp_path: Path,
+) -> None:
+    repo, origin = _repo(tmp_path)
+    branch = "task/160-delivery"
+    _git(repo, "switch", "-c", branch)
+    (repo / "task.txt").write_text("candidate\n", encoding="utf-8")
+    _git(repo, "add", "task.txt")
+    _git(repo, "commit", "-m", "candidate")
+
+    other = tmp_path / "other-fetch-failure"
+    subprocess.run(
+        ["git", "clone", str(origin), str(other)], check=True, capture_output=True
+    )
+    _git(other, "config", "user.name", "Other")
+    _git(other, "config", "user.email", "other@example.invalid")
+    _git(other, "switch", "-c", branch, "origin/main")
+    _git(other, "push", "-u", "origin", branch)
+
+    runner = RecordingGitRunner(repo, fail_fetch=True, force_missing_object=True)
+    resolver = lck.LiveStateResolver(repo, runner=runner, repository="owner/repo")
+    with pytest.raises(lck.LckStopError, match="REMOTE_HEAD_FETCH_FAILED") as error:
+        lck.EnsureRemoteBranchEffect(resolver).execute(branch)
+
+    diagnostic = str(error.value)
+    assert "local_object_available=false" in diagnostic
+    assert "git_exit_code=23" in diagnostic
+    assert len(diagnostic) < 1800
+    assert not any(command[:2] == ("git", "push") for command in runner.commands)
 
 
 class ValidationRunner:

--- a/tools/agent_workflow/lck.py
+++ b/tools/agent_workflow/lck.py
@@ -117,6 +117,7 @@ class FactProfile:
     include_remote_task_branches: bool = True
     include_open_pr: bool = True
     include_pr_history: bool = False
+    include_pr_history_details: bool = False
     include_checks: bool = False
     include_mergeability: bool = False
 
@@ -151,6 +152,7 @@ _DIAGNOSTIC_FACT_PROFILE: Final = FactProfile(
     include_remote_task_branches=True,
     include_open_pr=True,
     include_pr_history=True,
+    include_pr_history_details=True,
     include_checks=True,
     include_mergeability=True,
 )
@@ -158,7 +160,6 @@ _DIAGNOSTIC_FACT_PROFILE: Final = FactProfile(
 _OPERATION_FACT_PROFILES: Final = {
     "delivery-prepare": FactProfile(
         name="delivery-prepare",
-        include_workspace_inventory=True,
         include_pr_history=True,
     ),
     "delivery-complete": FactProfile(
@@ -195,8 +196,8 @@ _OPERATION_FACT_PROFILES: Final = {
         name="closeout",
         include_issue_closure=True,
         include_task_contract=False,
-        include_workspace_inventory=True,
         include_pr_history=True,
+        include_pr_history_details=True,
     ),
 }
 
@@ -823,6 +824,7 @@ class LiveStateResolver:
                         target_branch,
                         BASE_BRANCH,
                         warnings,
+                        include_history_details=True,
                     )
                 else:
                     history = list_matching_prs(
@@ -833,6 +835,7 @@ class LiveStateResolver:
                         warnings,
                         include_checks=False,
                         include_mergeability=False,
+                        include_history_details=profile.include_pr_history_details,
                     )
                 if not history and recovered_pr is not None:
                     history = [dict(recovered_pr)]

--- a/tools/agent_workflow/lck.py
+++ b/tools/agent_workflow/lck.py
@@ -5085,6 +5085,7 @@ class DeliveryCompleter:
         snapshot: OperationSnapshot,
         *,
         phase: Phase,
+        owned_remediation_candidate: bool = False,
         commit_message: str,
         summary: str,
         risks: str,
@@ -5092,7 +5093,11 @@ class DeliveryCompleter:
     ) -> DeliveryCompletionResult:
         state = snapshot.state
         task_number = state.task_number
-        decision = self.eligibility.resolve(state, phase)
+        decision = self.eligibility.resolve(
+            state,
+            phase,
+            owned_remediation_candidate=owned_remediation_candidate,
+        )
         if not decision.eligible:
             raise LckStopError(
                 f"{phase.value} STOP for Task #{task_number}: "
@@ -5251,6 +5256,7 @@ class DeliveryCompleter:
         risks: str = "",
         operation_snapshot: OperationSnapshot | None = None,
         phase: Phase = Phase.DELIVERY_COMPLETE,
+        owned_remediation_candidate: bool = False,
     ) -> DeliveryCompletionResult:
         if not summary.strip():
             raise LckStopError("Delivery summary must be non-empty")
@@ -5272,6 +5278,7 @@ class DeliveryCompleter:
             result = self._complete_from_snapshot(
                 snapshot,
                 phase=phase,
+                owned_remediation_candidate=owned_remediation_candidate,
                 commit_message=commit_message,
                 summary=summary,
                 risks=risks,
@@ -5941,6 +5948,7 @@ class RemediationCompleter:
             risks=risks,
             operation_snapshot=snapshot,
             phase=Phase.REMEDIATION_COMPLETE,
+            owned_remediation_candidate=owned_candidate,
         )
         if delivery.head_sha == start_head:
             raise LckStopError(

--- a/tools/agent_workflow/lck.py
+++ b/tools/agent_workflow/lck.py
@@ -26,7 +26,7 @@ import unicodedata
 import uuid
 
 import yaml
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
@@ -1246,7 +1246,13 @@ class PhaseDecision:
 class PhaseEligibilityResolver:
     """Apply static phase capabilities to current live preconditions."""
 
-    def resolve(self, state: LiveState, phase: Phase) -> PhaseDecision:
+    def resolve(
+        self,
+        state: LiveState,
+        phase: Phase,
+        *,
+        owned_remediation_candidate: bool = False,
+    ) -> PhaseDecision:
         reasons = list(state.stop_reasons)
         issue = state.issue
         relationships = state.relationships
@@ -1399,7 +1405,13 @@ class PhaseEligibilityResolver:
                 reasons.append("current OPEN PR base must match current origin/main")
             if state.remote_task_oid != pr_head:
                 reasons.append("remote Task branch must match current OPEN PR head")
-            if state.local_task_head is not None and state.local_task_head != pr_head:
+            if (
+                state.local_task_head is not None
+                and state.local_task_head != pr_head
+                and not (
+                    phase is Phase.REMEDIATION_COMPLETE and owned_remediation_candidate
+                )
+            ):
                 reasons.append("local Task branch must match current OPEN PR head")
             if phase is Phase.REMEDIATION_PREPARE:
                 capabilities = ("prepare_task_workspace", "load_review_findings")
@@ -2618,6 +2630,48 @@ class ReviewInvocationStore:
         atomic_write_json(path, payload)
         return path
 
+    def record_remediation_candidate(
+        self,
+        task_number: int,
+        review_id: str,
+        *,
+        start_head_sha: str,
+        candidate_head_sha: str,
+        candidate_tree_oid: str,
+    ) -> Path:
+        """Bind one exact committed candidate to its prepared Remediation session."""
+        session = self.read_remediation_session(task_number)
+        if session is None:
+            raise LckStopError(
+                "cannot record a Remediation candidate without a prepared session"
+            )
+        if (
+            session.get("review_id") != review_id
+            or session.get("start_head_sha") != start_head_sha
+        ):
+            raise LckStopError(
+                "Remediation candidate does not belong to the prepared session"
+            )
+        if not is_sha(candidate_head_sha) or not is_sha(candidate_tree_oid):
+            raise LckStopError("Remediation candidate identity is incomplete")
+        operation_id = session.get("operation_id")
+        if not isinstance(operation_id, str) or not operation_id:
+            operation_id = self.new_id()
+            session["operation_id"] = operation_id
+        candidate = {
+            "operation_id": operation_id,
+            "start_head_sha": start_head_sha,
+            "head_sha": candidate_head_sha,
+            "tree_oid": candidate_tree_oid,
+        }
+        existing = session.get("candidate")
+        if existing is not None and existing != candidate:
+            raise LckStopError(
+                "prepared Remediation session already owns a different candidate"
+            )
+        session["candidate"] = candidate
+        return self.write_remediation_session(task_number, session)
+
     def read_remediation_session(self, task_number: int) -> dict[str, Any] | None:
         path = self.remediation_session_path(task_number)
         if not path.exists():
@@ -3499,27 +3553,49 @@ class EnsureRemoteBranchEffect:
                 },
             )
         if remote_oid is not None:
-            fetch = self.resolver.runner.run(
-                ["git", "fetch", "--no-tags", "origin", f"refs/heads/{branch}"],
-                command_id="lck-fetch-observed-remote-task-branch",
+            remote_ref = f"refs/heads/{branch}"
+            available = self.resolver.runner.run(
+                ["git", "cat-file", "-e", f"{remote_oid}^{{commit}}"],
+                command_id="lck-observed-remote-object-available",
             )
-            if fetch.returncode != 0:
-                raise LckStopError("cannot verify existing remote Task branch ancestry")
-            fetched = self.resolver.runner.run(
-                ["git", "rev-parse", "FETCH_HEAD"],
-                command_id="lck-fetched-remote-task-head",
-            )
-            if fetched.returncode != 0 or fetched.stdout.strip() != remote_oid:
-                raise LckStopError(
-                    "remote Task branch changed during push precondition check"
+            local_object_available = available.returncode == 0
+            if not local_object_available:
+                fetch = self.resolver.runner.run(
+                    ["git", "fetch", "--no-tags", "origin", remote_ref],
+                    command_id="lck-fetch-observed-remote-task-branch",
                 )
+                if fetch.returncode != 0:
+                    diagnostic = stderr_tail(fetch.stderr or fetch.stdout, limit=1200)
+                    raise LckStopError(
+                        "REMOTE_HEAD_FETCH_FAILED: "
+                        f"remote_ref={remote_ref}; observed_remote_oid={remote_oid}; "
+                        f"candidate_oid={head}; local_object_available=false; "
+                        f"git_exit_code={fetch.returncode}; stderr={diagnostic or 'empty'}"
+                    )
+                fetched = self.resolver.runner.run(
+                    ["git", "rev-parse", "FETCH_HEAD"],
+                    command_id="lck-fetched-remote-task-head",
+                )
+                if fetched.returncode != 0 or fetched.stdout.strip() != remote_oid:
+                    observed = (
+                        fetched.stdout.strip()
+                        if fetched.returncode == 0
+                        else "unavailable"
+                    )
+                    raise LckStopError(
+                        "REMOTE_HEAD_CHANGED: "
+                        f"remote_ref={remote_ref}; observed_remote_oid={remote_oid}; "
+                        f"materialized_oid={observed}; candidate_oid={head}"
+                    )
             ancestor = self.resolver.runner.run(
                 ["git", "merge-base", "--is-ancestor", remote_oid, head],
                 command_id="lck-remote-fast-forward-check",
             )
             if ancestor.returncode != 0:
                 raise LckStopError(
-                    "remote Task branch is ahead/diverged; LCK will not rebase or force push"
+                    "REMOTE_BRANCH_DIVERGED: "
+                    f"remote_oid={remote_oid}; candidate_oid={head}; "
+                    "LCK will not rebase or force push"
                 )
             action = "fast-forwarded"
         else:
@@ -3536,9 +3612,11 @@ class EnsureRemoteBranchEffect:
             command_id="lck-push-task-branch",
         )
         if push.returncode != 0:
+            diagnostic = stderr_tail(push.stderr or push.stdout, limit=1200)
             raise LckStopError(
-                "Task branch push failed: "
-                + (push.stderr.strip() or push.stdout.strip())
+                "REMOTE_PUSH_REJECTED: "
+                f"remote_ref=refs/heads/{branch}; candidate_oid={head}; "
+                f"git_exit_code={push.returncode}; stderr={diagnostic or 'empty'}"
             )
         final_head, final_remote = self._identity(
             branch,
@@ -3546,7 +3624,8 @@ class EnsureRemoteBranchEffect:
         )
         if final_head != head or final_remote != head:
             raise LckStopError(
-                "push postcondition failed: local and remote heads differ"
+                "REMOTE_HEAD_CHANGED: push postcondition failed: "
+                f"candidate_oid={head}; local_oid={final_head}; remote_oid={final_remote}"
             )
         upstream = self._ensure_upstream(branch)
         return EffectReceipt(
@@ -4911,6 +4990,7 @@ class DeliveryCompleter:
         status_effect: SetReviewStatusEffect | None = None,
         checks_gate: DeliveryChecksGate | None = None,
         require_existing_open_pr: bool = False,
+        candidate_recorder: Callable[[str, str], None] | None = None,
     ) -> None:
         self.resolver = resolver
         self.snapshots = OperationSnapshotBuilder(resolver)
@@ -4922,6 +5002,7 @@ class DeliveryCompleter:
         self.status_effect = status_effect or SetReviewStatusEffect(resolver)
         self.checks_gate = checks_gate or DeliveryChecksGate(resolver)
         self.require_existing_open_pr = require_existing_open_pr
+        self.candidate_recorder = candidate_recorder
 
     def _run_critical_outcome(
         self,
@@ -5082,6 +5163,9 @@ class DeliveryCompleter:
             head = commit.details.get("head_sha")
             if not is_sha(head):
                 raise LckStopError("commit receipt did not contain a valid head SHA")
+
+        if self.candidate_recorder is not None:
+            self.candidate_recorder(str(head), validated_tree)
 
         progress.running("remote-branch")
         remote = self.remote_effect.execute(branch, expected_head_sha=str(head))
@@ -5423,6 +5507,7 @@ class RemediationPreparer:
                 "kind": "remediation-session",
                 "task_number": task_number,
                 "review_id": review_id,
+                "operation_id": self.store.new_id(),
                 "start_head_sha": pr_head,
                 "pr_number": pr_number,
                 "base_sha": pr_base,
@@ -5698,6 +5783,68 @@ class RemediationCompleter:
         self.store = store or ReviewInvocationStore(resolver.repo_root)
         self.checks_gate = checks_gate or DeliveryChecksGate(resolver)
 
+    def _owned_candidate_recovery(
+        self,
+        session: Mapping[str, Any],
+        state: LiveState,
+        *,
+        task_number: int,
+        review_id: str,
+    ) -> bool:
+        candidate = session.get("candidate")
+        if not isinstance(candidate, Mapping):
+            return False
+        operation_id = session.get("operation_id")
+        start_head = session.get("start_head_sha")
+        candidate_head = candidate.get("head_sha")
+        candidate_tree = candidate.get("tree_oid")
+        pr = state.open_pr or {}
+        exact_identity = (
+            session.get("task_number") == task_number
+            and session.get("review_id") == review_id
+            and isinstance(operation_id, str)
+            and bool(operation_id)
+            and candidate.get("operation_id") == operation_id
+            and candidate.get("start_head_sha") == start_head
+            and is_sha(start_head)
+            and is_sha(candidate_head)
+            and is_sha(candidate_tree)
+            and pr.get("number") == session.get("pr_number")
+            and pr.get("baseRefOid") == session.get("base_sha")
+            and pr.get("headRefOid") == start_head
+            and state.remote_task_oid == start_head
+            and state.local_task_head == candidate_head
+            and state.git.get("branch") == state.target_branch
+            and state.git.get("clean") is True
+        )
+        if not exact_identity:
+            raise LckStopError(
+                "Remediation committed candidate does not exactly match its owned session target"
+            )
+        tree = self.resolver.runner.run(
+            ["git", "rev-parse", "HEAD^{tree}"],
+            command_id="lck-remediation-owned-candidate-tree",
+        )
+        if tree.returncode != 0 or tree.stdout.strip() != candidate_tree:
+            raise LckStopError(
+                "Remediation committed candidate tree does not match its owned session identity"
+            )
+        ancestor = self.resolver.runner.run(
+            [
+                "git",
+                "merge-base",
+                "--is-ancestor",
+                str(start_head),
+                str(candidate_head),
+            ],
+            command_id="lck-remediation-owned-candidate-ancestry",
+        )
+        if ancestor.returncode != 0:
+            raise LckStopError(
+                "Remediation committed candidate is not a descendant of its session start head"
+            )
+        return True
+
     def complete(
         self,
         task_number: int,
@@ -5736,7 +5883,24 @@ class RemediationCompleter:
             operation=Phase.REMEDIATION_COMPLETE.value,
         )
         state = snapshot.state
-        decision = self.eligibility.resolve(state, Phase.REMEDIATION_COMPLETE)
+        owned_candidate = False
+        pr_head = state.open_pr.get("headRefOid") if state.open_pr else None
+        if (
+            session is not None
+            and session.get("candidate") is not None
+            and state.local_task_head != pr_head
+        ):
+            owned_candidate = self._owned_candidate_recovery(
+                session,
+                state,
+                task_number=task_number,
+                review_id=review_id,
+            )
+        decision = self.eligibility.resolve(
+            state,
+            Phase.REMEDIATION_COMPLETE,
+            owned_remediation_candidate=owned_candidate,
+        )
         if not decision.eligible:
             raise LckStopError(
                 f"Remediation Complete STOP for Task #{task_number}: "
@@ -5750,11 +5914,23 @@ class RemediationCompleter:
         # Initial Delivery already owns the bounded validate/commit/push/check
         # mechanics.  Remediation deliberately reuses those effects while
         # replacing PR create/resolve with a strict existing-PR postcondition.
+        def record_candidate(head_sha: str, tree_oid: str) -> None:
+            if session is None or start_head is None:
+                return
+            self.store.record_remediation_candidate(
+                task_number,
+                review_id,
+                start_head_sha=start_head,
+                candidate_head_sha=head_sha,
+                candidate_tree_oid=tree_oid,
+            )
+
         delivery = DeliveryCompleter(
             self.resolver,
             pr_effect=cast(Any, ReuseExistingOpenPrEffect(self.resolver)),
             checks_gate=self.checks_gate,
             require_existing_open_pr=True,
+            candidate_recorder=record_candidate,
         ).complete(
             task_number,
             commit_message=commit_message,

--- a/tools/agent_workflow/lck.py
+++ b/tools/agent_workflow/lck.py
@@ -179,8 +179,17 @@ _OPERATION_FACT_PROFILES: Final = {
         include_local_task_branches=False,
         include_checks=True,
     ),
-    "remediation-prepare": FactProfile(name="remediation-prepare"),
-    "remediation-no-change": FactProfile(name="remediation-no-change"),
+    # Remediation Prepare hands the current contract to the semantic repair
+    # caller; the no-change terminal operation has no semantic caller and does
+    # not need to reacquire the Issue body.
+    "remediation-prepare": FactProfile(
+        name="remediation-prepare",
+        include_task_contract=True,
+    ),
+    "remediation-no-change": FactProfile(
+        name="remediation-no-change",
+        include_task_contract=False,
+    ),
     "remediation-complete": FactProfile(
         name="remediation-complete",
         include_checks=True,
@@ -5304,6 +5313,11 @@ class RemediationContext:
     def state(self) -> LiveState:
         return self.operation_snapshot.state
 
+    @property
+    def task_contract(self) -> dict[str, Any]:
+        """Return the contract bound to this Remediation Prepare snapshot."""
+        return _task_contract_from_state(self.state)
+
     def to_dict(self) -> dict[str, Any]:
         pr = self.state.open_pr or {}
         return {
@@ -5315,6 +5329,7 @@ class RemediationContext:
             "action": self.action,
             "findings": self.findings,
             "findings_source": self.findings_source,
+            "task_contract": _jsonable(self.task_contract),
             "operation_snapshot": self.operation_snapshot.to_dict(),
             "live_target": {
                 "pr_number": pr.get("number"),

--- a/tools/agent_workflow/lck.py
+++ b/tools/agent_workflow/lck.py
@@ -103,6 +103,118 @@ class ResolutionStatus(StrEnum):
     STOP = "stop"
 
 
+@dataclass(frozen=True)
+class FactProfile:
+    """Stable bounded acquisition contract for one lifecycle operation."""
+
+    name: str
+    include_comments: bool = False
+    include_issue_closure: bool = False
+    include_task_contract: bool = True
+    include_git: bool = True
+    include_workspace_inventory: bool = False
+    include_local_task_branches: bool = True
+    include_remote_task_branches: bool = True
+    include_open_pr: bool = True
+    include_pr_history: bool = False
+    include_checks: bool = False
+    include_mergeability: bool = False
+
+    def facts(self) -> tuple[str, ...]:
+        enabled = []
+        for name in (
+            "comments",
+            "issue_closure",
+            "task_contract",
+            "git",
+            "workspace_inventory",
+            "local_task_branches",
+            "remote_task_branches",
+            "open_pr",
+            "pr_history",
+            "checks",
+            "mergeability",
+        ):
+            if getattr(self, f"include_{name}"):
+                enabled.append(name)
+        return tuple(enabled)
+
+
+_DIAGNOSTIC_FACT_PROFILE: Final = FactProfile(
+    name="diagnostic",
+    include_comments=True,
+    include_issue_closure=True,
+    include_task_contract=True,
+    include_git=True,
+    include_workspace_inventory=True,
+    include_local_task_branches=True,
+    include_remote_task_branches=True,
+    include_open_pr=True,
+    include_pr_history=True,
+    include_checks=True,
+    include_mergeability=True,
+)
+
+_OPERATION_FACT_PROFILES: Final = {
+    "delivery-prepare": FactProfile(
+        name="delivery-prepare",
+        include_workspace_inventory=True,
+        include_pr_history=True,
+    ),
+    "delivery-complete": FactProfile(
+        name="delivery-complete",
+        include_pr_history=True,
+        include_checks=True,
+    ),
+    "review-prepare": FactProfile(
+        name="review-prepare",
+        include_git=False,
+        include_local_task_branches=False,
+        include_checks=True,
+    ),
+    "review-complete": FactProfile(
+        name="review-complete",
+        include_git=False,
+        include_local_task_branches=False,
+        include_checks=True,
+    ),
+    "remediation-prepare": FactProfile(name="remediation-prepare"),
+    "remediation-no-change": FactProfile(name="remediation-no-change"),
+    "remediation-complete": FactProfile(
+        name="remediation-complete",
+        include_checks=True,
+    ),
+    "merge-preflight": FactProfile(
+        name="merge-preflight",
+        include_git=False,
+        include_local_task_branches=False,
+        include_checks=True,
+        include_mergeability=True,
+    ),
+    "closeout": FactProfile(
+        name="closeout",
+        include_issue_closure=True,
+        include_task_contract=False,
+        include_workspace_inventory=True,
+        include_pr_history=True,
+    ),
+}
+
+
+def _operation_key(operation: str) -> str:
+    return operation.strip().casefold().replace(" ", "-").replace("_", "-")
+
+
+def fact_profile_for_operation(operation: str) -> FactProfile:
+    key = _operation_key(operation)
+    try:
+        return _OPERATION_FACT_PROFILES[key]
+    except KeyError as exc:
+        raise LckStopError(
+            f"unsupported authoritative operation profile: {operation}"
+        ) from exc
+
+
 class LckStopError(WorkflowToolError):
     """A deterministic LCK gate could not identify one safe action."""
 
@@ -320,6 +432,8 @@ class OperationSnapshot:
     state: LiveState
     required_checks: Mapping[str, Any] | None = None
     acquisition_warnings: tuple[Mapping[str, Any], ...] = ()
+    fact_profile: str = "diagnostic"
+    acquired_facts: tuple[str, ...] = ()
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -328,6 +442,8 @@ class OperationSnapshot:
             "state": self.state.to_dict(),
             "required_checks": _jsonable(self.required_checks),
             "acquisition_warnings": _jsonable(self.acquisition_warnings),
+            "fact_profile": self.fact_profile,
+            "acquired_facts": list(self.acquired_facts),
         }
 
 
@@ -362,17 +478,26 @@ class LiveStateResolver:
         self,
         task_number: int,
         warnings: list[dict[str, Any]],
+        *,
+        include_local: bool = True,
+        include_remote: bool = True,
     ) -> tuple[set[str], dict[str, str], bool]:
-        local_lines = self._git_lines(
-            ["for-each-ref", "--format=%(refname:short)", "refs/heads"],
-            command_id="lck-local-task-branches",
-            warnings=warnings,
+        local_lines = (
+            self._git_lines(
+                ["for-each-ref", "--format=%(refname:short)", "refs/heads"],
+                command_id="lck-local-task-branches",
+                warnings=warnings,
+            )
+            if include_local
+            else []
         )
         local = {
             branch
             for branch in local_lines
             if _branch_matches_task(branch, task_number)
         }
+        if not include_remote:
+            return local, {}, True
         remote_result = self.runner.run(
             ["git", "ls-remote", "--heads", "origin"],
             command_id="lck-remote-task-branches",
@@ -540,6 +665,14 @@ class LiveStateResolver:
         return str(head_branch), dict(value), None
 
     def resolve(self, task_number: int) -> LiveState:
+        """Return the intentionally broad diagnostic status view."""
+        return self._resolve(task_number, _DIAGNOSTIC_FACT_PROFILE)
+
+    def resolve_for_operation(self, task_number: int, operation: str) -> LiveState:
+        """Acquire exactly one operation-bound current authority fact profile."""
+        return self._resolve(task_number, fact_profile_for_operation(operation))
+
+    def _resolve(self, task_number: int, profile: FactProfile) -> LiveState:
         if task_number <= 0:
             raise LckStopError(f"Task number must be positive: {task_number}")
 
@@ -555,6 +688,9 @@ class LiveStateResolver:
                 repository,
                 task_number,
                 warnings,
+                profile.include_comments,
+                profile.include_issue_closure,
+                profile.include_task_contract,
             )
             relationships = _relationship_snapshot(
                 self.runner, repository, task_number, warnings
@@ -562,25 +698,50 @@ class LiveStateResolver:
         else:
             reasons.append("repository identity unavailable")
 
-        git = _git_snapshot(self.runner, warnings, read_only_local_refs=True)
-        if not isinstance(git.get("branch"), str) or not git.get("branch"):
-            reasons.append("current local branch is unavailable")
-        if not is_sha(git.get("head_sha")):
-            reasons.append("current local HEAD is unavailable")
-        if not is_sha(git.get("local_main_sha")):
-            reasons.append("local main ref unavailable")
-        if not is_sha(_authoritative_remote_main_sha(git)):
-            reasons.append("remote main query failed")
-        if git.get("clean") not in {True, False}:
-            reasons.append("current worktree cleanliness is unavailable")
+        git: Mapping[str, Any]
+        if profile.include_git:
+            if profile.include_workspace_inventory:
+                git = _git_snapshot(
+                    self.runner,
+                    warnings,
+                    read_only_local_refs=True,
+                )
+            else:
+                git = _git_snapshot(
+                    self.runner,
+                    warnings,
+                    read_only_local_refs=True,
+                    include_workspace_inventory=False,
+                )
+            if not isinstance(git.get("branch"), str) or not git.get("branch"):
+                reasons.append("current local branch is unavailable")
+            if not is_sha(git.get("head_sha")):
+                reasons.append("current local HEAD is unavailable")
+            if not is_sha(git.get("local_main_sha")):
+                reasons.append("local main ref unavailable")
+            if not is_sha(_authoritative_remote_main_sha(git)):
+                reasons.append("remote main query failed")
+            if git.get("clean") not in {True, False}:
+                reasons.append("current worktree cleanliness is unavailable")
+        else:
+            git = {}
         if issue is None:
             reasons.append("Task metadata unavailable")
         if relationships.get("available") is not True:
             reasons.append("Task relationship facts unavailable")
         branch_warning_count = len(warnings)
-        local_branches, remote_branches, remote_available = self._task_branches(
-            task_number, warnings
-        )
+        if profile.include_local_task_branches and profile.include_remote_task_branches:
+            local_branches, remote_branches, remote_available = self._task_branches(
+                task_number,
+                warnings,
+            )
+        else:
+            local_branches, remote_branches, remote_available = self._task_branches(
+                task_number,
+                warnings,
+                include_local=profile.include_local_task_branches,
+                include_remote=profile.include_remote_task_branches,
+            )
         if len(warnings) > branch_warning_count:
             reasons.append("Task branch inventory contains unavailable facts")
         if not remote_available:
@@ -630,25 +791,49 @@ class LiveStateResolver:
         open_pr: Mapping[str, Any] | None = None
         merged_pr: Mapping[str, Any] | None = None
         merged_numbers: tuple[int, ...] = ()
-        if repository is not None:
+        if repository is not None and profile.include_open_pr:
             try:
-                open_pr = resolve_open_pr(
-                    self.runner,
-                    repository,
-                    target_branch,
-                    BASE_BRANCH,
-                    warnings,
-                )
+                if profile is _DIAGNOSTIC_FACT_PROFILE:
+                    open_pr = resolve_open_pr(
+                        self.runner,
+                        repository,
+                        target_branch,
+                        BASE_BRANCH,
+                        warnings,
+                    )
+                else:
+                    open_pr = resolve_open_pr(
+                        self.runner,
+                        repository,
+                        target_branch,
+                        BASE_BRANCH,
+                        warnings,
+                        profile.include_checks,
+                        profile.include_mergeability,
+                        False,
+                    )
             except PrResolveError as exc:
                 reasons.append(str(exc))
+        if repository is not None and profile.include_pr_history:
             try:
-                history = list_matching_prs(
-                    self.runner,
-                    repository,
-                    target_branch,
-                    BASE_BRANCH,
-                    warnings,
-                )
+                if profile is _DIAGNOSTIC_FACT_PROFILE:
+                    history = list_matching_prs(
+                        self.runner,
+                        repository,
+                        target_branch,
+                        BASE_BRANCH,
+                        warnings,
+                    )
+                else:
+                    history = list_matching_prs(
+                        self.runner,
+                        repository,
+                        target_branch,
+                        BASE_BRANCH,
+                        warnings,
+                        include_checks=False,
+                        include_mergeability=False,
+                    )
                 if not history and recovered_pr is not None:
                     history = [dict(recovered_pr)]
                 merged_items = [
@@ -665,7 +850,7 @@ class LiveStateResolver:
             except PrResolveError as exc:
                 reasons.append(str(exc))
 
-        if open_pr is not None:
+        if open_pr is not None and profile.include_checks:
             checks = _normalize_checks(open_pr.get("statusCheckRollup"))
         else:
             checks = _normalize_checks([])
@@ -965,12 +1150,20 @@ class OperationSnapshotBuilder:
         operation: str,
         include_required_checks: bool = False,
     ) -> OperationSnapshot:
-        state = copy.deepcopy(self.resolver.resolve(task_number))
+        profile = fact_profile_for_operation(operation)
+        operation_resolver = getattr(self.resolver, "resolve_for_operation", None)
+        if callable(operation_resolver):
+            state = copy.deepcopy(operation_resolver(task_number, operation))
+        else:
+            # Test/dedicated resolvers may already provide a pre-bounded state.
+            state = copy.deepcopy(self.resolver.resolve(task_number))
         snapshot = OperationSnapshot(
             operation=operation,
             state=state,
             required_checks=None,
             acquisition_warnings=(),
+            fact_profile=profile.name,
+            acquired_facts=profile.facts(),
         )
         if include_required_checks:
             snapshot = self.bind_required_checks(snapshot)
@@ -1006,6 +1199,8 @@ class OperationSnapshotBuilder:
             state=snapshot.state,
             required_checks=required,
             acquisition_warnings=snapshot.acquisition_warnings,
+            fact_profile=snapshot.fact_profile,
+            acquired_facts=snapshot.acquired_facts,
         )
 
 
@@ -1263,6 +1458,7 @@ class DeliveryContext:
             "branch": self.branch,
             "base_sha": self.base_sha,
             "action": self.action,
+            "task_contract": _jsonable(_task_contract_from_state(self.state)),
             "operation_snapshot": self.operation_snapshot.to_dict(),
             "eligibility": self.eligibility.to_dict(),
         }

--- a/tools/agent_workflow/pr_resolve.py
+++ b/tools/agent_workflow/pr_resolve.py
@@ -160,6 +160,7 @@ def list_matching_prs(
     limit: int = 100,
     include_checks: bool = True,
     include_mergeability: bool = True,
+    include_history_details: bool,
 ) -> list[dict[str, Any]]:
     """Read matching PRs for live-state consumers without any side effect."""
     if state not in {"open", "closed", "merged", "all"}:
@@ -182,10 +183,21 @@ def list_matching_prs(
             "--limit",
             str(limit),
             "--json",
-            _pr_fields(
-                include_checks=include_checks,
-                include_mergeability=include_mergeability,
-                include_history_details=True,
+            (
+                _pr_fields(
+                    include_checks=include_checks,
+                    include_mergeability=include_mergeability,
+                    include_history_details=True,
+                )
+                if include_history_details
+                else ",".join(
+                    (
+                        "number",
+                        "state",
+                        *(("statusCheckRollup",) if include_checks else ()),
+                        *(("mergeable",) if include_mergeability else ()),
+                    )
+                )
             ),
         ],
         command_id="gh-pr-list-live-state-history",

--- a/tools/agent_workflow/pr_resolve.py
+++ b/tools/agent_workflow/pr_resolve.py
@@ -53,6 +53,30 @@ _REQUIRED_PR_FIELDS: Final = (
 )
 
 
+def _pr_fields(
+    *,
+    include_checks: bool,
+    include_mergeability: bool,
+    include_history_details: bool,
+) -> str:
+    fields = list(_REQUIRED_PR_FIELDS)
+    if include_history_details:
+        fields.extend(
+            (
+                "mergeCommit",
+                "mergedAt",
+                "reviewDecision",
+                "headRepository",
+                "closingIssuesReferences",
+            )
+        )
+    if include_checks:
+        fields.append("statusCheckRollup")
+    if include_mergeability:
+        fields.append("mergeable")
+    return ",".join(fields)
+
+
 class PrResolveError(WorkflowToolError):
     """Expected fail-closed error from PR resolve/create operations."""
 
@@ -134,6 +158,8 @@ def list_matching_prs(
     *,
     state: str = "all",
     limit: int = 100,
+    include_checks: bool = True,
+    include_mergeability: bool = True,
 ) -> list[dict[str, Any]]:
     """Read matching PRs for live-state consumers without any side effect."""
     if state not in {"open", "closed", "merged", "all"}:
@@ -156,7 +182,11 @@ def list_matching_prs(
             "--limit",
             str(limit),
             "--json",
-            _PR_LIST_FIELDS,
+            _pr_fields(
+                include_checks=include_checks,
+                include_mergeability=include_mergeability,
+                include_history_details=True,
+            ),
         ],
         command_id="gh-pr-list-live-state-history",
     )
@@ -185,6 +215,9 @@ def resolve_open_pr(
     current_branch: str,
     base_branch: str,
     warnings: list[dict[str, Any]],
+    include_checks: bool = True,
+    include_mergeability: bool = True,
+    include_history_details: bool = True,
 ) -> dict[str, Any] | None:
     """Resolve the unique matching OPEN PR without creating or changing one.
 
@@ -208,7 +241,11 @@ def resolve_open_pr(
             "--limit",
             "2",
             "--json",
-            _PR_LIST_FIELDS,
+            _pr_fields(
+                include_checks=include_checks,
+                include_mergeability=include_mergeability,
+                include_history_details=include_history_details,
+            ),
         ],
         command_id="gh-pr-list-live-state",
     )
@@ -251,7 +288,11 @@ def resolve_open_pr(
             "--repo",
             repository,
             "--json",
-            _PR_VIEW_FIELDS,
+            _pr_fields(
+                include_checks=include_checks,
+                include_mergeability=include_mergeability,
+                include_history_details=include_history_details,
+            ),
         ],
         command_id="gh-pr-view-live-state",
     )

--- a/tools/agent_workflow/workflow_evidence.py
+++ b/tools/agent_workflow/workflow_evidence.py
@@ -226,6 +226,7 @@ def _git_snapshot(
     warnings: list[dict[str, Any]],
     *,
     read_only_local_refs: bool = False,
+    include_workspace_inventory: bool = True,
 ) -> dict[str, Any]:
     """Collect bounded Git facts for Feature audit and LCK queries.
 
@@ -279,23 +280,35 @@ def _git_snapshot(
         status_lines: list[str] | None = None
     else:
         status_lines = [line for line in status_result.stdout.splitlines() if line]
-    staged = _git_lines(
-        runner,
-        ["diff", "--cached", "--name-only"],
-        command_id="git-staged-files",
-        warnings=warnings,
+    staged = (
+        _git_lines(
+            runner,
+            ["diff", "--cached", "--name-only"],
+            command_id="git-staged-files",
+            warnings=warnings,
+        )
+        if include_workspace_inventory
+        else []
     )
-    changed = _git_lines(
-        runner,
-        ["diff", "--name-only"],
-        command_id="git-changed-files",
-        warnings=warnings,
+    changed = (
+        _git_lines(
+            runner,
+            ["diff", "--name-only"],
+            command_id="git-changed-files",
+            warnings=warnings,
+        )
+        if include_workspace_inventory
+        else []
     )
-    worktrees = _git_lines(
-        runner,
-        ["worktree", "list", "--porcelain"],
-        command_id="git-worktrees",
-        warnings=warnings,
+    worktrees = (
+        _git_lines(
+            runner,
+            ["worktree", "list", "--porcelain"],
+            command_id="git-worktrees",
+            warnings=warnings,
+        )
+        if include_workspace_inventory
+        else []
     )
     worktree_branches = sorted(
         line.removeprefix("branch refs/heads/")
@@ -326,10 +339,26 @@ def _git_snapshot(
         "remote_main_query": "pass" if is_sha(remote_main) else "unknown",
         "clean": None if status_lines is None else len(status_lines) == 0,
         "status_entries": None if status_lines is None else len(status_lines),
-        "staged_files": bounded_list(staged, item_limit=MAX_FILES),
-        "changed_files": bounded_list(changed, item_limit=MAX_FILES),
-        "worktree_count": sum(1 for line in worktrees if line.startswith("worktree ")),
-        "worktree_branches": bounded_list(worktree_branches, item_limit=MAX_FILES),
+        "staged_files": (
+            bounded_list(staged, item_limit=MAX_FILES)
+            if include_workspace_inventory
+            else None
+        ),
+        "changed_files": (
+            bounded_list(changed, item_limit=MAX_FILES)
+            if include_workspace_inventory
+            else None
+        ),
+        "worktree_count": (
+            sum(1 for line in worktrees if line.startswith("worktree "))
+            if include_workspace_inventory
+            else None
+        ),
+        "worktree_branches": (
+            bounded_list(worktree_branches, item_limit=MAX_FILES)
+            if include_workspace_inventory
+            else None
+        ),
     }
 
 
@@ -338,6 +367,9 @@ def _issue_view_with_contract(
     repository: str,
     number: int,
     warnings: list[dict[str, Any]],
+    include_comments: bool = True,
+    include_closure: bool = True,
+    include_contract: bool = True,
 ) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
     """Read one Issue once and return compact facts plus the Task contract.
 
@@ -346,10 +378,13 @@ def _issue_view_with_contract(
     single GitHub read therefore produces both representations so callers do
     not re-query the same Task later in an operation.
     """
-    fields = (
-        "number,title,body,comments,state,labels,projectItems,url,closedAt,"
-        "closedByPullRequestsReferences"
-    )
+    fields = ["number", "title", "state", "labels", "projectItems", "url"]
+    if include_contract:
+        fields.append("body")
+    if include_comments:
+        fields.append("comments")
+    if include_closure:
+        fields.extend(("closedAt", "closedByPullRequestsReferences"))
     result = runner.run(
         [
             "gh",
@@ -359,7 +394,7 @@ def _issue_view_with_contract(
             "--repo",
             repository,
             "--json",
-            fields,
+            ",".join(fields),
         ],
         command_id=f"gh-issue-view-{number}",
         retries=1,
@@ -374,7 +409,16 @@ def _issue_view_with_contract(
                 "--repo",
                 repository,
                 "--json",
-                "number,title,body,state,labels,url,closedAt",
+                ",".join(
+                    field
+                    for field in fields
+                    if field
+                    not in {
+                        "comments",
+                        "projectItems",
+                        "closedByPullRequestsReferences",
+                    }
+                ),
             ],
             command_id=f"gh-issue-view-fallback-{number}",
         )
@@ -437,7 +481,10 @@ def _issue_view_with_contract(
                     else None,
                 }
             )
-    content_facts = {"body": body, "comments": comment_facts}
+    content_facts = {
+        "body": body,
+        "comments": comment_facts if include_comments else None,
+    }
     issue = {
         "number": value.get("number"),
         "title": safe_text(value.get("title")),
@@ -445,7 +492,7 @@ def _issue_view_with_contract(
         "body_sha256": sha256_json({"body": body}),
         "body_characters": len(body) if body is not None else None,
         "critical_outcome": critical_outcome_snapshot(body),
-        "comment_count": len(comment_facts),
+        "comment_count": len(comment_facts) if include_comments else None,
         "state": safe_text(value.get("state")),
         "labels": bounded_list(sorted(normalized_labels)),
         "project_status": _find_project_status(value.get("projectItems")),
@@ -453,9 +500,10 @@ def _issue_view_with_contract(
         "closed_at": safe_text(value.get("closedAt")),
         "closing_pull_requests": bounded_list(pull_refs),
     }
-    issue["issue_closure"] = _issue_closure_snapshot(
-        runner, repository, number, warnings
-    )
+    if include_closure:
+        issue["issue_closure"] = _issue_closure_snapshot(
+            runner, repository, number, warnings
+        )
     contract = (
         {
             "number": value.get("number"),
@@ -465,7 +513,7 @@ def _issue_view_with_contract(
             "body_sha256": issue["body_sha256"],
             "critical_outcome": issue["critical_outcome"],
         }
-        if body is not None
+        if include_contract and body is not None
         else None
     )
     return issue, contract


### PR DESCRIPTION
Closes #178

## Summary
Bind authoritative LCK operations to explicit phase-specific fact profiles, return the snapshot-bound Task Contract to Delivery callers, and avoid unrelated Issue, Git workspace, PR history, and check queries while preserving one fresh acquisition boundary.

## Validation
- Critical Outcome: pass
- Formal Delivery validation: pass

## Risks / limitations
Diagnostic status intentionally retains the broad view; operation profiles remain fail-closed and exact post-effect queries are unchanged.
