### PR TITLE
[Task] 新增 Documentation Issue Form 并冻结 Documentation Issue Contract

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,68 @@
+name: Documentation
+description: 用于新增、修正或收敛文档事实，不改变系统运行行为。
+title: "[Documentation] "
+labels:
+  - "type:documentation"
+  - "codex:needs-spec"
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Documentation 是 documentation leaf work item，遵循 Minimum sufficient specification。
+        正文只描述本次文档变化特有且完成工作所必需的信息；Parent、blocked-by 和 Project metadata 使用 GitHub native state，不复制通用 workflow、标准 CI 或 repository-wide rules。
+        Documentation 用于新增、修正或收敛文档事实；如果工作需要修改 runtime、业务源码、测试、CI、Agent control behavior 或其它系统行为，应重新分类为 Task / Bug 或拆分新的 implementation leaf。
+        文件扩展名本身不能决定工作是否属于 Documentation。
+        如果文档成立需要修改系统行为、源码、测试或控制流程，应拆分为 Task 或 Bug，而不是扩大 Documentation 的范围。
+
+  - type: textarea
+    id: objective
+    attributes:
+      label: Documentation Goal
+      description: 说明本次需要新增、修正或收敛什么文档事实，以及完成后读者应能正确理解什么。
+      placeholder: |
+        更新……
+    validations:
+      required: true
+
+  - type: textarea
+    id: requirements
+    attributes:
+      label: Requirements
+      description: 只写本次文档变更特有的内容要求、事实边界和必要一致性要求；不要复制 Parent、架构全文、通用文档规则或标准验证流程。
+      placeholder: |
+        - ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance Criteria
+      description: 使用可明确判断的文档结果定义完成，例如内容准确、一致、链接有效或旧描述已被替换；不要填写通用 CI、PR 或 workflow checklist。
+      placeholder: |
+        - [ ] ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional documentation context
+      description: 可选。仅补充当前 Documentation 独有且确有必要的信息，例如事实来源、范围边界、重要约束、References 或标准检查之外的特殊验证；不要为了模板完整填写 N/A。
+      placeholder: |
+        仅在需要时填写，例如：
+
+        ### Sources / References
+        - ...
+
+        ### Scope Boundary / Non-goals
+        - ...
+
+        ### Constraints / Decisions
+        - ...
+
+        ### Documentation-specific Verification
+        - ...
+    validations:
+      required: false

--- a/docs/development/issue-authoring.md
+++ b/docs/development/issue-authoring.md
@@ -1,7 +1,7 @@
 # Issue Authoring (Issue Specification v2)
 
-本文件定义 TraceQuant 的 Issue Specification v2：五类 Issue（Epic / Feature / Task /
-Bug / Research）的职责、正文结构、authoring 规则和信息所有权。它与
+本文件定义 TraceQuant 的 Issue Specification v2：六类 Issue（Epic / Feature / Task /
+Bug / Documentation / Research）的职责、正文结构、authoring 规则和信息所有权。它与
 `.github/ISSUE_TEMPLATE/*.yml` 保持一致，是创建和迁移 Issue 的唯一 authoring 参考。
 
 > **核心原则：Minimum sufficient specification。**
@@ -22,13 +22,14 @@ Feature
 Leaf work item
 ├── Task      → implementation contract
 ├── Bug       → defect contract
+├── Documentation → documentation fact contract
 └── Research  → evidence / decision contract
 ```
 
-- Task、Bug、Research 是不同 work kind，但处于相同 leaf-work 层级，可作为 Feature 的
-  Sub-issue。
-- 少数情况下 Bug / Research 可直接挂在 Epic 下，但不是默认结构。
-- **不得**把五种类型理解为五个互斥层级。
+- Task、Bug、Documentation、Research 是不同 work kind，但处于相同 leaf-work 层级，可作为
+  Feature 的 Sub-issue。
+- 少数情况下 Bug / Documentation / Research 可直接挂在 Epic 下，但不是默认结构。
+- **不得**把六种类型理解为六个互斥层级。
 - 普通实现工作默认保持 `1 Task ≈ 1 PR ≈ 1 main squash commit`。
 
 ## 2. 信息所有权
@@ -47,6 +48,7 @@ Leaf work item
 | Behavioral capability | Feature |
 | Implementation contract | Task |
 | Defect contract | Bug |
+| Documentation fact contract | Documentation |
 | Evidence / decision investigation | Research |
 | Current Issue specification | Issue body |
 | Discussion / change history | Issue comments |
@@ -61,7 +63,7 @@ Leaf work item
 Issue body 中不得复制 repository-wide rules、标准验证、Git/PR workflow、Project
 metadata 或完整 Parent specification。
 
-## 3. 五类 Issue 的职责与正文结构
+## 3. 六类 Issue 的职责与正文结构
 
 ### Epic — outcome + boundaries
 
@@ -134,6 +136,22 @@ OPTIONAL：`Impact`、`Environment`、`Logs / Screenshots`、
 - Environment / Logs 非普适字段，均为 optional，不强迫填写 `N/A`。
 - Acceptance Criteria 描述恢复后的 contract，而不是简单“错误消失”。
 
+### Documentation — documentation fact contract（独立 Form，本身就是 leaf work item）
+
+> 用于新增、修正或收敛文档事实，完成后不改变系统运行行为。
+
+REQUIRED：`Documentation Goal`、`Requirements`、`Acceptance Criteria`
+OPTIONAL：`Additional documentation context`
+
+- Documentation Form 只收集完成本次文档变化所必需的最小信息；Sources / References、
+  Scope Boundary / Non-goals、Constraints / Decisions 和 documentation-specific
+  verification 仅在确有必要时通过 optional context 补充，不要求填写 `N/A`。
+- 如果工作需要修改 runtime、业务源码、测试、CI、Agent control behavior 或其它系统
+  行为，应重新分类为 Task / Bug，或拆分新的 implementation leaf，不得扩大 Documentation
+  范围。
+- 行为型 `.md`、policy、Agent instruction 或其它文件不会仅因文件扩展名而成为
+  Documentation；类型由工作是否改变文档事实与系统行为决定。
+
 ### Research — evidence / decision contract
 
 > 适用于 technical selection、exchange/API investigation、architecture spike、
@@ -172,6 +190,7 @@ state transition、regression condition。
 | Feature | REQUIRED |
 | Task | OPTIONAL（存在明显 scope-creep 风险时填写） |
 | Bug | OPTIONAL |
+| Documentation | OPTIONAL（仅在确有必要时通过 Additional documentation context 说明） |
 | Research | REQUIRED |
 
 不得为了模板完整强迫填写 `None` / `N/A` / `无`。
@@ -190,7 +209,7 @@ standard validation     → CI / repository rules
 branch / PR / Squash workflow → development docs / Ruleset
 ```
 
-标题前缀 `[Epic] / [Feature] / [Task] / [Bug] / [Research]` 和 `type:*` labels
+标题前缀 `[Epic] / [Feature] / [Task] / [Bug] / [Documentation] / [Research]` 和 `type:*` labels
 保留（personal account 下 native Issue Types 不可用，前缀对 notification、PR
 reference 和 plain-text Agent input 有辨识价值）。
 
@@ -207,7 +226,7 @@ reference 和 plain-text Agent input 有辨识价值）。
 1. Platform / maintainer / security hard boundaries
 2. Repository hard invariants and active durable decisions
    (applicable AGENTS.md, active architecture contracts, accepted ADRs)
-3. Current leaf Issue body (Task / Bug / Research)
+3. Current leaf Issue body (Task / Bug / Documentation / Research)
 4. Parent Feature current specification
 5. Parent Epic current outcome / constraints
 6. General conventions / background docs
@@ -277,7 +296,7 @@ observable behavior、meaningful edge cases、acceptance、important scope bound
 
 - `AGENTS.md` — repository hard safety、agent routing、issue-driven workflow。
 - `CLAUDE.md` — Claude Code 开发命令与架构上下文。
-- `.github/ISSUE_TEMPLATE/*.yml` — 五类 Issue Form 的字段定义（本文档的机器可执行
+- `.github/ISSUE_TEMPLATE/*.yml` — 六类 Issue Form 的字段定义（本文档的机器可执行
   对应物）。
 - `docs/architecture/*` — 稳定架构不变量。
 - `docs/development/*` — 可复用开发工作流（本文件即其一）。

--- a/tests/tools/test_issue_templates.py
+++ b/tests/tools/test_issue_templates.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+
+import yaml  # type: ignore[import-untyped]  # PyYAML is an existing test dependency.
+
+ROOT = Path(__file__).parents[2]
+
+
+def _load_documentation_form() -> dict[str, Any]:
+    path = ROOT / ".github" / "ISSUE_TEMPLATE" / "documentation.yml"
+    value = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(value, dict)
+    return cast(dict[str, Any], value)
+
+
+def test_documentation_issue_form_is_minimum_sufficient_leaf_contract() -> None:
+    form = _load_documentation_form()
+
+    assert form["name"] == "Documentation"
+    assert form["title"] == "[Documentation] "
+    assert form["labels"] == ["type:documentation", "codex:needs-spec"]
+
+    body = form["body"]
+    assert isinstance(body, list)
+    markdown = body[0]
+    fields = body[1:]
+    assert markdown["type"] == "markdown"
+    guidance = markdown["attributes"]["value"]
+    assert "新增、修正或收敛文档事实" in guidance
+    assert "runtime、业务源码、测试、CI、Agent control behavior" in guidance
+    assert "文件扩展名本身不能决定工作是否属于 Documentation" in guidance
+
+    assert [field["type"] for field in fields] == ["textarea"] * 4
+    assert [field["id"] for field in fields] == [
+        "objective",
+        "requirements",
+        "acceptance_criteria",
+        "additional_context",
+    ]
+    assert [field["attributes"]["label"] for field in fields] == [
+        "Documentation Goal",
+        "Requirements",
+        "Acceptance Criteria",
+        "Additional documentation context",
+    ]
+    assert [field["validations"]["required"] for field in fields] == [
+        True,
+        True,
+        True,
+        False,
+    ]
+
+    submitted = {
+        "objective": "Clarify the current data contract.",
+        "requirements": "Document the accepted timestamp and nullability rules.",
+        "acceptance_criteria": "Readers can identify the contract without consulting source code.",
+    }
+    rendered = "\n\n".join(
+        f"### {field['attributes']['label']}\n\n{submitted[field['id']]}"
+        for field in fields
+        if field["id"] in submitted
+    )
+    assert rendered == (
+        "### Documentation Goal\n\nClarify the current data contract.\n\n"
+        "### Requirements\n\nDocument the accepted timestamp and nullability rules.\n\n"
+        "### Acceptance Criteria\n\nReaders can identify the contract without consulting source code."
+    )
+    assert "Additional documentation context" not in rendered
+    assert "N/A" not in rendered


### PR DESCRIPTION
Closes #196

## Summary
Added the minimum-sufficient Documentation Issue Form, synchronized the canonical issue-authoring model and boundaries, and added schema and rendered-Markdown regression coverage.

## Validation
- Critical Outcome: pass
- Formal Delivery validation: pass

## Risks / limitations
No runtime behavior changes. GitHub Issue Form rendering is covered by repository-side contract assertions; GitHub-hosted UI behavior remains platform-owned.
