### PR TITLE
[Bug] 标题层级导致合法 issue contract 被误判

### DIFF
--- a/tests/tools/test_critical_outcome.py
+++ b/tests/tools/test_critical_outcome.py
@@ -73,6 +73,28 @@ def test_parser_rejects_duplicate_critical_outcome_headings_across_levels() -> N
         parse_critical_outcome(body)
 
 
+def test_parser_ignores_fenced_critical_outcome_heading() -> None:
+    body = """### Objective
+Do one thing.
+
+```markdown
+## Critical Outcome
+Caller: fake
+Capability: fake
+Observable result: fake
+Verification test: tests/tools/test_lck.py::test_fake
+```
+
+### Critical Outcome
+Caller: real
+Capability: bounded effect
+Observable result: observable result
+Verification test: tests/tools/test_lck.py::test_canonical_branch_is_derived_from_current_issue_title
+"""
+
+    assert parse_critical_outcome(body).caller == "real"
+
+
 def test_parser_accepts_markdown_bullet_and_bold_labels() -> None:
     body = """### Critical Outcome
 - **Caller:** CLI

--- a/tests/tools/test_critical_outcome.py
+++ b/tests/tools/test_critical_outcome.py
@@ -73,6 +73,20 @@ def test_parser_rejects_duplicate_critical_outcome_headings_across_levels() -> N
         parse_critical_outcome(body)
 
 
+def test_parser_does_not_absorb_fields_from_a_later_issue_section() -> None:
+    body = """### Critical Outcome
+Caller: task-delivery-runner initial Delivery
+Capability: LCK owns deterministic Delivery completion
+Observable result: validated Task head is committed, pushed and attached to one OPEN PR
+
+### Acceptance Criteria
+Verification test: tests/tools/test_lck.py::test_canonical_branch_is_derived_from_current_issue_title
+"""
+
+    with pytest.raises(CriticalOutcomeError, match="missing required fields"):
+        parse_critical_outcome(body)
+
+
 def test_parser_ignores_fenced_critical_outcome_heading() -> None:
     body = """### Objective
 Do one thing.

--- a/tests/tools/test_lck_research.py
+++ b/tests/tools/test_lck_research.py
@@ -892,6 +892,19 @@ def test_architecture_decision_requires_matching_downstream_contract() -> None:
     assert research_decision["status"] == "pass"
 
     assert architecture_decision_is_consistent(research_decision, downstream)
+    downstream_with_context = {
+        "body": """### Decision Contract
+
+Adopt the repository-backed workflow contract and record the resulting ADR.
+
+### Acceptance Criteria
+
+- The downstream issue records the implementation criteria.
+""",
+    }
+    assert architecture_decision_is_consistent(
+        research_decision, downstream_with_context
+    )
     assert not architecture_decision_is_consistent(
         research_decision,
         {"body": "### Decision Contract\n\nAn unrelated decision.\n"},

--- a/tests/tools/test_markdown_sections.py
+++ b/tests/tools/test_markdown_sections.py
@@ -103,7 +103,7 @@ content
     assert [section.name for section in sections] == ["Other"]
 
 
-def test_parent_section_includes_nested_subsections() -> None:
+def test_sections_end_at_next_heading_regardless_of_level() -> None:
     sections = extract_markdown_sections(
         """### Reproduction / Evidence
 introductory evidence
@@ -113,11 +113,69 @@ nested evidence
 
 ### Acceptance Criteria
 criterion
-"""
+        """
     )
 
-    assert sections[0].content == (
-        "introductory evidence\n\n#### Confirmed regression\nnested evidence"
+    assert [(section.name, section.level) for section in sections] == [
+        ("Reproduction / Evidence", 3),
+        ("Confirmed regression", 4),
+        ("Acceptance Criteria", 3),
+    ]
+    assert sections[0].content == "introductory evidence"
+
+
+def test_named_sections_keep_noncanonical_nested_headings_as_content() -> None:
+    sections = extract_markdown_sections(
+        """# Observed
+
+#### Confirmed regression
+evidence
+
+### Expected
+expected behavior
+""",
+        canonical_names=("Observed", "Expected"),
+    )
+
+    assert [section.name for section in sections] == ["Observed", "Expected"]
+    assert sections[0].content == "#### Confirmed regression\nevidence"
+
+
+@pytest.mark.parametrize("profile", ("bug", "documentation", "research"))
+def test_typed_contracts_accept_mixed_heading_levels(profile: str) -> None:
+    headings = SECTION_BODIES[profile]
+    levels = (1, 3, 2, 6, 4, 5)
+    body = "\n\n".join(
+        f"{'#' * levels[index]} {heading}\n\ncontent for {heading}"
+        for index, heading in enumerate(headings)
+    )
+    snapshots = {
+        "bug": bug_contract_snapshot,
+        "documentation": documentation_contract_snapshot,
+        "research": research_contract_snapshot,
+    }
+
+    assert snapshots[profile](body)["status"] == "pass"
+
+
+@pytest.mark.parametrize("first_content", ("", "..."))
+def test_bug_contract_rejects_mixed_level_empty_or_placeholder_first_section(
+    first_content: str,
+) -> None:
+    body = "\n\n".join(
+        (
+            f"{'#' * level} {heading}\n\n{first_content if index == 0 else f'valid {heading}'}"
+        )
+        for index, (heading, level) in enumerate(
+            zip(SECTION_BODIES["bug"], (1, 3, 2, 6), strict=True)
+        )
+    )
+
+    contract = bug_contract_snapshot(body)
+
+    assert contract["status"] == "reclassification_required"
+    assert "Observed" in (
+        contract["empty_sections"] + contract["insufficient_sections"]
     )
 
 

--- a/tests/tools/test_markdown_sections.py
+++ b/tests/tools/test_markdown_sections.py
@@ -124,7 +124,7 @@ criterion
     assert sections[0].content == "introductory evidence"
 
 
-def test_named_sections_keep_noncanonical_nested_headings_as_content() -> None:
+def test_named_sections_keep_deeper_noncanonical_headings_as_content() -> None:
     sections = extract_markdown_sections(
         """# Observed
 
@@ -139,6 +139,26 @@ expected behavior
 
     assert [section.name for section in sections] == ["Observed", "Expected"]
     assert sections[0].content == "#### Confirmed regression\nevidence"
+
+
+def test_named_sections_use_peer_noncanonical_headings_as_boundaries() -> None:
+    sections = extract_markdown_sections(
+        """### Observed
+
+observed content
+
+### Optional Context
+
+context must not be part of Observed
+
+### Expected
+expected behavior
+""",
+        canonical_names=("Observed", "Expected"),
+    )
+
+    assert [section.name for section in sections] == ["Observed", "Expected"]
+    assert sections[0].content == "observed content"
 
 
 @pytest.mark.parametrize("profile", ("bug", "documentation", "research"))
@@ -198,3 +218,25 @@ def test_typed_contracts_fail_closed_for_duplicate_missing_and_fenced_sections(
     assert snapshot(duplicate)["status"] == "reclassification_required"
     assert snapshot(missing)["status"] == "reclassification_required"
     assert snapshot(fenced)["status"] == "reclassification_required"
+
+
+@pytest.mark.parametrize("profile", ("bug", "documentation", "research"))
+def test_typed_contracts_do_not_absorb_optional_context_after_empty_section(
+    profile: str,
+) -> None:
+    headings = SECTION_BODIES[profile]
+    body = "\n\n".join(
+        f"### {heading}\n\n{f'content for {heading}' if index < len(headings) - 1 else ''}"
+        for index, heading in enumerate(headings)
+    )
+    body += "\n\n### Optional Context\n\ncontext must not satisfy a required section"
+    snapshots = {
+        "bug": bug_contract_snapshot,
+        "documentation": documentation_contract_snapshot,
+        "research": research_contract_snapshot,
+    }
+
+    contract = snapshots[profile](body)
+
+    assert contract["status"] == "reclassification_required"
+    assert contract["empty_sections"] == [headings[-1]]

--- a/tests/tools/test_markdown_sections.py
+++ b/tests/tools/test_markdown_sections.py
@@ -1,0 +1,142 @@
+# ruff: noqa: E402
+
+"""Regression tests for shared typed Issue Markdown section extraction."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parents[2]
+AGENT_WORKFLOW = str(ROOT / "tools" / "agent_workflow")
+if AGENT_WORKFLOW not in sys.path:
+    sys.path.insert(0, AGENT_WORKFLOW)
+
+from bug_policy import bug_contract_snapshot  # type: ignore[import-not-found]
+from documentation_policy import (  # type: ignore[import-not-found]
+    documentation_contract_snapshot,
+)
+from markdown_sections import (  # type: ignore[import-not-found]
+    extract_markdown_sections,
+)
+from research_policy import research_contract_snapshot  # type: ignore[import-not-found]
+
+SECTION_BODIES = {
+    "bug": (
+        "Observed",
+        "Expected",
+        "Reproduction / Evidence",
+        "Acceptance Criteria",
+    ),
+    "documentation": (
+        "Documentation Goal",
+        "Requirements",
+        "Acceptance Criteria",
+    ),
+    "research": (
+        "Question / Decision Needed",
+        "Context",
+        "Scope",
+        "Non-goals",
+        "Evidence / Evaluation Criteria",
+        "Expected Outcome / Artifact",
+    ),
+}
+
+
+def _body(headings: tuple[str, ...], level: int = 3) -> str:
+    return "\n\n".join(
+        f"{'#' * level} {heading}\n\ncontent for {heading}" for heading in headings
+    )
+
+
+@pytest.mark.parametrize("level", (1, 2, 3, 6))
+@pytest.mark.parametrize("profile", ("bug", "documentation", "research"))
+def test_typed_contracts_accept_equivalent_heading_levels(
+    profile: str,
+    level: int,
+) -> None:
+    body = _body(SECTION_BODIES[profile], level)
+    snapshots = {
+        "bug": bug_contract_snapshot,
+        "documentation": documentation_contract_snapshot,
+        "research": research_contract_snapshot,
+    }
+
+    assert snapshots[profile](body)["status"] == "pass"
+
+
+def test_extractor_ignores_plain_text_and_fenced_headings() -> None:
+    sections = extract_markdown_sections(
+        """A plain Section Name does not count.
+
+```markdown
+# Section Name
+### Section Name
+```
+
+## Section Name
+
+real content
+"""
+    )
+
+    assert [(section.name, section.level) for section in sections] == [
+        ("Section Name", 2)
+    ]
+    assert sections[0].content == "real content"
+
+
+def test_extractor_ignores_tilde_fenced_headings() -> None:
+    sections = extract_markdown_sections(
+        """~~~text
+## Section Name
+~~~
+
+### Other
+content
+"""
+    )
+
+    assert [section.name for section in sections] == ["Other"]
+
+
+def test_parent_section_includes_nested_subsections() -> None:
+    sections = extract_markdown_sections(
+        """### Reproduction / Evidence
+introductory evidence
+
+#### Confirmed regression
+nested evidence
+
+### Acceptance Criteria
+criterion
+"""
+    )
+
+    assert sections[0].content == (
+        "introductory evidence\n\n#### Confirmed regression\nnested evidence"
+    )
+
+
+@pytest.mark.parametrize("profile", ("bug", "documentation", "research"))
+def test_typed_contracts_fail_closed_for_duplicate_missing_and_fenced_sections(
+    profile: str,
+) -> None:
+    headings = SECTION_BODIES[profile]
+    snapshots = {
+        "bug": bug_contract_snapshot,
+        "documentation": documentation_contract_snapshot,
+        "research": research_contract_snapshot,
+    }
+    snapshot = snapshots[profile]
+
+    duplicate = _body(headings) + f"\n\n# {headings[0]}\n\nconflict"
+    missing = _body(headings[1:])
+    fenced = f"```markdown\n# {headings[0]}\n\nexample\n```\n\n" + _body(headings[1:])
+
+    assert snapshot(duplicate)["status"] == "reclassification_required"
+    assert snapshot(missing)["status"] == "reclassification_required"
+    assert snapshot(fenced)["status"] == "reclassification_required"

--- a/tools/agent_workflow/bug_policy.py
+++ b/tools/agent_workflow/bug_policy.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any, Final
 
 import yaml
+from markdown_sections import extract_markdown_sections
 
 BUG_TEMPLATE_PATH: Final = Path(".github/ISSUE_TEMPLATE/bug.yml")
 BUG_POLICY_ID: Final = "repository-bug-defect-contract-v1"
@@ -64,7 +65,6 @@ class BugContract:
         }
 
 
-_SECTION_RE: Final = re.compile(r"^###\s+(.+?)\s*$", re.MULTILINE)
 _PLACEHOLDER_VALUES: Final = frozenset(
     {
         "...",
@@ -182,21 +182,6 @@ def bug_template_contract(
     return BugTemplateContract(tuple(field_ids), tuple(section_labels))
 
 
-def _section_details(body: str) -> tuple[tuple[str, str], ...]:
-    matches = tuple(_SECTION_RE.finditer(body))
-    return tuple(
-        (
-            " ".join(match.group(1).split()),
-            body[
-                match.end() : matches[index + 1].start()
-                if index + 1 < len(matches)
-                else None
-            ].strip(),
-        )
-        for index, match in enumerate(matches)
-    )
-
-
 def _is_placeholder(content: str) -> bool:
     normalized = unicodedata.normalize("NFKC", " ".join(content.split())).casefold()
     if normalized in _PLACEHOLDER_VALUES or normalized in _VAGUE_VALUES:
@@ -270,7 +255,9 @@ def bug_contract_snapshot(
             detail="Bug body is unavailable",
         ).to_dict()
 
-    sections = _section_details(body)
+    sections = tuple(
+        (section.name, section.content) for section in extract_markdown_sections(body)
+    )
     section_keys = tuple(section.casefold() for section, _content in sections)
     required_keys = tuple(section.casefold() for section in template.section_labels)
     missing = tuple(

--- a/tools/agent_workflow/bug_policy.py
+++ b/tools/agent_workflow/bug_policy.py
@@ -256,7 +256,10 @@ def bug_contract_snapshot(
         ).to_dict()
 
     sections = tuple(
-        (section.name, section.content) for section in extract_markdown_sections(body)
+        (section.name, section.content)
+        for section in extract_markdown_sections(
+            body, canonical_names=template.section_labels
+        )
     )
     section_keys = tuple(section.casefold() for section, _content in sections)
     required_keys = tuple(section.casefold() for section in template.section_labels)

--- a/tools/agent_workflow/critical_outcome.py
+++ b/tools/agent_workflow/critical_outcome.py
@@ -14,10 +14,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Final
 
+from markdown_sections import extract_markdown_sections
 from workflow_common import CommandRunner, ProgressReporter, safe_text
 
-_SECTION_HEADING: Final = re.compile(r"^#{1,6}\s+Critical Outcome\s*$", re.IGNORECASE)
-_NEXT_HEADING: Final = re.compile(r"^#{1,6}\s+")
 _FIELD_LINE: Final = re.compile(
     r"^\s*(?:[-*+]\s*)?(?:\*\*)?"
     r"(?P<key>Caller|Capability|Observable result|Verification test)"
@@ -84,21 +83,18 @@ def parse_critical_outcome(body: str | None) -> CriticalOutcomeContract:
     if not isinstance(body, str) or not body.strip():
         raise CriticalOutcomeError("Task body is unavailable")
 
-    lines = body.splitlines()
-    section_starts = [
-        index
-        for index, line in enumerate(lines)
-        if _SECTION_HEADING.fullmatch(line.strip())
-    ]
-    if len(section_starts) != 1:
+    sections = tuple(
+        section
+        for section in extract_markdown_sections(body)
+        if section.name.casefold() == "critical outcome"
+    )
+    if len(sections) != 1:
         raise CriticalOutcomeError(
             "Task body must contain exactly one level 1-6 'Critical Outcome' section"
         )
 
     values: dict[str, str] = {}
-    for raw in lines[section_starts[0] + 1 :]:
-        if _NEXT_HEADING.match(raw.strip()):
-            break
+    for raw in sections[0].content.splitlines():
         match = _FIELD_LINE.fullmatch(raw)
         if match is None:
             continue

--- a/tools/agent_workflow/critical_outcome.py
+++ b/tools/agent_workflow/critical_outcome.py
@@ -85,7 +85,9 @@ def parse_critical_outcome(body: str | None) -> CriticalOutcomeContract:
 
     sections = tuple(
         section
-        for section in extract_markdown_sections(body)
+        for section in extract_markdown_sections(
+            body, canonical_names=("Critical Outcome",)
+        )
         if section.name.casefold() == "critical outcome"
     )
     if len(sections) != 1:

--- a/tools/agent_workflow/documentation_policy.py
+++ b/tools/agent_workflow/documentation_policy.py
@@ -186,7 +186,10 @@ def documentation_contract_snapshot(
         ).to_dict()
 
     section_details = tuple(
-        (section.name, section.content) for section in extract_markdown_sections(body)
+        (section.name, section.content)
+        for section in extract_markdown_sections(
+            body, canonical_names=template.section_labels
+        )
     )
     section_keys = tuple(section.casefold() for section, _content in section_details)
     required_keys = tuple(section.casefold() for section in template.section_labels)

--- a/tools/agent_workflow/documentation_policy.py
+++ b/tools/agent_workflow/documentation_policy.py
@@ -6,7 +6,6 @@ Issue-provided documentation context is never interpreted as a command plan.
 
 from __future__ import annotations
 
-import re
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from enum import StrEnum
@@ -14,6 +13,7 @@ from pathlib import Path
 from typing import Any, Final
 
 import yaml
+from markdown_sections import extract_markdown_sections
 
 
 class DocumentationPolicyStatus(StrEnum):
@@ -23,8 +23,6 @@ class DocumentationPolicyStatus(StrEnum):
 
 DOCUMENTATION_POLICY_ID: Final = "repository-documentation-safe-v1"
 DOCUMENTATION_TEMPLATE_PATH: Final = Path(".github/ISSUE_TEMPLATE/documentation.yml")
-_SECTION_RE: Final = re.compile(r"^###\s+(.+?)\s*$", re.MULTILINE)
-
 # Documentation deliberately has a narrow path allow-list.  Workflow and
 # development-policy prose is excluded because changing it changes the
 # repository's control contract even when the file happens to end in .md.
@@ -165,21 +163,6 @@ def documentation_template_contract(
     return DocumentationTemplateContract(tuple(field_ids), tuple(section_labels))
 
 
-def _section_details(body: str) -> tuple[tuple[str, str], ...]:
-    matches = tuple(_SECTION_RE.finditer(body))
-    return tuple(
-        (
-            " ".join(match.group(1).split()),
-            body[
-                match.end() : matches[index + 1].start()
-                if index + 1 < len(matches)
-                else None
-            ].strip(),
-        )
-        for index, match in enumerate(matches)
-    )
-
-
 def documentation_contract_snapshot(
     body: str | None,
     *,
@@ -202,7 +185,9 @@ def documentation_contract_snapshot(
             detail="Documentation body is unavailable",
         ).to_dict()
 
-    section_details = _section_details(body)
+    section_details = tuple(
+        (section.name, section.content) for section in extract_markdown_sections(body)
+    )
     section_keys = tuple(section.casefold() for section, _content in section_details)
     required_keys = tuple(section.casefold() for section in template.section_labels)
     missing = tuple(

--- a/tools/agent_workflow/markdown_sections.py
+++ b/tools/agent_workflow/markdown_sections.py
@@ -8,6 +8,7 @@ sections.
 from __future__ import annotations
 
 import re
+from collections.abc import Collection
 from dataclasses import dataclass
 from typing import Final
 
@@ -47,12 +48,18 @@ def _is_fence_close(line: str, opening_marker: str) -> bool:
     return marker[0] == opening_marker[0] and len(marker) >= len(opening_marker)
 
 
-def extract_markdown_sections(body: str) -> tuple[MarkdownSection, ...]:
+def extract_markdown_sections(
+    body: str,
+    *,
+    canonical_names: Collection[str] | None = None,
+) -> tuple[MarkdownSection, ...]:
     """Extract real H1-H6 sections while ignoring fenced code blocks.
 
     Only ATX headings with one to six markers are recognized.  Plain text,
     headings indented as code, and headings inside backtick/tilde fences are
-    deliberately excluded.
+    deliberately excluded.  Contract callers may provide canonical section
+    names so non-canonical nested headings remain content while canonical
+    sections still end at the next canonical heading regardless of level.
     """
     lines = body.splitlines()
     sections: list[tuple[int, str, int]] = []
@@ -80,16 +87,21 @@ def extract_markdown_sections(body: str) -> tuple[MarkdownSection, ...]:
             )
         )
 
+    if canonical_names is not None:
+        canonical_keys = {" ".join(name.split()).casefold() for name in canonical_names}
+        sections = [
+            section for section in sections if section[1].casefold() in canonical_keys
+        ]
+
     extracted: list[MarkdownSection] = []
     for position, (line_index, name, level) in enumerate(sections):
-        next_line_index = len(lines)
-        for next_position in range(position + 1, len(sections)):
-            candidate_line_index, _candidate_name, candidate_level = sections[
-                next_position
-            ]
-            if candidate_level <= level:
-                next_line_index = candidate_line_index
-                break
+        # Contract heading levels are presentation only.  A later canonical
+        # section may use a deeper level than the current one, so hierarchy
+        # based boundaries would incorrectly absorb it into the current
+        # section and hide empty or placeholder content.
+        next_line_index = (
+            sections[position + 1][0] if position + 1 < len(sections) else len(lines)
+        )
         extracted.append(
             MarkdownSection(
                 name=name,

--- a/tools/agent_workflow/markdown_sections.py
+++ b/tools/agent_workflow/markdown_sections.py
@@ -58,8 +58,9 @@ def extract_markdown_sections(
     Only ATX headings with one to six markers are recognized.  Plain text,
     headings indented as code, and headings inside backtick/tilde fences are
     deliberately excluded.  Contract callers may provide canonical section
-    names so non-canonical nested headings remain content while canonical
-    sections still end at the next canonical heading regardless of level.
+    names to select sections after boundaries have been computed.  Canonical
+    headings are peer section boundaries regardless of level; non-canonical
+    headings retain normal Markdown hierarchy boundaries.
     """
     lines = body.splitlines()
     sections: list[tuple[int, str, int]] = []
@@ -87,21 +88,29 @@ def extract_markdown_sections(
             )
         )
 
-    if canonical_names is not None:
-        canonical_keys = {" ".join(name.split()).casefold() for name in canonical_names}
-        sections = [
-            section for section in sections if section[1].casefold() in canonical_keys
-        ]
-
+    canonical_keys = (
+        {" ".join(name.split()).casefold() for name in canonical_names}
+        if canonical_names is not None
+        else None
+    )
     extracted: list[MarkdownSection] = []
     for position, (line_index, name, level) in enumerate(sections):
-        # Contract heading levels are presentation only.  A later canonical
-        # section may use a deeper level than the current one, so hierarchy
-        # based boundaries would incorrectly absorb it into the current
-        # section and hide empty or placeholder content.
-        next_line_index = (
-            sections[position + 1][0] if position + 1 < len(sections) else len(lines)
-        )
+        next_line_index = len(lines)
+        for next_position in range(position + 1, len(sections)):
+            candidate_line_index, candidate_name, candidate_level = sections[
+                next_position
+            ]
+            candidate_is_canonical = (
+                canonical_keys is not None
+                and candidate_name.casefold() in canonical_keys
+            )
+            if (
+                canonical_keys is None
+                or candidate_is_canonical
+                or candidate_level <= level
+            ):
+                next_line_index = candidate_line_index
+                break
         extracted.append(
             MarkdownSection(
                 name=name,
@@ -109,4 +118,8 @@ def extract_markdown_sections(
                 content="\n".join(lines[line_index + 1 : next_line_index]).strip(),
             )
         )
-    return tuple(extracted)
+    if canonical_keys is None:
+        return tuple(extracted)
+    return tuple(
+        section for section in extracted if section.name.casefold() in canonical_keys
+    )

--- a/tools/agent_workflow/markdown_sections.py
+++ b/tools/agent_workflow/markdown_sections.py
@@ -1,0 +1,100 @@
+"""Shared Markdown section extraction for typed Issue contracts.
+
+Issue contract headings are semantic markers.  Their Markdown level is only
+presentation, while fenced code examples are content and must not become
+sections.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Final
+
+_ATX_HEADING: Final = re.compile(
+    r"^[ \t]{0,3}(?P<marks>#{1,6})(?:[ \t]+(?P<name>.+?)[ \t]*|[ \t]*)$"
+)
+_FENCE: Final = re.compile(r"^[ \t]{0,3}(?P<marker>`{3,}|~{3,})(?P<remainder>.*)$")
+
+
+@dataclass(frozen=True)
+class MarkdownSection:
+    """One ATX heading and the content before the next real heading."""
+
+    name: str
+    level: int
+    content: str
+
+
+def _fence_marker(line: str) -> str | None:
+    match = _FENCE.fullmatch(line)
+    if match is None:
+        return None
+    marker = match.group("marker")
+    remainder = match.group("remainder")
+    # Backtick fences cannot have backticks in their info string.  Tilde
+    # fences have no equivalent restriction.
+    if marker[0] == "`" and "`" in remainder:
+        return None
+    return marker
+
+
+def _is_fence_close(line: str, opening_marker: str) -> bool:
+    match = _FENCE.fullmatch(line)
+    if match is None or match.group("remainder").strip():
+        return False
+    marker = match.group("marker")
+    return marker[0] == opening_marker[0] and len(marker) >= len(opening_marker)
+
+
+def extract_markdown_sections(body: str) -> tuple[MarkdownSection, ...]:
+    """Extract real H1-H6 sections while ignoring fenced code blocks.
+
+    Only ATX headings with one to six markers are recognized.  Plain text,
+    headings indented as code, and headings inside backtick/tilde fences are
+    deliberately excluded.
+    """
+    lines = body.splitlines()
+    sections: list[tuple[int, str, int]] = []
+    opening_fence: str | None = None
+
+    for index, line in enumerate(lines):
+        if opening_fence is not None:
+            if _is_fence_close(line, opening_fence):
+                opening_fence = None
+            continue
+
+        fence = _fence_marker(line)
+        if fence is not None:
+            opening_fence = fence
+            continue
+
+        heading = _ATX_HEADING.fullmatch(line)
+        if heading is None or not heading.group("name"):
+            continue
+        sections.append(
+            (
+                index,
+                " ".join(heading.group("name").split()),
+                len(heading.group("marks")),
+            )
+        )
+
+    extracted: list[MarkdownSection] = []
+    for position, (line_index, name, level) in enumerate(sections):
+        next_line_index = len(lines)
+        for next_position in range(position + 1, len(sections)):
+            candidate_line_index, _candidate_name, candidate_level = sections[
+                next_position
+            ]
+            if candidate_level <= level:
+                next_line_index = candidate_line_index
+                break
+        extracted.append(
+            MarkdownSection(
+                name=name,
+                level=level,
+                content="\n".join(lines[line_index + 1 : next_line_index]).strip(),
+            )
+        )
+    return tuple(extracted)

--- a/tools/agent_workflow/research_policy.py
+++ b/tools/agent_workflow/research_policy.py
@@ -207,7 +207,10 @@ def research_contract_snapshot(
         ).to_dict()
 
     section_details = tuple(
-        (section.name, section.content) for section in extract_markdown_sections(body)
+        (section.name, section.content)
+        for section in extract_markdown_sections(
+            body, canonical_names=template.section_labels
+        )
     )
     section_keys = tuple(section.casefold() for section, _content in section_details)
     required_keys = tuple(section.casefold() for section in template.section_labels)
@@ -291,7 +294,12 @@ def decision_contract_snapshot(
     if not isinstance(body, str) or not body.strip():
         return {"status": "unknown", "detail": "decision contract body unavailable"}
     sections = tuple(
-        (section.name, section.content) for section in extract_markdown_sections(body)
+        (section.name, section.content)
+        for section in extract_markdown_sections(
+            body,
+            canonical_names=tuple(_DECISION_CONTRACT_HEADINGS)
+            + ("Expected Outcome / Artifact",),
+        )
     )
     selected: tuple[str, str] | None = None
     for heading, content in sections:

--- a/tools/agent_workflow/research_policy.py
+++ b/tools/agent_workflow/research_policy.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any, Final
 
 import yaml
+from markdown_sections import extract_markdown_sections
 from workflow_common import sha256_json
 
 RESEARCH_POLICY_ID: Final = "repository-research-artifact-v1"
@@ -183,24 +184,6 @@ def research_template_contract(
     return ResearchTemplateContract(tuple(field_ids), tuple(section_labels))
 
 
-_SECTION_RE: Final = re.compile(r"^###\s+(.+?)\s*$", re.MULTILINE)
-
-
-def _section_details(body: str) -> tuple[tuple[str, str], ...]:
-    matches = tuple(_SECTION_RE.finditer(body))
-    return tuple(
-        (
-            " ".join(match.group(1).split()),
-            body[
-                match.end() : matches[index + 1].start()
-                if index + 1 < len(matches)
-                else None
-            ].strip(),
-        )
-        for index, match in enumerate(matches)
-    )
-
-
 def research_contract_snapshot(
     body: str | None,
     *,
@@ -223,7 +206,9 @@ def research_contract_snapshot(
             detail="Research body is unavailable",
         ).to_dict()
 
-    section_details = _section_details(body)
+    section_details = tuple(
+        (section.name, section.content) for section in extract_markdown_sections(body)
+    )
     section_keys = tuple(section.casefold() for section, _content in section_details)
     required_keys = tuple(section.casefold() for section in template.section_labels)
     missing = tuple(
@@ -305,7 +290,9 @@ def decision_contract_snapshot(
 
     if not isinstance(body, str) or not body.strip():
         return {"status": "unknown", "detail": "decision contract body unavailable"}
-    sections = _section_details(body)
+    sections = tuple(
+        (section.name, section.content) for section in extract_markdown_sections(body)
+    )
     selected: tuple[str, str] | None = None
     for heading, content in sections:
         if heading.casefold() in _DECISION_CONTRACT_HEADINGS:


### PR DESCRIPTION
Closes #213

## Summary
Add one shared Markdown section extractor for H1-H6 ATX headings, ignore fenced code examples, preserve nested subsection content, and use it across Bug, Documentation, Research, and Task Critical Outcome contracts with regression coverage.

## Validation
- Formal Delivery validation: pass

## Risks / limitations
Parser intentionally recognizes only standard ATX H1-H6 headings outside backtick or tilde fenced code blocks; contract names and fail-closed validation semantics remain unchanged.
