### PR TITLE
[Task] 定义初始公共领域模型与共享测试 Fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ See [Repository structure](docs/architecture/repository-structure.md) for bounda
 ## Documentation
 
 - [Technical baseline](docs/architecture/technical-baseline.md): current approved technology choices and architecture boundaries.
+- [Initial domain models](docs/architecture/domain-models.md): public Research MVP market-data models, validation, serialization, and test-factory boundaries.
 - [Project roadmap](docs/planning/project-roadmap.md): current four-stage plan, Issue navigation, dependencies, and implementation entry point.
 - [Planning baseline v1.0](docs/planning/quant-system-planning-baseline-v1.0.md): historical planning snapshot retained for context and decision history.
 - [Deep research report](docs/research/deep-research-report.md): historical broad research on markets, strategies, data, backtesting, and operations.

--- a/docs/architecture/domain-models.md
+++ b/docs/architecture/domain-models.md
@@ -1,0 +1,29 @@
+# Initial public domain models
+
+TraceQuant's Research MVP exposes its first internal public domain models from:
+
+```python
+from tracequant.domain import InstrumentId, OHLCVBar, TimeRange
+```
+
+`InstrumentId` normalizes a single-market symbol to at most 32 trimmed ASCII uppercase
+letters and digits. `TimeRange` represents a timezone-aware UTC half-open interval
+`[start, end)`. `OHLCVBar` binds an instrument and interval to finite `float` OHLCV
+values, a non-negative volume, and consistent high/low bounds. Aware non-UTC inputs
+follow the existing `tracequant.core.time` contract and are normalized to UTC; naive
+datetimes are rejected.
+
+Each immutable model provides explicit `to_dict` and `from_dict` methods. Their output
+contains only stable public values, uses the project's UTC ISO 8601 format, and can be
+handled directly by Python's standard `json` module. These are internal Research MVP
+interfaces, not a promise of long-term external serialization compatibility.
+
+Prices are intentionally allowed to be zero or negative at this boundary. These models
+do not model venues, market types, base/quote parsing, tick or lot sizes, timeframes,
+trade counts, VWAP, exchange metadata, orders, accounts, or persistence schemas.
+
+Tests keep one-off values in their owning test module. Deterministic constructors that
+are genuinely reused across modules live in `tests/fixtures/domain.py`; `conftest.py`
+only exposes those small factories as function-scoped pytest fixtures. Callers should
+override business-significant symbols, times, and prices explicitly rather than hide
+them behind a larger fixture platform.

--- a/src/tracequant/domain/__init__.py
+++ b/src/tracequant/domain/__init__.py
@@ -1,0 +1,10 @@
+"""Initial public domain models for the TraceQuant Research MVP."""
+
+from tracequant.domain.models import (
+    DomainValidationError,
+    InstrumentId,
+    OHLCVBar,
+    TimeRange,
+)
+
+__all__ = ["DomainValidationError", "InstrumentId", "OHLCVBar", "TimeRange"]

--- a/src/tracequant/domain/models.py
+++ b/src/tracequant/domain/models.py
@@ -82,9 +82,14 @@ class InstrumentId:
     def __post_init__(self) -> None:
         if not isinstance(self.value, str):
             raise TypeError("instrument value must be a string")
-        normalized = self.value.strip().upper()
-        if not normalized:
+        stripped = self.value.strip()
+        if not stripped:
             raise DomainValidationError("instrument value must not be empty")
+        if not stripped.isascii():
+            raise DomainValidationError(
+                "instrument value must contain only ASCII uppercase letters and digits"
+            )
+        normalized = stripped.upper()
         if len(normalized) > _MAX_INSTRUMENT_LENGTH:
             raise DomainValidationError(
                 f"instrument value must be at most {_MAX_INSTRUMENT_LENGTH} characters"

--- a/src/tracequant/domain/models.py
+++ b/src/tracequant/domain/models.py
@@ -1,0 +1,214 @@
+"""Validated, immutable market-data domain models."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime
+from math import isfinite
+from string import ascii_uppercase, digits
+from typing import Final, Self
+
+from tracequant.core.time import format_utc, parse_utc, to_utc
+
+_INSTRUMENT_CHARACTERS: Final = frozenset(ascii_uppercase + digits)
+_MAX_INSTRUMENT_LENGTH: Final = 32
+
+
+class DomainValidationError(ValueError):
+    """Raised when a value violates a public domain-model invariant."""
+
+
+def _require_exact_fields(
+    value: object, *, expected: frozenset[str], model: str
+) -> Mapping[str, object]:
+    if not isinstance(value, dict):
+        raise TypeError(f"{model} serialized value must be a JSON object")
+    if any(not isinstance(key, str) for key in value):
+        raise TypeError(f"{model} serialized field names must be strings")
+
+    actual = set(value)
+    missing = expected - actual
+    extra = actual - expected
+    if missing or extra:
+        details: list[str] = []
+        if missing:
+            details.append(f"missing fields: {', '.join(sorted(missing))}")
+        if extra:
+            details.append(f"extra fields: {', '.join(sorted(extra))}")
+        raise DomainValidationError(f"invalid {model} fields ({'; '.join(details)})")
+    return value
+
+
+def _require_string(value: object, *, field: str) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{field} must be a string")
+    return value
+
+
+def _require_float(value: object, *, field: str) -> float:
+    if type(value) is not float:
+        raise TypeError(f"{field} must be a float")
+    if not isfinite(value):
+        raise DomainValidationError(f"{field} must be finite")
+    return value
+
+
+def _normalize_datetime(value: object, *, field: str) -> datetime:
+    if not isinstance(value, datetime):
+        raise TypeError(f"{field} must be a datetime")
+    try:
+        return to_utc(value)
+    except ValueError as error:
+        raise DomainValidationError(f"{field} must be timezone-aware") from error
+
+
+def _parse_datetime(value: object, *, field: str) -> datetime:
+    text = _require_string(value, field=field)
+    try:
+        return parse_utc(text)
+    except ValueError as error:
+        raise DomainValidationError(
+            f"{field} must be an aware ISO 8601 datetime"
+        ) from error
+
+
+@dataclass(frozen=True, slots=True)
+class InstrumentId:
+    """A normalized instrument identifier in the current single-market context."""
+
+    value: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.value, str):
+            raise TypeError("instrument value must be a string")
+        normalized = self.value.strip().upper()
+        if not normalized:
+            raise DomainValidationError("instrument value must not be empty")
+        if len(normalized) > _MAX_INSTRUMENT_LENGTH:
+            raise DomainValidationError(
+                f"instrument value must be at most {_MAX_INSTRUMENT_LENGTH} characters"
+            )
+        if any(character not in _INSTRUMENT_CHARACTERS for character in normalized):
+            raise DomainValidationError(
+                "instrument value must contain only ASCII uppercase letters and digits"
+            )
+        object.__setattr__(self, "value", normalized)
+
+    def __str__(self) -> str:
+        return self.value
+
+    def to_dict(self) -> str:
+        """Return the stable JSON-compatible string representation."""
+        return self.value
+
+    @classmethod
+    def from_dict(cls, value: object) -> Self:
+        """Create an identifier from its JSON-compatible representation."""
+        return cls(_require_string(value, field="instrument"))
+
+
+@dataclass(frozen=True, slots=True)
+class TimeRange:
+    """A timezone-aware UTC half-open interval ``[start, end)``."""
+
+    start: datetime
+    end: datetime
+
+    def __post_init__(self) -> None:
+        start = _normalize_datetime(self.start, field="start")
+        end = _normalize_datetime(self.end, field="end")
+        if start >= end:
+            raise DomainValidationError("start must be earlier than end")
+        object.__setattr__(self, "start", start)
+        object.__setattr__(self, "end", end)
+
+    def to_dict(self) -> dict[str, str]:
+        """Return stable JSON-compatible interval fields."""
+        return {"start": format_utc(self.start), "end": format_utc(self.end)}
+
+    @classmethod
+    def from_dict(cls, value: object) -> Self:
+        """Create a range from exact serialized fields."""
+        fields = _require_exact_fields(
+            value, expected=frozenset({"start", "end"}), model="TimeRange"
+        )
+        return cls(
+            start=_parse_datetime(fields["start"], field="start"),
+            end=_parse_datetime(fields["end"], field="end"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class OHLCVBar:
+    """A validated OHLCV observation over a UTC half-open interval."""
+
+    instrument: InstrumentId
+    start: datetime
+    end: datetime
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.instrument, InstrumentId):
+            raise TypeError("instrument must be an InstrumentId")
+
+        interval = TimeRange(start=self.start, end=self.end)
+        object.__setattr__(self, "start", interval.start)
+        object.__setattr__(self, "end", interval.end)
+
+        for field in ("open", "high", "low", "close", "volume"):
+            _require_float(getattr(self, field), field=field)
+
+        if self.volume < 0:
+            raise DomainValidationError("volume must be greater than or equal to zero")
+        if self.high < max(self.open, self.low, self.close):
+            raise DomainValidationError("high must not be below open, low, or close")
+        if self.low > min(self.open, self.high, self.close):
+            raise DomainValidationError("low must not be above open, high, or close")
+
+    def to_dict(self) -> dict[str, str | float]:
+        """Return stable JSON-compatible bar fields."""
+        return {
+            "instrument": self.instrument.to_dict(),
+            "start": format_utc(self.start),
+            "end": format_utc(self.end),
+            "open": self.open,
+            "high": self.high,
+            "low": self.low,
+            "close": self.close,
+            "volume": self.volume,
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> Self:
+        """Create a bar from exact serialized fields."""
+        fields = _require_exact_fields(
+            value,
+            expected=frozenset(
+                {
+                    "instrument",
+                    "start",
+                    "end",
+                    "open",
+                    "high",
+                    "low",
+                    "close",
+                    "volume",
+                }
+            ),
+            model="OHLCVBar",
+        )
+        return cls(
+            instrument=InstrumentId.from_dict(fields["instrument"]),
+            start=_parse_datetime(fields["start"], field="start"),
+            end=_parse_datetime(fields["end"], field="end"),
+            open=_require_float(fields["open"], field="open"),
+            high=_require_float(fields["high"], field="high"),
+            low=_require_float(fields["low"], field="low"),
+            close=_require_float(fields["close"], field="close"),
+            volume=_require_float(fields["volume"], field="volume"),
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,26 @@
+"""Fixtures that are genuinely shared across domain test modules."""
+
+import pytest
+from fixtures.domain import (
+    BarFactory,
+    InstrumentFactory,
+    TimeRangeFactory,
+    make_bar,
+    make_instrument,
+    make_time_range,
+)
+
+
+@pytest.fixture
+def instrument_factory() -> InstrumentFactory:
+    return make_instrument
+
+
+@pytest.fixture
+def time_range_factory() -> TimeRangeFactory:
+    return make_time_range
+
+
+@pytest.fixture
+def bar_factory() -> BarFactory:
+    return make_bar

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,0 +1,1 @@
+"""Shared deterministic test factories."""

--- a/tests/fixtures/domain.py
+++ b/tests/fixtures/domain.py
@@ -1,0 +1,67 @@
+"""Small deterministic factories for public domain-model tests."""
+
+from datetime import UTC, datetime
+from typing import Protocol
+
+from tracequant.domain import InstrumentId, OHLCVBar, TimeRange
+
+FIXED_START = datetime(2024, 2, 29, 23, 45, tzinfo=UTC)
+FIXED_END = datetime(2024, 3, 1, 0, 0, tzinfo=UTC)
+
+
+class InstrumentFactory(Protocol):
+    def __call__(self, value: str = "BTCUSDT") -> InstrumentId: ...
+
+
+class TimeRangeFactory(Protocol):
+    def __call__(
+        self, *, start: datetime = FIXED_START, end: datetime = FIXED_END
+    ) -> TimeRange: ...
+
+
+class BarFactory(Protocol):
+    def __call__(
+        self,
+        *,
+        instrument: InstrumentId | None = None,
+        start: datetime = FIXED_START,
+        end: datetime = FIXED_END,
+        open: float = 100.0,
+        high: float = 110.0,
+        low: float = 90.0,
+        close: float = 105.0,
+        volume: float = 12.5,
+    ) -> OHLCVBar: ...
+
+
+def make_instrument(value: str = "BTCUSDT") -> InstrumentId:
+    return InstrumentId(value)
+
+
+def make_time_range(
+    *, start: datetime = FIXED_START, end: datetime = FIXED_END
+) -> TimeRange:
+    return TimeRange(start=start, end=end)
+
+
+def make_bar(
+    *,
+    instrument: InstrumentId | None = None,
+    start: datetime = FIXED_START,
+    end: datetime = FIXED_END,
+    open: float = 100.0,
+    high: float = 110.0,
+    low: float = 90.0,
+    close: float = 105.0,
+    volume: float = 12.5,
+) -> OHLCVBar:
+    return OHLCVBar(
+        instrument=instrument if instrument is not None else make_instrument(),
+        start=start,
+        end=end,
+        open=open,
+        high=high,
+        low=low,
+        close=close,
+        volume=volume,
+    )

--- a/tests/test_domain_acceptance.py
+++ b/tests/test_domain_acceptance.py
@@ -1,0 +1,39 @@
+import json
+from datetime import UTC, datetime
+
+import pytest
+from fixtures.domain import BarFactory, InstrumentFactory, TimeRangeFactory
+
+from tracequant.domain import InstrumentId, OHLCVBar, TimeRange
+
+
+def test_public_domain_models_support_validated_json_round_trip(
+    instrument_factory: InstrumentFactory,
+    time_range_factory: TimeRangeFactory,
+    bar_factory: BarFactory,
+) -> None:
+    instrument = instrument_factory("  btcusdt  ")
+    interval = time_range_factory(
+        start=datetime(2024, 2, 29, 23, 45, tzinfo=UTC),
+        end=datetime(2024, 3, 1, 0, 0, tzinfo=UTC),
+    )
+    bar = bar_factory(instrument=instrument, start=interval.start, end=interval.end)
+
+    assert str(instrument) == "BTCUSDT"
+    for model in (instrument, interval, bar):
+        serialized = model.to_dict()
+        json.dumps(serialized, allow_nan=False)
+        assert type(model).from_dict(serialized) == model
+
+    with pytest.raises(ValueError):
+        InstrumentId("BTC-USDT")
+    with pytest.raises(ValueError):
+        TimeRange(start=interval.start, end=interval.start)
+    with pytest.raises(ValueError):
+        bar_factory(high=99.0)
+
+
+def test_public_import_path_exposes_only_the_initial_domain_models() -> None:
+    assert InstrumentId.__module__ == "tracequant.domain.models"
+    assert TimeRange.__module__ == "tracequant.domain.models"
+    assert OHLCVBar.__module__ == "tracequant.domain.models"

--- a/tests/test_domain_models.py
+++ b/tests/test_domain_models.py
@@ -1,0 +1,192 @@
+import json
+from dataclasses import FrozenInstanceError
+from datetime import UTC, datetime, timedelta, timezone
+from math import inf, nan
+
+import pytest
+from fixtures.domain import BarFactory, InstrumentFactory, TimeRangeFactory
+
+from tracequant.domain import InstrumentId, OHLCVBar, TimeRange
+
+
+def test_instrument_normalizes_and_has_value_semantics(
+    instrument_factory: InstrumentFactory,
+) -> None:
+    first = instrument_factory("  ethusdc  ")
+    second = instrument_factory("ETHUSDC")
+
+    assert first == second
+    assert hash(first) == hash(second)
+    assert str(first) == "ETHUSDC"
+    with pytest.raises(FrozenInstanceError):
+        first.value = "BTCUSDT"  # type: ignore[misc]
+
+
+@pytest.mark.parametrize(
+    "invalid_value",
+    ["", "   ", "BTC-USDT", "BTC/USDT", "ＢＴＣＵＳＤＴ", "A" * 33],
+)
+def test_instrument_rejects_invalid_values(invalid_value: str) -> None:
+    with pytest.raises(ValueError):
+        InstrumentId(invalid_value)
+
+
+def test_time_range_normalizes_non_utc_aware_values(
+    time_range_factory: TimeRangeFactory,
+) -> None:
+    interval = time_range_factory(
+        start=datetime(2024, 3, 1, 7, 45, tzinfo=timezone(timedelta(hours=8))),
+        end=datetime(2024, 3, 1, 8, 0, tzinfo=timezone(timedelta(hours=8))),
+    )
+
+    assert interval.start == datetime(2024, 2, 29, 23, 45, tzinfo=UTC)
+    assert interval.end == datetime(2024, 3, 1, 0, 0, tzinfo=UTC)
+
+
+@pytest.mark.parametrize(
+    ("start", "end"),
+    [
+        (datetime(2024, 1, 1), datetime(2024, 1, 2, tzinfo=UTC)),
+        (datetime(2024, 1, 1, tzinfo=UTC), datetime(2024, 1, 2)),
+        (
+            datetime(2024, 1, 1, tzinfo=UTC),
+            datetime(2024, 1, 1, tzinfo=UTC),
+        ),
+        (
+            datetime(2024, 1, 2, tzinfo=UTC),
+            datetime(2024, 1, 1, tzinfo=UTC),
+        ),
+    ],
+)
+def test_time_range_rejects_naive_or_non_increasing_bounds(
+    start: datetime, end: datetime
+) -> None:
+    with pytest.raises(ValueError):
+        TimeRange(start=start, end=end)
+
+
+def test_time_range_supports_cross_day_month_and_leap_day() -> None:
+    interval = TimeRange(
+        start=datetime(2024, 2, 29, 23, 59, tzinfo=UTC),
+        end=datetime(2024, 3, 1, 0, 1, tzinfo=UTC),
+    )
+
+    assert interval.to_dict() == {
+        "start": "2024-02-29T23:59:00Z",
+        "end": "2024-03-01T00:01:00Z",
+    }
+
+
+def test_time_range_is_immutable_and_has_value_semantics(
+    time_range_factory: TimeRangeFactory,
+) -> None:
+    first = time_range_factory()
+    second = time_range_factory()
+
+    assert first == second
+    with pytest.raises(FrozenInstanceError):
+        first.end = first.start  # type: ignore[misc]
+
+
+@pytest.mark.parametrize("invalid_value", [nan, inf, -inf])
+@pytest.mark.parametrize("field", ["open", "high", "low", "close", "volume"])
+def test_bar_rejects_non_finite_numbers(
+    bar_factory: BarFactory, field: str, invalid_value: float
+) -> None:
+    values = {field: invalid_value}
+    with pytest.raises(ValueError, match=f"{field} must be finite"):
+        bar_factory(**values)  # type: ignore[arg-type]
+
+
+def test_bar_rejects_negative_volume(bar_factory: BarFactory) -> None:
+    with pytest.raises(ValueError, match="volume"):
+        bar_factory(volume=-0.1)
+
+
+def test_bar_reuses_time_range_validation_and_is_immutable(
+    bar_factory: BarFactory,
+) -> None:
+    with pytest.raises(ValueError, match="timezone-aware"):
+        bar_factory(start=datetime(2024, 1, 1))
+
+    bar = bar_factory()
+    with pytest.raises(FrozenInstanceError):
+        bar.close = 101.0  # type: ignore[misc]
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        {"open": 101.0, "high": 100.0},
+        {"close": 101.0, "high": 100.0},
+        {"low": 101.0, "high": 100.0},
+        {"open": 89.0, "low": 90.0},
+        {"close": 89.0, "low": 90.0},
+    ],
+)
+def test_bar_rejects_invalid_ohlc_relationships(
+    bar_factory: BarFactory, values: dict[str, float]
+) -> None:
+    with pytest.raises(ValueError):
+        bar_factory(**values)  # type: ignore[arg-type]
+
+
+def test_bar_currently_allows_zero_and_negative_prices(
+    bar_factory: BarFactory,
+) -> None:
+    zero = bar_factory(open=0.0, high=0.0, low=0.0, close=0.0)
+    negative = bar_factory(open=-2.0, high=-1.0, low=-3.0, close=-2.5)
+
+    assert zero.open == 0.0
+    assert negative.low == -3.0
+
+
+def test_serialization_round_trip_and_factory_calls_are_isolated(
+    bar_factory: BarFactory,
+) -> None:
+    first = bar_factory()
+    second = bar_factory()
+
+    assert first == second
+    assert first is not second
+    payload = first.to_dict()
+    assert json.loads(json.dumps(payload, allow_nan=False)) == payload
+    assert OHLCVBar.from_dict(payload) == first
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"start": "2024-01-01T00:00:00Z"},
+        {
+            "start": "2024-01-01T00:00:00Z",
+            "end": "2024-01-02T00:00:00Z",
+            "extra": "unexpected",
+        },
+        {"start": 1, "end": "2024-01-02T00:00:00Z"},
+        {"start": "2024-01-01T00:00:00", "end": "2024-01-02T00:00:00Z"},
+    ],
+)
+def test_time_range_rejects_malformed_deserialization(payload: object) -> None:
+    with pytest.raises((TypeError, ValueError)):
+        TimeRange.from_dict(payload)
+
+
+@pytest.mark.parametrize("payload", [1, None, {"value": "BTCUSDT"}])
+def test_instrument_rejects_malformed_deserialization(payload: object) -> None:
+    with pytest.raises((TypeError, ValueError)):
+        InstrumentId.from_dict(payload)
+
+
+def test_bar_rejects_missing_extra_and_wrong_serialized_fields(
+    bar_factory: BarFactory,
+) -> None:
+    valid = bar_factory().to_dict()
+    missing = dict(valid)
+    del missing["volume"]
+    extra = {**valid, "trades": 1.0}
+    wrong_type = {**valid, "volume": 1}
+
+    for payload in (missing, extra, wrong_type):
+        with pytest.raises((TypeError, ValueError)):
+            OHLCVBar.from_dict(payload)

--- a/tests/test_domain_models.py
+++ b/tests/test_domain_models.py
@@ -31,6 +31,12 @@ def test_instrument_rejects_invalid_values(invalid_value: str) -> None:
         InstrumentId(invalid_value)
 
 
+@pytest.mark.parametrize("invalid_value", ["ß", "ſ"])
+def test_instrument_rejects_non_ascii_before_uppercase(invalid_value: str) -> None:
+    with pytest.raises(ValueError, match="ASCII"):
+        InstrumentId(invalid_value)
+
+
 def test_time_range_normalizes_non_utc_aware_values(
     time_range_factory: TimeRangeFactory,
 ) -> None:


### PR DESCRIPTION
Closes #169

## Summary
Add immutable InstrumentId, TimeRange, and OHLCVBar models with strict validation and JSON-compatible round trips; add deterministic shared domain factories, cross-module fixtures, acceptance and boundary tests, and focused documentation.

## Validation
- Critical Outcome: pass
- Formal Delivery validation: pass

## Risks / limitations
Research MVP internal schema only; instrument identifiers are capped at 32 ASCII alphanumeric characters, aware non-UTC datetimes normalize to UTC, and numeric fields intentionally require float values. No long-term external serialization compatibility is promised.
