### PR TITLE
[Bug] Critical Outcome 标题层级导致合法 Task contract 被误判

### DIFF
--- a/tests/tools/test_critical_outcome.py
+++ b/tests/tools/test_critical_outcome.py
@@ -42,6 +42,37 @@ def test_parse_critical_outcome_contract() -> None:
     assert contract.verification_test.startswith("tests/tools/test_lck.py::")
 
 
+@pytest.mark.parametrize("heading_level", range(1, 7))
+def test_parser_accepts_all_standard_markdown_heading_levels(
+    heading_level: int,
+) -> None:
+    body = _body().replace(
+        "### Critical Outcome",
+        f"{'#' * heading_level} Critical Outcome",
+    )
+
+    assert parse_critical_outcome(body).capability == (
+        "LCK owns deterministic Delivery completion"
+    )
+
+
+def test_parser_rejects_plain_text_critical_outcome_marker() -> None:
+    body = _body().replace("### Critical Outcome", "Critical Outcome")
+
+    with pytest.raises(CriticalOutcomeError, match="exactly one"):
+        parse_critical_outcome(body)
+
+
+def test_parser_rejects_duplicate_critical_outcome_headings_across_levels() -> None:
+    body = _body().replace(
+        "### Acceptance Criteria",
+        "## Critical Outcome\n\n### Acceptance Criteria",
+    )
+
+    with pytest.raises(CriticalOutcomeError, match="exactly one"):
+        parse_critical_outcome(body)
+
+
 def test_parser_accepts_markdown_bullet_and_bold_labels() -> None:
     body = """### Critical Outcome
 - **Caller:** CLI

--- a/tools/agent_workflow/critical_outcome.py
+++ b/tools/agent_workflow/critical_outcome.py
@@ -16,7 +16,7 @@ from typing import Any, Final
 
 from workflow_common import CommandRunner, ProgressReporter, safe_text
 
-_SECTION_HEADING: Final = re.compile(r"^###\s+Critical Outcome\s*$", re.IGNORECASE)
+_SECTION_HEADING: Final = re.compile(r"^#{1,6}\s+Critical Outcome\s*$", re.IGNORECASE)
 _NEXT_HEADING: Final = re.compile(r"^#{1,6}\s+")
 _FIELD_LINE: Final = re.compile(
     r"^\s*(?:[-*+]\s*)?(?:\*\*)?"
@@ -76,7 +76,7 @@ def _normalize_key(value: str) -> str:
 
 
 def parse_critical_outcome(body: str | None) -> CriticalOutcomeContract:
-    """Parse the single required ``### Critical Outcome`` section.
+    """Parse the single required Markdown ``Critical Outcome`` section.
 
     The section uses four one-line fields so the semantic contract remains
     human-readable while the verification target stays machine-checkable.
@@ -92,7 +92,7 @@ def parse_critical_outcome(body: str | None) -> CriticalOutcomeContract:
     ]
     if len(section_starts) != 1:
         raise CriticalOutcomeError(
-            "Task body must contain exactly one '### Critical Outcome' section"
+            "Task body must contain exactly one level 1-6 'Critical Outcome' section"
         )
 
     values: dict[str, str] = {}


### PR DESCRIPTION
Closes #201

## Summary
Accept Critical Outcome sections at Markdown heading levels 1 through 6 while preserving single-section, field, and verification-node safety checks; add regression coverage for all levels, plain-text markers, and mixed-level duplicates.

## Validation
- Formal Delivery validation: pass

## Risks / limitations
Parser presentation matching is broadened only to standard Markdown heading levels 1-6; existing contract field and pytest node validation remains unchanged.
