### PR TITLE
[Task] 分离 LCK Agent 输出与完整审计 Receipt

### DIFF
--- a/docs/development/issue-workflow.md
+++ b/docs/development/issue-workflow.md
@@ -123,6 +123,11 @@ subprocesses continue to receive the same path through `build_workflow_env()`.
 - 每个 authoritative operation 在入口绑定一个稳定的 fact profile，并在 operation snapshot
   中记录 profile 与 acquired facts。Delivery Prepare 直接返回同一次 fresh acquisition 绑定的
   完整 Task Contract；semantic caller 不应为同一 operation 再查询 Task body。
+- LCK 最终 stdout 是紧凑的 `lck-agent-view`，只保留当前调用方判断状态与下一动作所需的
+  authoritative identity、result summary 和 `receipt_reference`。完整 operation snapshot、fact
+  acquisition、validation/effect/postcondition evidence 与诊断日志保存在
+  `.workflow.local/lck/audit-receipts/` 下的 operation-owned Audit Receipt；STOP、FAIL、stale
+  等结果同样使用结构化 Agent View 和 Receipt，不以 progress stderr 代替 lifecycle result。
 - Initial Delivery 的 lifecycle mechanics（workspace prepare、commit validated tree、
   remote synchronization、OPEN PR resolve/create、Project Status → Review）由 LCK
   deterministic control 执行；Agent/Skill 不提供 branch/SHA/PR/refspec authority。

--- a/docs/development/pr-review.md
+++ b/docs/development/pr-review.md
@@ -71,6 +71,12 @@ Contract、validation、checks 和 isolated `review_root`。Formal validation FA
 丢失时仍能从 marker + guard 判断 ownership；后续 Prepare 只有在 owner 已退出且
 handoff 的 clone/guard 不完整时才回收其 LCK-owned state。
 
+LCK 的最终 stdout 是紧凑的 `lck-agent-view`，并提供 `receipt_reference`；Review Prepare
+仍直接提供完整 Task Contract 与 sealed review target 所需的最小输入。完整 operation
+snapshot、guard、validation/check evidence 和诊断信息保存在 ignored
+`.workflow.local/lck/audit-receipts/` Receipt 中，progress heartbeat 仍只写 stderr，不能
+成为第二个 lifecycle result。
+
 ## 4. Fresh semantic context and read-only workspace
 
 LCK 在系统临时目录创建 reviewed head 的 detached standalone clone；它通过本地 clone

--- a/tests/tools/test_lck.py
+++ b/tests/tools/test_lck.py
@@ -1179,6 +1179,75 @@ def test_closeout_cleanup_keeps_exact_worktree_safety_precondition(
     assert runner.commands == [("git", "worktree", "list", "--porcelain")]
 
 
+def test_closeout_failure_receipt_preserves_completed_effects(
+    tmp_path: Path,
+) -> None:
+    state = replace(
+        _review_state(),
+        merged_pr={"number": 200},
+    )
+    resolver = cast(Any, StaticResolver(tmp_path, state))
+
+    class Eligible:
+        def resolve(
+            self,
+            _state: lck.LiveState,
+            phase: lck.Phase,
+        ) -> lck.PhaseDecision:
+            return lck.PhaseDecision(phase=phase, eligible=True)
+
+    class Main:
+        def execute(
+            self,
+            _state: lck.LiveState,
+            *,
+            merge_sha: str,
+        ) -> lck.EffectReceipt:
+            return lck.EffectReceipt(
+                "synchronize_main",
+                "synchronized",
+                {"merge_sha": merge_sha},
+            )
+
+    class FailingMetadata:
+        def execute(self, _state: lck.LiveState) -> lck.EffectReceipt:
+            raise lck.LckStopError("metadata convergence failed")
+
+    handler = lck.CloseoutCompleter(
+        resolver,
+        eligibility=cast(Any, Eligible()),
+        main_effect=cast(Any, Main()),
+        metadata_effect=cast(Any, FailingMetadata()),
+    )
+    handler._validate_merged_identity = lambda _state: (SHA, "b" * 40)
+    handler._validate_reviewed_identity = lambda _state, _pr: None
+
+    with pytest.raises(lck.LckStopError, match="metadata convergence failed"):
+        handler.complete(159)
+
+    assert [item.effect for item in handler.last_effects] == ["synchronize_main"]
+    store = lck.AuditReceiptStore(tmp_path)
+    payload = lck._write_failure_receipt(
+        operation="closeout",
+        task_number=159,
+        operation_id="e" * 32,
+        status="stop",
+        code=None,
+        error="metadata convergence failed",
+        handler=handler,
+        store=store,
+    )
+    receipt = store.read(payload["receipt_reference"])
+
+    assert receipt["audit"]["effects"] == [
+        {
+            "effect": "synchronize_main",
+            "action": "synchronized",
+            "details": {"merge_sha": "b" * 40},
+        }
+    ]
+
+
 def _review_identity_value(*, head: str = SHA, base: str = SHA) -> lck.ReviewIdentity:
     return lck.ReviewIdentity(
         task_number=159,
@@ -1492,6 +1561,59 @@ def test_review_prepare_returns_compact_agent_view_and_full_audit_receipt(
     assert receipt["operation_snapshot"] == snapshot.to_dict()
     assert receipt["agent_view"]["review_target"] == payload["review_target"]
     assert receipt["audit"]["review_guard"]["review_id"] == review_id
+
+
+def test_review_prepare_failure_receipt_preserves_validation_payload(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = _review_state()
+    identity = _review_identity_value()
+    validation = {
+        "status": "fail",
+        "phase": "review",
+        "commands": [
+            {
+                "command_id": "pytest",
+                "status": "fail",
+                "exit_code": 1,
+                "diagnostic": "review validation failed",
+            }
+        ],
+        "evidence_path": ".workflow.local/lck/review-validation/run",
+    }
+
+    class FailedValidation:
+        def run(self, _root: Path, _base: str, _head: str) -> dict[str, Any]:
+            return validation
+
+    resolver = cast(Any, StaticResolver(tmp_path, state))
+    monkeypatch.setattr(lck, "_review_identity", lambda *_args, **_kwargs: identity)
+    handler = lck.ReviewPreparer(
+        resolver,
+        validation=cast(Any, FailedValidation()),
+        checks_gate=cast(Any, FakeReviewChecks()),
+        workspace=cast(Any, FakeReviewWorkspace(tmp_path / "review-root")),
+        store=lck.ReviewInvocationStore(tmp_path),
+    )
+
+    with pytest.raises(lck.LckStopError, match="formal Review validation failed"):
+        handler.prepare(159)
+
+    store = lck.AuditReceiptStore(tmp_path)
+    payload = lck._write_failure_receipt(
+        operation="review-prepare",
+        task_number=159,
+        operation_id="c" * 32,
+        status="stop",
+        code=None,
+        error="formal Review validation failed: fail",
+        handler=handler,
+        store=store,
+    )
+    receipt = store.read(payload["receipt_reference"])
+
+    assert receipt["audit"]["validation"] == validation
 
 
 def test_lck_stop_result_has_structured_receipt_reference(
@@ -2422,6 +2544,74 @@ def test_review_complete_revalidates_current_checks(
 
     assert resolver.calls == 1
     assert store.read_latest_review(159) is None
+
+
+def test_review_complete_failure_receipt_preserves_bound_snapshot_and_checks(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    identity = _review_identity_value()
+    resolver = cast(Any, StaticResolver(tmp_path, _review_state()))
+    monkeypatch.setattr(lck, "_review_identity", lambda *_args, **_kwargs: identity)
+    store = lck.ReviewInvocationStore(tmp_path)
+    review_id = store.new_id()
+    review_root = tmp_path / "review-root"
+    review_root.mkdir()
+    store.write_guard(review_id, _review_guard(identity, review_root=review_root))
+
+    class FailingChecks:
+        last_result: dict[str, Any] | None = None
+
+        def evaluate(self, snapshot: lck.OperationSnapshot) -> dict[str, Any]:
+            self.last_result = {
+                "status": "fail",
+                "check_state": "pending",
+                "required": snapshot.required_checks["contexts"]["items"]
+                if snapshot.required_checks is not None
+                else [],
+                "pr": {"number": 200, "head_sha": SHA, "base_sha": SHA},
+            }
+            raise lck.LckStopError("PR checks are pending")
+
+    handler = lck.ReviewCompleter(
+        resolver,
+        checks_gate=cast(Any, FailingChecks()),
+        store=store,
+        workspace=cast(Any, FakeReviewWorkspace(review_root)),
+    )
+
+    with pytest.raises(lck.LckStopError, match="PR checks are pending"):
+        handler.complete(159, review_id, verdict="PASS")
+
+    assert handler.last_snapshot is not None
+    assert handler.last_snapshot.required_checks is not None
+    assert handler.last_snapshot.required_checks["source_sha"] == SHA
+    assert handler.last_snapshot.required_checks["contexts"]["items"] == ["quality"]
+    assert handler.last_checks == {
+        "status": "fail",
+        "check_state": "pending",
+        "required": ["quality"],
+        "pr": {"number": 200, "head_sha": SHA, "base_sha": SHA},
+    }
+
+    audit_store = lck.AuditReceiptStore(tmp_path)
+    payload = lck._write_failure_receipt(
+        operation="review-complete",
+        task_number=159,
+        operation_id="d" * 32,
+        status="stop",
+        code=None,
+        error="PR checks are pending",
+        handler=handler,
+        store=audit_store,
+    )
+    receipt = audit_store.read(payload["receipt_reference"])
+
+    assert receipt["operation_snapshot"]["required_checks"]["source_sha"] == SHA
+    assert receipt["operation_snapshot"]["required_checks"]["contexts"]["items"] == [
+        "quality"
+    ]
+    assert receipt["audit"]["checks"] == handler.last_checks
 
 
 def test_review_fail_is_not_delayed_by_pending_checks(

--- a/tests/tools/test_lck.py
+++ b/tests/tools/test_lck.py
@@ -3108,6 +3108,18 @@ def test_remediation_failure_receipt_preserves_nested_delivery_evidence(
             "authority": "test",
         },
     )
+    failed_validation = {
+        "status": "fail",
+        "commands": [
+            {
+                "command_id": "pytest",
+                "exit_code": 1,
+                "log_path": ".agents/validation.local/pytest.log",
+                "duration_ms": 23,
+                "diagnostic": "assertion failed",
+            }
+        ],
+    }
 
     class FailingDeliveryCompleter:
         def __init__(self, *_args: Any, **_kwargs: Any) -> None:
@@ -3119,7 +3131,7 @@ def test_remediation_failure_receipt_preserves_nested_delivery_evidence(
         def complete(self, *_args: Any, **kwargs: Any) -> Any:
             self.last_snapshot = kwargs["operation_snapshot"]
             self.last_critical_outcome = {"status": "pass"}
-            self.last_validation = {"status": "pass", "command_count": 6}
+            self.last_validation = failed_validation
             self.last_effects = [
                 lck.EffectReceipt(
                     "commit_current_tree",
@@ -3155,7 +3167,7 @@ def test_remediation_failure_receipt_preserves_nested_delivery_evidence(
 
     assert handler.last_snapshot is not None
     assert receipt["operation_snapshot"] == handler.last_snapshot.to_dict()
-    assert receipt["audit"]["validation"]["command_count"] == 6
+    assert receipt["audit"]["validation"] == failed_validation
     assert receipt["audit"]["effects"][0]["effect"] == "commit_current_tree"
 
 

--- a/tests/tools/test_lck.py
+++ b/tests/tools/test_lck.py
@@ -1525,6 +1525,62 @@ def test_lck_stop_result_has_structured_receipt_reference(
     assert receipt["agent_view"]["error"] == "live state is unavailable"
 
 
+def test_remediation_no_change_cli_replay_reuses_audit_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    state = _review_state()
+    resolver = cast(Any, StaticResolver(tmp_path, state))
+    store = lck.ReviewInvocationStore(tmp_path)
+    review_id = store.new_id()
+    store.write_remediation_session(
+        159,
+        {
+            "schema_version": lck.LCK_SCHEMA_VERSION,
+            "kind": "remediation-session",
+            "task_number": 159,
+            "review_id": review_id,
+            "start_head_sha": SHA,
+            "pr_number": 200,
+            "base_sha": SHA,
+            "findings_sha256": "f" * 64,
+            "findings_source": "local-review-record",
+            "authority": "test",
+        },
+    )
+    monkeypatch.setattr(
+        lck,
+        "LiveStateResolver",
+        lambda _root, repository=None: resolver,
+    )
+    argv = [
+        "--repo-root",
+        str(tmp_path),
+        "remediation",
+        "no-change",
+        "159",
+        "--review-id",
+        review_id,
+        "--summary",
+        "No implementation change required.",
+    ]
+
+    first_exit = lck.main(argv)
+    first = json.loads(capsys.readouterr().out)
+    second_exit = lck.main(argv)
+    second = json.loads(capsys.readouterr().out)
+
+    assert first_exit == second_exit == 0
+    assert first["replayed"] is False
+    assert second["replayed"] is True
+    assert first["receipt_reference"] == second["receipt_reference"]
+    assert second["next_action"]
+    receipt = lck.AuditReceiptStore(tmp_path).read(second["receipt_reference"])
+    assert receipt["agent_view"]["replayed"] is False
+    assert receipt["audit"]["replayed"] is False
+
+
 def test_review_prepare_allows_pending_checks_for_parallel_semantic_review(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -3027,6 +3083,80 @@ def test_remediation_complete_uses_prepared_session_without_review_record(
     required = store.read_review_required(159)
     assert required is not None
     assert required["remediated_head"] == repaired_head
+
+
+def test_remediation_failure_receipt_preserves_nested_delivery_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = _review_state(clean=False)
+    resolver = cast(Any, StaticResolver(tmp_path, state))
+    store = lck.ReviewInvocationStore(tmp_path)
+    review_id = store.new_id()
+    store.write_remediation_session(
+        159,
+        {
+            "schema_version": lck.LCK_SCHEMA_VERSION,
+            "kind": "remediation-session",
+            "task_number": 159,
+            "review_id": review_id,
+            "start_head_sha": SHA,
+            "pr_number": 200,
+            "base_sha": SHA,
+            "findings_sha256": "f" * 64,
+            "findings_source": "local-review-record",
+            "authority": "test",
+        },
+    )
+
+    class FailingDeliveryCompleter:
+        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+            self.last_snapshot: lck.OperationSnapshot | None = None
+            self.last_critical_outcome: dict[str, Any] | None = None
+            self.last_validation: dict[str, Any] | None = None
+            self.last_effects: list[lck.EffectReceipt] = []
+
+        def complete(self, *_args: Any, **kwargs: Any) -> Any:
+            self.last_snapshot = kwargs["operation_snapshot"]
+            self.last_critical_outcome = {"status": "pass"}
+            self.last_validation = {"status": "pass", "command_count": 6}
+            self.last_effects = [
+                lck.EffectReceipt(
+                    "commit_current_tree",
+                    "committed",
+                    {"head_sha": "b" * 40},
+                )
+            ]
+            raise lck.LckStopError("remote branch effect failed")
+
+    monkeypatch.setattr(lck, "DeliveryCompleter", FailingDeliveryCompleter)
+    handler = lck.RemediationCompleter(resolver, store=store)
+
+    with pytest.raises(lck.LckStopError, match="remote branch effect failed"):
+        handler.complete(
+            159,
+            review_id,
+            commit_message="repair",
+            summary="repair",
+        )
+
+    audit_store = lck.AuditReceiptStore(tmp_path)
+    payload = lck._write_failure_receipt(
+        operation="remediation-complete",
+        task_number=159,
+        operation_id="e" * 32,
+        status="stop",
+        code=None,
+        error="remote branch effect failed",
+        handler=handler,
+        store=audit_store,
+    )
+    receipt = audit_store.read(payload["receipt_reference"])
+
+    assert handler.last_snapshot is not None
+    assert receipt["operation_snapshot"] == handler.last_snapshot.to_dict()
+    assert receipt["audit"]["validation"]["command_count"] == 6
+    assert receipt["audit"]["effects"][0]["effect"] == "commit_current_tree"
 
 
 def test_remediation_no_change_closes_prepared_session_without_new_head(

--- a/tests/tools/test_lck.py
+++ b/tests/tools/test_lck.py
@@ -1407,6 +1407,124 @@ def test_review_prepare_builds_context_only_from_live_resolution(
     assert checks.calls == 1
 
 
+def test_review_prepare_returns_compact_agent_view_and_full_audit_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Critical Outcome: Review Prepare separates Agent output from evidence."""
+    state = _review_state()
+    identity = _review_identity_value()
+    review_id = "b" * 32
+    review_root = tmp_path / "review-root"
+    review_root.mkdir()
+    store = lck.ReviewInvocationStore(tmp_path)
+    snapshot = lck.OperationSnapshot(
+        operation="review-prepare",
+        state=state,
+        fact_profile="review-prepare",
+        acquired_facts=("task_contract", "remote_task_branches", "open_pr", "checks"),
+    )
+    guard = _review_guard(identity, review_root=review_root)
+    guard.update(
+        {
+            "schema_version": lck.LCK_SCHEMA_VERSION,
+            "kind": "review-invocation-guard",
+            "review_id": review_id,
+            "snapshot": snapshot.to_dict(),
+        }
+    )
+    store.write_guard(review_id, guard)
+    context = lck.ReviewContext(
+        review_id=review_id,
+        task_contract=state.task_contract or {},
+        identity=identity,
+        checks={
+            "status": "observed",
+            "check_state": "pending",
+            "pr": {"number": 200, "head_sha": SHA, "base_sha": SHA},
+            "observed": {"quality": {"status": "pending"}},
+        },
+        validation={"status": "pass", "commands": [{"command_id": "pytest"}]},
+        review_root=review_root,
+    )
+
+    class FakePreparer:
+        def __init__(self, _resolver: Any) -> None:
+            pass
+
+        def prepare(self, _task_number: int) -> lck.ReviewContext:
+            return context
+
+    resolver = StaticResolver(tmp_path, state)
+    monkeypatch.setattr(
+        lck,
+        "LiveStateResolver",
+        lambda _root, repository=None: resolver,
+    )
+    monkeypatch.setattr(lck, "ReviewPreparer", FakePreparer)
+
+    exit_code = lck.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--repository",
+            "owner/repo",
+            "review",
+            "prepare",
+            "159",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["kind"] == "lck-agent-view"
+    assert payload["status"] == "READY_FOR_SEMANTIC_REVIEW"
+    assert payload["review_target"] == identity.to_dict()
+    assert payload["task_contract"]["body"] == "Task Contract"
+    assert "operation_snapshot" not in payload
+    assert "observed" not in payload["checks"]
+
+    reference = payload["receipt_reference"]
+    receipt = lck.AuditReceiptStore(tmp_path).read(reference)
+    assert receipt["kind"] == "lck-audit-receipt"
+    assert receipt["operation"] == "review-prepare"
+    assert receipt["operation_snapshot"] == snapshot.to_dict()
+    assert receipt["agent_view"]["review_target"] == payload["review_target"]
+    assert receipt["audit"]["review_guard"]["review_id"] == review_id
+
+
+def test_lck_stop_result_has_structured_receipt_reference(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    class FailingResolver:
+        repo_root = tmp_path
+
+        def resolve(self, _task_number: int) -> lck.LiveState:
+            raise lck.LckStopError("live state is unavailable")
+
+    resolver = FailingResolver()
+    monkeypatch.setattr(
+        lck,
+        "LiveStateResolver",
+        lambda _root, repository=None: resolver,
+    )
+
+    exit_code = lck.main(["--repo-root", str(tmp_path), "status", "159"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 2
+    assert payload["kind"] == "lck-agent-view"
+    assert payload["operation"] == "status"
+    assert payload["status"] == "stop"
+    assert payload["next_action"]
+    receipt = lck.AuditReceiptStore(tmp_path).read(payload["receipt_reference"])
+    assert receipt["outcome"]["status"] == "stop"
+    assert receipt["agent_view"]["error"] == "live state is unavailable"
+
+
 def test_review_prepare_allows_pending_checks_for_parallel_semantic_review(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/tools/test_lck.py
+++ b/tests/tools/test_lck.py
@@ -1414,6 +1414,60 @@ class FakeReviewValidation:
         return {"status": "pass", "phase": "review"}
 
 
+def test_merge_preflight_failure_receipt_preserves_strict_check_evidence(
+    tmp_path: Path,
+) -> None:
+    state = _review_state()
+    resolver = cast(Any, StaticResolver(tmp_path, state))
+
+    class PassingReview:
+        def run(self, _task_number: int, _state: lck.LiveState) -> dict[str, Any]:
+            return {"status": "pass", "review_id": "r" * 32}
+
+    class FailingChecks:
+        last_result: dict[str, Any] | None = None
+
+        def evaluate(self, snapshot: lck.OperationSnapshot) -> dict[str, Any]:
+            pr = snapshot.state.open_pr or {}
+            self.last_result = {
+                "status": "fail",
+                "check_state": "pending",
+                "required": ["quality"],
+                "pr": {
+                    "number": pr["number"],
+                    "head_sha": pr["headRefOid"],
+                    "base_sha": pr["baseRefOid"],
+                },
+            }
+            raise lck.LckStopError("PR checks are pending")
+
+    checks = FailingChecks()
+    handler = lck.MergePreflight(
+        resolver,
+        review_gate=cast(Any, PassingReview()),
+        checks_gate=cast(Any, checks),
+    )
+
+    with pytest.raises(lck.LckStopError, match="PR checks are pending"):
+        handler.run(159)
+
+    assert handler.last_checks == checks.last_result
+    store = lck.AuditReceiptStore(tmp_path)
+    payload = lck._write_failure_receipt(
+        operation="merge-preflight",
+        task_number=159,
+        operation_id="a" * 32,
+        status="stop",
+        code=None,
+        error="PR checks are pending",
+        handler=handler,
+        store=store,
+    )
+    receipt = store.read(payload["receipt_reference"])
+
+    assert receipt["audit"]["checks"] == checks.last_result
+
+
 def _review_guard(
     identity: lck.ReviewIdentity,
     *,
@@ -3316,6 +3370,11 @@ def test_remediation_failure_receipt_preserves_nested_delivery_evidence(
             self.last_snapshot: lck.OperationSnapshot | None = None
             self.last_critical_outcome: dict[str, Any] | None = None
             self.last_validation: dict[str, Any] | None = None
+            self.last_checks: dict[str, Any] | None = {
+                "status": "observed",
+                "check_state": "pending",
+                "pr": {"number": 200, "head_sha": SHA, "base_sha": SHA},
+            }
             self.last_effects: list[lck.EffectReceipt] = []
 
         def complete(self, *_args: Any, **kwargs: Any) -> Any:
@@ -3358,6 +3417,7 @@ def test_remediation_failure_receipt_preserves_nested_delivery_evidence(
     assert handler.last_snapshot is not None
     assert receipt["operation_snapshot"] == handler.last_snapshot.to_dict()
     assert receipt["audit"]["validation"] == failed_validation
+    assert receipt["audit"]["checks"] == handler.last_checks
     assert receipt["audit"]["effects"][0]["effect"] == "commit_current_tree"
 
 

--- a/tests/tools/test_lck_delivery.py
+++ b/tests/tools/test_lck_delivery.py
@@ -623,11 +623,12 @@ class StubChecks:
     def __init__(self, *, fail: str | None = None) -> None:
         self.fail = fail
         self.calls = 0
+        self.last_result: dict[str, Any] | None = None
 
     def _result(self, number: int, head: str, base: str) -> dict[str, Any]:
         if self.fail:
             raise lck.LckStopError(self.fail)
-        return {
+        result = {
             "status": "pass",
             "configuration": "repository",
             "required": ["quality"],
@@ -640,6 +641,8 @@ class StubChecks:
             },
             "pr": {"number": number, "head_sha": head, "base_sha": base},
         }
+        self.last_result = dict(result)
+        return result
 
     def evaluate(self, snapshot: lck.OperationSnapshot) -> dict[str, Any]:
         self.calls += 1
@@ -661,6 +664,7 @@ class StubChecks:
         result["status"] = "observed"
         result["gate"] = "non-blocking"
         result["check_state"] = "pass"
+        self.last_result = dict(result)
         return result
 
     def observe_exact_pr(
@@ -676,6 +680,7 @@ class StubChecks:
         result["status"] = "observed"
         result["gate"] = "non-blocking"
         result["check_state"] = "pass"
+        self.last_result = dict(result)
         return result
 
     def query_exact_pr(
@@ -1822,6 +1827,7 @@ def test_delivery_failure_receipt_preserves_completed_operation_evidence(
 
     runner = FailingFinalRunner()
     resolver = SequenceResolver(tmp_path, runner, [state])
+    checks = StubChecks()
     handler = lck.DeliveryCompleter(
         cast(Any, resolver),
         formal_validation=cast(Any, StubValidation()),
@@ -1829,7 +1835,7 @@ def test_delivery_failure_receipt_preserves_completed_operation_evidence(
         remote_effect=cast(Any, StubEffect("ensure_remote_branch", "created")),
         pr_effect=cast(Any, StubEffect("ensure_open_pr", "created")),
         status_effect=cast(Any, StubEffect("set_review_status", "updated")),
-        checks_gate=cast(Any, StubChecks()),
+        checks_gate=cast(Any, checks),
     )
 
     with pytest.raises(lck.LckStopError, match="local postcondition failed"):
@@ -1856,6 +1862,12 @@ def test_delivery_failure_receipt_preserves_completed_operation_evidence(
     assert receipt["operation_snapshot"] == handler.last_snapshot.to_dict()
     assert receipt["audit"]["critical_outcome"]["status"] == "pass"
     assert receipt["audit"]["validation"]["status"] == "pass"
+    assert receipt["audit"]["checks"] == handler.last_checks
+    assert receipt["audit"]["checks"]["pr"] == {
+        "number": 10,
+        "head_sha": "b" * 40,
+        "base_sha": SHA,
+    }
     assert [item["effect"] for item in receipt["audit"]["effects"]] == [
         "commit_current_tree",
         "ensure_remote_branch",

--- a/tests/tools/test_lck_delivery.py
+++ b/tests/tools/test_lck_delivery.py
@@ -1527,8 +1527,9 @@ def test_strict_checks_gate_stops_on_failed_check(tmp_path: Path) -> None:
     state = _with_checks(base, _checks(category="failed", state_name="FAILURE"))
     resolver = SequenceResolver(tmp_path, CompletionRunner(), [state])
 
+    gate = lck.DeliveryChecksGate(cast(Any, resolver))
     with pytest.raises(lck.LckStopError, match="checks failed"):
-        lck.DeliveryChecksGate(cast(Any, resolver)).evaluate(
+        gate.evaluate(
             _snapshot(
                 state,
                 required={
@@ -1536,6 +1537,9 @@ def test_strict_checks_gate_stops_on_failed_check(tmp_path: Path) -> None:
                 },
             )
         )
+    assert gate.last_result is not None
+    assert gate.last_result["status"] == "fail"
+    assert gate.last_result["check_state"] == "failed"
     assert resolver.calls == 0
 
 

--- a/tests/tools/test_lck_delivery.py
+++ b/tests/tools/test_lck_delivery.py
@@ -429,9 +429,12 @@ def test_formal_validation_gate_fails_closed(
     resolver = lck.LiveStateResolver(
         tmp_path, runner=cast(Any, runner), repository="owner/repo"
     )
+    gate = lck.FormalValidationGate(resolver)
 
     with pytest.raises(lck.LckStopError, match="formal Delivery validation failed"):
-        lck.FormalValidationGate(resolver).run(SHA)
+        gate.run(SHA)
+
+    assert gate.last_payload == {"status": status}
 
 
 @pytest.mark.parametrize("mutation", ["merged", "invalid-target"])
@@ -1653,17 +1656,18 @@ def test_delivery_complete_critical_outcome_failure_blocks_commit_and_remote(
     resolver = SequenceResolver(tmp_path, runner, [pre])
     commit = StubCommit(dirty=True)
     remote = StubEffect("ensure_remote_branch", "created")
+    handler = lck.DeliveryCompleter(
+        cast(Any, resolver),
+        formal_validation=cast(Any, StubValidation()),
+        commit_effect=cast(Any, commit),
+        remote_effect=cast(Any, remote),
+        pr_effect=cast(Any, StubEffect("ensure_open_pr", "created")),
+        status_effect=cast(Any, StubEffect("set_review_status", "updated")),
+        checks_gate=cast(Any, StubChecks()),
+    )
 
     with pytest.raises(lck.LckStopError, match="Critical Outcome FAIL"):
-        lck.DeliveryCompleter(
-            cast(Any, resolver),
-            formal_validation=cast(Any, StubValidation()),
-            commit_effect=cast(Any, commit),
-            remote_effect=cast(Any, remote),
-            pr_effect=cast(Any, StubEffect("ensure_open_pr", "created")),
-            status_effect=cast(Any, StubEffect("set_review_status", "updated")),
-            checks_gate=cast(Any, StubChecks()),
-        ).complete(
+        handler.complete(
             160,
             commit_message="Implement LCK Delivery cutover",
             summary="Move initial Delivery mechanics into LCK.",
@@ -1671,6 +1675,117 @@ def test_delivery_complete_critical_outcome_failure_blocks_commit_and_remote(
 
     assert commit.calls == ["stage_candidate_tree"]
     assert remote.calls == 0
+
+    store = lck.AuditReceiptStore(tmp_path)
+    payload = lck._write_failure_receipt(
+        operation="delivery-complete",
+        task_number=160,
+        operation_id="c" * 32,
+        status="stop",
+        code=None,
+        error="Critical Outcome FAIL: test exited 1",
+        handler=handler,
+        store=store,
+    )
+    receipt = store.read(payload["receipt_reference"])
+
+    assert handler.last_critical_outcome is not None
+    assert receipt["audit"]["critical_outcome"]["status"] == "fail"
+    assert receipt["audit"]["critical_outcome"]["exit_code"] == 1
+    assert receipt["audit"]["critical_outcome"]["summary"] == "1 failed"
+
+
+def test_delivery_failure_receipt_preserves_failed_formal_validation_payload(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "tests" / "test_critical_path.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("def test_critical_path(): pass\n", encoding="utf-8")
+    state = _live_state(
+        head="d" * 40,
+        clean=False,
+        project_status="In Progress",
+        open_pr=None,
+        remote_oid=None,
+    )
+    validation_payload = {
+        "schema_version": 1,
+        "operation": "workflow-validation",
+        "run_id": "val-delivery-receipt",
+        "phase": "delivery",
+        "base_sha": SHA,
+        "status": "fail",
+        "command_count": 1,
+        "passed": 0,
+        "failed": 1,
+        "commands": [
+            {
+                "command_id": "pytest",
+                "status": "fail",
+                "exit_code": 1,
+                "duration_ms": 37,
+                "summary": "1 failed",
+                "log_path": ".agents/validation.local/pytest.log",
+                "diagnostic": "assertion failed",
+            }
+        ],
+        "limitations": [],
+        "output_dir": ".agents/validation.local",
+    }
+
+    class FailingFormalValidationRunner(CompletionRunner):
+        def run(
+            self,
+            argv: list[str] | tuple[str, ...],
+            *,
+            command_id: str,
+            **kwargs: Any,
+        ) -> CommandResult:
+            if command_id == "lck-formal-delivery-validation":
+                command = tuple(str(item) for item in argv)
+                self.commands.append(command)
+                return CommandResult(
+                    command_id,
+                    command,
+                    1,
+                    json.dumps(validation_payload),
+                    "",
+                )
+            return super().run(argv, command_id=command_id, **kwargs)
+
+    runner = FailingFormalValidationRunner()
+    resolver = SequenceResolver(tmp_path, runner, [state])
+    handler = lck.DeliveryCompleter(
+        cast(Any, resolver),
+        formal_validation=cast(Any, lck.FormalValidationGate(resolver)),
+        commit_effect=cast(Any, StubCommit(dirty=True)),
+        remote_effect=cast(Any, StubEffect("ensure_remote_branch", "created")),
+        pr_effect=cast(Any, StubEffect("ensure_open_pr", "created")),
+        status_effect=cast(Any, StubEffect("set_review_status", "updated")),
+        checks_gate=cast(Any, StubChecks()),
+    )
+
+    with pytest.raises(lck.LckStopError, match="formal Delivery validation failed"):
+        handler.complete(
+            160,
+            commit_message="Implement LCK Delivery cutover",
+            summary="Move initial Delivery mechanics into LCK.",
+        )
+
+    store = lck.AuditReceiptStore(tmp_path)
+    payload = lck._write_failure_receipt(
+        operation="delivery-complete",
+        task_number=160,
+        operation_id="e" * 32,
+        status="stop",
+        code=None,
+        error="formal Delivery validation failed: fail",
+        handler=handler,
+        store=store,
+    )
+    receipt = store.read(payload["receipt_reference"])
+
+    assert receipt["audit"]["validation"] == validation_payload
 
 
 def test_delivery_failure_receipt_preserves_completed_operation_evidence(

--- a/tests/tools/test_lck_delivery.py
+++ b/tests/tools/test_lck_delivery.py
@@ -1168,11 +1168,13 @@ def test_task_160_critical_outcome_initial_delivery_is_lck_owned(
     assert exit_code == 0, output
     assert payload["status"] == "READY_FOR_REVIEW"
     assert payload["human_boundary"] == "Independent Review must be started separately"
+    assert "operation_snapshot" not in payload
+    receipt = lck.AuditReceiptStore(tmp_path).read(payload["receipt_reference"])
     assert (
-        payload["operation_snapshot"]["operation"] == lck.Phase.DELIVERY_COMPLETE.value
+        receipt["operation_snapshot"]["operation"] == lck.Phase.DELIVERY_COMPLETE.value
     )
     assert (
-        payload["operation_snapshot"]["state"]["issue"]["project_status"]
+        receipt["operation_snapshot"]["state"]["issue"]["project_status"]
         == "In Progress"
     )
     assert payload["effects"][-1]["effect"] == "set_review_status"

--- a/tests/tools/test_lck_delivery.py
+++ b/tests/tools/test_lck_delivery.py
@@ -1673,6 +1673,78 @@ def test_delivery_complete_critical_outcome_failure_blocks_commit_and_remote(
     assert remote.calls == 0
 
 
+def test_delivery_failure_receipt_preserves_completed_operation_evidence(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "tests" / "test_critical_path.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("def test_critical_path(): pass\n", encoding="utf-8")
+    head = "b" * 40
+    state = _live_state(
+        head=head,
+        clean=True,
+        project_status="In Progress",
+        open_pr=None,
+        remote_oid=None,
+    )
+
+    class FailingFinalRunner(CompletionRunner):
+        def run(
+            self,
+            argv: list[str] | tuple[str, ...],
+            *,
+            command_id: str,
+            **kwargs: Any,
+        ) -> CommandResult:
+            result = super().run(argv, command_id=command_id, **kwargs)
+            if tuple(argv[:2]) == ("git", "status"):
+                return CommandResult(command_id, tuple(argv), 0, " M candidate\n", "")
+            return result
+
+    runner = FailingFinalRunner()
+    resolver = SequenceResolver(tmp_path, runner, [state])
+    handler = lck.DeliveryCompleter(
+        cast(Any, resolver),
+        formal_validation=cast(Any, StubValidation()),
+        commit_effect=cast(Any, StubCommit(dirty=False)),
+        remote_effect=cast(Any, StubEffect("ensure_remote_branch", "created")),
+        pr_effect=cast(Any, StubEffect("ensure_open_pr", "created")),
+        status_effect=cast(Any, StubEffect("set_review_status", "updated")),
+        checks_gate=cast(Any, StubChecks()),
+    )
+
+    with pytest.raises(lck.LckStopError, match="local postcondition failed"):
+        handler.complete(
+            160,
+            commit_message="Implement LCK Delivery cutover",
+            summary="Move initial Delivery mechanics into LCK.",
+        )
+
+    store = lck.AuditReceiptStore(tmp_path)
+    payload = lck._write_failure_receipt(
+        operation="delivery-complete",
+        task_number=160,
+        operation_id="d" * 32,
+        status="stop",
+        code=None,
+        error="Delivery local postcondition failed",
+        handler=handler,
+        store=store,
+    )
+    receipt = store.read(payload["receipt_reference"])
+
+    assert handler.last_snapshot is not None
+    assert receipt["operation_snapshot"] == handler.last_snapshot.to_dict()
+    assert receipt["audit"]["critical_outcome"]["status"] == "pass"
+    assert receipt["audit"]["validation"]["status"] == "pass"
+    assert [item["effect"] for item in receipt["audit"]["effects"]] == [
+        "commit_current_tree",
+        "ensure_remote_branch",
+        "ensure_open_pr",
+        "set_review_status",
+    ]
+
+
 def test_delivery_complete_freezes_authority_for_the_operation(tmp_path: Path) -> None:
     target = tmp_path / "tests" / "test_critical_path.py"
     target.parent.mkdir(parents=True)

--- a/tools/agent_workflow/lck.py
+++ b/tools/agent_workflow/lck.py
@@ -15,7 +15,6 @@ import argparse
 import copy
 import fcntl
 import hashlib
-import json
 import os
 import re
 import shutil
@@ -264,10 +263,235 @@ def _jsonable(value: Any) -> Any:
     return value
 
 
+@dataclass(frozen=True)
+class AuditReceiptReference:
+    """Stable, bounded locator for one operation-owned audit receipt."""
+
+    operation_id: str
+    path: str
+    sha256: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "operation_id": self.operation_id,
+            "path": self.path,
+            "sha256": self.sha256,
+        }
+
+
+class AuditReceiptStore:
+    """Persist complete operation evidence below the ignored LCK runtime root.
+
+    Agent-facing results contain only a compact view and this reference.  The
+    receipt is deliberately content-addressed in its reference and refuses to
+    silently overwrite an existing operation with a different payload.
+    """
+
+    _OPERATION = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+    _ID = re.compile(r"^[0-9a-f]{32}$")
+
+    def __init__(self, repo_root: Path) -> None:
+        self.repo_root = repo_root.resolve()
+        self.root = self.repo_root / ".workflow.local" / "lck" / "audit-receipts"
+
+    def receipt_path(self, task_number: int, operation: str, operation_id: str) -> Path:
+        operation = operation.strip().casefold()
+        if self._OPERATION.fullmatch(operation) is None:
+            raise LckStopError("invalid LCK audit receipt operation")
+        if self._ID.fullmatch(operation_id) is None:
+            raise LckStopError("invalid LCK audit receipt operation id")
+        if not isinstance(task_number, int) or isinstance(task_number, bool):
+            raise LckStopError("invalid LCK audit receipt Task number")
+        return self.root / operation / f"task-{task_number}-{operation_id}.json"
+
+    def reference_for(
+        self, task_number: int, operation: str, operation_id: str, sha256: str
+    ) -> AuditReceiptReference:
+        path = self.receipt_path(task_number, operation, operation_id)
+        return AuditReceiptReference(
+            operation_id=operation_id,
+            path=path.relative_to(self.repo_root).as_posix(),
+            sha256=sha256,
+        )
+
+    def write(
+        self,
+        task_number: int,
+        operation: str,
+        operation_id: str,
+        payload: Mapping[str, Any],
+    ) -> AuditReceiptReference:
+        path = self.receipt_path(task_number, operation, operation_id)
+        normalized = cast(dict[str, Any], _jsonable(payload))
+        digest = sha256_json(normalized)
+        if path.exists():
+            existing = read_json_file(path)
+            if existing != normalized:
+                raise LckStopError(
+                    "existing LCK audit receipt does not match this operation"
+                )
+        else:
+            atomic_write_json(path, normalized)
+        return self.reference_for(task_number, operation, operation_id, digest)
+
+    def read(self, reference: Mapping[str, Any]) -> dict[str, Any]:
+        path_value = reference.get("path")
+        expected_digest = reference.get("sha256")
+        operation_id = reference.get("operation_id")
+        if (
+            not isinstance(path_value, str)
+            or not isinstance(expected_digest, str)
+            or not isinstance(operation_id, str)
+            or self._ID.fullmatch(operation_id) is None
+        ):
+            raise LckStopError("LCK audit receipt reference is malformed")
+        path = (self.repo_root / path_value).resolve()
+        try:
+            path.relative_to(self.root)
+        except ValueError as exc:
+            raise LckStopError(
+                "LCK audit receipt reference escapes its owned root"
+            ) from exc
+        if not path.name.endswith(f"-{operation_id}.json"):
+            raise LckStopError(
+                "LCK audit receipt reference identity does not match its path"
+            )
+        value = read_json_file(path)
+        if (
+            not isinstance(value, dict)
+            or value.get("operation_id") != operation_id
+            or sha256_json(value) != expected_digest
+        ):
+            raise LckStopError("LCK audit receipt digest does not match its reference")
+        return value
+
+
 def _items(value: Any) -> list[Any]:
     if isinstance(value, Mapping) and isinstance(value.get("items"), list):
         return list(value["items"])
     return []
+
+
+def _pr_agent_view(value: Any) -> dict[str, Any] | None:
+    """Keep only the identity needed to reason about a current PR."""
+    if not isinstance(value, Mapping):
+        return None
+    result: dict[str, Any] = {}
+    for output, candidates in (
+        ("number", ("number",)),
+        ("url", ("url",)),
+        ("state", ("state",)),
+        ("is_draft", ("isDraft", "is_draft")),
+        ("base_branch", ("baseRefName", "base_branch")),
+        ("base_sha", ("baseRefOid", "base_sha")),
+        ("head_branch", ("headRefName", "head_branch")),
+        ("head_sha", ("headRefOid", "head_sha")),
+    ):
+        for candidate in candidates:
+            if candidate in value and value[candidate] is not None:
+                result[output] = value[candidate]
+                break
+    return result or None
+
+
+def _checks_agent_view(value: Any) -> dict[str, Any]:
+    """Summarize checks without copying observed runs or command diagnostics."""
+    if not isinstance(value, Mapping):
+        return {"status": "unknown"}
+    result: dict[str, Any] = {}
+    for key in ("status", "check_state", "configuration", "limitation"):
+        item = value.get(key)
+        if item is not None:
+            result[key] = item
+    pr = _pr_agent_view(value.get("pr"))
+    if pr is not None:
+        result["pr"] = pr
+    required = value.get("required")
+    if isinstance(required, list):
+        result["required_count"] = len(required)
+    observed = value.get("observed")
+    if isinstance(observed, Mapping):
+        result["observed_count"] = len(observed)
+    for key in ("failed", "pending", "success", "skipped_or_unknown", "all_success"):
+        item = value.get(key)
+        if item is not None:
+            result[key] = item
+    return result
+
+
+def _validation_agent_view(value: Any) -> dict[str, Any]:
+    """Summarize validation identity and outcome, leaving diagnostics in Receipt."""
+    if not isinstance(value, Mapping):
+        return {"status": "unknown"}
+    result: dict[str, Any] = {}
+    for key in (
+        "status",
+        "validated_base_sha",
+        "validated_head_sha",
+        "profile",
+        "profile_version",
+    ):
+        item = value.get(key)
+        if item is not None:
+            result[key] = item
+    commands = value.get("commands")
+    if isinstance(commands, list):
+        result["command_count"] = len(commands)
+        failed = next(
+            (
+                item
+                for item in commands
+                if isinstance(item, Mapping) and item.get("status") == "fail"
+            ),
+            None,
+        )
+        if isinstance(failed, Mapping):
+            result["failed_command"] = {
+                key: failed[key] for key in ("command_id", "exit_code") if key in failed
+            }
+    return result
+
+
+def _critical_outcome_agent_view(value: Any) -> dict[str, Any]:
+    """Summarize the formal Critical Outcome gate."""
+    if not isinstance(value, Mapping):
+        return {"status": "unknown"}
+    result: dict[str, Any] = {}
+    for key in ("status", "verification_test", "exit_code"):
+        item = value.get(key)
+        if item is not None:
+            result[key] = item
+    contract = value.get("contract")
+    if isinstance(contract, Mapping):
+        verification_test = contract.get("verification_test")
+        if verification_test is not None:
+            result.setdefault("verification_test", verification_test)
+    return result
+
+
+def _effect_agent_view(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, (list, tuple)):
+        return []
+    result: list[dict[str, Any]] = []
+    for item in value:
+        if isinstance(item, EffectReceipt):
+            result.append({"effect": item.effect, "action": item.action})
+        elif isinstance(item, Mapping):
+            compact = {key: item[key] for key in ("effect", "action") if key in item}
+            if compact:
+                result.append(compact)
+    return result
+
+
+def _issue_agent_view(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, Mapping):
+        return None
+    result: dict[str, Any] = {}
+    for key in ("number", "title", "url", "state", "project_status"):
+        item = value.get(key)
+        if item is not None:
+            result[key] = item
+    return result or None
 
 
 def _branch_matches_task(branch: str, task_number: int) -> bool:
@@ -425,6 +649,34 @@ class LiveState:
                 }
             ),
         )
+
+    def agent_view(self) -> dict[str, Any]:
+        """Return the compact result intended for the invoking Agent."""
+        return {
+            "schema_version": LCK_SCHEMA_VERSION,
+            "kind": "lck-agent-view",
+            "operation": "status",
+            "task_number": self.task_number,
+            "repository": self.repository,
+            "status": self.status,
+            "issue": _issue_agent_view(self.issue),
+            "target_branch": self.target_branch,
+            "task_branch": {
+                "local": self.local_task_branch,
+                "local_head_sha": self.local_task_head,
+                "remote": self.remote_task_branch,
+                "remote_head_sha": self.remote_task_oid,
+            },
+            "pr": _pr_agent_view(self.open_pr or self.merged_pr),
+            "checks": _checks_agent_view(self.checks),
+            "cleanup": _jsonable(self.cleanup),
+            "stop_reasons": list(self.stop_reasons),
+            "next_action": (
+                "inspect receipt and resolve STOP reasons"
+                if self.status is ResolutionStatus.STOP
+                else "use the phase-specific LCK operation for the next lifecycle action"
+            ),
+        }
 
 
 @dataclass(frozen=True)
@@ -1500,6 +1752,7 @@ class DeliveryPreparer:
         self.resolver = resolver
         self.snapshots = OperationSnapshotBuilder(resolver)
         self.eligibility = eligibility or PhaseEligibilityResolver()
+        self.last_snapshot: OperationSnapshot | None = None
 
     def _run_git(self, args: Sequence[str], command_id: str) -> None:
         result = self.resolver.runner.run(
@@ -1538,6 +1791,7 @@ class DeliveryPreparer:
             task_number,
             operation=Phase.DELIVERY_PREPARE.value,
         )
+        self.last_snapshot = snapshot
         state = snapshot.state
         decision = self.eligibility.resolve(state, Phase.DELIVERY_PREPARE)
         if not decision.eligible:
@@ -2928,6 +3182,7 @@ class ReviewPreparer:
         self.checks_gate = checks_gate or DeliveryChecksGate(resolver)
         self.workspace = workspace or ReviewWorkspaceManager(resolver)
         self.store = store or ReviewInvocationStore(resolver.repo_root)
+        self.last_snapshot: OperationSnapshot | None = None
 
     def prepare(self, task_number: int) -> ReviewContext:
         if self.store.read_remediation_session(task_number) is not None:
@@ -2985,6 +3240,7 @@ class ReviewPreparer:
                 task_number,
                 operation="review-prepare",
             )
+            self.last_snapshot = snapshot
             state = snapshot.state
             decision = self.eligibility.resolve(state, Phase.REVIEW_PREPARE)
             if not decision.eligible:
@@ -3148,6 +3404,7 @@ class ReviewCompleter:
         self.checks_gate = checks_gate or DeliveryChecksGate(resolver)
         self.store = store or ReviewInvocationStore(resolver.repo_root)
         self.workspace = workspace or ReviewWorkspaceManager(resolver)
+        self.last_snapshot: OperationSnapshot | None = None
 
     @staticmethod
     def _read_findings(path: Path | None, verdict: str) -> str:
@@ -3214,6 +3471,7 @@ class ReviewCompleter:
                 task_number,
                 operation="review-complete",
             )
+            self.last_snapshot = completion_snapshot
             state = completion_snapshot.state
             decision = self.eligibility.resolve(state, Phase.REVIEW_COMPLETE)
             if not decision.eligible:
@@ -4270,6 +4528,7 @@ class MergePreflightResult:
     checks: Mapping[str, Any]
     blockers: Mapping[str, Any]
     mergeability: str
+    operation_snapshot: OperationSnapshot | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -4304,6 +4563,7 @@ class MergePreflight:
         self.snapshots = OperationSnapshotBuilder(resolver)
         self.review_gate = review_gate or ReviewPassGate(resolver)
         self.checks_gate = checks_gate or DeliveryChecksGate(resolver)
+        self.last_snapshot: OperationSnapshot | None = None
 
     def run(self, task_number: int) -> MergePreflightResult:
         snapshot = self.snapshots.acquire(
@@ -4311,6 +4571,7 @@ class MergePreflight:
             operation="merge-preflight",
             include_required_checks=True,
         )
+        self.last_snapshot = snapshot
         state = snapshot.state
         if state.status is not ResolutionStatus.RESOLVED:
             raise LckStopError("Merge Preflight STOP: " + "; ".join(state.stop_reasons))
@@ -4370,6 +4631,7 @@ class MergePreflight:
             checks=checks,
             blockers=blockers,
             mergeability=mergeability,
+            operation_snapshot=snapshot,
         )
 
 
@@ -4802,6 +5064,7 @@ class CloseoutCompleter:
         self.metadata_effect = metadata_effect or CloseoutMetadataEffect(resolver)
         self.cleanup_effect = cleanup_effect or CleanupTaskRefsEffect(resolver)
         self.review_store = review_store or ReviewInvocationStore(resolver.repo_root)
+        self.last_snapshot: OperationSnapshot | None = None
 
     @staticmethod
     def _validate_merged_identity(state: LiveState) -> tuple[str, str]:
@@ -4906,6 +5169,7 @@ class CloseoutCompleter:
 
     def complete(self, task_number: int) -> CloseoutResult:
         snapshot = self.snapshots.acquire(task_number, operation="closeout")
+        self.last_snapshot = snapshot
         state = snapshot.state
         decision = self.eligibility.resolve(state, Phase.CLOSEOUT)
         if not decision.eligible:
@@ -5015,6 +5279,7 @@ class DeliveryCompleter:
         self.checks_gate = checks_gate or DeliveryChecksGate(resolver)
         self.require_existing_open_pr = require_existing_open_pr
         self.candidate_recorder = candidate_recorder
+        self.last_snapshot: OperationSnapshot | None = None
 
     def _run_critical_outcome(
         self,
@@ -5282,6 +5547,7 @@ class DeliveryCompleter:
                 task_number,
                 operation=phase.value,
             )
+            self.last_snapshot = snapshot
             if snapshot.state.task_number != task_number:
                 raise LckStopError("operation snapshot belongs to another Task")
             result = self._complete_from_snapshot(
@@ -5430,6 +5696,7 @@ class RemediationPreparer:
         self.snapshots = OperationSnapshotBuilder(resolver)
         self.eligibility = eligibility or PhaseEligibilityResolver()
         self.store = store or ReviewInvocationStore(resolver.repo_root)
+        self.last_snapshot: OperationSnapshot | None = None
 
     def _run_git(self, args: Sequence[str], command_id: str) -> None:
         result = self.resolver.runner.run(["git", *args], command_id=command_id)
@@ -5481,6 +5748,7 @@ class RemediationPreparer:
             task_number,
             operation=Phase.REMEDIATION_PREPARE.value,
         )
+        self.last_snapshot = snapshot
         state = snapshot.state
         decision = self.eligibility.resolve(state, Phase.REMEDIATION_PREPARE)
         if not decision.eligible:
@@ -5609,6 +5877,7 @@ class RemediationNoChangeCompleter:
         self.snapshots = OperationSnapshotBuilder(resolver)
         self.eligibility = eligibility or PhaseEligibilityResolver()
         self.store = store or ReviewInvocationStore(resolver.repo_root)
+        self.last_snapshot: OperationSnapshot | None = None
 
     @staticmethod
     def _session_identity(
@@ -5676,6 +5945,7 @@ class RemediationNoChangeCompleter:
             snapshot = self.snapshots.acquire(
                 task_number, operation=Phase.REMEDIATION_NO_CHANGE.value
             )
+            self.last_snapshot = snapshot
             decision = self.eligibility.resolve(
                 snapshot.state, Phase.REMEDIATION_NO_CHANGE
             )
@@ -5712,6 +5982,7 @@ class RemediationNoChangeCompleter:
         snapshot = self.snapshots.acquire(
             task_number, operation=Phase.REMEDIATION_NO_CHANGE.value
         )
+        self.last_snapshot = snapshot
         decision = self.eligibility.resolve(snapshot.state, Phase.REMEDIATION_NO_CHANGE)
         if not decision.eligible:
             raise LckStopError(
@@ -5978,6 +6249,328 @@ class RemediationCompleter:
         )
 
 
+def _delivery_pr_agent_view(effects: Any) -> dict[str, Any] | None:
+    if not isinstance(effects, (list, tuple)):
+        return None
+    for item in reversed(effects):
+        details: Mapping[str, Any] | None = None
+        if isinstance(item, EffectReceipt):
+            details = item.details
+        elif isinstance(item, Mapping) and isinstance(item.get("details"), Mapping):
+            details = cast(Mapping[str, Any], item["details"])
+        if details is not None and "number" in details:
+            return {
+                key: details[key]
+                for key in ("number", "url", "base_sha", "head_sha")
+                if key in details
+            }
+    return None
+
+
+def _agent_view_for_result(value: Any) -> dict[str, Any]:
+    """Convert one internal LCK result into the bounded Agent-facing view."""
+    if isinstance(value, LiveState):
+        return value.agent_view()
+    if isinstance(value, DeliveryContext):
+        return {
+            "schema_version": LCK_SCHEMA_VERSION,
+            "kind": "lck-agent-view",
+            "operation": "delivery-prepare",
+            "task_number": value.task_number,
+            "repository": value.repository,
+            "status": "READY_FOR_DELIVERY",
+            "branch": value.branch,
+            "base_sha": value.base_sha,
+            "action": value.action,
+            "task_contract": _jsonable(_task_contract_from_state(value.state)),
+            "eligibility": {
+                "eligible": value.eligibility.eligible,
+                "reasons": list(value.eligibility.reasons),
+            },
+            "human_boundary": "implement the Task before LCK Delivery Complete",
+            "next_action": "implement the Task and run LCK Delivery Complete",
+        }
+    if isinstance(value, ReviewContext):
+        return {
+            "schema_version": LCK_SCHEMA_VERSION,
+            "kind": "lck-agent-view",
+            "operation": "review-prepare",
+            "status": "READY_FOR_SEMANTIC_REVIEW",
+            "task_number": value.identity.task_number,
+            "review_id": value.review_id,
+            "task_contract": _jsonable(value.task_contract),
+            "review_target": value.identity.to_dict(),
+            "checks": _checks_agent_view(value.checks),
+            "validation": _validation_agent_view(value.validation),
+            "review_root": str(value.review_root),
+            "workspace_mode": "implementation-read-only",
+            "agent_role": ["Inspect", "Reason", "Judge", "Report"],
+            "mechanical_authority": "live Git/GitHub state resolved by LCK",
+            "human_boundary": "semantic Review must be completed before Review Complete",
+            "next_action": "perform an independent semantic Review, then run Review Complete",
+        }
+    if isinstance(value, ReviewCompletionResult):
+        return {
+            "schema_version": LCK_SCHEMA_VERSION,
+            "kind": "lck-agent-view",
+            "operation": "review-complete",
+            "task_number": value.task_number,
+            "review_id": value.review_id,
+            "verdict": value.verdict,
+            "status": value.status,
+            "review_target": value.identity.to_dict(),
+            "human_boundary": (
+                "STOP; run deterministic Merge Preflight before any manual merge"
+                if value.verdict == "PASS"
+                else "STOP; Human must explicitly choose remediation, redesign, or abandon"
+            ),
+            "next_action": (
+                "run LCK Merge Preflight"
+                if value.verdict == "PASS"
+                else "stop; Human must explicitly choose remediation, redesign, or abandon"
+            ),
+        }
+    if isinstance(value, DeliveryCompletionResult):
+        base_sha = _authoritative_remote_main_sha(value.operation_snapshot.state.git)
+        return {
+            "schema_version": LCK_SCHEMA_VERSION,
+            "kind": "lck-agent-view",
+            "operation": "delivery-complete",
+            "task_number": value.task_number,
+            "status": value.status,
+            "branch": value.branch,
+            "base_sha": base_sha,
+            "head_sha": value.head_sha,
+            "pr": _delivery_pr_agent_view(value.effects),
+            "critical_outcome": _critical_outcome_agent_view(value.critical_outcome),
+            "validation": _validation_agent_view(value.validation),
+            "checks": _checks_agent_view(value.checks),
+            "effects": _effect_agent_view(value.effects),
+            "human_boundary": "Independent Review must be started separately",
+            "next_action": "start an independent Review in a fresh invocation",
+        }
+    if isinstance(value, MergePreflightResult):
+        return {
+            "schema_version": LCK_SCHEMA_VERSION,
+            "kind": "lck-agent-view",
+            "operation": "merge-preflight",
+            "task_number": value.task_number,
+            "status": value.status,
+            "pr": _pr_agent_view(value.pr),
+            "review": {
+                key: value.review[key]
+                for key in ("status", "review_id", "identity")
+                if key in value.review
+            },
+            "checks": _checks_agent_view(value.checks),
+            "blockers": {
+                key: value.blockers[key]
+                for key in ("status", "detail", "count")
+                if key in value.blockers
+            },
+            "mergeability": value.mergeability,
+            "human_boundary": "STOP — maintainer must perform the manual Squash Merge; LCK has no auto-merge path",
+            "next_action": "maintainer must perform the manual Squash Merge",
+        }
+    if isinstance(value, CloseoutResult):
+        return {
+            "schema_version": LCK_SCHEMA_VERSION,
+            "kind": "lck-agent-view",
+            "operation": "closeout",
+            "task_number": value.task_number,
+            "status": value.status,
+            "business_delivery": value.business_delivery,
+            "cleanup": value.cleanup,
+            "effects": _effect_agent_view(value.effects),
+            "automatic_merge": False,
+            "manual_issue_close": False,
+            "next_action": "stop; closeout is complete"
+            if value.cleanup == "COMPLETE"
+            else "resolve pending closeout cleanup",
+        }
+    if isinstance(value, RemediationContext):
+        return {
+            "schema_version": LCK_SCHEMA_VERSION,
+            "kind": "lck-agent-view",
+            "operation": "remediation-prepare",
+            "task_number": value.task_number,
+            "review_id": value.review_id,
+            "status": "READY_FOR_REMEDIATION",
+            "action": value.action,
+            "findings": value.findings,
+            "findings_source": value.findings_source,
+            "task_contract": _jsonable(value.task_contract),
+            "live_target": {
+                "pr_number": (value.state.open_pr or {}).get("number"),
+                "base_sha": _pr_base_sha(value.state.open_pr),
+                "head_sha": _pr_head_sha(value.state.open_pr),
+                "branch": value.state.target_branch,
+            },
+            "next_action": "repair the implementation and run Remediation Complete",
+        }
+    if isinstance(value, RemediationNoChangeResult):
+        return {
+            "schema_version": LCK_SCHEMA_VERSION,
+            "kind": "lck-agent-view",
+            "operation": "remediation-no-change",
+            "task_number": value.task_number,
+            "review_id": value.review_id,
+            "status": "NO_IMPLEMENTATION_CHANGE",
+            "head_sha": value.head_sha,
+            "pr_number": value.pr_number,
+            "base_sha": value.base_sha,
+            "summary": value.summary,
+            "candidate_changed": False,
+            "fresh_review_required": False,
+            "session_released": True,
+            "replayed": value.replayed,
+            "human_boundary": "STOP — continue external acceptance work on the unchanged head",
+            "next_action": "continue external acceptance work on the unchanged head",
+        }
+    if isinstance(value, RemediationCompletionResult):
+        delivery = value.delivery
+        return {
+            "schema_version": LCK_SCHEMA_VERSION,
+            "kind": "lck-agent-view",
+            "operation": "remediation-complete",
+            "task_number": value.task_number,
+            "review_id": value.review_id,
+            "status": "READY_FOR_NEW_REVIEW",
+            "head_sha": delivery.head_sha,
+            "critical_outcome": _critical_outcome_agent_view(delivery.critical_outcome),
+            "validation": _validation_agent_view(delivery.validation),
+            "checks": _checks_agent_view(delivery.checks),
+            "effects": _effect_agent_view(delivery.effects),
+            "human_boundary": "STOP — a new Independent Review must be started explicitly in a fresh invocation",
+            "next_action": "start a new independent Review in a fresh invocation",
+        }
+    raise LckStopError(f"unsupported LCK result type: {type(value).__name__}")
+
+
+def _audit_payload_for_result(
+    value: Any,
+    *,
+    store: AuditReceiptStore,
+) -> dict[str, Any]:
+    """Build the complete receipt payload without using it as Agent output."""
+    payload = value.to_dict()
+    if isinstance(value, LiveState):
+        state_payload = dict(payload)
+        payload["operation_snapshot"] = {
+            "schema_version": LCK_SCHEMA_VERSION,
+            "operation": "status",
+            "state": state_payload,
+        }
+    elif isinstance(value, ReviewContext):
+        guard = ReviewInvocationStore(store.repo_root).read_guard(value.review_id)
+        payload["review_guard"] = guard
+        payload["operation_snapshot"] = guard.get("snapshot")
+    elif isinstance(value, ReviewCompletionResult):
+        if value.record_path.exists():
+            record = read_json_file(value.record_path)
+            payload["review_record"] = record
+            if isinstance(record, Mapping):
+                payload["operation_snapshot"] = record.get("completion_snapshot")
+    elif isinstance(value, MergePreflightResult):
+        if value.operation_snapshot is not None:
+            payload["operation_snapshot"] = value.operation_snapshot.to_dict()
+    return cast(dict[str, Any], _jsonable(payload))
+
+
+def _result_operation_id(value: Any, fallback: str) -> str:
+    for attribute in ("review_id",):
+        candidate = getattr(value, attribute, None)
+        if isinstance(candidate, str) and AuditReceiptStore._ID.fullmatch(candidate):
+            return candidate
+    return fallback
+
+
+def _write_success_receipt(
+    value: Any,
+    *,
+    operation: str,
+    task_number: int,
+    operation_id: str,
+    store: AuditReceiptStore,
+) -> dict[str, Any]:
+    agent_view = cast(dict[str, Any], _jsonable(_agent_view_for_result(value)))
+    audit_payload = _audit_payload_for_result(value, store=store)
+    receipt_payload = {
+        "schema_version": LCK_SCHEMA_VERSION,
+        "kind": "lck-audit-receipt",
+        "operation": operation,
+        "operation_id": operation_id,
+        "task_number": task_number,
+        "outcome": {"status": agent_view.get("status")},
+        "agent_view": agent_view,
+        "operation_snapshot": audit_payload.get("operation_snapshot"),
+        "audit": audit_payload,
+    }
+    reference = store.write(
+        task_number,
+        operation,
+        operation_id,
+        receipt_payload,
+    )
+    agent_view["receipt_reference"] = reference.to_dict()
+    return agent_view
+
+
+def _write_failure_receipt(
+    *,
+    operation: str,
+    task_number: int,
+    operation_id: str,
+    status: str,
+    code: str | None,
+    error: str,
+    handler: Any,
+    store: AuditReceiptStore,
+) -> dict[str, Any]:
+    snapshot = getattr(handler, "last_snapshot", None)
+    snapshot_payload = (
+        snapshot.to_dict() if isinstance(snapshot, OperationSnapshot) else None
+    )
+    detail = {
+        "status": status,
+        "code": code,
+        "error": safe_text(error, limit=2000),
+    }
+    next_action = (
+        "start a fresh Review Prepare for the current target"
+        if status == "stale"
+        else "inspect the receipt and resolve the STOP condition"
+    )
+    agent_view = {
+        "schema_version": LCK_SCHEMA_VERSION,
+        "kind": "lck-agent-view",
+        "operation": operation,
+        "task_number": task_number,
+        **detail,
+        "next_action": next_action,
+    }
+    receipt_payload = {
+        "schema_version": LCK_SCHEMA_VERSION,
+        "kind": "lck-audit-receipt",
+        "operation": operation,
+        "operation_id": operation_id,
+        "task_number": task_number,
+        "outcome": detail,
+        "agent_view": agent_view,
+        "operation_snapshot": snapshot_payload,
+        "audit": {"outcome": detail, "operation_snapshot": snapshot_payload},
+    }
+    reference = store.write(
+        task_number,
+        operation,
+        operation_id,
+        receipt_payload,
+    )
+    view = dict(agent_view)
+    view["receipt_reference"] = reference.to_dict()
+    return cast(dict[str, Any], _jsonable(view))
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="LCK v1 live state operations")
     parser.add_argument("--repo-root", type=Path, default=Path.cwd())
@@ -6039,90 +6632,166 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _cli_operation(args: argparse.Namespace) -> str:
+    if args.command == "status":
+        return "status"
+    if args.command == "delivery":
+        return f"delivery-{args.delivery_command}"
+    if args.command == "review":
+        return f"review-{args.review_command}"
+    if args.command == "remediation":
+        return f"remediation-{args.remediation_command}"
+    if args.command in {"merge", "merge-preflight"}:
+        return "merge-preflight"
+    if args.command == "closeout":
+        return "closeout"
+    return "unknown"
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     args = _build_parser().parse_args(argv)
     resolver = LiveStateResolver(
         args.repo_root,
         repository=args.repository,
     )
+    operation = _cli_operation(args)
+    task_number = args.task
+    operation_id = uuid.uuid4().hex
+    receipt_store = AuditReceiptStore(resolver.repo_root)
+    handler: Any = resolver
+
+    def emit_success(value: Any) -> int:
+        nonlocal operation_id
+        operation_id = _result_operation_id(value, operation_id)
+        print_json(
+            _write_success_receipt(
+                value,
+                operation=operation,
+                task_number=task_number,
+                operation_id=operation_id,
+                store=receipt_store,
+            ),
+            pretty=True,
+        )
+        if isinstance(value, LiveState) and value.status is ResolutionStatus.STOP:
+            return 2
+        return 0
+
     try:
         if args.command == "status":
-            state = resolver.resolve(args.task)
-            print_json(state.to_dict(), pretty=True)
-            return 0 if state.status is ResolutionStatus.RESOLVED else 2
+            return emit_success(resolver.resolve(task_number))
         if args.command == "delivery" and args.delivery_command == "prepare":
-            context = DeliveryPreparer(resolver).prepare(args.task)
-            print_json(context.to_dict(), pretty=True)
-            return 0
+            handler = DeliveryPreparer(resolver)
+            return emit_success(handler.prepare(task_number))
         if args.command == "delivery" and args.delivery_command == "complete":
-            result = DeliveryCompleter(resolver).complete(
-                args.task,
-                commit_message=args.commit_message,
-                summary=args.summary,
-                risks=args.risks,
+            handler = DeliveryCompleter(resolver)
+            return emit_success(
+                handler.complete(
+                    task_number,
+                    commit_message=args.commit_message,
+                    summary=args.summary,
+                    risks=args.risks,
+                )
             )
-            print_json(result.to_dict(), pretty=True)
-            return 0
         if args.command == "review" and args.review_command == "prepare":
-            context = ReviewPreparer(resolver).prepare(args.task)
-            print_json(context.to_dict(), pretty=True)
-            return 0
+            handler = ReviewPreparer(resolver)
+            return emit_success(handler.prepare(task_number))
         if args.command == "review" and args.review_command == "complete":
-            result = ReviewCompleter(resolver).complete(
-                args.task,
-                args.review_id,
-                verdict=args.verdict,
-                findings_file=args.findings_file,
+            handler = ReviewCompleter(resolver)
+            return emit_success(
+                handler.complete(
+                    task_number,
+                    args.review_id,
+                    verdict=args.verdict,
+                    findings_file=args.findings_file,
+                )
             )
-            print_json(result.to_dict(), pretty=True)
-            return 0
         if args.command == "remediation" and args.remediation_command == "prepare":
-            context = RemediationPreparer(resolver).prepare(
-                args.task,
-                args.review_id,
-                findings_file=args.findings_file,
+            handler = RemediationPreparer(resolver)
+            return emit_success(
+                handler.prepare(
+                    task_number,
+                    args.review_id,
+                    findings_file=args.findings_file,
+                )
             )
-            print_json(context.to_dict(), pretty=True)
-            return 0
         if args.command == "remediation" and args.remediation_command == "no-change":
-            result = RemediationNoChangeCompleter(resolver).complete(
-                args.task,
-                args.review_id,
-                summary=args.summary,
+            handler = RemediationNoChangeCompleter(resolver)
+            return emit_success(
+                handler.complete(
+                    task_number,
+                    args.review_id,
+                    summary=args.summary,
+                )
             )
-            print_json(result.to_dict(), pretty=True)
-            return 0
         if args.command == "remediation" and args.remediation_command == "complete":
-            result = RemediationCompleter(resolver).complete(
-                args.task,
-                args.review_id,
-                commit_message=args.commit_message,
-                summary=args.summary,
-                risks=args.risks,
+            handler = RemediationCompleter(resolver)
+            return emit_success(
+                handler.complete(
+                    task_number,
+                    args.review_id,
+                    commit_message=args.commit_message,
+                    summary=args.summary,
+                    risks=args.risks,
+                )
             )
-            print_json(result.to_dict(), pretty=True)
-            return 0
         if (
             args.command == "merge" and args.merge_command == "preflight"
         ) or args.command == "merge-preflight":
-            result = MergePreflight(resolver).run(args.task)
-            print_json(result.to_dict(), pretty=True)
-            return 0
+            handler = MergePreflight(resolver)
+            return emit_success(handler.run(task_number))
         if args.command == "closeout":
-            result = CloseoutCompleter(resolver).complete(args.task)
-            print_json(result.to_dict(), pretty=True)
-            return 0
+            handler = CloseoutCompleter(resolver)
+            return emit_success(handler.complete(task_number))
         raise LckStopError("unsupported LCK command")
     except ReviewStaleError as exc:
-        print(
-            json.dumps(
-                {"status": "stale", "code": exc.code, "error": str(exc)},
-                ensure_ascii=False,
+        try:
+            payload = _write_failure_receipt(
+                operation=operation,
+                task_number=task_number,
+                operation_id=operation_id,
+                status="stale",
+                code=exc.code,
+                error=str(exc),
+                handler=handler,
+                store=receipt_store,
             )
-        )
+        except WorkflowToolError as receipt_error:
+            payload = {
+                "schema_version": LCK_SCHEMA_VERSION,
+                "kind": "lck-agent-view",
+                "operation": operation,
+                "task_number": task_number,
+                "status": "stale",
+                "code": exc.code,
+                "error": safe_text(str(exc), limit=2000),
+                "receipt_error": safe_text(str(receipt_error), limit=1000),
+            }
+        print_json(payload)
         return 3
     except WorkflowToolError as exc:
-        print(json.dumps({"status": "stop", "error": str(exc)}, ensure_ascii=False))
+        try:
+            payload = _write_failure_receipt(
+                operation=operation,
+                task_number=task_number,
+                operation_id=operation_id,
+                status="stop",
+                code=None,
+                error=str(exc),
+                handler=handler,
+                store=receipt_store,
+            )
+        except WorkflowToolError as receipt_error:
+            payload = {
+                "schema_version": LCK_SCHEMA_VERSION,
+                "kind": "lck-agent-view",
+                "operation": operation,
+                "task_number": task_number,
+                "status": "stop",
+                "error": safe_text(str(exc), limit=2000),
+                "receipt_error": safe_text(str(receipt_error), limit=1000),
+            }
+        print_json(payload)
         return 2
 
 

--- a/tools/agent_workflow/lck.py
+++ b/tools/agent_workflow/lck.py
@@ -4647,8 +4647,18 @@ class MergePreflight:
         self.review_gate = review_gate or ReviewPassGate(resolver)
         self.checks_gate = checks_gate or DeliveryChecksGate(resolver)
         self.last_snapshot: OperationSnapshot | None = None
+        self.last_checks: dict[str, Any] | None = None
+
+    def _capture_checks_from_gate(self) -> None:
+        """Retain a check gate's result when strict evaluation raises."""
+        for attribute in ("last_result", "last_checks"):
+            value = getattr(self.checks_gate, attribute, None)
+            if isinstance(value, Mapping):
+                self.last_checks = dict(value)
+                return
 
     def run(self, task_number: int) -> MergePreflightResult:
+        self.last_checks = None
         snapshot = self.snapshots.acquire(
             task_number,
             operation="merge-preflight",
@@ -4693,7 +4703,12 @@ class MergePreflight:
                 + str(blockers.get("detail") or blockers.get("status"))
             )
         review = self.review_gate.run(task_number, state)
-        checks = self.checks_gate.evaluate(snapshot)
+        try:
+            checks = self.checks_gate.evaluate(snapshot)
+        except BaseException:
+            self._capture_checks_from_gate()
+            raise
+        self.last_checks = dict(checks)
         if checks.get("limitation"):
             raise LckStopError(
                 "Merge Preflight cannot prove required checks: "
@@ -5369,7 +5384,16 @@ class DeliveryCompleter:
         self.last_snapshot: OperationSnapshot | None = None
         self.last_critical_outcome: dict[str, Any] | None = None
         self.last_validation: dict[str, Any] | None = None
+        self.last_checks: dict[str, Any] | None = None
         self.last_effects: list[EffectReceipt] = []
+
+    def _capture_checks_from_gate(self) -> None:
+        """Retain a check gate's result before a later failure is reported."""
+        for attribute in ("last_result", "last_checks"):
+            value = getattr(self.checks_gate, attribute, None)
+            if isinstance(value, Mapping):
+                self.last_checks = dict(value)
+                return
 
     def _run_critical_outcome(
         self,
@@ -5474,6 +5498,7 @@ class DeliveryCompleter:
         self.last_effects = effects
         self.last_critical_outcome = None
         self.last_validation = None
+        self.last_checks = None
         decision = self.eligibility.resolve(
             state,
             phase,
@@ -5584,22 +5609,29 @@ class DeliveryCompleter:
 
         progress.running("checks")
         snapshot_pr = state.open_pr
-        if (
-            isinstance(snapshot_pr, Mapping)
-            and snapshot_pr.get("number") == pr_number
-            and snapshot_pr.get("headRefOid") == head
-            and snapshot_pr.get("baseRefOid") == base_sha
-        ):
-            checks = self.checks_gate.observe(snapshot)
-        else:
-            if not isinstance(state.repository, str):
-                raise LckStopError("repository identity is unavailable for PR checks")
-            checks = self.checks_gate.observe_exact_pr(
-                state.repository,
-                pr_number,
-                expected_head_sha=str(head),
-                expected_base_sha=base_sha,
-            )
+        try:
+            if (
+                isinstance(snapshot_pr, Mapping)
+                and snapshot_pr.get("number") == pr_number
+                and snapshot_pr.get("headRefOid") == head
+                and snapshot_pr.get("baseRefOid") == base_sha
+            ):
+                checks = self.checks_gate.observe(snapshot)
+            else:
+                if not isinstance(state.repository, str):
+                    raise LckStopError(
+                        "repository identity is unavailable for PR checks"
+                    )
+                checks = self.checks_gate.observe_exact_pr(
+                    state.repository,
+                    pr_number,
+                    expected_head_sha=str(head),
+                    expected_base_sha=base_sha,
+                )
+        except BaseException:
+            self._capture_checks_from_gate()
+            raise
+        self.last_checks = dict(checks)
 
         checks_pr = checks.get("pr")
         if not isinstance(checks_pr, Mapping):
@@ -5638,6 +5670,7 @@ class DeliveryCompleter:
         phase: Phase = Phase.DELIVERY_COMPLETE,
         owned_remediation_candidate: bool = False,
     ) -> DeliveryCompletionResult:
+        self.last_checks = None
         if not summary.strip():
             raise LckStopError("Delivery summary must be non-empty")
         operation = (
@@ -6187,6 +6220,7 @@ class RemediationCompleter:
         self.last_snapshot: OperationSnapshot | None = None
         self.last_critical_outcome: dict[str, Any] | None = None
         self.last_validation: dict[str, Any] | None = None
+        self.last_checks: dict[str, Any] | None = None
         self.last_effects: list[EffectReceipt] = []
 
     def _capture_delivery_evidence(self, delivery: Any) -> None:
@@ -6200,6 +6234,9 @@ class RemediationCompleter:
         validation = getattr(delivery, "last_validation", None)
         if isinstance(validation, dict):
             self.last_validation = validation
+        checks = getattr(delivery, "last_checks", None)
+        if isinstance(checks, Mapping):
+            self.last_checks = dict(checks)
         effects = getattr(delivery, "last_effects", None)
         if isinstance(effects, list):
             self.last_effects = effects
@@ -6275,6 +6312,7 @@ class RemediationCompleter:
         summary: str,
         risks: str = "",
     ) -> RemediationCompletionResult:
+        self.last_checks = None
         if self.store.read_review_required(task_number) is not None:
             raise LckStopError(
                 "Remediation STOP: a fresh Independent Review is required after the previous remediation"

--- a/tools/agent_workflow/lck.py
+++ b/tools/agent_workflow/lck.py
@@ -334,6 +334,29 @@ class AuditReceiptStore:
             atomic_write_json(path, normalized)
         return self.reference_for(task_number, operation, operation_id, digest)
 
+    def existing_reference(
+        self, task_number: int, operation: str, operation_id: str
+    ) -> AuditReceiptReference | None:
+        """Return the reference for an existing, identity-matching receipt."""
+        path = self.receipt_path(task_number, operation, operation_id)
+        if not path.exists():
+            return None
+        existing = read_json_file(path)
+        if (
+            not isinstance(existing, dict)
+            or existing.get("kind") != "lck-audit-receipt"
+            or existing.get("operation") != operation
+            or existing.get("operation_id") != operation_id
+            or existing.get("task_number") != task_number
+        ):
+            raise LckStopError("existing LCK audit receipt identity is invalid")
+        return self.reference_for(
+            task_number,
+            operation,
+            operation_id,
+            sha256_json(existing),
+        )
+
     def read(self, reference: Mapping[str, Any]) -> dict[str, Any]:
         path_value = reference.get("path")
         expected_digest = reference.get("sha256")
@@ -5280,6 +5303,9 @@ class DeliveryCompleter:
         self.require_existing_open_pr = require_existing_open_pr
         self.candidate_recorder = candidate_recorder
         self.last_snapshot: OperationSnapshot | None = None
+        self.last_critical_outcome: dict[str, Any] | None = None
+        self.last_validation: dict[str, Any] | None = None
+        self.last_effects: list[EffectReceipt] = []
 
     def _run_critical_outcome(
         self,
@@ -5367,6 +5393,10 @@ class DeliveryCompleter:
     ) -> DeliveryCompletionResult:
         state = snapshot.state
         task_number = state.task_number
+        effects: list[EffectReceipt] = []
+        self.last_effects = effects
+        self.last_critical_outcome = None
+        self.last_validation = None
         decision = self.eligibility.resolve(
             state,
             phase,
@@ -5398,7 +5428,6 @@ class DeliveryCompleter:
                     "resolved Task branch/base"
                 )
 
-        effects: list[EffectReceipt] = []
         if state.git.get("clean") is True:
             progress.running("revalidating-candidate")
             if not self._has_task_diff(base_sha):
@@ -5408,8 +5437,10 @@ class DeliveryCompleter:
             validated_tree = self.commit_effect.current_head_tree()
             progress.running("critical-outcome")
             critical = self._run_critical_outcome(state, progress=progress)
+            self.last_critical_outcome = critical
             progress.running("formal-validation")
             validation = self.formal_validation.run(base_sha)
+            self.last_validation = validation
             validated_head = state.local_task_head
             if not is_sha(validated_head):
                 raise LckStopError("current Task head is unavailable")
@@ -5430,8 +5461,10 @@ class DeliveryCompleter:
             validated_tree = self.commit_effect.stage_candidate_tree()
             progress.running("critical-outcome")
             critical = self._run_critical_outcome(state, progress=progress)
+            self.last_critical_outcome = critical
             progress.running("formal-validation")
             validation = self.formal_validation.run(base_sha)
+            self.last_validation = validation
             self.commit_effect.verify_tree_unchanged(
                 validated_tree,
                 expected_head_sha=state.local_task_head,
@@ -6078,6 +6111,25 @@ class RemediationCompleter:
         self.eligibility = eligibility or PhaseEligibilityResolver()
         self.store = store or ReviewInvocationStore(resolver.repo_root)
         self.checks_gate = checks_gate or DeliveryChecksGate(resolver)
+        self.last_snapshot: OperationSnapshot | None = None
+        self.last_critical_outcome: dict[str, Any] | None = None
+        self.last_validation: dict[str, Any] | None = None
+        self.last_effects: list[EffectReceipt] = []
+
+    def _capture_delivery_evidence(self, delivery: Any) -> None:
+        """Expose nested Delivery evidence to the outer failure receipt."""
+        snapshot = getattr(delivery, "last_snapshot", None)
+        if isinstance(snapshot, OperationSnapshot):
+            self.last_snapshot = snapshot
+        critical = getattr(delivery, "last_critical_outcome", None)
+        if isinstance(critical, dict):
+            self.last_critical_outcome = critical
+        validation = getattr(delivery, "last_validation", None)
+        if isinstance(validation, dict):
+            self.last_validation = validation
+        effects = getattr(delivery, "last_effects", None)
+        if isinstance(effects, list):
+            self.last_effects = effects
 
     def _owned_candidate_recovery(
         self,
@@ -6178,6 +6230,7 @@ class RemediationCompleter:
             task_number,
             operation=Phase.REMEDIATION_COMPLETE.value,
         )
+        self.last_snapshot = snapshot
         state = snapshot.state
         owned_candidate = False
         pr_head = state.open_pr.get("headRefOid") if state.open_pr else None
@@ -6221,21 +6274,27 @@ class RemediationCompleter:
                 candidate_tree_oid=tree_oid,
             )
 
-        delivery = DeliveryCompleter(
+        delivery_completer = DeliveryCompleter(
             self.resolver,
             pr_effect=cast(Any, ReuseExistingOpenPrEffect(self.resolver)),
             checks_gate=self.checks_gate,
             require_existing_open_pr=True,
             candidate_recorder=record_candidate,
-        ).complete(
-            task_number,
-            commit_message=commit_message,
-            summary=summary,
-            risks=risks,
-            operation_snapshot=snapshot,
-            phase=Phase.REMEDIATION_COMPLETE,
-            owned_remediation_candidate=owned_candidate,
         )
+        try:
+            delivery = delivery_completer.complete(
+                task_number,
+                commit_message=commit_message,
+                summary=summary,
+                risks=risks,
+                operation_snapshot=snapshot,
+                phase=Phase.REMEDIATION_COMPLETE,
+                owned_remediation_candidate=owned_candidate,
+            )
+        except BaseException:
+            self._capture_delivery_evidence(delivery_completer)
+            raise
+        self._capture_delivery_evidence(delivery_completer)
         if delivery.head_sha == start_head:
             raise LckStopError(
                 "Remediation Complete did not produce a new head; fresh Review boundary cannot advance"
@@ -6494,7 +6553,19 @@ def _write_success_receipt(
     store: AuditReceiptStore,
 ) -> dict[str, Any]:
     agent_view = cast(dict[str, Any], _jsonable(_agent_view_for_result(value)))
+    if isinstance(value, RemediationNoChangeResult) and value.replayed:
+        existing = store.existing_reference(task_number, operation, operation_id)
+        if existing is not None:
+            agent_view["receipt_reference"] = existing.to_dict()
+            return agent_view
     audit_payload = _audit_payload_for_result(value, store=store)
+    receipt_agent_view = dict(agent_view)
+    if isinstance(value, RemediationNoChangeResult):
+        # ``replayed`` describes this CLI invocation, not the durable operation.
+        # Keep the original operation receipt immutable across valid replays.
+        receipt_agent_view["replayed"] = False
+        audit_payload = dict(audit_payload)
+        audit_payload["replayed"] = False
     receipt_payload = {
         "schema_version": LCK_SCHEMA_VERSION,
         "kind": "lck-audit-receipt",
@@ -6502,7 +6573,7 @@ def _write_success_receipt(
         "operation_id": operation_id,
         "task_number": task_number,
         "outcome": {"status": agent_view.get("status")},
-        "agent_view": agent_view,
+        "agent_view": receipt_agent_view,
         "operation_snapshot": audit_payload.get("operation_snapshot"),
         "audit": audit_payload,
     }
@@ -6536,11 +6607,7 @@ def _write_failure_receipt(
         "code": code,
         "error": safe_text(error, limit=2000),
     }
-    next_action = (
-        "start a fresh Review Prepare for the current target"
-        if status == "stale"
-        else "inspect the receipt and resolve the STOP condition"
-    )
+    next_action = _failure_next_action(status)
     agent_view = {
         "schema_version": LCK_SCHEMA_VERSION,
         "kind": "lck-agent-view",
@@ -6558,7 +6625,20 @@ def _write_failure_receipt(
         "outcome": detail,
         "agent_view": agent_view,
         "operation_snapshot": snapshot_payload,
-        "audit": {"outcome": detail, "operation_snapshot": snapshot_payload},
+        "audit": {
+            "outcome": detail,
+            "operation_snapshot": snapshot_payload,
+            "critical_outcome": _jsonable(
+                getattr(handler, "last_critical_outcome", None)
+            ),
+            "validation": _jsonable(getattr(handler, "last_validation", None)),
+            "effects": _jsonable(
+                [
+                    item.to_dict() if isinstance(item, EffectReceipt) else item
+                    for item in getattr(handler, "last_effects", [])
+                ]
+            ),
+        },
     }
     reference = store.write(
         task_number,
@@ -6566,9 +6646,48 @@ def _write_failure_receipt(
         operation_id,
         receipt_payload,
     )
-    view = dict(agent_view)
+    view = cast(dict[str, Any], dict(agent_view))
     view["receipt_reference"] = reference.to_dict()
     return cast(dict[str, Any], _jsonable(view))
+
+
+def _failure_next_action(status: str) -> str:
+    return (
+        "start a fresh Review Prepare for the current target"
+        if status == "stale"
+        else "inspect the receipt and resolve the STOP condition"
+    )
+
+
+def _failure_fallback(
+    *,
+    operation: str,
+    task_number: int,
+    operation_id: str,
+    status: str,
+    code: str | None,
+    error: str,
+    receipt_error: WorkflowToolError,
+    store: AuditReceiptStore,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "schema_version": LCK_SCHEMA_VERSION,
+        "kind": "lck-agent-view",
+        "operation": operation,
+        "task_number": task_number,
+        "status": status,
+        "code": code,
+        "error": safe_text(error, limit=2000),
+        "receipt_error": safe_text(str(receipt_error), limit=1000),
+        "next_action": _failure_next_action(status),
+    }
+    try:
+        reference = store.existing_reference(task_number, operation, operation_id)
+    except WorkflowToolError:
+        reference = None
+    if reference is not None:
+        payload["receipt_reference"] = reference.to_dict()
+    return payload
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -6757,16 +6876,16 @@ def main(argv: Sequence[str] | None = None) -> int:
                 store=receipt_store,
             )
         except WorkflowToolError as receipt_error:
-            payload = {
-                "schema_version": LCK_SCHEMA_VERSION,
-                "kind": "lck-agent-view",
-                "operation": operation,
-                "task_number": task_number,
-                "status": "stale",
-                "code": exc.code,
-                "error": safe_text(str(exc), limit=2000),
-                "receipt_error": safe_text(str(receipt_error), limit=1000),
-            }
+            payload = _failure_fallback(
+                operation=operation,
+                task_number=task_number,
+                operation_id=operation_id,
+                status="stale",
+                code=exc.code,
+                error=str(exc),
+                receipt_error=receipt_error,
+                store=receipt_store,
+            )
         print_json(payload)
         return 3
     except WorkflowToolError as exc:
@@ -6782,15 +6901,16 @@ def main(argv: Sequence[str] | None = None) -> int:
                 store=receipt_store,
             )
         except WorkflowToolError as receipt_error:
-            payload = {
-                "schema_version": LCK_SCHEMA_VERSION,
-                "kind": "lck-agent-view",
-                "operation": operation,
-                "task_number": task_number,
-                "status": "stop",
-                "error": safe_text(str(exc), limit=2000),
-                "receipt_error": safe_text(str(receipt_error), limit=1000),
-            }
+            payload = _failure_fallback(
+                operation=operation,
+                task_number=task_number,
+                operation_id=operation_id,
+                status="stop",
+                code=None,
+                error=str(exc),
+                receipt_error=receipt_error,
+                store=receipt_store,
+            )
         print_json(payload)
         return 2
 

--- a/tools/agent_workflow/lck.py
+++ b/tools/agent_workflow/lck.py
@@ -3212,8 +3212,10 @@ class ReviewPreparer:
         self.workspace = workspace or ReviewWorkspaceManager(resolver)
         self.store = store or ReviewInvocationStore(resolver.repo_root)
         self.last_snapshot: OperationSnapshot | None = None
+        self.last_validation: dict[str, Any] | None = None
 
     def prepare(self, task_number: int) -> ReviewContext:
+        self.last_validation = None
         if self.store.read_remediation_session(task_number) is not None:
             raise LckStopError(
                 "Review Prepare STOP: a prepared Remediation session must be completed "
@@ -3313,6 +3315,9 @@ class ReviewPreparer:
             validation = self.validation.run(
                 review_root, identity.base_sha, identity.head_sha
             )
+            # Preserve the structured validation result before applying the
+            # pass gate so a rejected Review Prepare has complete evidence.
+            self.last_validation = validation
             mark(
                 "validation-persisted",
                 identity=identity.to_dict(),
@@ -3434,6 +3439,15 @@ class ReviewCompleter:
         self.store = store or ReviewInvocationStore(resolver.repo_root)
         self.workspace = workspace or ReviewWorkspaceManager(resolver)
         self.last_snapshot: OperationSnapshot | None = None
+        self.last_checks: dict[str, Any] | None = None
+
+    def _capture_checks_from_gate(self) -> None:
+        """Retain a check gate's result when strict evaluation raises."""
+        for attribute in ("last_result", "last_checks"):
+            value = getattr(self.checks_gate, attribute, None)
+            if isinstance(value, Mapping):
+                self.last_checks = dict(value)
+                return
 
     @staticmethod
     def _read_findings(path: Path | None, verdict: str) -> str:
@@ -3457,6 +3471,7 @@ class ReviewCompleter:
         verdict: str,
         findings_file: Path | None = None,
     ) -> ReviewCompletionResult:
+        self.last_checks = None
         verdict = verdict.upper()
         if verdict not in {"PASS", "FAIL"}:
             raise LckStopError("Review verdict must be PASS or FAIL")
@@ -3490,6 +3505,7 @@ class ReviewCompleter:
             prepared_checks = guard.get("checks")
             if not isinstance(prepared_checks, Mapping):
                 raise LckStopError("Review invocation has no PR check observation")
+            self.last_checks = dict(prepared_checks)
             prepared_snapshot = guard.get("snapshot")
             if not isinstance(prepared_snapshot, Mapping):
                 raise LckStopError("Review invocation has no sealed operation snapshot")
@@ -3528,9 +3544,22 @@ class ReviewCompleter:
                 completion_snapshot = self.snapshots.bind_required_checks(
                     completion_snapshot, repo_root=review_root
                 )
-                completion_checks = self.checks_gate.evaluate(completion_snapshot)
+                # Binding may return a new immutable snapshot. Publish it
+                # before the strict gate so a later failure receipt contains
+                # the policy bound to this Review Complete operation.
+                self.last_snapshot = completion_snapshot
+                try:
+                    completion_checks = self.checks_gate.evaluate(completion_snapshot)
+                except BaseException:
+                    self._capture_checks_from_gate()
+                    raise
             else:
-                completion_checks = self.checks_gate.observe(completion_snapshot)
+                try:
+                    completion_checks = self.checks_gate.observe(completion_snapshot)
+                except BaseException:
+                    self._capture_checks_from_gate()
+                    raise
+            self.last_checks = dict(completion_checks)
             record = {
                 "schema_version": LCK_SCHEMA_VERSION,
                 "kind": "independent-review-record",
@@ -4247,6 +4276,10 @@ class DeliveryChecksGate:
 
     def __init__(self, resolver: LiveStateResolver) -> None:
         self.runner = resolver.runner
+        self.last_result: dict[str, Any] | None = None
+
+    def _remember_result(self, result: dict[str, Any]) -> None:
+        self.last_result = dict(result)
 
     @staticmethod
     def _required_names(required: Mapping[str, Any]) -> set[str]:
@@ -4292,6 +4325,7 @@ class DeliveryChecksGate:
         required: Mapping[str, Any] | None,
         *,
         require_success: bool = True,
+        capture: Callable[[dict[str, Any]], None] | None = None,
     ) -> dict[str, Any]:
         checks = _normalize_checks(pr.get("statusCheckRollup"))
         required_names = (
@@ -4312,23 +4346,6 @@ class DeliveryChecksGate:
             if observed.get(name) not in {None, "success"}
         }
         missing = required_names - set(observed)
-        if require_success:
-            if failed > 0 or unknown > 0:
-                raise LckStopError("PR checks failed, cancelled, skipped, or unknown")
-            if pending > 0:
-                raise LckStopError(
-                    "PR checks are pending; strict check gate is not satisfied"
-                )
-            if failed_required:
-                raise LckStopError(
-                    "required PR checks are not successful: "
-                    + ", ".join(sorted(failed_required))
-                )
-            if missing:
-                raise LckStopError(
-                    "required PR checks are not present: " + ", ".join(sorted(missing))
-                )
-
         if failed > 0 or failed_required:
             check_state = "failed"
         elif unknown > 0:
@@ -4354,9 +4371,33 @@ class DeliveryChecksGate:
                     "check_state": check_state,
                 }
             )
+        if capture is not None:
+            failed_result = dict(result)
+            if require_success:
+                failed_result["check_state"] = check_state
+                if check_state != "pass":
+                    failed_result["status"] = "fail"
+            capture(failed_result)
+        if require_success:
+            if failed > 0 or unknown > 0:
+                raise LckStopError("PR checks failed, cancelled, skipped, or unknown")
+            if pending > 0:
+                raise LckStopError(
+                    "PR checks are pending; strict check gate is not satisfied"
+                )
+            if failed_required:
+                raise LckStopError(
+                    "required PR checks are not successful: "
+                    + ", ".join(sorted(failed_required))
+                )
+            if missing:
+                raise LckStopError(
+                    "required PR checks are not present: " + ", ".join(sorted(missing))
+                )
         return result
 
     def evaluate(self, snapshot: OperationSnapshot) -> dict[str, Any]:
+        self.last_result = None
         state = snapshot.state
         if state.status is not ResolutionStatus.RESOLVED:
             raise LckStopError(
@@ -4370,10 +4411,16 @@ class DeliveryChecksGate:
         if not isinstance(required, Mapping):
             raise LckStopError("required PR check configuration was not acquired")
         _required_check_contract_for_snapshot(snapshot)
-        return self._evaluate_pr_checks(pr, required, require_success=True)
+        return self._evaluate_pr_checks(
+            pr,
+            required,
+            require_success=True,
+            capture=self._remember_result,
+        )
 
     def observe(self, snapshot: OperationSnapshot) -> dict[str, Any]:
         """Return a bounded check observation without requiring CI success."""
+        self.last_result = None
         state = snapshot.state
         if state.status is not ResolutionStatus.RESOLVED:
             raise LckStopError(
@@ -4383,7 +4430,12 @@ class DeliveryChecksGate:
         pr = state.open_pr
         if not isinstance(pr, Mapping):
             raise LckStopError("PR checks require one OPEN PR in operation snapshot")
-        return self._evaluate_pr_checks(pr, None, require_success=False)
+        return self._evaluate_pr_checks(
+            pr,
+            None,
+            require_success=False,
+            capture=self._remember_result,
+        )
 
     def query_exact_pr(
         self,
@@ -4414,6 +4466,7 @@ class DeliveryChecksGate:
         required_checks: Mapping[str, Any] | None,
         require_success: bool,
     ) -> dict[str, Any]:
+        self.last_result = None
         result = self.runner.run(
             [
                 "gh",
@@ -4447,6 +4500,7 @@ class DeliveryChecksGate:
             value,
             required_checks,
             require_success=require_success,
+            capture=self._remember_result,
         )
 
     def observe_exact_pr(
@@ -5094,6 +5148,7 @@ class CloseoutCompleter:
         self.cleanup_effect = cleanup_effect or CleanupTaskRefsEffect(resolver)
         self.review_store = review_store or ReviewInvocationStore(resolver.repo_root)
         self.last_snapshot: OperationSnapshot | None = None
+        self.last_effects: list[EffectReceipt] = []
 
     @staticmethod
     def _validate_merged_identity(state: LiveState) -> tuple[str, str]:
@@ -5197,6 +5252,10 @@ class CloseoutCompleter:
             )
 
     def complete(self, task_number: int) -> CloseoutResult:
+        effects: list[EffectReceipt] = []
+        # Keep the same list object while effects run so any effect failure
+        # still leaves already-completed effects visible to the failure path.
+        self.last_effects = effects
         snapshot = self.snapshots.acquire(task_number, operation="closeout")
         self.last_snapshot = snapshot
         state = snapshot.state
@@ -5209,7 +5268,6 @@ class CloseoutCompleter:
         if not isinstance(state.merged_pr, Mapping):
             raise LckStopError("Closeout STOP: merged PR identity is unavailable")
         self._validate_reviewed_identity(state, state.merged_pr)
-        effects: list[EffectReceipt] = []
         main = self.main_effect.execute(state, merge_sha=merge_sha)
         effects.append(main)
 
@@ -6647,6 +6705,7 @@ def _write_failure_receipt(
                 getattr(handler, "last_critical_outcome", None)
             ),
             "validation": _jsonable(getattr(handler, "last_validation", None)),
+            "checks": _jsonable(getattr(handler, "last_checks", None)),
             "effects": _jsonable(
                 [
                     item.to_dict() if isinstance(item, EffectReceipt) else item

--- a/tools/agent_workflow/lck.py
+++ b/tools/agent_workflow/lck.py
@@ -1901,8 +1901,10 @@ class FormalValidationGate:
 
     def __init__(self, resolver: LiveStateResolver) -> None:
         self.resolver = resolver
+        self.last_payload: dict[str, Any] | None = None
 
     def run(self, base_sha: str) -> dict[str, Any]:
+        self.last_payload = None
         if not is_sha(base_sha):
             raise LckStopError("formal validation base SHA is unavailable")
         tool = (
@@ -1948,6 +1950,10 @@ class FormalValidationGate:
                 raise LckStopError(str(exc)) from exc
             if not isinstance(payload, dict):
                 raise LckStopError("formal Delivery validation result is not an object")
+            # Keep the structured result available to the owning phase before
+            # applying the gate.  A failed validation is still the evidence
+            # needed by the failure Receipt.
+            self.last_payload = payload
             if result.returncode != 0 or payload.get("status") != "pass":
                 raise LckStopError(
                     "formal Delivery validation failed: "
@@ -5328,12 +5334,25 @@ class DeliveryCompleter:
         except CriticalOutcomeError as exc:
             raise LckStopError(f"Critical Outcome contract invalid: {exc}") from exc
         payload = result.to_dict()
+        self.last_critical_outcome = payload
         if result.status != "pass":
             raise LckStopError(
                 "Critical Outcome FAIL: "
                 f"{contract.verification_test} exited {result.exit_code}"
             )
         return payload
+
+    def _run_formal_validation(self, base_sha: str) -> dict[str, Any]:
+        """Retain a parsed validation payload when the gate rejects it."""
+        try:
+            validation = self.formal_validation.run(base_sha)
+        except BaseException:
+            payload = getattr(self.formal_validation, "last_payload", None)
+            if isinstance(payload, dict):
+                self.last_validation = payload
+            raise
+        self.last_validation = validation
+        return validation
 
     def _has_task_diff(self, base_sha: str) -> bool:
         result = self.resolver.runner.run(
@@ -5437,10 +5456,8 @@ class DeliveryCompleter:
             validated_tree = self.commit_effect.current_head_tree()
             progress.running("critical-outcome")
             critical = self._run_critical_outcome(state, progress=progress)
-            self.last_critical_outcome = critical
             progress.running("formal-validation")
-            validation = self.formal_validation.run(base_sha)
-            self.last_validation = validation
+            validation = self._run_formal_validation(base_sha)
             validated_head = state.local_task_head
             if not is_sha(validated_head):
                 raise LckStopError("current Task head is unavailable")
@@ -5461,10 +5478,8 @@ class DeliveryCompleter:
             validated_tree = self.commit_effect.stage_candidate_tree()
             progress.running("critical-outcome")
             critical = self._run_critical_outcome(state, progress=progress)
-            self.last_critical_outcome = critical
             progress.running("formal-validation")
-            validation = self.formal_validation.run(base_sha)
-            self.last_validation = validation
+            validation = self._run_formal_validation(base_sha)
             self.commit_effect.verify_tree_unchanged(
                 validated_tree,
                 expected_head_sha=state.local_task_head,


### PR DESCRIPTION
Closes #179

## Summary
Separate LCK final stdout into compact Agent Views with stable receipt references while preserving complete operation evidence under the ignored LCK runtime root.

## Validation
- Critical Outcome: pass
- Formal Delivery validation: pass

## Risks / limitations
Receipt persistence is local to the ignored .workflow.local/lck/audit-receipts root; downstream consumers must follow receipt_reference for full audit details.
