### PR TITLE
[Task] 建立 LCK Leaf Issue Workflow Profile 与类型路由

### DIFF
--- a/tests/tools/test_lck_closeout.py
+++ b/tests/tools/test_lck_closeout.py
@@ -544,6 +544,7 @@ def test_resolver_recovers_deleted_noncanonical_branch_from_closing_pr(
         "number": 162,
         "title": "[Task] 将 Merge Preflight、Closeout 与 Recovery 迁移至 LCK",
         "state": "CLOSED",
+        "labels": {"items": ["type:task"]},
         "issue_closure": {
             "evidence_status": "complete",
             "closed_by_pull_requests": {

--- a/tests/tools/test_lck_issue_profiles.py
+++ b/tests/tools/test_lck_issue_profiles.py
@@ -1,0 +1,143 @@
+# ruff: noqa: E402, I001
+
+"""Acceptance tests for the canonical LCK leaf Issue profile resolver."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+ROOT = Path(__file__).parents[2]
+AGENT_WORKFLOW = str(ROOT / "tools" / "agent_workflow")
+if AGENT_WORKFLOW not in sys.path:
+    sys.path.insert(0, AGENT_WORKFLOW)
+
+from lck_core.models import Phase  # type: ignore[import-not-found]  # noqa: E402
+from lck_core import (  # type: ignore[import-not-found]  # noqa: E402
+    eligibility as lck_eligibility,
+    issue_profiles as lck_profiles,
+)
+from lck_test_support import (  # noqa: E402
+    FakeRunner,
+    _install_facts,
+    _issue,
+    _relationships,
+    _resolver,
+)
+
+
+def _issue_with_labels(*labels: str, title: str = "ordinary title") -> dict[str, Any]:
+    return {
+        "labels": list(labels),
+        "title": title,
+        "body": "body text that must not participate in type resolution",
+    }
+
+
+def test_leaf_issue_profile_resolution_is_exact_and_fail_closed() -> None:
+    profiles = {
+        "type:task": ("task", True, "task/", True),
+        "type:bug": ("bug", False, "bug/", False),
+        "type:documentation": ("documentation", False, "documentation/", False),
+        "type:research": ("research", False, "research/", False),
+    }
+
+    for label, expected in profiles.items():
+        resolution = lck_profiles.resolve_leaf_issue_profile(_issue_with_labels(label))
+        assert resolution.resolved
+        assert resolution.profile is not None
+        profile = resolution.profile
+        assert (
+            profile.issue_kind.value,
+            profile.requires_critical_outcome,
+            profile.branch_namespace,
+            profile.lifecycle_enabled,
+        ) == expected
+        assert profile.canonical_type_label == label
+        assert profile.eligibility_policy == expected[0]
+        assert profile.validation_policy == expected[0]
+        assert profile.completion_policy == expected[0]
+
+    invalid_cases = (
+        (_issue_with_labels(), "MISSING_TYPE"),
+        (_issue_with_labels("type:task", "type:bug"), "MULTIPLE_TYPES"),
+        (_issue_with_labels("type:task", "type:task"), "MULTIPLE_TYPES"),
+        (_issue_with_labels("type:unknown"), "UNKNOWN_TYPE"),
+        (_issue_with_labels("type:feature"), "NON_LEAF_TYPE"),
+        (_issue_with_labels("type:epic"), "NON_LEAF_TYPE"),
+    )
+    for issue, expected_status in invalid_cases:
+        resolution = lck_profiles.resolve_leaf_issue_profile(issue)
+        assert not resolution.resolved
+        assert resolution.terminal_status == expected_status
+        assert resolution.profile is None
+
+    # The resolver has one input authority: changing title/body or supplying a
+    # GitHub Issue Type-shaped field cannot reclassify the canonical label.
+    resolution = lck_profiles.resolve_leaf_issue_profile(
+        {
+            "labels": [{"name": "type:task"}],
+            "title": "[Bug] type:bug",
+            "body": "### Objective\nThis is not a type carrier.",
+            "issue_type": "Bug",
+        }
+    )
+    assert resolution.profile is lck_profiles.TASK_PROFILE
+
+
+@pytest.mark.parametrize("label", ["type:bug", "type:documentation", "type:research"])
+def test_unenabled_leaf_profiles_return_typed_terminal_status(
+    monkeypatch: pytest.MonkeyPatch,
+    label: str,
+) -> None:
+    fake = FakeRunner(branch="main")
+    issue = _issue()
+    issue["labels"] = {"items": [label, "codex:ready"]}
+    _install_facts(
+        monkeypatch,
+        fake,
+        issue=issue,
+        relationships=_relationships(issue_type="Task"),
+    )
+
+    state = _resolver(fake).resolve(159)
+    decision = lck_eligibility.PhaseEligibilityResolver().resolve(
+        state, Phase.DELIVERY_PREPARE
+    )
+
+    assert not decision.eligible
+    assert any(
+        f"PROFILE_NOT_ENABLED: workflow profile {label}" in reason
+        for reason in decision.reasons
+    )
+    assert not any(
+        "target Issue is not a type:task" in reason for reason in decision.reasons
+    )
+    assert decision.issue_profile is not None
+    assert decision.issue_profile["profile"]["canonical_type_label"] == label
+
+
+def test_task_profile_uses_labels_without_issue_type_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = FakeRunner(branch="main")
+    issue = _issue()
+    _install_facts(
+        monkeypatch,
+        fake,
+        issue=issue,
+        relationships=_relationships(issue_type="Bug"),
+    )
+
+    state = _resolver(fake).resolve(159)
+    decision = lck_eligibility.PhaseEligibilityResolver().resolve(
+        state, Phase.DELIVERY_PREPARE
+    )
+
+    assert decision.eligible
+    assert state.issue_profile is not None
+    assert state.issue_profile["profile"]["issue_kind"] == "task"
+    assert state.target_branch == "task/159-lck-core-live-state-resolution"

--- a/tools/agent_workflow/lck_core/README.md
+++ b/tools/agent_workflow/lck_core/README.md
@@ -5,7 +5,8 @@ maintainer or reviewer can start with the responsibility that owns the behavior.
 
 | Concern | Start here | Typical companion modules |
 | --- | --- | --- |
-| contracts, immutable state/result models | `models.py` | — |
+| leaf Issue type/profile contract and routing | `issue_profiles.py` | `models.py`, `eligibility.py` |
+| contracts, immutable state/result models | `models.py` | `issue_profiles.py` |
 | live Git/GitHub facts, Fact Profiles, operation snapshots | `state.py` | `models.py` |
 | lifecycle admission / eligibility | `eligibility.py` | `state.py` |
 | formal validation and required-check gates | `validation.py` | `state.py` |
@@ -34,6 +35,7 @@ plus at most its direct companion modules before broad repository searches.
 The former mixed `tests/tools/test_lck.py` suite is responsibility-owned too:
 
 - `test_lck_state.py` — live-state, Fact Profiles, resolver query contracts.
+- `test_lck_issue_profiles.py` — canonical leaf Issue type/profile resolution.
 - `test_lck_prepare.py` — prepare/admission and eligibility behavior.
 - `test_lck_review.py` — Review workspace, Review Complete, Merge Preflight.
 - `test_lck_remediation.py` — remediation sessions and partial-effect recovery.

--- a/tools/agent_workflow/lck_core/eligibility.py
+++ b/tools/agent_workflow/lck_core/eligibility.py
@@ -7,6 +7,7 @@ from typing import Any
 from workflow_common import is_sha
 from workflow_evidence import _formal_blockers_gate
 
+from .issue_profiles import LeafIssueKind, resolve_issue_profile
 from .models import (
     LiveState,
     Phase,
@@ -23,6 +24,7 @@ class PhaseDecision:
     eligible: bool
     reasons: tuple[str, ...] = ()
     capabilities: tuple[str, ...] = ()
+    issue_profile: Mapping[str, Any] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -30,6 +32,7 @@ class PhaseDecision:
             "eligible": self.eligible,
             "reasons": list(self.reasons),
             "capabilities": list(self.capabilities),
+            "issue_profile": self.issue_profile,
         }
 
 
@@ -46,6 +49,10 @@ class PhaseEligibilityResolver:
         reasons = list(state.stop_reasons)
         issue = state.issue
         relationships = state.relationships
+        profile_resolution = resolve_issue_profile(
+            issue if isinstance(issue, Mapping) else None
+        )
+        issue_profile = profile_resolution.to_dict()
         if state.status is not ResolutionStatus.RESOLVED:
             reasons.append("live state resolution stopped")
         if state.repository is None:
@@ -53,6 +60,11 @@ class PhaseEligibilityResolver:
         if not isinstance(issue, Mapping):
             reasons.append("Task metadata is unavailable")
         else:
+            profile = profile_resolution.profile
+            if not profile_resolution.resolved:
+                reasons.append(profile_resolution.error_message)
+            elif profile is not None and not profile.lifecycle_enabled:
+                reasons.append(profile_resolution.error_message)
             issue_state = str(issue.get("state", "")).upper()
             if phase is not Phase.CLOSEOUT and issue_state != "OPEN":
                 reasons.append("Task is not OPEN")
@@ -68,12 +80,6 @@ class PhaseEligibilityResolver:
                         "lifecycle labels must be exactly ['codex:ready']: "
                         f"{sorted(lifecycle_labels) or 'none'}"
                     )
-                issue_type = relationships.get("issue_type")
-                is_task = "type:task" in labels or (
-                    isinstance(issue_type, str) and issue_type.casefold() == "task"
-                )
-                if not is_task:
-                    reasons.append("target Issue is not a type:task")
             project = issue.get("project_status")
             allowed_projects = {
                 Phase.DELIVERY_PREPARE: {"Ready", "In Progress"},
@@ -100,23 +106,29 @@ class PhaseEligibilityResolver:
             if project not in allowed_projects:
                 reasons.append("Project Status is unavailable or unknown")
             if phase in {Phase.DELIVERY_PREPARE, Phase.DELIVERY_COMPLETE}:
-                critical = issue.get("critical_outcome")
                 if (
-                    not isinstance(critical, Mapping)
-                    or critical.get("status") != "valid"
+                    profile is not None
+                    and profile.issue_kind is LeafIssueKind.TASK
+                    and profile.requires_critical_outcome
                 ):
-                    detail = (
-                        critical.get("detail")
-                        if isinstance(critical, Mapping)
-                        else "contract unavailable"
-                    )
-                    reasons.append(f"Critical Outcome contract invalid: {detail}")
+                    critical = issue.get("critical_outcome")
+                    if (
+                        not isinstance(critical, Mapping)
+                        or critical.get("status") != "valid"
+                    ):
+                        detail = (
+                            critical.get("detail")
+                            if isinstance(critical, Mapping)
+                            else "contract unavailable"
+                        )
+                        reasons.append(f"Critical Outcome contract invalid: {detail}")
 
         blocker_gate = _formal_blockers_gate(relationships)
         if blocker_gate.get("status") != "pass":
             detail = blocker_gate.get("detail") or "formal blocker gate did not pass"
             reasons.append(f"formal blocker gate: {detail}")
 
+        capabilities: tuple[str, ...] = ()
         if phase is Phase.DELIVERY_PREPARE:
             if state.merged is True:
                 reasons.append("Task already has a merged PR")
@@ -234,4 +246,5 @@ class PhaseEligibilityResolver:
             eligible=not reasons,
             reasons=tuple(dict.fromkeys(reasons)),
             capabilities=capabilities,
+            issue_profile=issue_profile,
         )

--- a/tools/agent_workflow/lck_core/issue_profiles.py
+++ b/tools/agent_workflow/lck_core/issue_profiles.py
@@ -1,0 +1,284 @@
+"""Canonical leaf Issue workflow profiles and type-label resolution.
+
+Issue labels are the only authoritative carrier for a leaf Issue's workflow
+kind.  This module deliberately contains policy facts only; lifecycle state
+acquisition and effects remain owned by the existing LCK controllers.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any, Final
+
+
+class LeafIssueKind(StrEnum):
+    TASK = "task"
+    BUG = "bug"
+    DOCUMENTATION = "documentation"
+    RESEARCH = "research"
+
+
+class IssueProfileResolutionStatus(StrEnum):
+    RESOLVED = "resolved"
+    MISSING_TYPE = "missing_type"
+    MULTIPLE_TYPES = "multiple_types"
+    UNKNOWN_TYPE = "unknown_type"
+    NON_LEAF_TYPE = "non_leaf_type"
+
+
+@dataclass(frozen=True)
+class WorkflowPolicyEntrypoints:
+    """Named policy entrypoints reserved by one profile.
+
+    The values are stable identifiers rather than callables so selecting a
+    profile cannot create a second lifecycle engine or introduce import
+    coupling between policy and phase controllers.
+    """
+
+    eligibility: str
+    validation: str
+    completion: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "eligibility": self.eligibility,
+            "validation": self.validation,
+            "completion": self.completion,
+        }
+
+
+@dataclass(frozen=True)
+class LeafIssueWorkflowProfile:
+    """The complete type-specific contract shared by all LCK phases."""
+
+    profile_id: str
+    issue_kind: LeafIssueKind
+    canonical_type_label: str
+    requires_critical_outcome: bool
+    branch_namespace: str
+    lifecycle_enabled: bool
+    policy_entrypoints: WorkflowPolicyEntrypoints
+
+    @property
+    def eligibility_policy(self) -> str:
+        return self.policy_entrypoints.eligibility
+
+    @property
+    def validation_policy(self) -> str:
+        return self.policy_entrypoints.validation
+
+    @property
+    def completion_policy(self) -> str:
+        return self.policy_entrypoints.completion
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "profile_id": self.profile_id,
+            "issue_kind": self.issue_kind.value,
+            "canonical_type_label": self.canonical_type_label,
+            "requires_critical_outcome": self.requires_critical_outcome,
+            "branch_namespace": self.branch_namespace,
+            "lifecycle_enabled": self.lifecycle_enabled,
+            "policy_entrypoints": self.policy_entrypoints.to_dict(),
+        }
+
+
+def _profile(
+    kind: LeafIssueKind,
+    *,
+    requires_critical_outcome: bool,
+    lifecycle_enabled: bool,
+    branch_namespace: str,
+) -> LeafIssueWorkflowProfile:
+    return LeafIssueWorkflowProfile(
+        profile_id=kind.value,
+        issue_kind=kind,
+        canonical_type_label=f"type:{kind.value}",
+        requires_critical_outcome=requires_critical_outcome,
+        branch_namespace=branch_namespace,
+        lifecycle_enabled=lifecycle_enabled,
+        policy_entrypoints=WorkflowPolicyEntrypoints(
+            eligibility=kind.value,
+            validation=kind.value,
+            completion=kind.value,
+        ),
+    )
+
+
+TASK_PROFILE: Final = _profile(
+    LeafIssueKind.TASK,
+    requires_critical_outcome=True,
+    lifecycle_enabled=True,
+    branch_namespace="task/",
+)
+BUG_PROFILE: Final = _profile(
+    LeafIssueKind.BUG,
+    requires_critical_outcome=False,
+    lifecycle_enabled=False,
+    branch_namespace="bug/",
+)
+DOCUMENTATION_PROFILE: Final = _profile(
+    LeafIssueKind.DOCUMENTATION,
+    requires_critical_outcome=False,
+    lifecycle_enabled=False,
+    branch_namespace="documentation/",
+)
+RESEARCH_PROFILE: Final = _profile(
+    LeafIssueKind.RESEARCH,
+    requires_critical_outcome=False,
+    lifecycle_enabled=False,
+    branch_namespace="research/",
+)
+
+PROFILES_BY_TYPE_LABEL: Final = {
+    profile.canonical_type_label: profile
+    for profile in (
+        TASK_PROFILE,
+        BUG_PROFILE,
+        DOCUMENTATION_PROFILE,
+        RESEARCH_PROFILE,
+    )
+}
+_NON_LEAF_TYPE_LABELS: Final = frozenset({"type:feature", "type:epic"})
+
+
+def _label_names(issue: Mapping[str, Any] | None) -> tuple[str, ...]:
+    if not isinstance(issue, Mapping):
+        return ()
+    raw_labels: Any = issue.get("labels")
+    if isinstance(raw_labels, Mapping):
+        raw_labels = raw_labels.get("items")
+    if not isinstance(raw_labels, list):
+        return ()
+    labels: list[str] = []
+    for item in raw_labels:
+        if isinstance(item, str):
+            labels.append(item)
+        elif isinstance(item, Mapping) and isinstance(item.get("name"), str):
+            labels.append(item["name"])
+    return tuple(labels)
+
+
+@dataclass(frozen=True)
+class IssueProfileResolution:
+    status: IssueProfileResolutionStatus
+    profile: LeafIssueWorkflowProfile | None = None
+    type_labels: tuple[str, ...] = ()
+    detail: str = ""
+
+    @property
+    def resolved(self) -> bool:
+        return self.status is IssueProfileResolutionStatus.RESOLVED
+
+    @property
+    def terminal_status(self) -> str:
+        if self.resolved and self.profile is not None:
+            return (
+                "PROFILE_ENABLED"
+                if self.profile.lifecycle_enabled
+                else "PROFILE_NOT_ENABLED"
+            )
+        return self.status.value.upper()
+
+    @property
+    def error_message(self) -> str:
+        if self.resolved:
+            if self.profile is None:
+                return "PROFILE_RESOLUTION_FAILED: resolved profile is unavailable"
+            if not self.profile.lifecycle_enabled:
+                return (
+                    "PROFILE_NOT_ENABLED: workflow profile "
+                    f"{self.profile.canonical_type_label} is not enabled"
+                )
+            return ""
+        return f"{self.terminal_status}: {self.detail}"
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "status": self.status.value,
+            "terminal_status": self.terminal_status,
+            "type_labels": list(self.type_labels),
+        }
+        if self.detail:
+            result["detail"] = self.detail
+        if self.profile is not None:
+            result["profile"] = self.profile.to_dict()
+        return result
+
+
+def resolve_leaf_issue_profile(
+    issue: Mapping[str, Any] | None,
+) -> IssueProfileResolution:
+    """Resolve exactly one profile from canonical ``type:*`` labels.
+
+    Title, body, GitHub's Issue Type field, and all non-type labels are
+    intentionally ignored.  Duplicate labels are treated as ambiguous input
+    even though GitHub normally prevents duplicate labels on one Issue.
+    """
+
+    labels = _label_names(issue)
+    type_labels = tuple(label for label in labels if label.startswith("type:"))
+    if not type_labels:
+        return IssueProfileResolution(
+            status=IssueProfileResolutionStatus.MISSING_TYPE,
+            detail="exactly one canonical type:* label is required",
+        )
+    if len(type_labels) != 1:
+        return IssueProfileResolution(
+            status=IssueProfileResolutionStatus.MULTIPLE_TYPES,
+            type_labels=type_labels,
+            detail=(
+                "exactly one canonical type:* label is required; found "
+                + ", ".join(type_labels)
+            ),
+        )
+
+    type_label = type_labels[0]
+    if type_label in _NON_LEAF_TYPE_LABELS:
+        return IssueProfileResolution(
+            status=IssueProfileResolutionStatus.NON_LEAF_TYPE,
+            type_labels=type_labels,
+            detail=(
+                "target Issue is not a type:task; non-leaf type labels are not "
+                f"eligible: {type_label}"
+            ),
+        )
+    profile = PROFILES_BY_TYPE_LABEL.get(type_label)
+    if profile is None:
+        return IssueProfileResolution(
+            status=IssueProfileResolutionStatus.UNKNOWN_TYPE,
+            type_labels=type_labels,
+            detail=f"unsupported canonical type label: {type_label}",
+        )
+    return IssueProfileResolution(
+        status=IssueProfileResolutionStatus.RESOLVED,
+        profile=profile,
+        type_labels=type_labels,
+    )
+
+
+def resolve_issue_profile(
+    issue: Mapping[str, Any] | None,
+) -> IssueProfileResolution:
+    """Compatibility-oriented name for the canonical leaf resolver."""
+
+    return resolve_leaf_issue_profile(issue)
+
+
+def canonical_branch_for_profile(
+    profile: LeafIssueWorkflowProfile,
+    issue_number: int,
+    title: str,
+) -> str:
+    """Derive a profile-owned branch name without reading Issue semantics."""
+
+    title_without_prefix = re.sub(r"^\s*\[[^]]+\]\s*", "", title)
+    normalized = unicodedata.normalize("NFKD", title_without_prefix)
+    ascii_title = normalized.encode("ascii", "ignore").decode("ascii")
+    words = re.findall(r"[a-zA-Z0-9]+", ascii_title.casefold())
+    slug = "-".join(words[:12]).strip("-") or profile.issue_kind.value
+    return f"{profile.branch_namespace}{issue_number}-{slug}"

--- a/tools/agent_workflow/lck_core/models.py
+++ b/tools/agent_workflow/lck_core/models.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import re
-import unicodedata
 from collections.abc import Mapping
 from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any, Final, cast
 
 from workflow_common import WorkflowToolError, is_sha
+
+from .issue_profiles import TASK_PROFILE, canonical_branch_for_profile
 
 BASE_BRANCH: Final = "main"
 REQUIRED_CHECKS_WORKFLOW: Final = ".github/workflows/ci.yml"
@@ -181,14 +182,7 @@ def canonical_task_branch(task_number: int, title: str) -> str:
     keeps the branch stable for mixed-language titles without trusting a
     branch name supplied by an Agent.
     """
-    title_without_prefix = re.sub(r"^\s*\[[^]]+\]\s*", "", title)
-    normalized = unicodedata.normalize("NFKD", title_without_prefix)
-    ascii_title = normalized.encode("ascii", "ignore").decode("ascii")
-    words = re.findall(r"[a-zA-Z0-9]+", ascii_title.casefold())
-    slug = "-".join(words[:12]).strip("-")
-    if not slug:
-        slug = "task"
-    return f"task/{task_number}-{slug}"
+    return canonical_branch_for_profile(TASK_PROFILE, task_number, title)
 
 
 def _jsonable(value: Any) -> Any:
@@ -388,7 +382,7 @@ def _pr_base_sha(pr: Mapping[str, Any] | None) -> str | None:
 
 @dataclass(frozen=True)
 class LiveState:
-    """Current mechanical facts acquired from Git and GitHub."""
+    """Current mechanical facts acquired from Git and GitHub for one Issue."""
 
     task_number: int
     repository: str | None
@@ -410,6 +404,7 @@ class LiveState:
     warnings: tuple[Mapping[str, Any], ...] = ()
     merged_pr: Mapping[str, Any] | None = None
     task_contract: Mapping[str, Any] | None = None
+    issue_profile: Mapping[str, Any] | None = None
 
     @property
     def project_status(self) -> str | None:
@@ -451,6 +446,7 @@ class LiveState:
                         if isinstance(self.task_contract, Mapping)
                         else None
                     ),
+                    "issue_profile": self.issue_profile,
                     "relationships": self.relationships,
                     "git": self.git,
                     "target_branch": self.target_branch,
@@ -481,6 +477,7 @@ class LiveState:
             "repository": self.repository,
             "status": self.status,
             "issue": _issue_agent_view(self.issue),
+            "issue_profile": self.issue_profile,
             "target_branch": self.target_branch,
             "task_branch": {
                 "local": self.local_task_branch,

--- a/tools/agent_workflow/lck_core/state.py
+++ b/tools/agent_workflow/lck_core/state.py
@@ -24,6 +24,7 @@ from workflow_evidence import (
     _repository_slug,
 )
 
+from .issue_profiles import canonical_branch_for_profile, resolve_issue_profile
 from .models import (
     _DIAGNOSTIC_FACT_PROFILE,
     BASE_BRANCH,
@@ -295,6 +296,11 @@ class LiveStateResolver:
         else:
             reasons.append("repository identity unavailable")
 
+        profile_resolution = resolve_issue_profile(issue)
+        issue_profile = profile_resolution.to_dict()
+        if not profile_resolution.resolved:
+            reasons.append(profile_resolution.error_message)
+
         git: Mapping[str, Any]
         if profile.include_git:
             if profile.include_workspace_inventory:
@@ -345,7 +351,15 @@ class LiveStateResolver:
             reasons.append("remote Task branch facts unavailable")
         title = issue.get("title") if isinstance(issue, Mapping) else None
         title_text = title if isinstance(title, str) else f"Task {task_number}"
-        canonical = canonical_task_branch(task_number, title_text)
+        canonical = (
+            canonical_branch_for_profile(
+                profile_resolution.profile,
+                task_number,
+                title_text,
+            )
+            if profile_resolution.profile is not None
+            else canonical_task_branch(task_number, title_text)
+        )
         candidates = sorted(local_branches | set(remote_branches))
         if len(candidates) > 1:
             reasons.append(f"multiple Task branch candidates: {candidates}")
@@ -512,6 +526,7 @@ class LiveStateResolver:
             stop_reasons=tuple(reasons),
             warnings=tuple(warnings),
             merged_pr=merged_pr,
+            issue_profile=issue_profile,
         )
 
 


### PR DESCRIPTION
Closes #197

## Summary
Add one canonical label-driven leaf Issue profile contract, preserve Task lifecycle behavior, and return typed disabled results for Bug, Documentation, and Research profiles.

## Validation
- Critical Outcome: pass
- Formal Delivery validation: pass

## Risks / limitations
Non-Task profiles are intentionally defined but lifecycle-disabled until their dedicated Tasks enable them; existing Task branch and Critical Outcome semantics remain unchanged.
