### PR TITLE
[Task] 收敛开发环境、README、架构与风险文档

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,188 +1,281 @@
 # TraceQuant
 
-An auditable research-to-live quantitative trading system for cryptocurrency perpetual futures.
+TraceQuant is intended to become an auditable research-to-live quantitative
+trading system for cryptocurrency perpetual futures. The current repository is
+the Research MVP foundation: it contains a small, validated Python package and
+the engineering documentation around it. It does not contain a trading system
+or an executable strategy yet.
 
-## Initial scope
+## Current capability and boundary
 
-- Exchange: Binance
-- Markets: USD-margined perpetual futures
-- Initial instruments: BTC and ETH USDT/USDC perpetual contracts
-- Decision horizon: approximately 15 minutes to 4 hours
-- Research focus:
-  - multi-factor signals;
-  - machine-learning filters;
-  - cost-aware backtesting;
-  - maker-preferred execution;
-  - strict risk control and auditability.
+The currently implemented public package is `tracequant` under `src/`:
 
-## Development principles
+- `tracequant.config`: explicit, immutable application settings and a
+  representation-safe `SecretValue` helper;
+- `tracequant.logging`: explicit JSON console/file logging and recursive
+  redaction of known sensitive fields;
+- `tracequant.core.time`: timezone-aware UTC validation, conversion, parsing,
+  and formatting;
+- `tracequant.domain`: the initial immutable `InstrumentId`, `TimeRange`, and
+  `OHLCVBar` models with validation and JSON-compatible serialization.
 
-- Correctness before performance.
-- Research before live trading.
-- Gross and net results must be reported separately.
-- Fees, funding, slippage, missed fills, and execution delay must be modeled.
-- Strategy, risk, execution, and exchange connectivity must remain separated.
-- Live trading must be disabled by default.
-- All implementation work is tracked through GitHub Issues and Pull Requests.
+The `apps/`, `packages/`, and `deploy/` directories currently establish future
+boundaries through small README files. They are not implemented product
+packages. There is currently no exchange client, market-data ingestion,
+database, data pipeline, feature or label pipeline, backtester, strategy,
+machine-learning model, order or account service, risk engine, live runtime,
+or multi-exchange implementation.
 
-## Repository structure
-
-TraceQuant is a modular monorepo. The current bootstrap package remains in `src/tracequant/` while product boundaries are established before implementation is moved into them.
-
-- `apps/research/`: research-facing orchestration.
-- `apps/runtime/`: Shadow, Demo, and Live runtime entry points.
-- `apps/console/`: future operator UI/control-plane boundary.
-- `packages/contracts/`: stable cross-boundary schemas and interfaces.
-- `packages/domain/`: core domain models and invariants.
-- `packages/adapters/`: exchange, storage, database, filesystem, and vendor integrations.
-- `deploy/research|staging|live/`: environment-specific deployment assets.
-- `src/tracequant/`: currently implemented bootstrap Python package.
-- `tests/`: unit, integration, and regression tests.
-- `docs/`: architecture, research reports, risk rules, ADRs, and workflow documentation.
-- `.github/`: Issue templates, Pull Request template, and CI workflows.
-
-See [Repository structure](docs/architecture/repository-structure.md) for boundary rules and future extraction criteria.
-
-## Documentation
-
-- [Technical baseline](docs/architecture/technical-baseline.md): current approved technology choices and architecture boundaries.
-- [Initial domain models](docs/architecture/domain-models.md): public Research MVP market-data models, validation, serialization, and test-factory boundaries.
-- [Project roadmap](docs/planning/project-roadmap.md): current four-stage plan, Issue navigation, dependencies, and implementation entry point.
-- [Planning baseline v1.0](docs/planning/quant-system-planning-baseline-v1.0.md): historical planning snapshot retained for context and decision history.
-- [Deep research report](docs/research/deep-research-report.md): historical broad research on markets, strategies, data, backtesting, and operations.
-- [Deep research report 2](docs/research/deep-research-report-2.md): historical follow-up research used to refine the technical direction.
-- [Technical roadmap research](docs/research/technical-roadmap-research.md): historical comparative research behind the selected implementation route.
-- [WSL2 Codex environment](docs/workflows/wsl2-codex-environment/README.md): reproducible WSL2 setup, diagnostics, approval boundaries, rollback, and troubleshooting.
-- [Historical WSL2 GitHub evidence runner archive](docs/workflows/wsl2-github-evidence-runner/README.md): frozen pre-LCK publication evidence only; the executable Task lifecycle Runner, profiles, and Rules were removed during LCK v1 cutover.
-
-## Current status
-
-The project is in its initial planning and repository setup stage. No live-trading capability has been implemented.
+“Research MVP” therefore means a reliable foundation for later research work,
+not a claim that research, backtesting, Demo, or Live trading is available.
 
 ## Development environment
 
-Python 3.13 and [uv](https://docs.astral.sh/uv/) are required. The repository `.python-version` pins the project environment to Python 3.13, matching CI and the supported TraceQuant runtime baseline. Create or update the local environment with:
+Use a clean checkout with:
+
+- Python `3.13` (`>=3.13,<3.14`), as pinned by `.python-version` and CI;
+- uv `0.12.1`, the version used by the repository workflow;
+- Git and a supported shell.
+
+uv creates and manages the project environment. No manual virtual-environment
+activation is required:
 
 ```console
 uv sync --locked --dev
+uv run --frozen python -c "import tracequant; print(tracequant.__name__)"
 ```
 
-Verify that the project package is importable with:
+The first command is the clean-install command. It uses `uv.lock`; do not
+replace it with an unlocked install when reproducing CI.
 
-```console
-uv run python -c "import tracequant; print(tracequant.__name__)"
+### Environment variables
+
+The committed [`.env.example`](.env.example) lists the current variable
+contract. The application does not automatically read `.env`, `.env.*`, or
+`.env.example`. Copying `.env.example` is only a reference operation; values
+must be exported, supplied by IDE/env-file tooling, or passed explicitly to
+`load_settings`.
+
+For a POSIX shell (Linux/macOS/WSL):
+
+```sh
+export TRACEQUANT_ENV=development
+export TRACEQUANT_LOG_FORMAT=json
+uv run --frozen pytest
 ```
 
-Run the test suite with:
+For Windows PowerShell:
 
-```console
-uv run pytest
+```powershell
+$env:TRACEQUANT_ENV = "development"
+$env:TRACEQUANT_LOG_FORMAT = "json"
+uv run --frozen pytest
 ```
 
-Run lint and formatting checks with:
+PowerShell uses `$env:NAME = "value"`, while POSIX shells use `export
+NAME=value`. `uv run` works without activating `.venv` on either platform.
+When setting `TRACEQUANT_LOG_DIR`, use the host platform's path syntax, such as
+`logs/app` on POSIX or `logs\app` on Windows. Keep repository text files UTF-8
+with LF line endings; check a change with `git diff --check`.
 
-```console
-uv run ruff check .
-uv run ruff format --check .
-```
+### Canonical quality commands
 
-Run strict type checking with:
+These are the one set of local commands corresponding to the current CI
+workflow (`.github/workflows/ci.yml`):
 
-```console
-uv run mypy src tests
-```
+| Purpose | Command |
+| --- | --- |
+| Install locked development dependencies | `uv sync --locked --dev` |
+| Tests | `uv run --frozen pytest` |
+| Ruff lint | `uv run --frozen ruff check .` |
+| Ruff format check | `uv run --frozen ruff format --check .` |
+| Strict type check | `uv run --frozen mypy src tests` |
 
-For the supported VS Code Remote WSL + Codex environment, including pinned uv, GitHub CLI authentication, proxy behavior, diagnostics, and rollback, see [the WSL2 environment guide](docs/workflows/wsl2-codex-environment/README.md).
+CI also runs `uv lock --check` after syncing dependencies. It runs the same
+pytest, Ruff, and mypy commands shown above for pull requests targeting `main`
+and pushes to `main`. Do not introduce a second command set in another guide.
 
-## Continuous integration
-
-Pull requests targeting `main` and pushes to `main` automatically run CI. The workflow runs pytest, Ruff lint, Ruff format checking, and mypy. Use the equivalent local commands in the existing Development environment section above.
-
-## UTC time handling
-
-Internal datetimes must be timezone-aware and use UTC as the standard timezone. Naive datetimes are explicitly rejected. Time utilities are provided by `tracequant.core.time`.
-
-## Configuration
-
-Application configuration is loaded explicitly with `tracequant.config.load_settings`.
-Importing the module does not read environment variables, parse `.env` files, create
-directories, or cache a global settings singleton.
-
-Supported environment variables:
-
-- `TRACEQUANT_ENV`: required; one of `development`, `test`, or `production`.
-- `TRACEQUANT_LOG_LEVEL`: optional; one of `DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL`; defaults to `INFO`.
-- `TRACEQUANT_LOG_FORMAT`: optional; one of `text` or `json`; defaults to `json`. Logging currently supports `json`.
-- `TRACEQUANT_LOG_DIR`: optional; empty or unset disables file logging.
-
-Loading priority is:
+## Repository layout
 
 ```text
-explicit load_settings arguments
-> process environment variables
-> defaults
+src/tracequant/                 implemented bootstrap package
+  config.py                     explicit settings loading
+  logging.py                    structured JSON logging
+  core/time.py                  UTC utilities
+  domain/models.py              initial domain models
+tests/                          package and workflow tests
+  fixtures/domain.py            deterministic domain factories, test-only
+apps/                           future research/runtime/console boundaries
+packages/                       future contracts/domain/adapters boundaries
+deploy/                         future environment-specific deployment assets
+docs/                           architecture, development, research, workflow docs
+.env.example                    documented environment-variable names
+pyproject.toml                  package and tool configuration
+uv.lock                         locked dependency resolution
 ```
 
-Use `.env.example` as the committed variable list and copy values into your shell,
-IDE, or env-file tooling when needed. Local `.env` and `.env.*` files remain ignored
-by Git and are not read automatically by this project.
+The `tests/tools/` subtree tests the repository workflow tooling. It is not a
+runtime dependency of `tracequant`. The intended boundaries and dependency
+direction are described in [Repository structure](docs/architecture/repository-structure.md).
 
-Tests can construct isolated settings directly:
+## Public API quick start
+
+### Configuration
+
+Loading is explicit. The `environ` argument makes a deterministic isolated
+mapping useful in tests; omitting it reads the process environment at call
+time:
+
+```python
+from tracequant.config import Environment, Settings, load_settings
+
+settings = load_settings(environ={"TRACEQUANT_ENV": "development"})
+assert settings == Settings(environment=Environment.DEVELOPMENT)
+```
+
+Explicit arguments take precedence over environment values, which take
+precedence over defaults. `TRACEQUANT_ENV` is required. Importing the config
+module does not read environment values, load dotenv files, create directories,
+or create a global settings object.
+
+### Structured logging
+
+Configure logging explicitly after loading settings:
 
 ```python
 from tracequant.config import Environment, Settings
+from tracequant.logging import configure_logging
 
-settings = Settings(environment=Environment.TEST)
+settings = Settings(environment=Environment.DEVELOPMENT)
+configure_logging(settings)
 ```
 
-`SecretValue` provides redacted `repr` and `str` output for future sensitive fields.
-It is a display-safety boundary only, not encryption, a secrets manager, or a system
-keyring. Current configuration scope does not include exchange credentials, account
-settings, databases, trading modes, structured logging setup, or automatic log
-directory creation.
+The current logging implementation emits one-line JSON records to stderr. It
+can additionally append to `tracequant.jsonl` below an explicitly configured
+directory. It only accepts `LogFormat.JSON`; although the configuration parser
+accepts both `text` and `json` as values for `TRACEQUANT_LOG_FORMAT`, passing
+`LogFormat.TEXT` to `configure_logging` raises `LoggingConfigError`. Use JSON
+for the current logging path.
 
-## Structured logging
+Known sensitive mapping keys are redacted case-insensitively, and
+`SecretValue` is representation-safe. This is not encryption or a secret
+manager, and redaction cannot reliably detect a credential manually
+concatenated into a free-text message. Never put credentials in log messages.
 
-Applications configure logging explicitly with `tracequant.logging.configure_logging(settings)`.
-Importing the logging module does not configure handlers, create directories, or open
-files. Modules should continue to use `logging.getLogger(__name__)`.
+### UTC time
 
-JSON log records are single-line UTF-8 objects with stable `timestamp`, `level`,
-`logger`, and `message` fields. Timestamps are timezone-aware UTC ISO 8601 strings.
-When `settings.log_dir` is set, the exact directory is created and logs are appended
-to `tracequant.jsonl`; when it is empty or unset, only console logging is enabled.
+All domain timestamps must be timezone-aware. Utilities accept aware non-UTC
+values and normalize them to UTC; naive values are rejected:
 
-Known sensitive keys are redacted case-insensitively in structured fields and
-exception output: `password`, `secret`, `token`, `api_key`, `apikey`,
-`authorization`, and `cookie`. This boundary does not guarantee detection of secrets
-that callers manually concatenate into free-text messages, so callers must not place
-raw credentials in log messages.
+```python
+from datetime import UTC, datetime
 
-## Agent workflow evidence and validation
+from tracequant.core.time import format_utc, parse_utc
 
-Repository workflow Skills use LCK for lifecycle mechanics and the fixed
-Validation Runner for deterministic validation summaries:
-
-```text
-tools/agent_workflow/lck.py
-tools/agent_workflow/wsl2_validation_runner.py
+when = datetime(2024, 2, 29, 23, 45, tzinfo=UTC)
+assert format_utc(when) == "2024-02-29T23:45:00Z"
+assert parse_utc("2024-02-29T23:45:00Z") == when
 ```
 
-Local outputs are stored only in Git-ignored directories:
+### Initial domain models
 
-```text
-.agents/evidence.local/
-.agents/validation.local/
+The public import path is:
+
+```python
+import json
+from datetime import UTC, datetime
+
+from tracequant.domain import InstrumentId, OHLCVBar
+
+bar = OHLCVBar(
+    instrument=InstrumentId("BTCUSDT"),
+    start=datetime(2024, 2, 29, 23, 45, tzinfo=UTC),
+    end=datetime(2024, 3, 1, 0, 0, tzinfo=UTC),
+    open=100.0,
+    high=110.0,
+    low=90.0,
+    close=105.0,
+    volume=12.5,
+)
+json.dumps(bar.to_dict(), allow_nan=False)
 ```
 
-See `.agents/policies/workflow-evidence.md`. These tools do not replace semantic
-review, independent PR review, manual Merge, or Feature closeout.
+Models are immutable and validate their inputs. `InstrumentId` is a trimmed,
+ASCII uppercase letters-and-digits identifier of at most 32 characters;
+`TimeRange` is a UTC half-open interval; and `OHLCVBar` contains finite float
+OHLCV values with non-negative volume and consistent high/low bounds. These
+models intentionally do not represent venues, order books, orders, accounts,
+timeframes, persistence schemas, or exchange metadata. See [Initial public
+domain models](docs/architecture/domain-models.md) for the full boundary.
 
-- [LCK v1 Design Charter](docs/workflows/LCK-v1-Design-Charter.md): live-state Task lifecycle authority and phase boundaries.
-- [Agent workflow Skills](docs/workflows/agent-skills.md): current Codex/Claude Skills, source-of-truth ownership, and validation entry points.
-- [Validation Runner](docs/workflows/wsl2-validation-runner/README.md): fixed validation profiles, compact artifacts, exact argv, and process cleanup.
-- [Task Skill runner migration](docs/workflows/task-skill-runner-migration/README.md): historical migration record only; not an operational guide.
+### Shared test fixtures
+
+Reusable deterministic factories belong to `tests/fixtures/domain.py`, not to
+the production package. `tests/conftest.py` exposes them as function-scoped
+pytest fixtures:
+
+```python
+from fixtures.domain import BarFactory
+
+
+def test_example_bar(bar_factory: BarFactory) -> None:
+    bar = bar_factory()
+    assert str(bar.instrument) == "BTCUSDT"
+```
+
+Use explicit symbols, UTC timestamps, and prices when those values matter to a
+test. The fixed factory defaults are test conveniences and are not production
+data or runtime configuration.
+
+## Security and known limitations
+
+- Live trading is disabled because no trading runtime exists. Do not add real
+  exchange credentials or API keys to the repository, examples, issues, or
+  logs. Local `.env` files, keys, logs, databases, and research data are
+  ignored by Git, but ignoring a file is not a substitute for secret hygiene.
+- The current configuration only covers environment name, log level, log
+  format, and an optional log directory. It has no exchange credentials,
+  account, database, trading-mode, or automatic log-setup fields.
+- File logging is an explicit logging setup action. An empty or unset
+  `TRACEQUANT_LOG_DIR` disables it; a non-empty path is created by
+  `configure_logging`, not by importing a module. The current logger writes
+  JSON only and appends to one file named `tracequant.jsonl`.
+- UTC utilities reject naive datetimes, but callers still own the boundary
+  validation for external data. Domain serialization is explicit and
+  JSON-compatible; it is not a versioned external storage contract. OHLCV
+  numeric fields require finite Python `float` values, while zero and negative
+  prices are currently allowed at this initial boundary.
+- The shared fixtures cover only the initial domain models. They do not model
+  exchange responses, missing or duplicated market data, fills, accounts, or
+  production state.
+- The current repository does not provide database storage, raw/canonical data
+  layers, factors, labels, backtesting, model training, execution, risk
+  decisions, monitoring, or multi-exchange adapters. Those are future Issues,
+  not available capabilities.
+- Documentation and Agent workflow controls have separate responsibilities.
+  LCK and the Validation Runner describe repository lifecycle mechanics; they
+  do not add business or trading functionality. See the [WSL2 Codex environment
+  guide](docs/workflows/wsl2-codex-environment/README.md) only when working in
+  that specific environment.
+
+## Documentation map
+
+- [Technical baseline](docs/architecture/technical-baseline.md): current
+  implementation facts and explicitly deferred research/trading architecture.
+- [Repository structure](docs/architecture/repository-structure.md): current
+  tree, dependency direction, and future boundary rules.
+- [Initial public domain models](docs/architecture/domain-models.md): model
+  invariants, serialization, and test-factory boundary.
+- [Project roadmap](docs/planning/project-roadmap.md): planning and Issue
+  navigation, not proof that planned capabilities are implemented.
+- [Issue workflow](docs/development/issue-workflow.md): repository lifecycle
+  semantics for implementation work.
+- [Agent workflow Skills](docs/workflows/agent-skills.md): current workflow
+  controls, separate from the business architecture.
+- [WSL2 Codex environment](docs/workflows/wsl2-codex-environment/README.md):
+  environment-specific setup and diagnostics.
 
 ## License
 
-TraceQuant is publicly accessible but is not currently distributed under an open-source license. All rights are reserved. See `LICENSE`.
+TraceQuant is publicly accessible but is not currently distributed under an
+open-source license. See [LICENSE](LICENSE).

--- a/docs/architecture/domain-models.md
+++ b/docs/architecture/domain-models.md
@@ -1,29 +1,96 @@
 # Initial public domain models
 
-TraceQuant's Research MVP exposes its first internal public domain models from:
+The current Research MVP foundation exposes three immutable value models from
+one public import path:
 
 ```python
-from tracequant.domain import InstrumentId, OHLCVBar, TimeRange
+from tracequant.domain import DomainValidationError, InstrumentId, OHLCVBar, TimeRange
 ```
 
-`InstrumentId` normalizes a single-market symbol to at most 32 trimmed ASCII uppercase
-letters and digits. `TimeRange` represents a timezone-aware UTC half-open interval
-`[start, end)`. `OHLCVBar` binds an instrument and interval to finite `float` OHLCV
-values, a non-negative volume, and consistent high/low bounds. Aware non-UTC inputs
-follow the existing `tracequant.core.time` contract and are normalized to UTC; naive
-datetimes are rejected.
+These are internal Python interfaces for the current repository. They are not
+an exchange schema, an order/account model, or a promise of long-term external
+serialization compatibility.
 
-Each immutable model provides explicit `to_dict` and `from_dict` methods. Their output
-contains only stable public values, uses the project's UTC ISO 8601 format, and can be
-handled directly by Python's standard `json` module. These are internal Research MVP
-interfaces, not a promise of long-term external serialization compatibility.
+## Invariants
 
-Prices are intentionally allowed to be zero or negative at this boundary. These models
-do not model venues, market types, base/quote parsing, tick or lot sizes, timeframes,
-trade counts, VWAP, exchange metadata, orders, accounts, or persistence schemas.
+| Model | Current contract |
+| --- | --- |
+| `InstrumentId` | Trims surrounding whitespace, normalizes to ASCII uppercase letters and digits, and rejects empty values or values longer than 32 characters. |
+| `TimeRange` | Contains `start` and `end` as a timezone-aware UTC half-open interval `[start, end)`, with `start < end`. Aware non-UTC values are normalized to UTC; naive values are rejected. |
+| `OHLCVBar` | Binds an `InstrumentId` to a `TimeRange` and finite Python `float` OHLCV values. Volume is non-negative; `high` is not below open/low/close and `low` is not above open/high/close. |
 
-Tests keep one-off values in their owning test module. Deterministic constructors that
-are genuinely reused across modules live in `tests/fixtures/domain.py`; `conftest.py`
-only exposes those small factories as function-scoped pytest fixtures. Callers should
-override business-significant symbols, times, and prices explicitly rather than hide
-them behind a larger fixture platform.
+`OHLCVBar` currently allows zero and negative prices. That is an intentional
+boundary decision for this initial model, not a complete venue or instrument
+validation policy. The models do not represent venues, market types, quote/base
+assets, tick or lot sizes, timeframes, trade counts, VWAP, funding, mark/index
+prices, exchange metadata, orders, accounts, persistence, or risk decisions.
+
+Validation failures are `ValueError` subclasses. `DomainValidationError` is
+exported for callers that need to distinguish domain invariant failures from
+ordinary type errors.
+
+## Serialization
+
+Each model has explicit `to_dict()` and `from_dict()` methods. The output uses
+only JSON-compatible strings and finite floats:
+
+- `InstrumentId.to_dict()` returns its string value;
+- `TimeRange.to_dict()` returns exact `start` and `end` fields;
+- `OHLCVBar.to_dict()` returns exact instrument, interval, and OHLCV fields;
+- deserialization rejects missing, extra, or incorrectly typed fields;
+- datetime strings use the UTC ISO 8601 form with a `Z` suffix.
+
+The following deterministic example uses the current public API:
+
+```python
+import json
+from datetime import UTC, datetime
+
+from tracequant.domain import InstrumentId, OHLCVBar
+
+bar = OHLCVBar(
+    instrument=InstrumentId("BTCUSDT"),
+    start=datetime(2024, 2, 29, 23, 45, tzinfo=UTC),
+    end=datetime(2024, 3, 1, 0, 0, tzinfo=UTC),
+    open=100.0,
+    high=110.0,
+    low=90.0,
+    close=105.0,
+    volume=12.5,
+)
+payload = bar.to_dict()
+json.dumps(payload, allow_nan=False)
+assert OHLCVBar.from_dict(payload) == bar
+```
+
+Serialization is a validated interchange helper for the current package. It
+does not define a versioned database schema, a canonical exchange-data schema,
+or a persistence strategy.
+
+## UTC boundary
+
+`tracequant.core.time` is the shared boundary for `ensure_aware`, `to_utc`,
+`parse_utc`, and `format_utc`. Domain constructors normalize aware values and
+reject naive values; callers remain responsible for validating external event
+time semantics before constructing a model. No domain model consults the
+machine's local timezone.
+
+## Test-factory boundary
+
+One-off values stay in the owning test. Deterministic factories reused across
+domain tests live in `tests/fixtures/domain.py`:
+
+- `make_instrument(value="BTCUSDT")`;
+- `make_time_range(start=..., end=...)`;
+- `make_bar(instrument=..., start=..., end=..., open=..., high=..., low=...,
+  close=..., volume=...)`.
+
+The default range is the fixed UTC interval
+`2024-02-29T23:45:00Z` to `2024-03-01T00:00:00Z`, and default prices/volume are
+fixed constants. `tests/conftest.py` exposes these callables as function-scoped
+`instrument_factory`, `time_range_factory`, and `bar_factory` fixtures.
+
+Fixtures import the production models so tests can construct valid values, but
+production modules never import fixtures. The factories are not a data source,
+runtime dependency, exchange simulator, or substitute for future market-data
+fixtures.

--- a/docs/architecture/repository-structure.md
+++ b/docs/architecture/repository-structure.md
@@ -52,7 +52,7 @@ Python standard library
 └── tracequant.logging ──> tracequant.config
                          └> tracequant.core.time
 
-tracequant.core.time ──> tracequant.domain.models
+tracequant.domain.models ──> tracequant.core.time
 
 tests ──> tracequant public APIs
 tests ──> tests/fixtures/domain.py ──> tracequant.domain
@@ -60,8 +60,8 @@ tests ──> tests/fixtures/domain.py ──> tracequant.domain
 
 The diagram is an import graph, not a claim that fixtures are part of the
 runtime. The responsibility layers can be read as configuration and time
-primitives supporting logging and domain models, with test factories as a
-separate test-support layer.
+primitives supporting logging, while domain models depend on the UTC
+primitives; test factories remain a separate test-support layer.
 
 ### Allowed boundaries
 

--- a/docs/architecture/repository-structure.md
+++ b/docs/architecture/repository-structure.md
@@ -1,43 +1,115 @@
 # TraceQuant repository structure
 
-## Decision
+This document describes the current repository and the boundaries that future
+implementation work must respect. Directory names under `apps/`, `packages/`,
+and `deploy/` are architectural scaffolding; their presence does not mean that
+the corresponding product capability exists.
 
-TraceQuant remains a **modular monorepo**. The repository establishes product and dependency boundaries before considering physical repository extraction.
+## Current tree
 
 ```text
-apps/
-  research/
-  runtime/
-  console/
-packages/
-  contracts/
-  domain/
-  adapters/
-deploy/
-  research/
-  staging/
-  live/
 src/tracequant/
+  config.py
+  logging.py
+  core/time.py
+  domain/models.py
 tests/
-docs/
+  test_config.py
+  test_logging.py
+  core/test_time.py
+  test_domain_models.py
+  test_domain_acceptance.py
+  fixtures/domain.py
+  tools/                         repository workflow tests
+apps/
+  research/                      boundary README only
+  runtime/                       boundary README only
+  console/                       boundary README only
+packages/
+  contracts/                     boundary README only
+  domain/                        boundary README only
+  adapters/                      boundary README only
+deploy/
+  research/                      deployment boundary README only
+  staging/                       deployment boundary README only
+  live/                          deployment boundary README only
+docs/                            architecture and project documentation
 ```
 
-## Bootstrap package
+`src/tracequant/` is deliberately the current bootstrap package. Moving these
+modules into a product package requires a separate behavior-preserving change
+with import compatibility validation. The repository is not currently split
+into independently installable application or package projects.
 
-`src/tracequant/` is the current bootstrap Python package. It contains the already implemented shared configuration, logging, and UTC utilities. This migration deliberately does **not** force those existing modules into an artificial product package merely to satisfy directory aesthetics.
+## Current dependency direction
 
-As Research, Runtime, Contracts, Domain, and Adapter implementations are added, new code must be placed behind the corresponding boundary. Moving an existing bootstrap module into a product package requires a behavior-preserving Task with import and compatibility validation.
+The direct imports in the implemented package are intentionally small:
 
-## Boundary rules
+```text
+Python standard library
+├── tracequant.config
+├── tracequant.core.time
+└── tracequant.logging ──> tracequant.config
+                         └> tracequant.core.time
 
-- `apps/research`: offline research orchestration; no production exchange writes.
-- `apps/runtime`: Shadow/Demo/Live orchestration; live disabled by default and fail closed.
-- `apps/console`: operator UI/control-plane boundary; independently deployable only when justified.
-- `packages/contracts`: stable cross-boundary schemas and interfaces.
-- `packages/domain`: core domain models and invariants; no exchange/network/UI/deployment dependencies.
-- `packages/adapters`: exchange, storage, database, filesystem, transport, and vendor integrations.
-- `deploy/research|staging|live`: environment-specific deployment assets with explicit separation.
+tracequant.core.time ──> tracequant.domain.models
 
-## Repository extraction
+tests ──> tracequant public APIs
+tests ──> tests/fixtures/domain.py ──> tracequant.domain
+```
 
-Do not split repositories by default. Physical extraction is considered only when independent release cadence, security boundary, dependency isolation, or independent Console deployment creates sustained operational value.
+The diagram is an import graph, not a claim that fixtures are part of the
+runtime. The responsibility layers can be read as configuration and time
+primitives supporting logging and domain models, with test factories as a
+separate test-support layer.
+
+### Allowed boundaries
+
+- `tracequant.config` owns explicit settings parsing. It reads process
+  environment values only when `load_settings()` is called; it has no network,
+  filesystem, dotenv, or global-singleton behavior.
+- `tracequant.core.time` owns timezone-aware UTC conversion, parsing, and
+  formatting. It depends only on the standard library.
+- `tracequant.logging` owns explicit project logging setup. It may depend on
+  configuration types and UTC formatting, but importing it must not configure
+  handlers, create directories, or open files.
+- `tracequant.domain` owns immutable, risk-independent initial market-data
+  value models. It may depend on `core.time`, but not on exchanges, network
+  clients, logging setup, UI code, deployment code, or test fixtures.
+- `tests` may import public production APIs and test-only factories. Fixtures
+  must remain deterministic, function-scoped where exposed by `conftest.py`,
+  and independent of production runtime imports.
+
+## Future product boundaries
+
+When implemented by separately scoped Issues, the directory boundaries mean:
+
+- `apps/research`: offline research orchestration and reproducible reports;
+  never production exchange writes;
+- `apps/runtime`: explicit Shadow, Demo, and Live orchestration, with live
+  disabled by default and fail-closed safety gates;
+- `apps/console`: operator UI and control-plane code;
+- `packages/contracts`: stable cross-boundary schemas and interfaces;
+- `packages/domain`: broader domain invariants that remain independent of
+  exchange and transport details;
+- `packages/adapters`: exchange, storage, database, filesystem, transport, and
+  vendor integrations. Venue-specific semantics terminate here;
+- `deploy/research`, `deploy/staging`, and `deploy/live`: explicit,
+  environment-specific deployment assets.
+
+None of these future boundaries currently provides data ingestion, factors,
+backtesting, model training, order execution, account state, risk decisions,
+or multi-exchange support.
+
+## Import and side-effect rules
+
+Modules must not perform I/O, read environment variables, create directories,
+or cache global singletons during import. Configuration, logging setup, file
+creation, and future network/exchange operations must be explicit calls owned by
+the appropriate application or adapter boundary. Secrets must remain outside
+source, tests, documentation, and logs; domain models must remain independent
+of secret and transport concerns.
+
+Physical repository extraction is not the default. Consider it only when
+independent release cadence, a security boundary, dependency isolation, or
+independent Console deployment creates sustained operational value.

--- a/docs/architecture/technical-baseline.md
+++ b/docs/architecture/technical-baseline.md
@@ -22,7 +22,7 @@ Python standard library
 ├── tracequant.core.time
 └── tracequant.logging ──> config + core.time
 
-core.time ──> tracequant.domain.models
+tracequant.domain.models ──> tracequant.core.time
 ```
 
 The public foundation consists of:
@@ -202,8 +202,9 @@ not be presented as trading functionality.
 
 ## 9. Placeholder and stub audit
 
-The repository was searched for `TODO`, `FIXME`, `NotImplementedError`,
-`pass`, `placeholder`, and `stub`, with matches classified by context:
+The tracked repository was searched for `TODO`, `FIXME`, `NotImplementedError`,
+`pass`, `placeholder`, and `stub` (excluding `.git` and ignored local
+workflow artifacts), with matches classified by context:
 
 - `src/tracequant/` contains no matching unfinished-work marker. The current
   production package has no undocumented code placeholder.
@@ -215,11 +216,24 @@ The repository was searched for `TODO`, `FIXME`, `NotImplementedError`,
   `pass` in exception cleanup/no-op branches and use `pass` as a serialized
   status value. These are workflow-tool implementation details, not business
   module stubs.
+- The active workflow Skills in `.agents/skills/` and `.claude/skills/` use
+  `pass`/`PASS` for lifecycle outcomes and review protocol language; the
+  feature-audit Skill also uses `placeholder` when describing a finding to
+  inspect. These are workflow instructions and review vocabulary, not product
+  implementation stubs.
+- `AGENTS.md`, `.agents/policies/`, and `docs/development/` use `pass`/`PASS`
+  as governance, validation, and lifecycle terminology. These matches state
+  protocol outcomes or constraints and do not identify unfinished runtime
+  work.
 - `.github/ISSUE_TEMPLATE/*.yml` uses `placeholder` as GitHub form-field UI
   metadata. It is not application code.
-- Historical workflow reports, publication registers, and templates contain
-  `placeholder`/`FILL_ME` as explicitly historical or template status values.
-  They are not current implementation evidence and must not be read as product
+- `docs/workflows/task-workflow-architecture-audit.md` uses `placeholder` for
+  unavailable historical Task #86 evidence and `pass`/`PASS` for audit status
+  and protocol outcomes. It is a workflow audit record, not product code.
+- Other `docs/workflows/` reports, evidence records, publication registers,
+  and templates use `pass`/`PASS` as validation or protocol status values and
+  `placeholder`/`FILL_ME` as explicitly historical or template values. They
+  are not current implementation evidence and must not be read as product
   functionality.
 
 No current production data, research, execution, or risk capability is being

--- a/docs/architecture/technical-baseline.md
+++ b/docs/architecture/technical-baseline.md
@@ -1,601 +1,237 @@
-# TraceQuant 技术基线
+# TraceQuant technical baseline
 
-- **版本：** 1.0
-- **日期：** 2026-07-19
-- **适用仓库：** `PhoenixSss/tracequant`
-- **状态：** 当前有效设计基线
-**目标读者：** 项目维护者、Codex、代码审查者
+- **Version:** 1.1
+- **Date:** 2026-08-29
+- **Repository:** `PhoenixSss/tracequant`
+- **Status:** current implementation facts plus explicitly deferred boundaries
 
-> **文档定位：** 本文档是当前技术选型基线。项目阶段、Issue 结构和当前实施入口见
-> [项目路线图](../planning/project-roadmap.md)，历史研究依据见 [research 目录](../research/)。
-> 仓库物理边界与 modular monorepo 规则见 [Repository structure](repository-structure.md)。
-> 对已经实施的事实，仍以 ADR、已合并 PR 及对应代码为准；规划职责以当前 GitHub Issue 为准。
+This document separates what is implemented on the current `main` line from
+the architecture that later Issues may introduce. The current code and tests,
+`pyproject.toml`, `uv.lock`, `.env.example`, and CI workflow are the authority
+for implemented behavior. The [project roadmap](../planning/project-roadmap.md)
+and research reports describe plans or historical reasoning; they do not turn
+planned systems into available capabilities.
 
----
+## 1. Current implementation
 
-## 1. 文档目的
-
-本文档提炼并固化量化系统当前有效的技术决策。
-
-它不是原始调研报告的替代品，也不是实现细节说明。原始调研报告保存完整的比较过程、候选方案和长期设想；本文档只记录当前项目应遵循的技术主线、阶段边界、自研与复用边界，以及需要通过正式决策才能改变的架构约束。
-
-实施者在规划或编码前必须同时阅读：
-
-1. 根目录 `AGENTS.md`；
-2. 当前 GitHub Issue；
-3. 本文档；
-4. 当前 Issue 明确引用的研究或规划文档。
-
-若本文档与已批准的 ADR、Issue 或 PR 决策冲突，以更新且更具体的已批准决策为准，并应通过后续 PR 同步修订本文档。
-
----
-
-## 2. 总体架构判断
-
-项目采用：
-
-> **自研研究逻辑与风险规则，复用成熟交易内核和通用基础设施。**
-
-不采用以下极端路线：
-
-- 从零开发完整交易所适配、事件总线、撮合引擎、订单状态机和实盘恢复体系；
-- 将数据、研究、回测、执行、风控和运维全部绑定在一个通用交易机器人框架中；
-- 在研究基础尚未稳定时优先构建高频、多交易所、多节点或复杂深度学习平台。
-
-项目的核心竞争力应来自：
-
-- 数据真相与质量；
-- 特征和标签；
-- 防未来数据泄漏验证；
-- 成本和执行真实性；
-- 策略与模型研究纪律；
-- 账户级风险规则；
-- 可审计和可恢复的运行流程。
-
----
-
-## 3. 首期业务与研究边界
-
-### 3.1 首期市场
-
-- 交易场所：Binance；
-- 产品类型：USDⓈ-M 线性永续合约；
-- 首批研究标的：BTC、ETH；
-- 首批确定合约：`BTCUSDT`、`ETHUSDT`；
-- `BTCUSDC`、`ETHUSDC`：在公开数据、合约状态、费率和适配语义确认后纳入；
-- 首期不支持多交易所生产执行。
-
-### 3.2 时间粒度
-
-- 基础历史行情粒度：`1m`；
-- 主要研究和决策周期：`15m`～`4h`；
-- `15m`、`30m`、`1h`、`2h`、`4h` 应由标准化层从基础数据统一聚合；
-- 不将多种下载周期分别视为独立历史真相；
-- 所有时间必须使用 timezone-aware UTC；
-- 不依赖系统本地时区。
-
-### 3.3 首期策略方向
-
-优先研究：
-
-- BTC/ETH 中频趋势与反转；
-- 波动率和市场状态；
-- 基差；
-- 资金费率；
-- 持仓量及相关衍生品结构；
-- 可解释多因子；
-- 表格型机器学习。
-
-后置：
-
-- 超低延迟高频；
-- 纯订单簿做市；
-- 跨所延迟套利；
-- 大规模山寨币篮子；
-- GNN、RL 或复杂深度时序模型；
-- LLM 直接产生交易决策。
-
----
-
-## 4. 数据架构基线
-
-### 4.1 数据分层
-
-固定采用以下分层：
+The repository currently implements one dependency-light bootstrap package:
 
 ```text
-官方公共数据源
-    ↓
-不可变 Raw 数据层
-    ↓
-Canonical 标准化层
-    ↓
-数据质量与聚合层
-    ↓
-特征、标签和研究数据集
-    ↓
-向量化研究与事件驱动回测
+Python standard library
+├── tracequant.config
+├── tracequant.core.time
+└── tracequant.logging ──> config + core.time
+
+core.time ──> tracequant.domain.models
 ```
 
-各层必须保持职责分离。
-
-### 4.2 原始数据层
-
-原始数据层要求：
-
-- 官方交易所数据优先；
-- 大区间历史回填优先使用 Binance 官方历史文件；
-- REST 用于最近数据、元数据和明确缺口修复；
-- 公共 WebSocket 录制在实时阶段引入；
-- 原始数据不可被标准化或清洗结果覆盖；
-- 使用稳定目录、分区、manifest 和校验信息；
-- 支持原子写入、幂等执行和中断恢复；
-- 不在 Raw 层填补缺失值、修正异常值或聚合周期。
-
-### 4.3 研究存储与处理
-
-当前选择：
-
-- 列式文件格式：Parquet；
-- 主批量处理引擎：Polars；
-- 主分析查询和切片引擎：DuckDB；
-- pandas：仅作为兼容、展示或特定生态接口，不作为主流水线；
-- PostgreSQL：用于未来运行状态、订单、仓位、审计和事务性元数据，不作为海量历史特征主仓。
-
-### 4.4 Canonical schema
-
-Canonical schema、标准化规则和数据质量约束必须自研。
-
-至少应明确：
-
-- market / venue；
-- instrument；
-- source；
-- event time；
-- arrival time（适用时）；
-- 时间边界语义；
-- price / quantity；
-- side；
-- sequence 或去重标识；
-- funding、mark、index 等数据类型的独立语义；
-- schema version；
-- data version。
-
-不得让交易所原始字段直接扩散到所有研究和执行模块。
-
----
-
-## 5. 回测与验证基线
-
-项目采用双层验证。
-
-### 5.1 向量化研究层
-
-职责：
-
-- 快速检验因子统计关系；
-- 进行规则和参数粗筛；
-- 运行大批量实验；
-- 评估粗成本下的可行性；
-- 生成候选策略。
-
-该层应轻量、可重复，并由项目自行控制关键逻辑。
-
-### 5.2 事件驱动验真层
-
-使用 NautilusTrader 作为事件驱动回测和未来执行底座。
-
-职责：
-
-- 订单生命周期；
-- 部分成交；
-- 撤单和重报；
-- maker/taker 路径；
-- fee model；
-- funding；
-- fill model；
-- latency model；
-- 必要时的 queue / L1 / L2 / L3 仿真；
-- 研究、Demo 和 Live 语义尽可能一致。
-
-向量化结果不能单独作为实盘可行性结论。
-
-### 5.3 研究验证纪律
-
-必须自研并固定：
-
-- 时间序列切分；
-- walk-forward；
-- purging；
-- embargo；
-- 滚动或扩展窗口；
-- 未来数据泄漏检查；
-- 样本外评估；
-- 固定随机种子；
-- 成本敏感性；
-- 参数稳定性；
-- 数据版本和代码版本追踪。
-
-禁止使用随机打乱的普通训练/测试切分替代金融时间序列验证。
-
----
-
-## 6. 模型与实验基线
-
-### 6.1 模型路线
-
-采用：
-
-1. 规则基线；
-2. 线性或其他简单统计基线；
-3. LightGBM 主模型；
-4. XGBoost Challenger；
-5. 只有在数据、验证和基线稳定后，才评估 PyTorch 时序模型；
-6. GNN、RL 和 LLM 直接交易后置到专项研究。
-
-模型不能取代因子定义、标签设计和研究验证。
-
-### 6.2 标签原则
-
-标签必须与真实交易目标一致，并显式考虑：
-
-- 持有期；
-- 手续费；
-- maker/taker 差异；
-- 滑点；
-- 资金费率；
-- 执行延迟；
-- 可实现价格；
-- purge / embargo 边界。
-
-不得仅使用未扣成本的未来价格收益作为最终策略评价目标。
-
-### 6.3 实验追踪
-
-MLflow 作为实验追踪和模型登记的优先方案。
-
-每个可审计实验至少记录：
-
-- 原始数据版本；
-- 标准化和特征版本；
-- 标签定义；
-- 训练、验证、测试时间范围；
-- 模型和参数；
-- 随机种子；
-- 成本模型；
-- 回测引擎及配置；
-- Git commit；
-- 指标和产物；
-- 已知限制。
-
-具体引入时间由对应 Feature 和 Task 决定，不要求在工程基础阶段提前安装全部依赖。
-
----
-
-## 7. 执行与交易内核基线
-
-### 7.1 NautilusTrader 定位
-
-NautilusTrader 是：
-
-- 事件驱动回测内核；
-- Binance Demo / Live 的优先执行底座；
-- 订单状态、事件语义和对账能力的复用来源。
-
-NautilusTrader 不是：
-
-- 原始数据真相的唯一来源；
-- 特征、标签和模型逻辑的所有者；
-- 项目全部领域模型的替代品；
-- 风控政策和执行 policy 的决定者。
-
-项目应避免让 Alpha 和研究逻辑与 NautilusTrader 具体对象过度耦合。
-
-### 7.2 执行 policy
-
-必须自研：
-
-- maker-first 行为；
-- post-only 使用条件；
-- 挂单等待时间；
-- cancel/replace；
-- 部分成交处理；
-- 转 taker 条件；
-- reduce-only 使用；
-- 异常行情降级；
-- 订单规模和分批规则。
-
-Binance 期货 post-only / GTX 等真实场所语义必须进入测试和回测。
-
-### 7.3 账户和持仓默认方向
-
-在 Live 设计冻结前，默认倾向：
-
-- 单向持仓；
-- 逐仓；
-- 低杠杆；
-- reduce-only 平仓；
-- 低总名义风险。
-
-双向持仓、多资产保证金和复杂跨标的共享风险属于架构级变化，必须通过独立 Issue / ADR 决策。
-
----
-
-## 8. 风控基线
-
-风控必须独立于策略信号，并在架构层固化。
-
-至少规划：
-
-- 总名义敞口；
-- 单标的敞口；
-- 杠杆上限；
-- 数据新鲜度闸门；
-- 数据质量闸门；
-- 连续下单失败熔断；
-- 连续亏损和回撤阈值；
-- 资金费率暴露；
-- 对账差异时禁止新开仓；
-- 停止新开仓；
-- 仅允许减仓；
-- 全部撤单；
-- 紧急平仓或人工接管。
-
-具体数值不得在缺乏资金规模和运行证据时写死为长期架构常量。
-
----
-
-## 9. 运行、存储与可观测性基线
-
-### 9.1 运行状态
-
-未来使用 PostgreSQL 保存：
-
-- 订单；
-- 成交；
-- 持仓；
-- 账户权益；
-- 风控事件；
-- 模型发布；
-- 审批和回滚记录；
-- 运行心跳；
-- 审计记录。
-
-### 9.2 缓存和状态
-
-需要缓存、去重、限流或轻量队列时：
-
-- 接口按 Redis 兼容协议抽象；
-- 部署优先考虑 Valkey；
-- 不把 Pub/Sub 当作可靠持久事件账本；
-- 不在 Research MVP 过早引入。
-
-### 9.3 日志、指标和告警
-
-演进顺序：
+The public foundation consists of:
+
+1. explicit settings loading for `TRACEQUANT_ENV`, log level, log format, and
+   an optional log directory;
+2. explicit structured JSON logging with known-key redaction;
+3. timezone-aware UTC conversion, parsing, and formatting;
+4. immutable initial domain models for instrument identifiers, UTC ranges, and
+   OHLCV bars, including explicit JSON-compatible serialization;
+5. deterministic test-only factories for those domain models.
+
+There are no runtime third-party dependencies in `pyproject.toml`. Development
+dependencies are pytest, Ruff, mypy, and PyYAML. The current package does not
+use an exchange SDK, database, Parquet engine, dataframe engine, backtest
+engine, model library, or execution framework.
+
+## 2. Engineering boundaries
+
+The full current tree and import rules are in
+[Repository structure](repository-structure.md). The important boundaries are:
+
+- configuration is explicit and immutable; importing it does not read env vars,
+  load `.env`, create directories, or cache a singleton;
+- logging is explicit; importing it does not configure handlers, create
+  directories, or open files;
+- UTC conversion is centralized in `tracequant.core.time`;
+- domain models depend on UTC utilities but not on network, exchange, UI,
+  deployment, logging setup, or test fixtures;
+- tests may use `tests/fixtures`, but fixtures are not production runtime
+  dependencies;
+- future exchange, storage, transport, and vendor behavior must terminate at
+  adapter boundaries rather than leak into domain or research logic.
+
+No module may obtain credentials, perform network I/O, create runtime state, or
+activate live trading as an import side effect. Secrets are not documented as
+values and must not be printed, logged, committed, or included in fixtures.
+
+## 3. Configuration and environment
+
+`load_settings()` accepts explicit arguments and optionally a mapping for
+deterministic tests. Its precedence is:
 
 ```text
-结构化日志 → 指标 → Dashboard → 告警 → Runbook
+explicit arguments > process environment (or supplied mapping) > defaults
 ```
 
-未来优先采用：
+The current fields are:
 
-- Prometheus；
-- Grafana；
-- Alertmanager。
+| Field | Values and default |
+| --- | --- |
+| `TRACEQUANT_ENV` | Required: `development`, `test`, or `production`. |
+| `TRACEQUANT_LOG_LEVEL` | Optional: `DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL`; default `INFO`. |
+| `TRACEQUANT_LOG_FORMAT` | Optional: `text` or `json`; parser default `json`. Current logger accepts only `json`. |
+| `TRACEQUANT_LOG_DIR` | Optional path; empty or unset means no file handler. The path is created only during explicit logging setup. |
 
-交易系统指标必须由项目定义，不能只监控 CPU 和内存。至少包括：
+`.env.example` documents these names but is not parsed automatically. The
+current config surface deliberately does not include exchange credentials,
+account settings, database URLs, trading mode, strategy parameters, or automatic
+dotenv loading. `SecretValue` protects ordinary `repr` and `str` output; it is
+not encryption, key storage, or a secret manager.
 
-- 数据 freshness；
-- 缺口和乱序；
-- 信号延迟；
-- 下单、撤单和拒单；
-- 成交偏差；
-- 对账差异；
-- 手续费和资金费率异常；
-- 风控触发；
-- 恢复时间。
+## 4. Logging and observability boundary
 
----
+`configure_logging(settings)` installs project-owned handlers explicitly. The
+current output is one-line UTF-8 JSON with stable `timestamp`, `level`,
+`logger`, and `message` fields, plus optional `extra` and exception fields.
+Timestamps are aware UTC ISO 8601 strings. Console output uses stderr. A
+non-empty `log_dir` creates that exact directory and appends to
+`tracequant.jsonl`; an empty value leaves only the console handler.
 
-## 10. 部署基线
+Known sensitive mapping keys are redacted case-insensitively:
+`password`, `secret`, `token`, `api_key`, `apikey`, `authorization`, and
+`cookie`. `SecretValue` and nested structured values are also handled. The
+redactor cannot guarantee detection of a secret manually concatenated into free
+text, so callers must keep credentials out of messages. There is currently no
+metrics, dashboard, alerting, audit store, or log rotation subsystem.
 
-### Research 阶段
+## 5. UTC and domain boundary
 
-- 以本地高性能 Windows 开发/研究机为主；
-- 保持可在全新环境中按锁文件安装；
-- 不要求 Kubernetes；
-- 不要求多节点。
+`ensure_aware`, `to_utc`, `parse_utc`, and `format_utc` reject naive datetimes.
+Aware values with a non-zero offset are converted to UTC, and formatted values
+use `Z`. The initial domain models are documented in
+[domain-models.md](domain-models.md). They intentionally stop at validated
+single-instrument OHLCV values and do not define venue metadata, canonical
+market-data schemas, orders, accounts, persistence, or risk policy.
 
-### Shadow / Demo 阶段
+Finite Python `float` values are required for OHLCV fields. Non-finite values
+are rejected, volume cannot be negative, and zero or negative prices are still
+allowed. Explicit `to_dict`/`from_dict` methods support deterministic JSON
+round trips but are not an external compatibility or database contract.
 
-- 实时运行进程与 notebook 分离；
-- 允许使用稳定 VPS 或专用节点；
-- 采用受控进程或容器；
-- 引入 Docker Compose；
-- 研究机和实时节点逐步解耦。
+## 6. Current quality baseline
 
-### Live 阶段
-
-- 研究环境与实盘环境分离；
-- 凭据分环境；
-- 实盘 API Key 不启用提现权限；
-- 使用 IP 白名单等交易所支持的安全措施；
-- 支持可审计发布、回滚和恢复。
-
-### Production Expansion
-
-只有出现明确需求时再考虑：
-
-- 多节点；
-- 高可用；
-- 独立 stateful 服务；
-- Kubernetes；
-- 复杂消息平台；
-- 多区域部署。
-
----
-
-## 11. 阶段隔离
-
-### Research MVP 不得包含
-
-- 私有 API；
-- API Key / Secret；
-- 账户余额、订单和持仓；
-- user data stream；
-- Demo 或 Live 下单；
-- 实盘数据库；
-- 生产告警和值班；
-- L2/L3 付费历史数据；
-- 多交易所生产适配。
-
-### Shadow & Demo MVP 才引入
-
-- 实时公共行情；
-- 在线特征与信号；
-- Shadow 虚拟账户；
-- Binance Demo；
-- 运行时风控；
-- 对账和恢复；
-- 监控、告警和 Runbook。
-
-### Live MVP 才引入
-
-- 真实凭据；
-- 真实账户和订单；
-- 真实手续费和资金费率；
-- 极小资金；
-- 生产审计；
-- 实盘发布、回滚和紧急降级。
-
----
-
-## 12. 明确后置的能力
-
-以下能力保留在长期路线，但不得侵入当前 MVP：
-
-- OKX、Bybit、Coinbase 等多交易所；
-- L2/L3 历史订单簿；
-- Tardis 等付费数据；
-- HftBacktest 专项微结构验证；
-- 链上数据；
-- 新闻和社交数据；
-- 多币种组合；
-- 自动重训；
-- 深度学习；
-- GNN；
-- RL；
-- LLM 直接输出交易信号；
-- Kubernetes；
-- 多机高可用和复杂容灾。
-
-引入这些能力必须先证明其解决了已经存在且经过测量的问题。
-
----
-
-## 13. 依赖与版本策略
-
-- 使用 uv 管理 Python 依赖和锁文件；
-- 运行时依赖与开发依赖必须分离；
-- 关键依赖应明确锁定策略；
-- NautilusTrader 等活跃且可能存在 breaking changes 的依赖，升级必须经过人工审查和回归测试；
-- 不在本基线中永久写死所有第三方库的具体版本；
-- 具体版本由对应 Task 基于当时官方稳定版本、Python 兼容性和测试结果决定；
-- 不使用 `latest` 漂移作为生产依赖策略；
-- 新增重大依赖必须说明：
-  - 用途；
-  - 替代方案；
-  - 许可证；
-  - 维护状态；
-  - 版本约束；
-  - 对锁文件和部署的影响。
-
----
-
-## 14. 质量与工程约束
-
-所有实现必须：
-
-- Python 3.13；
-- 完整类型标注；
-- mypy strict；
-- pytest；
-- Ruff lint；
-- Ruff format check；
-- GitHub Actions CI；
-- UTF-8；
-- LF；
-- `git diff --check`；
-- 通过 Issue → Branch → PR → Review → Merge 流程；
-- 不在模块导入时产生隐藏 I/O 或外部副作用；
-- 不创建未经 Issue 批准的全局单例、隐式缓存或环境依赖；
-- 不让当前工作目录成为未经定义的隐式输入；
-- 不让系统本地时区参与业务时间计算。
-
----
-
-## 15. 变更控制
-
-以下变化属于重大技术路线变更，必须通过 Issue、ADR 或文档 PR 明确批准：
-
-- 更换首期交易所；
-- 更换事件驱动回测/执行底座；
-- 更换历史数据主格式；
-- 更换 Polars / DuckDB 主路线；
-- 更换首期模型主路线；
-- 改变基础历史粒度；
-- 将私有 API 或 Live 能力提前到 Research；
-- 引入多交易所生产执行；
-- 引入 L2/L3 作为首期依赖；
-- 引入 Kubernetes；
-- 改变账户模式、保证金模式或杠杆默认原则；
-- 合并或跨越阶段门禁。
-
-不得通过聊天中的临时建议静默改变本基线。
-
----
-
-## 16. 当前有效架构摘要
+Python `3.13` and uv `0.12.1` are fixed by the repository environment. The
+canonical development and CI commands are maintained in the root
+[README](../../README.md) and are:
 
 ```text
-Binance 官方公共数据
-        ↓
-不可变 Raw Parquet + manifest
-        ↓
-自研 Canonical schema 与数据质量
-        ↓
-Polars 变换 + DuckDB 查询
-        ↓
-特征、标签和研究数据集
-        ↓
-自研向量化研究回测
-        ↓
-LightGBM 主模型 / XGBoost Challenger
-        ↓
-NautilusTrader 事件驱动验真
-        ↓
-Shadow
-        ↓
-Binance Demo
-        ↓
-极小资金 Live
-        ↓
-生产强化与扩展
+uv sync --locked --dev
+uv lock --check
+uv run --frozen pytest
+uv run --frozen ruff check .
+uv run --frozen ruff format --check .
+uv run --frozen mypy src tests
 ```
 
----
+The lock check is a CI integrity check; the other commands are the same local
+quality commands. Do not create a competing quality command set in an
+architecture document.
 
-## 17. 最终原则
+## 7. Explicitly deferred system architecture
 
-> 先正确，再真实，最后扩张。
->
-> 数据和实验必须可追溯。
->
-> 向量化回测负责筛选，事件驱动回测负责验真。
->
-> 自研 Alpha、标签、验证、执行 policy 和风险规则。
->
-> 复用交易内核、数据库、监控和部署基础设施。
->
-> 复杂度必须由已经观察到的问题驱动，而不是由工具吸引力驱动。
+The following are future boundaries, not current implementations. A future
+Issue must supply its own contracts, data fingerprints, tests, and safety gates
+before any of them can be described as available.
+
+### Data and research
+
+The intended future flow is:
+
+```text
+public exchange data
+  -> immutable raw data
+  -> canonical normalization and quality checks
+  -> features, labels, and research datasets
+  -> vectorized research and event-driven verification
+```
+
+This flow does not currently exist. In particular, there is no Binance client,
+raw data lake, Parquet storage, manifest, schema registry, missing/duplicate/
+out-of-order detector, feature pipeline, label pipeline, or future-data-leakage
+check. No exchange-specific field may be treated as a current canonical schema.
+
+### Backtesting, models, and experiments
+
+There is no backtester, strategy, factor library, model training, or experiment
+tracking in the current repository. Future research must preserve chronological
+walk-forward validation, purging, embargo, point-in-time features, explicit
+fees/funding/slippage/fill assumptions, gross and net performance, and code/data
+fingerprints. A future event-driven engine may validate execution realism, but
+no such engine is installed or callable today.
+
+### Execution and risk
+
+There is no Shadow, Demo, or Live runtime; no order/account/position ledger; no
+exchange adapter; and no risk authority. Future runtime work must keep strategy,
+risk, execution, and exchange connectivity separate. The risk layer must have
+final authority to reject or reduce orders, fail closed on disagreement with
+exchange state, reconcile unknown order state before retrying, and keep live
+trading explicitly disabled by default. These are safety requirements for
+future work, not evidence of current trading capability.
+
+### Storage, deployment, and observability
+
+PostgreSQL, Redis/Valkey, Parquet, Polars, DuckDB, Prometheus, Grafana,
+Alertmanager, NautilusTrader, MLflow, Kubernetes, and multi-exchange support
+are not current dependencies or services. Introducing one requires a scoped
+Issue that documents purpose, alternatives, license/maintenance considerations,
+version constraints, safety impact, and reproducible validation. Future
+`apps/`, `packages/`, and `deploy/` directories remain boundaries until such an
+Issue is implemented and reviewed.
+
+## 8. Research and trading scope limits
+
+The eventual product direction may study Binance USDⓈ-M perpetual market data,
+BTC/ETH instruments, cost-aware research, and auditable risk-controlled
+execution. None of the following is currently available: Binance public or
+private data access, BTC/ETH data files, multi-timeframe aggregation, factors,
+models, backtests, Demo orders, Live orders, private API credentials, database
+state, or multi-exchange production execution.
+
+Historical research, planning documents, and workflow documentation must retain
+their stated roles. Workflow controls such as LCK and the Validation Runner
+govern repository delivery and review; they are not business modules and must
+not be presented as trading functionality.
+
+## 9. Placeholder and stub audit
+
+The repository was searched for `TODO`, `FIXME`, `NotImplementedError`,
+`pass`, `placeholder`, and `stub`, with matches classified by context:
+
+- `src/tracequant/` contains no matching unfinished-work marker. The current
+  production package has no undocumented code placeholder.
+- `tests/tools/` contains intentional `Stub*` test doubles, literal
+  `validation stub` input strings, and no-op `pass` branches used to exercise
+  workflow failure/cleanup behavior. They are test scaffolding, not runtime
+  capability claims.
+- `tools/agent_workflow/` and `tools/wsl2_codex_diagnostic.py` contain
+  `pass` in exception cleanup/no-op branches and use `pass` as a serialized
+  status value. These are workflow-tool implementation details, not business
+  module stubs.
+- `.github/ISSUE_TEMPLATE/*.yml` uses `placeholder` as GitHub form-field UI
+  metadata. It is not application code.
+- Historical workflow reports, publication registers, and templates contain
+  `placeholder`/`FILL_ME` as explicitly historical or template status values.
+  They are not current implementation evidence and must not be read as product
+  functionality.
+
+No current production data, research, execution, or risk capability is being
+hidden behind one of these matches. A future real code gap must receive its own
+scoped Issue rather than being made to look complete by documentation.
+
+## 10. Change control
+
+Any future change that adds runtime dependencies, moves bootstrap modules,
+introduces network or persistence I/O, changes UTC or serialization semantics,
+adds exchange/order/risk authority, or crosses Research/Shadow/Demo/Live
+boundaries requires a dedicated Issue and appropriate tests/documentation.
+Do not make a planned technology choice appear implemented by editing this
+baseline alone. Keep future claims explicitly marked until the corresponding
+code and validation exist.


### PR DESCRIPTION
Closes #66

## Summary
Align README and canonical architecture docs with the implemented configuration, logging, UTC, domain-model, fixture, environment, quality-command, safety, and deferred-capability boundaries.

## Validation
- Critical Outcome: pass
- Formal Delivery validation: pass

## Risks / limitations
Documentation-only change. The configuration parser accepts text and json log formats, while configure_logging currently supports JSON only; this limitation is documented and examples use JSON. No source capability is added.
