### PR TITLE
[Task] 建立 LCK Typed Profile Policy 与 Evidence Boundary

### DIFF
--- a/tests/tools/test_lck_profile_architecture.py
+++ b/tests/tools/test_lck_profile_architecture.py
@@ -17,7 +17,17 @@ AGENT_WORKFLOW = str(ROOT / "tools" / "agent_workflow")
 if AGENT_WORKFLOW not in sys.path:
     sys.path.insert(0, AGENT_WORKFLOW)
 
-from lck_core import issue_profiles  # type: ignore[import-not-found]  # noqa: E402
+from lck_core import (  # type: ignore[import-not-found]  # noqa: E402
+    delivery as lck_delivery,
+    issue_profiles,
+    models as lck_models,
+    receipts as lck_receipts,
+    remediation as lck_remediation,
+)
+from lck_core.issue_profiles import (  # type: ignore[import-not-found]  # noqa: E402
+    IssueProfileResolution,
+    IssueProfileResolutionStatus,
+)
 from lck_core.profile_policies import (  # type: ignore[import-not-found]  # noqa: E402
     DEFAULT_PROFILE_POLICY_REGISTRY,
     PolicyBlocker,
@@ -25,9 +35,19 @@ from lck_core.profile_policies import (  # type: ignore[import-not-found]  # noq
     ProfileEvidenceEnvelope,
     ProfileEvidenceRecord,
     ProfilePolicyRegistry,
+    evaluate_profile_blockers,
+    validate_profile_candidate,
+    validate_profile_contract,
     run_profile_delivery_gates,
 )
-from workflow_common import sha256_json  # type: ignore[import-not-found]  # noqa: E402
+from workflow_common import (  # type: ignore[import-not-found]  # noqa: E402
+    CommandResult,
+    sha256_json,
+)
+from lck_test_support import (  # noqa: E402
+    StaticResolver,
+    _review_state,
+)
 
 
 @dataclass(frozen=True)
@@ -36,16 +56,23 @@ class SyntheticPolicy:
 
     profile_id: str = "synthetic"
     canonical_type_label: str = "type:synthetic"
+    contract_kind: str = "synthetic.contract.v1"
+    candidate_kind: str = "synthetic.candidate.v1"
 
     def validate_contract(
         self, context: PolicyContext, leaf_contract: Mapping[str, Any]
     ) -> ProfileEvidenceRecord:
         del context
         return ProfileEvidenceRecord(
-            "synthetic.contract.v1",
+            self.contract_kind,
             1,
             {
                 "policy_id": self.profile_id,
+                "contract_ref": {
+                    "number": leaf_contract["number"],
+                    "body_sha256": leaf_contract["body_sha256"],
+                },
+                "contract": {"status": "pass"},
                 "contract_digest": sha256_json(
                     {
                         "number": leaf_contract.get("number"),
@@ -72,21 +99,36 @@ class SyntheticPolicy:
     ) -> ProfileEvidenceRecord:
         del context, leaf_contract
         return ProfileEvidenceRecord(
-            "synthetic.candidate.v1",
+            self.candidate_kind,
             1,
             {
                 "policy_id": self.profile_id,
+                "contract_ref": contract_evidence.payload["contract_ref"],
                 "contract_digest": contract_evidence.payload["contract_digest"],
                 "result": {"status": "pass"},
+                "status": "pass",
             },
         )
 
     def validate_evidence(self, record: ProfileEvidenceRecord) -> bool:
-        return (
-            record.kind in {"synthetic.contract.v1", "synthetic.candidate.v1"}
-            and record.schema_version == 1
-            and record.payload.get("policy_id") == self.profile_id
-        )
+        if (
+            record.schema_version != 1
+            or record.payload.get("policy_id") != self.profile_id
+        ):
+            return False
+        if record.kind == self.contract_kind:
+            contract = record.payload.get("contract")
+            return isinstance(contract, Mapping) and dict(contract) == {
+                "status": "pass"
+            }
+        if record.kind == self.candidate_kind:
+            result = record.payload.get("result")
+            return (
+                record.payload.get("status") == "pass"
+                and isinstance(result, Mapping)
+                and dict(result) == {"status": "pass"}
+            )
+        return False
 
 
 def test_synthetic_policy_contract_blocker_candidate_use_frozen_registry_and_envelope() -> (
@@ -107,14 +149,34 @@ def test_synthetic_policy_contract_blocker_candidate_use_frozen_registry_and_env
     }
     context = PolicyContext(profile=profile, issue=leaf_contract)
 
-    contract = policy.validate_contract(context, leaf_contract)
-    blockers = tuple(policy.evaluate_blockers(context, leaf_contract, contract))
-    candidate = policy.validate_candidate(context, leaf_contract, contract)
+    contract_check = validate_profile_contract(
+        profile,
+        leaf_contract,
+        registry=registry,
+        context=context,
+    )
+    assert contract_check.valid
+    assert contract_check.evidence is not None
+    contract = contract_check.evidence
+    blockers = evaluate_profile_blockers(
+        profile,
+        leaf_contract,
+        contract_evidence=contract,
+        registry=registry,
+        context=context,
+    )
+    candidate = validate_profile_candidate(
+        profile,
+        leaf_contract,
+        contract_evidence=contract,
+        registry=registry,
+        context=context,
+    )
     envelope = ProfileEvidenceEnvelope(
         profile_id=policy.profile_id,
         contract=contract,
         candidate=candidate,
-    ).validated(registry)
+    ).validated(registry, leaf_contract=leaf_contract)
 
     assert registry.resolve(profile).profile_id == policy.profile_id
     assert "synthetic" not in DEFAULT_PROFILE_POLICY_REGISTRY.policies
@@ -147,3 +209,285 @@ def test_synthetic_policy_contract_blocker_candidate_use_frozen_registry_and_env
         registry=registry,
     )
     assert gates.profile_evidence == envelope
+
+
+def test_profile_evidence_rejects_wrong_stage_malformed_payload_and_stale_contract() -> (
+    None
+):
+    policy = SyntheticPolicy()
+    registry = ProfilePolicyRegistry.from_policies(policy)
+    profile = replace(
+        issue_profiles.TASK_PROFILE,
+        profile_id=policy.profile_id,
+        canonical_type_label=policy.canonical_type_label,
+        candidate_capability="synthetic_candidate",
+    )
+    first_contract = {
+        "number": 217,
+        "body": "first canonical input",
+        "body_sha256": "a" * 64,
+    }
+    second_contract = {**first_contract, "body_sha256": "b" * 64}
+    context = PolicyContext(profile=profile, issue=first_contract)
+    contract = validate_profile_contract(
+        profile, first_contract, registry=registry, context=context
+    ).evidence
+    assert contract is not None
+
+    with pytest.raises(ValueError, match="contract reference"):
+        validate_profile_candidate(
+            profile,
+            second_contract,
+            contract_evidence=contract,
+            registry=registry,
+            context=replace(context, issue=second_contract),
+        )
+
+    malformed_contract = ProfileEvidenceRecord(
+        policy.contract_kind,
+        1,
+        {
+            "policy_id": policy.profile_id,
+            "contract_ref": contract.payload["contract_ref"],
+            "contract": {},
+        },
+    )
+    with pytest.raises(ValueError, match="policy rejected evidence"):
+        ProfileEvidenceEnvelope(
+            profile_id=policy.profile_id,
+            contract=malformed_contract,
+        ).validated(registry, leaf_contract=first_contract)
+
+    wrong_stage = replace(
+        contract,
+        kind=policy.candidate_kind,
+        payload={
+            **contract.payload,
+            "status": "not-a-result",
+            "result": {},
+        },
+    )
+    with pytest.raises(ValueError, match="contract stage"):
+        ProfileEvidenceEnvelope(
+            profile_id=policy.profile_id,
+            contract=wrong_stage,
+        ).validated(registry, leaf_contract=first_contract)
+
+
+def test_profile_registry_rejects_conflicting_canonical_labels() -> None:
+    first = SyntheticPolicy(profile_id="synthetic-a")
+    second = SyntheticPolicy(profile_id="synthetic-b")
+    with pytest.raises(ValueError, match="duplicate canonical type label"):
+        ProfilePolicyRegistry.from_policies(first, second)
+
+
+def test_synthetic_policy_dispatches_through_delivery_remediation_and_receipts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    policy = SyntheticPolicy()
+    registry = ProfilePolicyRegistry.from_policies(policy)
+    profile = replace(
+        issue_profiles.TASK_PROFILE,
+        profile_id=policy.profile_id,
+        canonical_type_label=policy.canonical_type_label,
+        candidate_capability="synthetic_candidate",
+        requires_critical_outcome=False,
+    )
+
+    def resolve_synthetic(_issue: Mapping[str, Any] | None) -> IssueProfileResolution:
+        return IssueProfileResolution(
+            status=IssueProfileResolutionStatus.RESOLVED,
+            profile=profile,
+            type_labels=(profile.canonical_type_label,),
+        )
+
+    state = _review_state(clean=False)
+    resolver = StaticResolver(tmp_path, state)
+    start_head = "a" * 40
+    candidate_head = "e" * 40
+    candidate_tree = "f" * 40
+
+    class ControllerRunner:
+        def __init__(self) -> None:
+            self.head = start_head
+
+        def run(
+            self,
+            argv: list[str] | tuple[str, ...],
+            *,
+            command_id: str,
+            **_: Any,
+        ) -> CommandResult:
+            args = tuple(str(item) for item in argv)
+            if args == ("git", "branch", "--show-current"):
+                return CommandResult(command_id, args, 0, state.target_branch, "")
+            if args == ("git", "rev-parse", "HEAD"):
+                return CommandResult(command_id, args, 0, self.head, "")
+            if args == ("git", "status", "--porcelain=v1", "--untracked-files=all"):
+                return CommandResult(command_id, args, 0, "", "")
+            return CommandResult(command_id, args, 1, "", "unsupported fake command")
+
+    runner = ControllerRunner()
+    resolver.runner = runner
+
+    class CommitEffect:
+        def current_head_tree(self) -> str:
+            return candidate_tree
+
+        def stage_candidate_tree(self) -> str:
+            return candidate_tree
+
+        def verify_tree_unchanged(
+            self, _tree: str, *, expected_head_sha: str | None = None
+        ) -> None:
+            assert expected_head_sha == start_head
+
+        def execute(
+            self,
+            _tree: str,
+            _message: str,
+            *,
+            expected_parent_sha: str | None = None,
+        ) -> lck_models.EffectReceipt:
+            assert expected_parent_sha == start_head
+            runner.head = candidate_head
+            return lck_models.EffectReceipt(
+                "commit_current_tree",
+                "committed",
+                {"head_sha": candidate_head, "tree_oid": candidate_tree},
+            )
+
+    class RemoteEffect:
+        def execute(
+            self, _branch: str, *, expected_head_sha: str
+        ) -> lck_models.EffectReceipt:
+            return lck_models.EffectReceipt(
+                "ensure_remote_branch",
+                "fast-forwarded",
+                {"remote_oid": expected_head_sha},
+            )
+
+    class PrEffect:
+        def execute(self, _state: Any, **kwargs: Any) -> lck_models.EffectReceipt:
+            return lck_models.EffectReceipt(
+                "ensure_open_pr",
+                "reused-current-open-pr",
+                {
+                    "number": 200,
+                    "head_sha": kwargs["head_sha"],
+                    "base_sha": kwargs["expected_base_sha"],
+                    "url": "https://example.invalid/pr/200",
+                },
+            )
+
+    class ChecksGate:
+        def observe_exact_pr(
+            self,
+            _repository: str,
+            _pr_number: int,
+            *,
+            expected_head_sha: str,
+            expected_base_sha: str,
+        ) -> dict[str, Any]:
+            return {
+                "status": "observed",
+                "pr": {
+                    "number": 200,
+                    "head_sha": expected_head_sha,
+                    "base_sha": expected_base_sha,
+                },
+            }
+
+    class StatusEffect:
+        def execute(self, *_args: Any, **_kwargs: Any) -> lck_models.EffectReceipt:
+            return lck_models.EffectReceipt("set_review_status", "already-review", {})
+
+    class Validation:
+        def run(self, _base_sha: str) -> dict[str, Any]:
+            return {"status": "pass"}
+
+    delivery = lck_delivery.DeliveryCompleter(
+        resolver,
+        formal_validation=Validation(),
+        commit_effect=CommitEffect(),
+        remote_effect=RemoteEffect(),
+        pr_effect=PrEffect(),
+        status_effect=StatusEffect(),
+        checks_gate=ChecksGate(),
+        policy_registry=registry,
+        profile_resolver=resolve_synthetic,
+    ).complete(
+        state.task_number,
+        commit_message="synthetic repair",
+        summary="exercise synthetic policy dispatch",
+        operation_snapshot=lck_models.OperationSnapshot(
+            operation=lck_models.Phase.DELIVERY_COMPLETE.value,
+            state=state,
+        ),
+    )
+
+    assert delivery.profile_evidence is not None
+    assert delivery.profile_evidence.profile_id == policy.profile_id
+    delivery_receipt = lck_receipts._write_success_receipt(
+        delivery,
+        operation="delivery-complete",
+        task_number=state.task_number,
+        operation_id="a" * 32,
+        store=lck_receipts.AuditReceiptStore(tmp_path),
+    )
+    assert (
+        delivery_receipt["profile_evidence"]["candidate"]["kind"]
+        == policy.candidate_kind
+    )
+
+    review_id = "b" * 32
+    store = lck_remediation.ReviewInvocationStore(tmp_path)
+    store.write_remediation_session(
+        state.task_number,
+        {
+            "schema_version": 1,
+            "kind": "remediation-session",
+            "task_number": state.task_number,
+            "review_id": review_id,
+            "operation_id": "c" * 32,
+            "start_head_sha": start_head,
+            "pr_number": 200,
+            "base_sha": start_head,
+            "findings_sha256": "d" * 64,
+            "findings_source": "local-review-record",
+        },
+    )
+    captured: dict[str, Any] = {}
+
+    class RemediationDelivery:
+        def __init__(self, *_args: Any, **kwargs: Any) -> None:
+            captured.update(kwargs)
+            self.last_profile_evidence = delivery.profile_evidence
+
+        def complete(
+            self, *_args: Any, **_kwargs: Any
+        ) -> lck_delivery.DeliveryCompletionResult:
+            return delivery
+
+    monkeypatch.setattr(lck_remediation, "DeliveryCompleter", RemediationDelivery)
+    remediation = lck_remediation.RemediationCompleter(
+        resolver,
+        store=store,
+        policy_registry=registry,
+        profile_resolver=resolve_synthetic,
+    ).complete(
+        state.task_number,
+        review_id,
+        commit_message="synthetic remediation",
+        summary="exercise remediation evidence propagation",
+    )
+    assert captured["profile_resolver"] is resolve_synthetic
+    remediation_receipt = lck_receipts._write_success_receipt(
+        remediation,
+        operation="remediation-complete",
+        task_number=state.task_number,
+        operation_id="e" * 32,
+        store=lck_receipts.AuditReceiptStore(tmp_path),
+    )
+    assert remediation_receipt["profile_evidence"]["profile_id"] == policy.profile_id

--- a/tests/tools/test_lck_profile_architecture.py
+++ b/tests/tools/test_lck_profile_architecture.py
@@ -1,0 +1,149 @@
+# ruff: noqa: E402, I001
+
+"""Acceptance tests for the typed profile policy/evidence boundary."""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass, replace
+from pathlib import Path
+from collections.abc import Mapping
+from typing import Any
+
+import pytest
+
+ROOT = Path(__file__).parents[2]
+AGENT_WORKFLOW = str(ROOT / "tools" / "agent_workflow")
+if AGENT_WORKFLOW not in sys.path:
+    sys.path.insert(0, AGENT_WORKFLOW)
+
+from lck_core import issue_profiles  # type: ignore[import-not-found]  # noqa: E402
+from lck_core.profile_policies import (  # type: ignore[import-not-found]  # noqa: E402
+    DEFAULT_PROFILE_POLICY_REGISTRY,
+    PolicyBlocker,
+    PolicyContext,
+    ProfileEvidenceEnvelope,
+    ProfileEvidenceRecord,
+    ProfilePolicyRegistry,
+    run_profile_delivery_gates,
+)
+from workflow_common import sha256_json  # type: ignore[import-not-found]  # noqa: E402
+
+
+@dataclass(frozen=True)
+class SyntheticPolicy:
+    """A fifth policy proving the injection seam is independent of production."""
+
+    profile_id: str = "synthetic"
+    canonical_type_label: str = "type:synthetic"
+
+    def validate_contract(
+        self, context: PolicyContext, leaf_contract: Mapping[str, Any]
+    ) -> ProfileEvidenceRecord:
+        del context
+        return ProfileEvidenceRecord(
+            "synthetic.contract.v1",
+            1,
+            {
+                "policy_id": self.profile_id,
+                "contract_digest": sha256_json(
+                    {
+                        "number": leaf_contract.get("number"),
+                        "body_sha256": leaf_contract.get("body_sha256"),
+                    }
+                ),
+            },
+        )
+
+    def evaluate_blockers(
+        self,
+        context: PolicyContext,
+        leaf_contract: Mapping[str, Any],
+        contract_evidence: ProfileEvidenceRecord,
+    ) -> tuple[PolicyBlocker, ...]:
+        del context, leaf_contract, contract_evidence
+        return ()
+
+    def validate_candidate(
+        self,
+        context: PolicyContext,
+        leaf_contract: Mapping[str, Any],
+        contract_evidence: ProfileEvidenceRecord,
+    ) -> ProfileEvidenceRecord:
+        del context, leaf_contract
+        return ProfileEvidenceRecord(
+            "synthetic.candidate.v1",
+            1,
+            {
+                "policy_id": self.profile_id,
+                "contract_digest": contract_evidence.payload["contract_digest"],
+                "result": {"status": "pass"},
+            },
+        )
+
+    def validate_evidence(self, record: ProfileEvidenceRecord) -> bool:
+        return (
+            record.kind in {"synthetic.contract.v1", "synthetic.candidate.v1"}
+            and record.schema_version == 1
+            and record.payload.get("policy_id") == self.profile_id
+        )
+
+
+def test_synthetic_policy_contract_blocker_candidate_use_frozen_registry_and_envelope() -> (
+    None
+):
+    policy = SyntheticPolicy()
+    registry = ProfilePolicyRegistry.from_policies(policy)
+    profile = replace(
+        issue_profiles.TASK_PROFILE,
+        profile_id=policy.profile_id,
+        canonical_type_label=policy.canonical_type_label,
+        candidate_capability="synthetic_candidate",
+    )
+    leaf_contract = {
+        "number": 217,
+        "body": "canonical input must not be copied into evidence",
+        "body_sha256": "a" * 64,
+    }
+    context = PolicyContext(profile=profile, issue=leaf_contract)
+
+    contract = policy.validate_contract(context, leaf_contract)
+    blockers = tuple(policy.evaluate_blockers(context, leaf_contract, contract))
+    candidate = policy.validate_candidate(context, leaf_contract, contract)
+    envelope = ProfileEvidenceEnvelope(
+        profile_id=policy.profile_id,
+        contract=contract,
+        candidate=candidate,
+    ).validated(registry)
+
+    assert registry.resolve(profile).profile_id == policy.profile_id
+    assert "synthetic" not in DEFAULT_PROFILE_POLICY_REGISTRY.policies
+    with pytest.raises(TypeError):
+        registry.policies["other"] = policy
+    assert blockers == ()
+    assert set(envelope.to_dict()) == {
+        "profile_id",
+        "schema_version",
+        "contract",
+        "candidate",
+        "review",
+        "completion",
+    }
+    assert envelope.to_dict()["review"] is None
+    assert envelope.to_dict()["completion"] is None
+    assert "body" not in envelope.to_dict()["contract"]["payload"]
+    assert envelope.serialize() == envelope.serialize()
+
+    gates = run_profile_delivery_gates(
+        profile,
+        base_sha="b" * 40,
+        head_sha="c" * 40,
+        include_index=False,
+        progress=None,
+        documentation_validation=None,
+        research_validation=None,
+        critical_outcome=lambda: {"status": "unused"},
+        issue=leaf_contract,
+        registry=registry,
+    )
+    assert gates.profile_evidence == envelope

--- a/tools/agent_workflow/lck_core/README.md
+++ b/tools/agent_workflow/lck_core/README.md
@@ -32,6 +32,13 @@ module mutation to bypass this direction.
 Bug, Documentation, Research, and Task-specific candidate hooks. Lifecycle phase
 modules must not add another type-driven dispatch table.
 
+The same module owns the immutable production `ProfilePolicyRegistry`, the
+injectable `LeafIssuePolicy` seam, and the frozen four-stage
+`ProfileEvidenceEnvelope` (`contract`, `candidate`, `review`, `completion`).
+Policy blockers and stage payloads are validated by the selected policy before
+the shared kernel transports or records them; the canonical leaf contract is
+referenced by identity/digest rather than copied into the envelope.
+
 When diagnosing a lifecycle issue, read this map first and inspect the owner module
 plus at most its direct companion modules before broad repository searches.
 
@@ -48,6 +55,7 @@ The former mixed `tests/tools/test_lck.py` suite is responsibility-owned too:
 - `test_lck_receipts.py` — Agent View / Audit Receipt and failure evidence.
 - `test_lck_closeout.py` plus `test_lck_closeout_additional.py` — Closeout.
 - `test_lck_delivery.py` — Delivery completion and bounded effects.
+- `test_lck_profile_architecture.py` — injectable policy and evidence envelope.
 - `test_lck_structure.py` — facade/module dependency guardrails.
 
 `tests/tools/test_lck.py` intentionally retains only the long-lived Critical Outcome

--- a/tools/agent_workflow/lck_core/delivery.py
+++ b/tools/agent_workflow/lck_core/delivery.py
@@ -19,7 +19,7 @@ from .effects import (
     SetReviewStatusEffect,
 )
 from .eligibility import PhaseDecision, PhaseEligibilityResolver
-from .issue_profiles import resolve_issue_profile
+from .issue_profiles import resolve_leaf_issue_profile
 from .models import (
     BASE_BRANCH,
     LCK_SCHEMA_VERSION,
@@ -37,6 +37,8 @@ from .profile_policies import (
     ProfileEvidenceEnvelope,
     ProfileGateFailure,
     ProfilePolicyRegistry,
+    ProfileResolver,
+    resolve_issue_policy,
     run_profile_delivery_gates,
 )
 from .state import (
@@ -90,10 +92,18 @@ class DeliveryPreparer:
         resolver: LiveStateResolver,
         *,
         eligibility: PhaseEligibilityResolver | None = None,
+        profile_resolver: ProfileResolver | None = None,
     ) -> None:
         self.resolver = resolver
         self.snapshots = OperationSnapshotBuilder(resolver)
-        self.eligibility = eligibility or PhaseEligibilityResolver()
+        self.profile_resolver = (
+            profile_resolver
+            or getattr(eligibility, "profile_resolver", None)
+            or resolve_leaf_issue_profile
+        )
+        self.eligibility = eligibility or PhaseEligibilityResolver(
+            profile_resolver=self.profile_resolver
+        )
         self.last_snapshot: OperationSnapshot | None = None
 
     def _run_git(self, args: Sequence[str], command_id: str) -> None:
@@ -261,14 +271,21 @@ class DeliveryCompleter:
         documentation_validation: DocumentationValidationGate | None = None,
         research_validation: ResearchValidationGate | None = None,
         policy_registry: ProfilePolicyRegistry | None = None,
+        profile_resolver: ProfileResolver | None = None,
         require_existing_open_pr: bool = False,
         candidate_recorder: Callable[[str, str], None] | None = None,
     ) -> None:
         self.resolver = resolver
         self.snapshots = OperationSnapshotBuilder(resolver)
         self.policy_registry = policy_registry or DEFAULT_PROFILE_POLICY_REGISTRY
+        self.profile_resolver = (
+            profile_resolver
+            or getattr(eligibility, "profile_resolver", None)
+            or resolve_leaf_issue_profile
+        )
         self.eligibility = eligibility or PhaseEligibilityResolver(
-            registry=policy_registry
+            registry=self.policy_registry,
+            profile_resolver=self.profile_resolver,
         )
         self.formal_validation = formal_validation or FormalValidationGate(resolver)
         self.commit_effect = commit_effect or CommitCurrentTreeEffect(resolver)
@@ -351,10 +368,18 @@ class DeliveryCompleter:
         include_index: bool = False,
         head_sha: str | None = None,
     ) -> dict[str, Any] | None:
-        profile_resolution = resolve_issue_profile(state.issue)
-        profile = profile_resolution.profile
-        if profile is None or not profile_resolution.resolved:
+        if not isinstance(state.issue, Mapping):
             raise LckStopError("current leaf Issue workflow profile is unavailable")
+        try:
+            profile, _policy = resolve_issue_policy(
+                state.issue,
+                registry=self.policy_registry,
+                profile_resolver=self.profile_resolver,
+            )
+        except (TypeError, ValueError) as exc:
+            raise LckStopError(
+                f"current leaf Issue workflow profile is unavailable: {exc}"
+            ) from exc
         self.last_documentation_validation = None
         self.last_research_validation = None
         self.last_profile_evidence = None

--- a/tools/agent_workflow/lck_core/delivery.py
+++ b/tools/agent_workflow/lck_core/delivery.py
@@ -32,7 +32,13 @@ from .models import (
     _is_clean_current_main,
     _jsonable,
 )
-from .profile_policies import run_profile_delivery_gates
+from .profile_policies import (
+    DEFAULT_PROFILE_POLICY_REGISTRY,
+    ProfileEvidenceEnvelope,
+    ProfileGateFailure,
+    ProfilePolicyRegistry,
+    run_profile_delivery_gates,
+)
 from .state import (
     LiveStateResolver,
     OperationSnapshotBuilder,
@@ -207,6 +213,7 @@ class DeliveryCompletionResult:
     effects: tuple[EffectReceipt, ...]
     operation_snapshot: OperationSnapshot
     research_artifact: Mapping[str, Any] | None = None
+    profile_evidence: ProfileEvidenceEnvelope | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -221,6 +228,9 @@ class DeliveryCompletionResult:
             "validation": _jsonable(self.validation),
             "checks": _jsonable(self.checks),
             "research_artifact": _jsonable(self.research_artifact),
+            "profile_evidence": (
+                self.profile_evidence.to_dict() if self.profile_evidence else None
+            ),
             "effects": [item.to_dict() for item in self.effects],
             "operation_snapshot": self.operation_snapshot.to_dict(),
             "human_boundary": "Independent Review must be started separately",
@@ -250,12 +260,16 @@ class DeliveryCompleter:
         checks_gate: DeliveryChecksGate | None = None,
         documentation_validation: DocumentationValidationGate | None = None,
         research_validation: ResearchValidationGate | None = None,
+        policy_registry: ProfilePolicyRegistry | None = None,
         require_existing_open_pr: bool = False,
         candidate_recorder: Callable[[str, str], None] | None = None,
     ) -> None:
         self.resolver = resolver
         self.snapshots = OperationSnapshotBuilder(resolver)
-        self.eligibility = eligibility or PhaseEligibilityResolver()
+        self.policy_registry = policy_registry or DEFAULT_PROFILE_POLICY_REGISTRY
+        self.eligibility = eligibility or PhaseEligibilityResolver(
+            registry=policy_registry
+        )
         self.formal_validation = formal_validation or FormalValidationGate(resolver)
         self.commit_effect = commit_effect or CommitCurrentTreeEffect(resolver)
         self.remote_effect = remote_effect or EnsureRemoteBranchEffect(resolver)
@@ -274,6 +288,7 @@ class DeliveryCompleter:
         self.last_critical_outcome: dict[str, Any] | None = None
         self.last_documentation_validation: dict[str, Any] | None = None
         self.last_research_validation: dict[str, Any] | None = None
+        self.last_profile_evidence: ProfileEvidenceEnvelope | None = None
         self.last_validation: dict[str, Any] | None = None
         self.last_checks: dict[str, Any] | None = None
         self.last_effects: list[EffectReceipt] = []
@@ -342,6 +357,7 @@ class DeliveryCompleter:
             raise LckStopError("current leaf Issue workflow profile is unavailable")
         self.last_documentation_validation = None
         self.last_research_validation = None
+        self.last_profile_evidence = None
         try:
             results = run_profile_delivery_gates(
                 profile,
@@ -354,7 +370,15 @@ class DeliveryCompleter:
                 critical_outcome=lambda: self._run_critical_outcome(
                     state, progress=progress
                 ),
+                issue=state.issue,
+                registry=self.policy_registry,
             )
+        except ProfileGateFailure as exc:
+            self.last_profile_evidence = exc.profile_evidence
+            self.last_research_validation = getattr(
+                self.research_validation, "last_result", None
+            )
+            raise
         except LckStopError:
             self.last_research_validation = getattr(
                 self.research_validation, "last_result", None
@@ -363,6 +387,7 @@ class DeliveryCompleter:
         self.last_documentation_validation = results.documentation_validation
         self.last_research_validation = results.research_validation
         self.last_critical_outcome = results.critical_outcome
+        self.last_profile_evidence = results.profile_evidence
         return results.critical_outcome
 
     def _has_task_diff(self, base_sha: str) -> bool:
@@ -427,6 +452,7 @@ class DeliveryCompleter:
         self.last_effects = effects
         self.last_critical_outcome = None
         self.last_documentation_validation = None
+        self.last_profile_evidence = None
         self.last_validation = None
         self.last_checks = None
         decision = self.eligibility.resolve(
@@ -606,6 +632,7 @@ class DeliveryCompleter:
             effects=tuple(effects),
             operation_snapshot=snapshot,
             research_artifact=self.last_research_validation,
+            profile_evidence=self.last_profile_evidence,
         )
 
     def complete(

--- a/tools/agent_workflow/lck_core/eligibility.py
+++ b/tools/agent_workflow/lck_core/eligibility.py
@@ -16,7 +16,14 @@ from .models import (
     _is_clean_current_main,
     _items,
 )
-from .profile_policies import validate_profile_contract
+from .profile_policies import (
+    DEFAULT_PROFILE_POLICY_REGISTRY,
+    PolicyContext,
+    ProfilePolicyRegistry,
+    evaluate_profile_blockers,
+    resolve_profile_policy,
+    validate_profile_contract,
+)
 
 
 @dataclass(frozen=True)
@@ -39,6 +46,13 @@ class PhaseDecision:
 
 class PhaseEligibilityResolver:
     """Apply static phase capabilities to current live preconditions."""
+
+    def __init__(
+        self,
+        *,
+        registry: ProfilePolicyRegistry | None = None,
+    ) -> None:
+        self.registry = registry or DEFAULT_PROFILE_POLICY_REGISTRY
 
     def resolve(
         self,
@@ -66,6 +80,11 @@ class PhaseEligibilityResolver:
                 reasons.append(profile_resolution.error_message)
             elif profile is not None and not profile.lifecycle_enabled:
                 reasons.append(profile_resolution.error_message)
+            elif profile is not None:
+                try:
+                    resolve_profile_policy(profile, registry=self.registry)
+                except ValueError as exc:
+                    reasons.append(f"profile policy resolution failed: {exc}")
             issue_state = str(issue.get("state", "")).upper()
             if phase is not Phase.CLOSEOUT and issue_state != "OPEN":
                 reasons.append("Task is not OPEN")
@@ -81,10 +100,41 @@ class PhaseEligibilityResolver:
                         "lifecycle labels must be exactly ['codex:ready']: "
                         f"{sorted(lifecycle_labels) or 'none'}"
                     )
-            if profile is not None:
-                contract_check = validate_profile_contract(profile, issue)
-                if contract_check is not None and not contract_check.valid:
+            validate_contract_at_entry = phase in {
+                Phase.DELIVERY_PREPARE,
+                Phase.DELIVERY_COMPLETE,
+                Phase.REMEDIATION_PREPARE,
+                Phase.REMEDIATION_COMPLETE,
+            }
+            if profile is not None and (
+                profile.contract_policy is not None or validate_contract_at_entry
+            ):
+                contract_check = validate_profile_contract(
+                    profile, issue, registry=self.registry
+                )
+                if not contract_check.valid:
                     reasons.append(contract_check.failure_reason)
+                else:
+                    try:
+                        policy_blockers = evaluate_profile_blockers(
+                            profile,
+                            issue,
+                            contract_evidence=contract_check.evidence,
+                            registry=self.registry,
+                            context=PolicyContext(
+                                profile=profile,
+                                phase=phase.value,
+                                issue=issue,
+                                relationships=relationships,
+                            ),
+                        )
+                    except ValueError as exc:
+                        reasons.append(f"profile blocker evaluation failed: {exc}")
+                    else:
+                        reasons.extend(
+                            f"policy blocker [{blocker.code}]: {blocker.detail}"
+                            for blocker in policy_blockers
+                        )
             project = issue.get("project_status")
             allowed_projects = {
                 Phase.DELIVERY_PREPARE: {"Ready", "In Progress"},
@@ -110,19 +160,6 @@ class PhaseEligibilityResolver:
             }[phase]
             if project not in allowed_projects:
                 reasons.append("Project Status is unavailable or unknown")
-            if phase in {Phase.DELIVERY_PREPARE, Phase.DELIVERY_COMPLETE}:
-                if profile is not None and profile.requires_critical_outcome:
-                    critical = issue.get("critical_outcome")
-                    if (
-                        not isinstance(critical, Mapping)
-                        or critical.get("status") != "valid"
-                    ):
-                        detail = (
-                            critical.get("detail")
-                            if isinstance(critical, Mapping)
-                            else "contract unavailable"
-                        )
-                        reasons.append(f"Critical Outcome contract invalid: {detail}")
 
         downstream_contract = (
             state.task_contract if isinstance(state.task_contract, Mapping) else issue

--- a/tools/agent_workflow/lck_core/eligibility.py
+++ b/tools/agent_workflow/lck_core/eligibility.py
@@ -7,7 +7,7 @@ from typing import Any
 from workflow_common import is_sha
 from workflow_evidence import _formal_blockers_gate
 
-from .issue_profiles import resolve_issue_profile
+from .issue_profiles import resolve_leaf_issue_profile
 from .models import (
     LiveState,
     Phase,
@@ -20,6 +20,7 @@ from .profile_policies import (
     DEFAULT_PROFILE_POLICY_REGISTRY,
     PolicyContext,
     ProfilePolicyRegistry,
+    ProfileResolver,
     evaluate_profile_blockers,
     resolve_profile_policy,
     validate_profile_contract,
@@ -51,8 +52,10 @@ class PhaseEligibilityResolver:
         self,
         *,
         registry: ProfilePolicyRegistry | None = None,
+        profile_resolver: ProfileResolver | None = None,
     ) -> None:
         self.registry = registry or DEFAULT_PROFILE_POLICY_REGISTRY
+        self.profile_resolver = profile_resolver or resolve_leaf_issue_profile
 
     def resolve(
         self,
@@ -64,7 +67,7 @@ class PhaseEligibilityResolver:
         reasons = list(state.stop_reasons)
         issue = state.issue
         relationships = state.relationships
-        profile_resolution = resolve_issue_profile(
+        profile_resolution = self.profile_resolver(
             issue if isinstance(issue, Mapping) else None
         )
         issue_profile = profile_resolution.to_dict()

--- a/tools/agent_workflow/lck_core/profile_policies.py
+++ b/tools/agent_workflow/lck_core/profile_policies.py
@@ -17,7 +17,11 @@ from types import MappingProxyType
 from typing import Any, Final, Protocol, cast, runtime_checkable
 
 from bug_policy import bug_contract_snapshot, is_valid_bug_contract
-from critical_outcome import contract_from_snapshot, critical_outcome_snapshot
+from critical_outcome import (
+    CriticalOutcomeError,
+    contract_from_snapshot,
+    critical_outcome_snapshot,
+)
 from documentation_policy import (
     DocumentationChangeResult,
     documentation_contract_snapshot,
@@ -27,17 +31,26 @@ from documentation_policy import (
 from research_policy import is_valid_research_contract, research_contract_snapshot
 from workflow_common import sha256_json
 
-from .issue_profiles import LeafIssueWorkflowProfile, resolve_leaf_issue_profile
+from .issue_profiles import (
+    IssueProfileResolution,
+    LeafIssueWorkflowProfile,
+    resolve_leaf_issue_profile,
+)
 from .models import LckStopError
 
 PROFILE_EVIDENCE_SCHEMA_VERSION: Final = 1
 PROFILE_EVIDENCE_STAGES: Final = ("contract", "candidate", "review", "completion")
 _KIND_PATTERN: Final = r"^[a-z][a-z0-9_.-]*$"
 _CODE_PATTERN: Final = r"^[A-Z][A-Z0-9_.-]*$"
+_TYPE_LABEL_PATTERN: Final = r"^type:[a-z][a-z0-9_.-]*$"
+_SHA256_PATTERN: Final = r"^[0-9a-f]{64}$"
 
 
 class ProfilePolicyError(ValueError):
     """A profile policy or its typed evidence cannot be accepted safely."""
+
+
+ProfileResolver = Callable[[Mapping[str, Any] | None], IssueProfileResolution]
 
 
 def _jsonable(value: Any) -> Any:
@@ -166,6 +179,8 @@ class ProfileEvidenceEnvelope:
     def validated(
         self,
         registry: ProfilePolicyRegistry | None = None,
+        *,
+        leaf_contract: Mapping[str, Any] | None = None,
     ) -> ProfileEvidenceEnvelope:
         selected = registry or DEFAULT_PROFILE_POLICY_REGISTRY
         if not isinstance(self.profile_id, str) or not self.profile_id:
@@ -175,35 +190,54 @@ class ProfileEvidenceEnvelope:
                 "unsupported ProfileEvidenceEnvelope schema version"
             )
         policy = selected.resolve_profile_id(self.profile_id)
-        for record in (self.contract, self.candidate, self.review, self.completion):
+        records = (
+            ("contract", self.contract),
+            ("candidate", self.candidate),
+            ("review", self.review),
+            ("completion", self.completion),
+        )
+        if leaf_contract is None and any(record is not None for _, record in records):
+            raise ProfilePolicyError(
+                "canonical leaf contract is required to validate profile evidence"
+            )
+        for stage, record in records:
             if record is not None:
-                _validate_policy_evidence(policy, record)
+                _validate_policy_evidence(
+                    policy,
+                    record,
+                    stage=stage,
+                    leaf_contract=leaf_contract,
+                )
         return self
 
     def validate_evidence(
         self,
         registry: ProfilePolicyRegistry | None = None,
+        *,
+        leaf_contract: Mapping[str, Any] | None = None,
     ) -> ProfileEvidenceEnvelope:
         """Compatibility spelling for the lifecycle validation boundary."""
-        return self.validated(registry)
+        return self.validated(registry, leaf_contract=leaf_contract)
 
 
 def serialize_profile_evidence(
     value: ProfileEvidenceEnvelope,
     *,
     registry: ProfilePolicyRegistry | None = None,
+    leaf_contract: Mapping[str, Any] | None = None,
 ) -> str:
     """Serialize a validated envelope deterministically."""
-    return value.validated(registry).serialize()
+    return value.validated(registry, leaf_contract=leaf_contract).serialize()
 
 
 def validate_profile_evidence(
     value: ProfileEvidenceEnvelope,
     *,
     registry: ProfilePolicyRegistry | None = None,
+    leaf_contract: Mapping[str, Any] | None = None,
 ) -> ProfileEvidenceEnvelope:
     """Validate and return an envelope at a lifecycle boundary."""
-    return value.validated(registry)
+    return value.validated(registry, leaf_contract=leaf_contract)
 
 
 @dataclass(frozen=True)
@@ -271,6 +305,7 @@ class ProfilePolicyRegistry:
             else tuple(policies)
         )
         selected: dict[str, LeafIssuePolicy] = {}
+        by_type_label: dict[str, LeafIssuePolicy] = {}
         for policy in values:
             profile_id = getattr(policy, "profile_id", None)
             if not isinstance(profile_id, str) or not profile_id:
@@ -281,8 +316,22 @@ class ProfilePolicyRegistry:
                 raise ProfilePolicyError(
                     f"registered policy {profile_id!r} does not implement LeafIssuePolicy"
                 )
+            type_label = getattr(policy, "canonical_type_label", None)
+            if (
+                not isinstance(type_label, str)
+                or re.fullmatch(_TYPE_LABEL_PATTERN, type_label) is None
+            ):
+                raise ProfilePolicyError(
+                    f"registered policy {profile_id!r} has a malformed canonical type label"
+                )
+            if type_label in by_type_label:
+                raise ProfilePolicyError(
+                    f"duplicate canonical type label: {type_label}"
+                )
             selected[profile_id] = policy
+            by_type_label[type_label] = policy
         self._policies = MappingProxyType(selected)
+        self._policies_by_type_label = MappingProxyType(by_type_label)
 
     @classmethod
     def from_policies(cls, *policies: LeafIssuePolicy) -> ProfilePolicyRegistry:
@@ -291,6 +340,10 @@ class ProfilePolicyRegistry:
     @property
     def policies(self) -> Mapping[str, LeafIssuePolicy]:
         return self._policies
+
+    @property
+    def policies_by_type_label(self) -> Mapping[str, LeafIssuePolicy]:
+        return self._policies_by_type_label
 
     def resolve_profile_id(self, profile_id: str) -> LeafIssuePolicy:
         if not isinstance(profile_id, str) or not profile_id:
@@ -305,10 +358,12 @@ class ProfilePolicyRegistry:
     def resolve(self, profile: LeafIssueWorkflowProfile | str) -> LeafIssuePolicy:
         if isinstance(profile, str):
             if profile.startswith("type:"):
-                for candidate in self._policies.values():
-                    if getattr(candidate, "canonical_type_label", None) == profile:
-                        return candidate
-                raise ProfilePolicyError(f"profile policy is not registered: {profile}")
+                try:
+                    return self._policies_by_type_label[profile]
+                except KeyError as exc:
+                    raise ProfilePolicyError(
+                        f"profile policy is not registered: {profile}"
+                    ) from exc
             return self.resolve_profile_id(profile)
         if not isinstance(profile, LeafIssueWorkflowProfile):
             raise ProfilePolicyError("profile metadata is malformed")
@@ -321,9 +376,12 @@ class ProfilePolicyRegistry:
         return policy
 
     def resolve_issue(
-        self, issue: Mapping[str, Any]
+        self,
+        issue: Mapping[str, Any],
+        *,
+        profile_resolver: ProfileResolver = resolve_leaf_issue_profile,
     ) -> tuple[LeafIssueWorkflowProfile, LeafIssuePolicy]:
-        resolution = resolve_leaf_issue_profile(issue)
+        resolution = profile_resolver(issue)
         if not resolution.resolved or resolution.profile is None:
             raise ProfilePolicyError(
                 resolution.error_message or "profile resolution failed"
@@ -350,12 +408,73 @@ def _contract_reference(leaf_contract: Mapping[str, Any]) -> dict[str, Any]:
     return reference
 
 
+def _valid_contract_reference(value: Any) -> bool:
+    if not isinstance(value, Mapping):
+        return False
+    number = value.get("number")
+    if not isinstance(number, int) or isinstance(number, bool) or number <= 0:
+        return False
+    body_sha256 = value.get("body_sha256")
+    contract_sha256 = value.get("contract_sha256")
+    if body_sha256 is not None and (
+        not isinstance(body_sha256, str)
+        or re.fullmatch(_SHA256_PATTERN, body_sha256) is None
+    ):
+        return False
+    if contract_sha256 is not None and (
+        not isinstance(contract_sha256, str)
+        or re.fullmatch(_SHA256_PATTERN, contract_sha256) is None
+    ):
+        return False
+    if body_sha256 is None and contract_sha256 is None:
+        return False
+    if body_sha256 is not None and contract_sha256 is not None:
+        return False
+    return set(value) == (
+        {"number", "body_sha256"}
+        if body_sha256 is not None
+        else {"number", "body_sha256", "contract_sha256"}
+    )
+
+
+def _contract_reference_matches(
+    value: Any,
+    leaf_contract: Mapping[str, Any],
+) -> bool:
+    return _valid_contract_reference(value) and dict(value) == _contract_reference(
+        leaf_contract
+    )
+
+
+def _expected_evidence_kind(policy: LeafIssuePolicy, stage: str) -> str:
+    value = getattr(policy, f"{stage}_kind", None)
+    if value is None:
+        value = f"{policy.profile_id}.{stage}.v1"
+    if not isinstance(value, str) or re.fullmatch(_KIND_PATTERN, value) is None:
+        raise ProfilePolicyError(f"policy evidence kind for {stage} is malformed")
+    return value
+
+
 def _validate_policy_evidence(
-    policy: LeafIssuePolicy, record: ProfileEvidenceRecord
+    policy: LeafIssuePolicy,
+    record: ProfileEvidenceRecord,
+    *,
+    stage: str | None = None,
+    leaf_contract: Mapping[str, Any] | None = None,
 ) -> None:
     if record.schema_version != PROFILE_EVIDENCE_SCHEMA_VERSION:
         raise ProfilePolicyError(
             f"unsupported evidence schema version for {record.kind}"
+        )
+    if stage is not None and record.kind != _expected_evidence_kind(policy, stage):
+        raise ProfilePolicyError(
+            f"policy evidence kind does not match {stage} stage: {record.kind}"
+        )
+    if leaf_contract is not None and not _contract_reference_matches(
+        record.payload.get("contract_ref"), leaf_contract
+    ):
+        raise ProfilePolicyError(
+            "profile evidence contract reference does not match the canonical leaf contract"
         )
     try:
         valid = policy.validate_evidence(record)
@@ -398,6 +517,10 @@ class _BuiltinPolicy:
     legacy_result_field: str | None = None
     candidate_requires_result: bool = False
 
+    def _validate_contract_payload(self, value: object) -> bool:
+        del value
+        return False
+
     def _record(
         self,
         kind: str,
@@ -439,13 +562,18 @@ class _BuiltinPolicy:
         ):
             return False
         if record.kind == self.contract_kind:
-            return isinstance(payload.get("contract"), Mapping)
-        if not isinstance(payload.get("status"), str):
+            return self._validate_contract_payload(payload.get("contract"))
+        status = payload.get("status")
+        if status not in {"pass", "fail"}:
             return False
-        if payload.get("status") == "fail":
-            return True
-        return not self.candidate_requires_result or isinstance(
-            payload.get("result"), Mapping
+        result = payload.get("result")
+        if result is not None and not isinstance(result, Mapping):
+            return False
+        if status == "fail":
+            error = payload.get("error")
+            return isinstance(error, str) and bool(error.strip())
+        return not self.candidate_requires_result or (
+            isinstance(result, Mapping) and result.get("status") == "pass"
         )
 
     def evaluate_blockers(
@@ -454,8 +582,13 @@ class _BuiltinPolicy:
         leaf_contract: Mapping[str, Any],
         contract_evidence: ProfileEvidenceRecord,
     ) -> Iterable[PolicyBlocker]:
-        del context, leaf_contract
-        _validate_policy_evidence(cast(LeafIssuePolicy, self), contract_evidence)
+        del context
+        _validate_policy_evidence(
+            cast(LeafIssuePolicy, self),
+            contract_evidence,
+            stage="contract",
+            leaf_contract=leaf_contract,
+        )
         return ()
 
     def candidate_failure(
@@ -490,6 +623,13 @@ class _TaskPolicy(_BuiltinPolicy):
     legacy_result_field = "critical_outcome"
     candidate_requires_result = True
 
+    def _validate_contract_payload(self, value: object) -> bool:
+        try:
+            contract_from_snapshot(value)
+        except (CriticalOutcomeError, ValueError):
+            return False
+        return True
+
     def validate_contract(
         self, context: PolicyContext, leaf_contract: Mapping[str, Any]
     ) -> ProfileEvidenceRecord:
@@ -516,7 +656,12 @@ class _TaskPolicy(_BuiltinPolicy):
     ) -> ProfileEvidenceRecord:
         if context.critical_outcome is None:
             raise ProfilePolicyError("Task Critical Outcome verifier is unavailable")
-        _validate_policy_evidence(self, contract_evidence)
+        _validate_policy_evidence(
+            self,
+            contract_evidence,
+            stage="contract",
+            leaf_contract=leaf_contract,
+        )
         result = context.critical_outcome()
         if not isinstance(result, Mapping):
             raise ProfilePolicyError("Task Critical Outcome result is malformed")
@@ -538,6 +683,9 @@ class _BugPolicy(_BuiltinPolicy):
     candidate_kind = "bug.candidate.v1"
     policy_label = "Bug defect"
 
+    def _validate_contract_payload(self, value: object) -> bool:
+        return is_valid_bug_contract(value)
+
     def validate_contract(
         self, context: PolicyContext, leaf_contract: Mapping[str, Any]
     ) -> ProfileEvidenceRecord:
@@ -558,7 +706,12 @@ class _BugPolicy(_BuiltinPolicy):
         leaf_contract: Mapping[str, Any],
         contract_evidence: ProfileEvidenceRecord,
     ) -> ProfileEvidenceRecord:
-        _validate_policy_evidence(self, contract_evidence)
+        _validate_policy_evidence(
+            self,
+            contract_evidence,
+            stage="contract",
+            leaf_contract=leaf_contract,
+        )
         return self._record(self.candidate_kind, context, leaf_contract, status="pass")
 
 
@@ -570,6 +723,9 @@ class _DocumentationPolicy(_BuiltinPolicy):
     policy_label = "Documentation"
     legacy_result_field = "documentation_validation"
     candidate_requires_result = True
+
+    def _validate_contract_payload(self, value: object) -> bool:
+        return is_valid_documentation_contract(value)
 
     def validate_contract(
         self, context: PolicyContext, leaf_contract: Mapping[str, Any]
@@ -591,7 +747,12 @@ class _DocumentationPolicy(_BuiltinPolicy):
         leaf_contract: Mapping[str, Any],
         contract_evidence: ProfileEvidenceRecord,
     ) -> ProfileEvidenceRecord:
-        _validate_policy_evidence(self, contract_evidence)
+        _validate_policy_evidence(
+            self,
+            contract_evidence,
+            stage="contract",
+            leaf_contract=leaf_contract,
+        )
         if context.documentation_validation is not None:
             result = context.documentation_validation()
         else:
@@ -616,6 +777,9 @@ class _ResearchPolicy(_BuiltinPolicy):
     legacy_result_field = "research_validation"
     candidate_requires_result = True
 
+    def _validate_contract_payload(self, value: object) -> bool:
+        return is_valid_research_contract(value)
+
     def validate_contract(
         self, context: PolicyContext, leaf_contract: Mapping[str, Any]
     ) -> ProfileEvidenceRecord:
@@ -636,7 +800,12 @@ class _ResearchPolicy(_BuiltinPolicy):
         leaf_contract: Mapping[str, Any],
         contract_evidence: ProfileEvidenceRecord,
     ) -> ProfileEvidenceRecord:
-        _validate_policy_evidence(self, contract_evidence)
+        _validate_policy_evidence(
+            self,
+            contract_evidence,
+            stage="contract",
+            leaf_contract=leaf_contract,
+        )
         if context.research_validation is None:
             raise ProfilePolicyError("Research candidate validator is unavailable")
         result = context.research_validation()
@@ -731,8 +900,9 @@ def resolve_issue_policy(
     issue: Mapping[str, Any],
     *,
     registry: ProfilePolicyRegistry = DEFAULT_PROFILE_POLICY_REGISTRY,
+    profile_resolver: ProfileResolver = resolve_leaf_issue_profile,
 ) -> tuple[LeafIssueWorkflowProfile, LeafIssuePolicy]:
-    return registry.resolve_issue(issue)
+    return registry.resolve_issue(issue, profile_resolver=profile_resolver)
 
 
 def _context_for(
@@ -774,7 +944,7 @@ def validate_profile_contract(
         policy = resolve_profile_policy(profile, registry=registry)
         execution_context = _context_for(profile, issue=issue, context=context)
         evidence = _coerce_evidence(policy.validate_contract(execution_context, issue))
-        _validate_policy_evidence(policy, evidence)
+        _validate_policy_evidence(policy, evidence, leaf_contract=issue)
     except (ProfilePolicyError, ValueError) as exc:
         label = getattr(policy, "policy_label", profile.profile_id.title())
         return ProfileContractCheck(
@@ -819,8 +989,8 @@ def evaluate_profile_blockers(
                 evidence_ref={"profile_id": profile.profile_id},
             ),
         )
-    evidence = contract_evidence or check.evidence
-    _validate_policy_evidence(policy, evidence)
+    evidence = contract_evidence if contract_evidence is not None else check.evidence
+    _validate_policy_evidence(policy, evidence, leaf_contract=issue)
     raw = policy.evaluate_blockers(execution_context, issue, evidence)
     if raw is None:
         raise ProfilePolicyError("policy returned no blocker collection")
@@ -849,12 +1019,17 @@ def validate_profile_candidate(
     )
     if not check.valid or check.evidence is None:
         raise ProfilePolicyError(check.failure_reason)
-    evidence = contract_evidence or check.evidence
-    _validate_policy_evidence(policy, evidence)
+    evidence = contract_evidence if contract_evidence is not None else check.evidence
+    _validate_policy_evidence(policy, evidence, leaf_contract=issue)
     candidate = _coerce_evidence(
         policy.validate_candidate(execution_context, issue, evidence)
     )
-    _validate_policy_evidence(policy, candidate)
+    _validate_policy_evidence(
+        policy,
+        candidate,
+        stage="candidate",
+        leaf_contract=issue,
+    )
     expected_kind = getattr(policy, "candidate_kind", candidate.kind)
     if candidate.kind != expected_kind:
         raise ProfilePolicyError("policy returned evidence for the wrong stage")
@@ -972,14 +1147,14 @@ def run_profile_delivery_gates(
             profile_id=profile.profile_id,
             contract=check.evidence,
             candidate=failure,
-        ).validated(registry)
+        ).validated(registry, leaf_contract=issue)
         raise ProfileGateFailure(str(exc), envelope) from exc
 
     envelope = ProfileEvidenceEnvelope(
         profile_id=profile.profile_id,
         contract=check.evidence,
         candidate=candidate,
-    ).validated(registry)
+    ).validated(registry, leaf_contract=issue)
     result = _result_from_candidate(candidate)
     legacy: dict[str, Any] = getattr(policy, "legacy_result", lambda _result: {})(
         result

--- a/tools/agent_workflow/lck_core/profile_policies.py
+++ b/tools/agent_workflow/lck_core/profile_policies.py
@@ -1,18 +1,23 @@
-"""The single profile-policy dispatch layer used by the LCK kernel.
+"""Typed leaf policy dispatch and profile-owned evidence contracts.
 
-The four leaf policy modules own their business contracts.  This module owns
-only the mapping from a resolved profile to the shared lifecycle hooks.  Phase
-controllers must call these helpers instead of maintaining their own type
-allowlists or importing the profile type enum.
+The LCK kernel owns lifecycle mechanics. This module owns the small seam at
+which a resolved leaf profile becomes executable policy. The seam is explicit:
+production uses :data:`DEFAULT_PROFILE_POLICY_REGISTRY` and tests may construct
+an independent registry without mutating production state.
 """
 
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping, Sequence
+import json
+import re
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass
-from typing import Any
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Final, Protocol, cast, runtime_checkable
 
 from bug_policy import bug_contract_snapshot, is_valid_bug_contract
+from critical_outcome import contract_from_snapshot, critical_outcome_snapshot
 from documentation_policy import (
     DocumentationChangeResult,
     documentation_contract_snapshot,
@@ -20,19 +25,650 @@ from documentation_policy import (
     is_valid_documentation_contract,
 )
 from research_policy import is_valid_research_contract, research_contract_snapshot
+from workflow_common import sha256_json
 
-from .issue_profiles import LeafIssueWorkflowProfile
+from .issue_profiles import LeafIssueWorkflowProfile, resolve_leaf_issue_profile
+from .models import LckStopError
+
+PROFILE_EVIDENCE_SCHEMA_VERSION: Final = 1
+PROFILE_EVIDENCE_STAGES: Final = ("contract", "candidate", "review", "completion")
+_KIND_PATTERN: Final = r"^[a-z][a-z0-9_.-]*$"
+_CODE_PATTERN: Final = r"^[A-Z][A-Z0-9_.-]*$"
+
+
+class ProfilePolicyError(ValueError):
+    """A profile policy or its typed evidence cannot be accepted safely."""
+
+
+def _jsonable(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(key): _jsonable(nested) for key, nested in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(item) for item in value]
+    return value
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(
+        _jsonable(value),
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+@dataclass(frozen=True)
+class ProfileEvidenceRecord:
+    """One policy-owned, strongly shaped stage-evidence record."""
+
+    kind: str
+    schema_version: int
+    payload: Mapping[str, Any]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.kind, str) or not self.kind:
+            raise ProfilePolicyError("evidence kind is required")
+        if not isinstance(self.schema_version, int) or isinstance(
+            self.schema_version, bool
+        ):
+            raise ProfilePolicyError("evidence schema_version must be an integer")
+        if not isinstance(self.payload, Mapping):
+            raise ProfilePolicyError("evidence payload must be a mapping")
+        if any(not isinstance(key, str) for key in self.payload):
+            raise ProfilePolicyError("evidence payload keys must be strings")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "schema_version": self.schema_version,
+            "payload": _jsonable(self.payload),
+        }
+
+    def serialize(self) -> str:
+        """Return deterministic JSON for this record."""
+        return _canonical_json(self.to_dict())
+
+
+EvidenceRecord = ProfileEvidenceRecord
+StageEvidence = ProfileEvidenceRecord
+
+
+@dataclass(frozen=True)
+class PolicyBlocker:
+    """A normalized blocker emitted by one profile policy."""
+
+    code: str
+    kind: str
+    detail: str
+    evidence_ref: str | Mapping[str, Any] | None = None
+
+    @property
+    def stable_code(self) -> str:
+        return self.code
+
+    @property
+    def evidence_reference(self) -> str | Mapping[str, Any] | None:
+        return self.evidence_ref
+
+    def __post_init__(self) -> None:
+        if re.fullmatch(_CODE_PATTERN, self.code or "") is None:
+            raise ProfilePolicyError("policy blocker code is malformed")
+        if re.fullmatch(_KIND_PATTERN, self.kind or "") is None:
+            raise ProfilePolicyError("policy blocker kind is malformed")
+        if not isinstance(self.detail, str) or not self.detail.strip():
+            raise ProfilePolicyError("policy blocker detail is required")
+        if self.evidence_ref is not None and not isinstance(
+            self.evidence_ref, (str, Mapping)
+        ):
+            raise ProfilePolicyError("policy blocker evidence reference is malformed")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "code": self.code,
+            "kind": self.kind,
+            "detail": self.detail,
+            "evidence_ref": _jsonable(self.evidence_ref),
+        }
+
+
+ProfileBlocker = PolicyBlocker
+
+
+@dataclass(frozen=True)
+class ProfileEvidenceEnvelope:
+    """Frozen four-stage envelope shared by every leaf profile.
+
+    ``leaf_contract`` never appears here. The contract stage contains
+    validation evidence and may contain a bounded identity/digest reference to
+    the canonical acquisition input.
+    """
+
+    profile_id: str
+    schema_version: int = PROFILE_EVIDENCE_SCHEMA_VERSION
+    contract: ProfileEvidenceRecord | None = None
+    candidate: ProfileEvidenceRecord | None = None
+    review: ProfileEvidenceRecord | None = None
+    completion: ProfileEvidenceRecord | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "profile_id": self.profile_id,
+            "schema_version": self.schema_version,
+            "contract": self.contract.to_dict() if self.contract else None,
+            "candidate": self.candidate.to_dict() if self.candidate else None,
+            "review": self.review.to_dict() if self.review else None,
+            "completion": self.completion.to_dict() if self.completion else None,
+        }
+
+    def serialize(self) -> str:
+        return _canonical_json(self.to_dict())
+
+    def validated(
+        self,
+        registry: ProfilePolicyRegistry | None = None,
+    ) -> ProfileEvidenceEnvelope:
+        selected = registry or DEFAULT_PROFILE_POLICY_REGISTRY
+        if not isinstance(self.profile_id, str) or not self.profile_id:
+            raise ProfilePolicyError("evidence envelope profile_id is required")
+        if self.schema_version != PROFILE_EVIDENCE_SCHEMA_VERSION:
+            raise ProfilePolicyError(
+                "unsupported ProfileEvidenceEnvelope schema version"
+            )
+        policy = selected.resolve_profile_id(self.profile_id)
+        for record in (self.contract, self.candidate, self.review, self.completion):
+            if record is not None:
+                _validate_policy_evidence(policy, record)
+        return self
+
+    def validate_evidence(
+        self,
+        registry: ProfilePolicyRegistry | None = None,
+    ) -> ProfileEvidenceEnvelope:
+        """Compatibility spelling for the lifecycle validation boundary."""
+        return self.validated(registry)
+
+
+def serialize_profile_evidence(
+    value: ProfileEvidenceEnvelope,
+    *,
+    registry: ProfilePolicyRegistry | None = None,
+) -> str:
+    """Serialize a validated envelope deterministically."""
+    return value.validated(registry).serialize()
+
+
+def validate_profile_evidence(
+    value: ProfileEvidenceEnvelope,
+    *,
+    registry: ProfilePolicyRegistry | None = None,
+) -> ProfileEvidenceEnvelope:
+    """Validate and return an envelope at a lifecycle boundary."""
+    return value.validated(registry)
+
+
+@dataclass(frozen=True)
+class PolicyContext:
+    """Bounded inputs and callbacks exposed to a leaf policy."""
+
+    profile: LeafIssueWorkflowProfile | None = None
+    profile_id: str | None = None
+    phase: str | None = None
+    issue: Mapping[str, Any] | None = None
+    relationships: Mapping[str, Any] | None = None
+    repo_root: Path | None = None
+    base_sha: str | None = None
+    head_sha: str | None = None
+    include_index: bool = False
+    changed_files: tuple[str, ...] = ()
+    progress: Any = None
+    critical_outcome: Callable[[], Mapping[str, Any]] | None = None
+    documentation_validation: Callable[[], Mapping[str, Any]] | None = None
+    research_validation: Callable[[], Mapping[str, Any]] | None = None
+
+    @property
+    def resolved_profile_id(self) -> str | None:
+        return self.profile.profile_id if self.profile is not None else self.profile_id
+
+
+@runtime_checkable
+class LeafIssuePolicy(Protocol):
+    """Minimal executable policy API for one canonical leaf profile."""
+
+    @property
+    def profile_id(self) -> str: ...
+
+    def validate_contract(
+        self, context: PolicyContext, leaf_contract: Mapping[str, Any]
+    ) -> ProfileEvidenceRecord: ...
+
+    def evaluate_blockers(
+        self,
+        context: PolicyContext,
+        leaf_contract: Mapping[str, Any],
+        contract_evidence: ProfileEvidenceRecord,
+    ) -> Iterable[PolicyBlocker]: ...
+
+    def validate_candidate(
+        self,
+        context: PolicyContext,
+        leaf_contract: Mapping[str, Any],
+        contract_evidence: ProfileEvidenceRecord,
+    ) -> ProfileEvidenceRecord: ...
+
+    def validate_evidence(self, record: ProfileEvidenceRecord) -> bool: ...
+
+
+class ProfilePolicyRegistry:
+    """Immutable explicit registry used to resolve executable policies."""
+
+    def __init__(
+        self,
+        policies: Mapping[str, LeafIssuePolicy] | Iterable[LeafIssuePolicy],
+    ) -> None:
+        values = (
+            tuple(policies.values())
+            if isinstance(policies, Mapping)
+            else tuple(policies)
+        )
+        selected: dict[str, LeafIssuePolicy] = {}
+        for policy in values:
+            profile_id = getattr(policy, "profile_id", None)
+            if not isinstance(profile_id, str) or not profile_id:
+                raise ProfilePolicyError("registered policy has no profile_id")
+            if profile_id in selected:
+                raise ProfilePolicyError(f"duplicate registered profile: {profile_id}")
+            if not isinstance(policy, LeafIssuePolicy):
+                raise ProfilePolicyError(
+                    f"registered policy {profile_id!r} does not implement LeafIssuePolicy"
+                )
+            selected[profile_id] = policy
+        self._policies = MappingProxyType(selected)
+
+    @classmethod
+    def from_policies(cls, *policies: LeafIssuePolicy) -> ProfilePolicyRegistry:
+        return cls(policies)
+
+    @property
+    def policies(self) -> Mapping[str, LeafIssuePolicy]:
+        return self._policies
+
+    def resolve_profile_id(self, profile_id: str) -> LeafIssuePolicy:
+        if not isinstance(profile_id, str) or not profile_id:
+            raise ProfilePolicyError("profile policy identity is unavailable")
+        try:
+            return self._policies[profile_id]
+        except KeyError as exc:
+            raise ProfilePolicyError(
+                f"profile policy is not registered: {profile_id}"
+            ) from exc
+
+    def resolve(self, profile: LeafIssueWorkflowProfile | str) -> LeafIssuePolicy:
+        if isinstance(profile, str):
+            if profile.startswith("type:"):
+                for candidate in self._policies.values():
+                    if getattr(candidate, "canonical_type_label", None) == profile:
+                        return candidate
+                raise ProfilePolicyError(f"profile policy is not registered: {profile}")
+            return self.resolve_profile_id(profile)
+        if not isinstance(profile, LeafIssueWorkflowProfile):
+            raise ProfilePolicyError("profile metadata is malformed")
+        policy = self.resolve_profile_id(profile.profile_id)
+        policy_label = getattr(policy, "canonical_type_label", None)
+        if policy_label is not None and policy_label != profile.canonical_type_label:
+            raise ProfilePolicyError(
+                f"profile/policy canonical type label mismatch: {profile.profile_id}"
+            )
+        return policy
+
+    def resolve_issue(
+        self, issue: Mapping[str, Any]
+    ) -> tuple[LeafIssueWorkflowProfile, LeafIssuePolicy]:
+        resolution = resolve_leaf_issue_profile(issue)
+        if not resolution.resolved or resolution.profile is None:
+            raise ProfilePolicyError(
+                resolution.error_message or "profile resolution failed"
+            )
+        return resolution.profile, self.resolve(resolution.profile)
+
+
+LeafIssuePolicyRegistry = ProfilePolicyRegistry
+
+
+def _contract_reference(leaf_contract: Mapping[str, Any]) -> dict[str, Any]:
+    reference = {
+        "number": leaf_contract.get("number"),
+        "body_sha256": leaf_contract.get("body_sha256"),
+    }
+    if not isinstance(reference["body_sha256"], str) or not reference["body_sha256"]:
+        reference["contract_sha256"] = sha256_json(
+            {
+                "number": leaf_contract.get("number"),
+                "title": leaf_contract.get("title"),
+                "url": leaf_contract.get("url"),
+            }
+        )
+    return reference
+
+
+def _validate_policy_evidence(
+    policy: LeafIssuePolicy, record: ProfileEvidenceRecord
+) -> None:
+    if record.schema_version != PROFILE_EVIDENCE_SCHEMA_VERSION:
+        raise ProfilePolicyError(
+            f"unsupported evidence schema version for {record.kind}"
+        )
+    try:
+        valid = policy.validate_evidence(record)
+    except (ProfilePolicyError, ValueError) as exc:
+        raise ProfilePolicyError(str(exc)) from exc
+    if valid is not True:
+        raise ProfilePolicyError(f"policy rejected evidence kind: {record.kind}")
+
+
+def _coerce_evidence(value: Any) -> ProfileEvidenceRecord:
+    if isinstance(value, ProfileEvidenceRecord):
+        return value
+    if isinstance(value, Mapping):
+        kind = value.get("kind")
+        schema_version = value.get("schema_version")
+        payload = value.get("payload")
+        if (
+            not isinstance(kind, str)
+            or not isinstance(schema_version, int)
+            or isinstance(schema_version, bool)
+            or not isinstance(payload, Mapping)
+        ):
+            raise ProfilePolicyError("policy returned malformed evidence")
+        return ProfileEvidenceRecord(
+            kind=kind,
+            schema_version=schema_version,
+            payload=payload,
+        )
+    raise ProfilePolicyError("policy returned malformed evidence")
+
+
+class _BuiltinPolicy:
+    """Small common codec used only by repository-owned policies."""
+
+    profile_id: str
+    canonical_type_label: str
+    contract_kind: str
+    candidate_kind: str
+    policy_label: str
+    legacy_result_field: str | None = None
+    candidate_requires_result: bool = False
+
+    def _record(
+        self,
+        kind: str,
+        context: PolicyContext,
+        leaf_contract: Mapping[str, Any],
+        **payload: Any,
+    ) -> ProfileEvidenceRecord:
+        del context
+        return ProfileEvidenceRecord(
+            kind,
+            PROFILE_EVIDENCE_SCHEMA_VERSION,
+            {
+                "policy_id": self.profile_id,
+                "contract_ref": _contract_reference(leaf_contract),
+                **payload,
+            },
+        )
+
+    def _contract_snapshot(
+        self,
+        leaf_contract: Mapping[str, Any],
+        field_name: str,
+        snapshot: Callable[[str | None], Mapping[str, Any]],
+    ) -> Mapping[str, Any]:
+        value = leaf_contract.get(field_name)
+        if isinstance(value, Mapping):
+            return value
+        body = leaf_contract.get("body")
+        return snapshot(body if isinstance(body, str) else None)
+
+    def validate_evidence(self, record: ProfileEvidenceRecord) -> bool:
+        if record.schema_version != PROFILE_EVIDENCE_SCHEMA_VERSION:
+            return False
+        if record.kind not in {self.contract_kind, self.candidate_kind}:
+            return False
+        payload = record.payload
+        if payload.get("policy_id") != self.profile_id or not isinstance(
+            payload.get("contract_ref"), Mapping
+        ):
+            return False
+        if record.kind == self.contract_kind:
+            return isinstance(payload.get("contract"), Mapping)
+        if not isinstance(payload.get("status"), str):
+            return False
+        if payload.get("status") == "fail":
+            return True
+        return not self.candidate_requires_result or isinstance(
+            payload.get("result"), Mapping
+        )
+
+    def evaluate_blockers(
+        self,
+        context: PolicyContext,
+        leaf_contract: Mapping[str, Any],
+        contract_evidence: ProfileEvidenceRecord,
+    ) -> Iterable[PolicyBlocker]:
+        del context, leaf_contract
+        _validate_policy_evidence(cast(LeafIssuePolicy, self), contract_evidence)
+        return ()
+
+    def candidate_failure(
+        self,
+        context: PolicyContext,
+        leaf_contract: Mapping[str, Any],
+        contract_evidence: ProfileEvidenceRecord,
+        result: Mapping[str, Any] | None,
+        error: str,
+    ) -> ProfileEvidenceRecord:
+        return self._record(
+            self.candidate_kind,
+            context,
+            leaf_contract,
+            result=_jsonable(result) if result is not None else None,
+            status="fail",
+            error=error,
+        )
+
+    def legacy_result(self, result: Mapping[str, Any] | None) -> dict[str, Any]:
+        if self.legacy_result_field is None or result is None:
+            return {}
+        return {self.legacy_result_field: dict(result)}
+
+
+class _TaskPolicy(_BuiltinPolicy):
+    profile_id = "task"
+    canonical_type_label = "type:task"
+    contract_kind = "task.contract.v1"
+    candidate_kind = "task.candidate.v1"
+    policy_label = "Critical Outcome"
+    legacy_result_field = "critical_outcome"
+    candidate_requires_result = True
+
+    def validate_contract(
+        self, context: PolicyContext, leaf_contract: Mapping[str, Any]
+    ) -> ProfileEvidenceRecord:
+        snapshot = self._contract_snapshot(
+            leaf_contract, "critical_outcome", critical_outcome_snapshot
+        )
+        try:
+            contract = contract_from_snapshot(snapshot)
+        except ValueError as exc:
+            raise ProfilePolicyError(str(exc)) from exc
+        return self._record(
+            self.contract_kind,
+            context,
+            leaf_contract,
+            contract=snapshot,
+            verification_test=contract.verification_test,
+        )
+
+    def validate_candidate(
+        self,
+        context: PolicyContext,
+        leaf_contract: Mapping[str, Any],
+        contract_evidence: ProfileEvidenceRecord,
+    ) -> ProfileEvidenceRecord:
+        if context.critical_outcome is None:
+            raise ProfilePolicyError("Task Critical Outcome verifier is unavailable")
+        _validate_policy_evidence(self, contract_evidence)
+        result = context.critical_outcome()
+        if not isinstance(result, Mapping):
+            raise ProfilePolicyError("Task Critical Outcome result is malformed")
+        if result.get("status") != "pass":
+            raise ProfilePolicyError("Task Critical Outcome candidate did not pass")
+        return self._record(
+            self.candidate_kind,
+            context,
+            leaf_contract,
+            result=dict(result),
+            status=result.get("status"),
+        )
+
+
+class _BugPolicy(_BuiltinPolicy):
+    profile_id = "bug"
+    canonical_type_label = "type:bug"
+    contract_kind = "bug.contract.v1"
+    candidate_kind = "bug.candidate.v1"
+    policy_label = "Bug defect"
+
+    def validate_contract(
+        self, context: PolicyContext, leaf_contract: Mapping[str, Any]
+    ) -> ProfileEvidenceRecord:
+        snapshot = self._contract_snapshot(
+            leaf_contract, "bug_contract", bug_contract_snapshot
+        )
+        if not is_valid_bug_contract(snapshot):
+            raise ProfilePolicyError(
+                str(snapshot.get("detail") or "Bug defect contract is invalid")
+            )
+        return self._record(
+            self.contract_kind, context, leaf_contract, contract=snapshot
+        )
+
+    def validate_candidate(
+        self,
+        context: PolicyContext,
+        leaf_contract: Mapping[str, Any],
+        contract_evidence: ProfileEvidenceRecord,
+    ) -> ProfileEvidenceRecord:
+        _validate_policy_evidence(self, contract_evidence)
+        return self._record(self.candidate_kind, context, leaf_contract, status="pass")
+
+
+class _DocumentationPolicy(_BuiltinPolicy):
+    profile_id = "documentation"
+    canonical_type_label = "type:documentation"
+    contract_kind = "documentation.contract.v1"
+    candidate_kind = "documentation.candidate.v1"
+    policy_label = "Documentation"
+    legacy_result_field = "documentation_validation"
+    candidate_requires_result = True
+
+    def validate_contract(
+        self, context: PolicyContext, leaf_contract: Mapping[str, Any]
+    ) -> ProfileEvidenceRecord:
+        snapshot = self._contract_snapshot(
+            leaf_contract, "documentation_contract", documentation_contract_snapshot
+        )
+        if not is_valid_documentation_contract(snapshot):
+            raise ProfilePolicyError(
+                str(snapshot.get("detail") or "Documentation contract is invalid")
+            )
+        return self._record(
+            self.contract_kind, context, leaf_contract, contract=snapshot
+        )
+
+    def validate_candidate(
+        self,
+        context: PolicyContext,
+        leaf_contract: Mapping[str, Any],
+        contract_evidence: ProfileEvidenceRecord,
+    ) -> ProfileEvidenceRecord:
+        _validate_policy_evidence(self, contract_evidence)
+        if context.documentation_validation is not None:
+            result = context.documentation_validation()
+        else:
+            result = evaluate_documentation_changes(context.changed_files).to_dict()
+        if not isinstance(result, Mapping):
+            raise ProfilePolicyError("Documentation candidate result is malformed")
+        return self._record(
+            self.candidate_kind,
+            context,
+            leaf_contract,
+            result=dict(result),
+            status=result.get("status"),
+        )
+
+
+class _ResearchPolicy(_BuiltinPolicy):
+    profile_id = "research"
+    canonical_type_label = "type:research"
+    contract_kind = "research.contract.v1"
+    candidate_kind = "research.candidate.v1"
+    policy_label = "Research"
+    legacy_result_field = "research_validation"
+    candidate_requires_result = True
+
+    def validate_contract(
+        self, context: PolicyContext, leaf_contract: Mapping[str, Any]
+    ) -> ProfileEvidenceRecord:
+        snapshot = self._contract_snapshot(
+            leaf_contract, "research_contract", research_contract_snapshot
+        )
+        if not is_valid_research_contract(snapshot):
+            raise ProfilePolicyError(
+                str(snapshot.get("detail") or "Research contract is invalid")
+            )
+        return self._record(
+            self.contract_kind, context, leaf_contract, contract=snapshot
+        )
+
+    def validate_candidate(
+        self,
+        context: PolicyContext,
+        leaf_contract: Mapping[str, Any],
+        contract_evidence: ProfileEvidenceRecord,
+    ) -> ProfileEvidenceRecord:
+        _validate_policy_evidence(self, contract_evidence)
+        if context.research_validation is None:
+            raise ProfilePolicyError("Research candidate validator is unavailable")
+        result = context.research_validation()
+        if not isinstance(result, Mapping):
+            raise ProfilePolicyError("Research candidate result is malformed")
+        return self._record(
+            self.candidate_kind,
+            context,
+            leaf_contract,
+            result=dict(result),
+            status=result.get("status"),
+        )
+
+
+DEFAULT_PROFILE_POLICY_REGISTRY: Final = ProfilePolicyRegistry(
+    (_TaskPolicy(), _BugPolicy(), _DocumentationPolicy(), _ResearchPolicy())
+)
+PRODUCTION_PROFILE_POLICY_REGISTRY: Final = DEFAULT_PROFILE_POLICY_REGISTRY
+PROFILE_POLICY_REGISTRY: Final = DEFAULT_PROFILE_POLICY_REGISTRY
+POLICIES_BY_PROFILE_ID: Final = DEFAULT_PROFILE_POLICY_REGISTRY.policies
 
 
 @dataclass(frozen=True)
 class ProfileContractCheck:
-    """Bounded result for a profile-specific Issue contract."""
+    """Bounded result for one profile's Issue contract."""
 
     policy: str
     label: str
     valid: bool
     contract: Mapping[str, Any] | None
     detail: str = ""
+    evidence: ProfileEvidenceRecord | None = None
 
     @property
     def failure_reason(self) -> str:
@@ -41,11 +677,23 @@ class ProfileContractCheck:
 
 @dataclass(frozen=True)
 class ProfileGateResults:
-    """Results of the profile-specific Delivery gates."""
+    """Results of generic profile candidate dispatch."""
 
     critical_outcome: dict[str, Any] | None = None
     documentation_validation: dict[str, Any] | None = None
     research_validation: dict[str, Any] | None = None
+    profile_evidence: ProfileEvidenceEnvelope | None = None
+
+
+@dataclass(frozen=True)
+class ProfileGateFailure(LckStopError):
+    """Candidate policy failure carrying evidence produced before failure."""
+
+    detail: str
+    profile_evidence: ProfileEvidenceEnvelope | None = None
+
+    def __str__(self) -> str:
+        return self.detail
 
 
 @dataclass(frozen=True)
@@ -55,7 +703,9 @@ class _ContractPolicy:
     is_valid: Callable[[object], bool]
 
 
-_CONTRACT_POLICIES: dict[str, _ContractPolicy] = {
+# Compatibility/readability map for typed Issue contract snapshots. Executable
+# behavior is owned by the registry above.
+_CONTRACT_POLICIES: Final = {
     "bug": _ContractPolicy("Bug defect", bug_contract_snapshot, is_valid_bug_contract),
     "documentation": _ContractPolicy(
         "Documentation",
@@ -68,49 +718,156 @@ _CONTRACT_POLICIES: dict[str, _ContractPolicy] = {
 }
 
 
+def resolve_profile_policy(
+    profile: LeafIssueWorkflowProfile,
+    *,
+    registry: ProfilePolicyRegistry = DEFAULT_PROFILE_POLICY_REGISTRY,
+) -> LeafIssuePolicy:
+    """Resolve profile metadata to one executable policy through the registry."""
+    return registry.resolve(profile)
+
+
+def resolve_issue_policy(
+    issue: Mapping[str, Any],
+    *,
+    registry: ProfilePolicyRegistry = DEFAULT_PROFILE_POLICY_REGISTRY,
+) -> tuple[LeafIssueWorkflowProfile, LeafIssuePolicy]:
+    return registry.resolve_issue(issue)
+
+
+def _context_for(
+    profile: LeafIssueWorkflowProfile,
+    *,
+    issue: Mapping[str, Any] | None = None,
+    context: PolicyContext | None = None,
+    **updates: Any,
+) -> PolicyContext:
+    if context is not None:
+        return context
+    return PolicyContext(profile=profile, issue=issue, **updates)
+
+
+def _raw_contract_snapshot(
+    profile: LeafIssueWorkflowProfile,
+    issue: Mapping[str, Any],
+) -> Mapping[str, Any] | None:
+    if profile.profile_id == "task":
+        field_name = "critical_outcome"
+    elif profile.contract_policy is not None:
+        field_name = f"{profile.contract_policy}_contract"
+    else:
+        return None
+    value = issue.get(field_name)
+    return value if isinstance(value, Mapping) else None
+
+
 def validate_profile_contract(
     profile: LeafIssueWorkflowProfile,
     issue: Mapping[str, Any],
-) -> ProfileContractCheck | None:
-    """Validate the contract selected by one canonical profile.
-
-    A Task's Critical Outcome is validated by its dedicated gate, so Task has
-    no form contract here.  The remaining typed leaf contracts are selected by
-    profile metadata and dispatched through the one registry above.
-    """
-
-    policy_name = profile.contract_policy
-    if policy_name is None:
-        return None
-    policy = _CONTRACT_POLICIES.get(policy_name)
-    if policy is None:
+    *,
+    registry: ProfilePolicyRegistry = DEFAULT_PROFILE_POLICY_REGISTRY,
+    context: PolicyContext | None = None,
+) -> ProfileContractCheck:
+    """Validate one canonical contract through its executable policy."""
+    policy: LeafIssuePolicy | None = None
+    try:
+        policy = resolve_profile_policy(profile, registry=registry)
+        execution_context = _context_for(profile, issue=issue, context=context)
+        evidence = _coerce_evidence(policy.validate_contract(execution_context, issue))
+        _validate_policy_evidence(policy, evidence)
+    except (ProfilePolicyError, ValueError) as exc:
+        label = getattr(policy, "policy_label", profile.profile_id.title())
         return ProfileContractCheck(
-            policy=policy_name,
-            label=policy_name.title(),
+            policy=profile.profile_id,
+            label=label,
             valid=False,
-            contract=None,
-            detail="profile contract policy is not registered",
+            contract=_raw_contract_snapshot(profile, issue),
+            detail=str(exc),
         )
-
-    field_name = f"{policy_name}_contract"
-    contract = issue.get(field_name)
-    if not isinstance(contract, Mapping):
-        body = issue.get("body")
-        contract = policy.snapshot(body if isinstance(body, str) else None)
-    bounded = dict(contract) if isinstance(contract, Mapping) else None
-    valid = policy.is_valid(bounded)
-    detail = (
-        bounded.get("detail")
-        if isinstance(bounded, Mapping) and isinstance(bounded.get("detail"), str)
-        else "contract is invalid"
-    )
     return ProfileContractCheck(
-        policy=policy_name,
-        label=policy.label,
-        valid=valid,
-        contract=bounded,
-        detail="" if valid else detail,
+        policy=profile.profile_id,
+        label=getattr(policy, "policy_label", profile.profile_id.title()),
+        valid=True,
+        contract=_raw_contract_snapshot(profile, issue),
+        evidence=evidence,
     )
+
+
+def evaluate_profile_blockers(
+    profile: LeafIssueWorkflowProfile,
+    issue: Mapping[str, Any],
+    *,
+    contract_evidence: ProfileEvidenceRecord | None = None,
+    registry: ProfilePolicyRegistry = DEFAULT_PROFILE_POLICY_REGISTRY,
+    context: PolicyContext | None = None,
+) -> tuple[PolicyBlocker, ...]:
+    """Dispatch and validate generic profile blockers deterministically."""
+    policy = resolve_profile_policy(profile, registry=registry)
+    execution_context = _context_for(profile, issue=issue, context=context)
+    check = validate_profile_contract(
+        profile,
+        issue,
+        registry=registry,
+        context=execution_context,
+    )
+    if not check.valid or check.evidence is None:
+        return (
+            PolicyBlocker(
+                code="CONTRACT_INVALID",
+                kind="contract",
+                detail=check.failure_reason,
+                evidence_ref={"profile_id": profile.profile_id},
+            ),
+        )
+    evidence = contract_evidence or check.evidence
+    _validate_policy_evidence(policy, evidence)
+    raw = policy.evaluate_blockers(execution_context, issue, evidence)
+    if raw is None:
+        raise ProfilePolicyError("policy returned no blocker collection")
+    blockers = tuple(raw)
+    if any(not isinstance(blocker, PolicyBlocker) for blocker in blockers):
+        raise ProfilePolicyError("policy returned malformed blocker")
+    return tuple(sorted(blockers, key=lambda item: (item.code, item.kind, item.detail)))
+
+
+def validate_profile_candidate(
+    profile: LeafIssueWorkflowProfile,
+    issue: Mapping[str, Any],
+    *,
+    contract_evidence: ProfileEvidenceRecord | None = None,
+    registry: ProfilePolicyRegistry = DEFAULT_PROFILE_POLICY_REGISTRY,
+    context: PolicyContext | None = None,
+) -> ProfileEvidenceRecord:
+    """Dispatch one candidate validator without profile branching in callers."""
+    policy = resolve_profile_policy(profile, registry=registry)
+    execution_context = _context_for(profile, issue=issue, context=context)
+    check = validate_profile_contract(
+        profile,
+        issue,
+        registry=registry,
+        context=execution_context,
+    )
+    if not check.valid or check.evidence is None:
+        raise ProfilePolicyError(check.failure_reason)
+    evidence = contract_evidence or check.evidence
+    _validate_policy_evidence(policy, evidence)
+    candidate = _coerce_evidence(
+        policy.validate_candidate(execution_context, issue, evidence)
+    )
+    _validate_policy_evidence(policy, candidate)
+    expected_kind = getattr(policy, "candidate_kind", candidate.kind)
+    if candidate.kind != expected_kind:
+        raise ProfilePolicyError("policy returned evidence for the wrong stage")
+    return candidate
+
+
+def _result_from_candidate(
+    record: ProfileEvidenceRecord | None,
+) -> dict[str, Any] | None:
+    if record is None:
+        return None
+    result = record.payload.get("result")
+    return dict(result) if isinstance(result, Mapping) else None
 
 
 def run_profile_delivery_gates(
@@ -123,32 +880,113 @@ def run_profile_delivery_gates(
     documentation_validation: Any,
     research_validation: Any,
     critical_outcome: Callable[[], dict[str, Any]],
+    issue: Mapping[str, Any] | None = None,
+    registry: ProfilePolicyRegistry = DEFAULT_PROFILE_POLICY_REGISTRY,
 ) -> ProfileGateResults:
-    """Run one profile's candidate gates in the shared Delivery sequence."""
+    """Run contract and candidate stages through the selected policy."""
+    policy = resolve_profile_policy(profile, registry=registry)
+    observed_result: dict[str, Any] | None = None
 
-    documentation_result: dict[str, Any] | None = None
-    research_result: dict[str, Any] | None = None
-    critical_result: dict[str, Any] | None = None
+    def run_documentation() -> Mapping[str, Any]:
+        nonlocal observed_result
+        try:
+            result = documentation_validation.run(base_sha)
+        except BaseException:
+            result = getattr(documentation_validation, "last_result", None)
+            if isinstance(result, Mapping):
+                observed_result = dict(result)
+            raise
+        if not isinstance(result, Mapping):
+            raise ProfilePolicyError("Documentation candidate result is malformed")
+        observed_result = dict(result)
+        return result
 
-    if profile.change_policy == "documentation":
-        progress.running("documentation-policy")
-        documentation_result = documentation_validation.run(base_sha)
-    elif profile.artifact_policy == "research":
-        progress.running("research-artifact-policy")
-        research_result = research_validation.run(
-            base_sha,
-            head_sha=head_sha,
-            include_index=include_index,
+    def run_research() -> Mapping[str, Any]:
+        nonlocal observed_result
+        try:
+            result = research_validation.run(
+                base_sha,
+                head_sha=head_sha,
+                include_index=include_index,
+            )
+        except BaseException:
+            result = getattr(research_validation, "last_result", None)
+            if isinstance(result, Mapping):
+                observed_result = dict(result)
+            raise
+        if not isinstance(result, Mapping):
+            raise ProfilePolicyError("Research candidate result is malformed")
+        observed_result = dict(result)
+        return result
+
+    def run_critical() -> Mapping[str, Any]:
+        nonlocal observed_result
+        result = critical_outcome()
+        if not isinstance(result, Mapping):
+            raise ProfilePolicyError("Critical Outcome result is malformed")
+        observed_result = dict(result)
+        return result
+
+    context = PolicyContext(
+        profile=profile,
+        phase="delivery",
+        issue=issue,
+        base_sha=base_sha,
+        head_sha=head_sha,
+        include_index=include_index,
+        progress=progress,
+        critical_outcome=run_critical,
+        documentation_validation=run_documentation,
+        research_validation=run_research,
+    )
+    if not isinstance(issue, Mapping):
+        raise LckStopError("current leaf Issue contract is unavailable")
+    check = validate_profile_contract(
+        profile, issue, registry=registry, context=context
+    )
+    if not check.valid or check.evidence is None:
+        raise LckStopError(check.failure_reason)
+
+    try:
+        candidate = validate_profile_candidate(
+            profile,
+            issue,
+            contract_evidence=check.evidence,
+            registry=registry,
+            context=context,
         )
+    except BaseException as exc:
+        failure_builder = getattr(policy, "candidate_failure", None)
+        failure = (
+            failure_builder(
+                context,
+                issue,
+                check.evidence,
+                observed_result,
+                str(exc),
+            )
+            if callable(failure_builder)
+            else None
+        )
+        envelope = ProfileEvidenceEnvelope(
+            profile_id=profile.profile_id,
+            contract=check.evidence,
+            candidate=failure,
+        ).validated(registry)
+        raise ProfileGateFailure(str(exc), envelope) from exc
 
-    if profile.requires_critical_outcome:
-        progress.running("critical-outcome")
-        critical_result = critical_outcome()
-
+    envelope = ProfileEvidenceEnvelope(
+        profile_id=profile.profile_id,
+        contract=check.evidence,
+        candidate=candidate,
+    ).validated(registry)
+    result = _result_from_candidate(candidate)
+    legacy: dict[str, Any] = getattr(policy, "legacy_result", lambda _result: {})(
+        result
+    )
     return ProfileGateResults(
-        critical_outcome=critical_result,
-        documentation_validation=documentation_result,
-        research_validation=research_result,
+        **legacy,
+        profile_evidence=envelope,
     )
 
 
@@ -156,16 +994,13 @@ def evaluate_profile_changes(
     profile: LeafIssueWorkflowProfile,
     changed_files: Sequence[str],
 ) -> DocumentationChangeResult | None:
-    """Evaluate a profile's candidate file policy when one exists."""
-
+    """Evaluate a profile's legacy Review change-policy projection."""
     if profile.change_policy == "documentation":
         return evaluate_documentation_changes(changed_files)
     return None
 
 
 def profile_cleanup_label(profile: LeafIssueWorkflowProfile) -> str:
-    """Return the bounded human-facing name for cleanup diagnostics."""
-
     return profile.issue_kind.value.title()
 
 

--- a/tools/agent_workflow/lck_core/receipts.py
+++ b/tools/agent_workflow/lck_core/receipts.py
@@ -31,6 +31,7 @@ from .models import (
     _pr_head_sha,
     _validation_agent_view,
 )
+from .profile_policies import ProfileEvidenceEnvelope
 from .remediation import (
     RemediationCompletionResult,
     RemediationContext,
@@ -211,6 +212,15 @@ def _issue_profile_agent_view(value: Any) -> Any:
     return None
 
 
+def _profile_evidence(value: Any) -> Any:
+    """Serialize the generic profile envelope without profile-specific fields."""
+    if isinstance(value, ProfileEvidenceEnvelope):
+        return value.to_dict()
+    if isinstance(value, Mapping):
+        return _jsonable(value)
+    return None
+
+
 def _agent_view_for_result(value: Any) -> dict[str, Any]:
     """Convert one internal LCK result into the bounded Agent-facing view."""
     if isinstance(value, LiveState):
@@ -292,6 +302,7 @@ def _agent_view_for_result(value: Any) -> dict[str, Any]:
             "pr": _delivery_pr_agent_view(value.effects),
             "critical_outcome": _critical_outcome_agent_view(value.critical_outcome),
             "research_artifact": _jsonable(value.research_artifact),
+            "profile_evidence": _profile_evidence(value.profile_evidence),
             "validation": _validation_agent_view(value.validation),
             "checks": _checks_agent_view(value.checks),
             "effects": _effect_agent_view(value.effects),
@@ -397,6 +408,7 @@ def _agent_view_for_result(value: Any) -> dict[str, Any]:
             "status": "READY_FOR_NEW_REVIEW",
             "head_sha": delivery.head_sha,
             "critical_outcome": _critical_outcome_agent_view(delivery.critical_outcome),
+            "profile_evidence": _profile_evidence(delivery.profile_evidence),
             "validation": _validation_agent_view(delivery.validation),
             "checks": _checks_agent_view(delivery.checks),
             "effects": _effect_agent_view(delivery.effects),
@@ -538,6 +550,9 @@ def _write_failure_receipt(
             ),
             "documentation_policy": _jsonable(
                 getattr(handler, "last_documentation_validation", None)
+            ),
+            "profile_evidence": _profile_evidence(
+                getattr(handler, "last_profile_evidence", None)
             ),
             "validation": _jsonable(getattr(handler, "last_validation", None)),
             "checks": _jsonable(getattr(handler, "last_checks", None)),

--- a/tools/agent_workflow/lck_core/remediation.py
+++ b/tools/agent_workflow/lck_core/remediation.py
@@ -20,6 +20,11 @@ from .models import (
     Phase,
     _jsonable,
 )
+from .profile_policies import (
+    DEFAULT_PROFILE_POLICY_REGISTRY,
+    ProfileEvidenceEnvelope,
+    ProfilePolicyRegistry,
+)
 from .review_workspace import ReviewInvocationStore, _identity_from_mapping
 from .state import (
     LiveStateResolver,
@@ -514,6 +519,7 @@ class RemediationCompletionResult:
                 self.delivery.operation_snapshot.state.issue_profile
             ),
             "critical_outcome": payload["critical_outcome"],
+            "profile_evidence": payload["profile_evidence"],
             "validation": payload["validation"],
             "checks": payload["checks"],
             "effects": payload["effects"],
@@ -540,14 +546,19 @@ class RemediationCompleter:
         eligibility: PhaseEligibilityResolver | None = None,
         store: ReviewInvocationStore | None = None,
         checks_gate: DeliveryChecksGate | None = None,
+        policy_registry: ProfilePolicyRegistry | None = None,
     ) -> None:
         self.resolver = resolver
         self.snapshots = OperationSnapshotBuilder(resolver)
-        self.eligibility = eligibility or PhaseEligibilityResolver()
+        self.policy_registry = policy_registry or DEFAULT_PROFILE_POLICY_REGISTRY
+        self.eligibility = eligibility or PhaseEligibilityResolver(
+            registry=self.policy_registry
+        )
         self.store = store or ReviewInvocationStore(resolver.repo_root)
         self.checks_gate = checks_gate or DeliveryChecksGate(resolver)
         self.last_snapshot: OperationSnapshot | None = None
         self.last_critical_outcome: dict[str, Any] | None = None
+        self.last_profile_evidence: ProfileEvidenceEnvelope | None = None
         self.last_validation: dict[str, Any] | None = None
         self.last_checks: dict[str, Any] | None = None
         self.last_effects: list[EffectReceipt] = []
@@ -560,6 +571,9 @@ class RemediationCompleter:
         critical = getattr(delivery, "last_critical_outcome", None)
         if isinstance(critical, dict):
             self.last_critical_outcome = critical
+        profile_evidence = getattr(delivery, "last_profile_evidence", None)
+        if isinstance(profile_evidence, ProfileEvidenceEnvelope):
+            self.last_profile_evidence = profile_evidence
         validation = getattr(delivery, "last_validation", None)
         if isinstance(validation, dict):
             self.last_validation = validation
@@ -718,6 +732,7 @@ class RemediationCompleter:
             self.resolver,
             pr_effect=cast(Any, ReuseExistingOpenPrEffect(self.resolver)),
             checks_gate=self.checks_gate,
+            policy_registry=self.policy_registry,
             require_existing_open_pr=True,
             candidate_recorder=record_candidate,
         )

--- a/tools/agent_workflow/lck_core/remediation.py
+++ b/tools/agent_workflow/lck_core/remediation.py
@@ -24,6 +24,7 @@ from .profile_policies import (
     DEFAULT_PROFILE_POLICY_REGISTRY,
     ProfileEvidenceEnvelope,
     ProfilePolicyRegistry,
+    ProfileResolver,
 )
 from .review_workspace import ReviewInvocationStore, _identity_from_mapping
 from .state import (
@@ -160,10 +161,16 @@ class RemediationPreparer:
         *,
         eligibility: PhaseEligibilityResolver | None = None,
         store: ReviewInvocationStore | None = None,
+        profile_resolver: ProfileResolver | None = None,
     ) -> None:
         self.resolver = resolver
         self.snapshots = OperationSnapshotBuilder(resolver)
-        self.eligibility = eligibility or PhaseEligibilityResolver()
+        selected_profile_resolver = profile_resolver or getattr(
+            eligibility, "profile_resolver", None
+        )
+        self.eligibility = eligibility or PhaseEligibilityResolver(
+            profile_resolver=selected_profile_resolver
+        )
         self.store = store or ReviewInvocationStore(resolver.repo_root)
         self.last_snapshot: OperationSnapshot | None = None
 
@@ -342,10 +349,16 @@ class RemediationNoChangeCompleter:
         *,
         eligibility: PhaseEligibilityResolver | None = None,
         store: ReviewInvocationStore | None = None,
+        profile_resolver: ProfileResolver | None = None,
     ) -> None:
         self.resolver = resolver
         self.snapshots = OperationSnapshotBuilder(resolver)
-        self.eligibility = eligibility or PhaseEligibilityResolver()
+        selected_profile_resolver = profile_resolver or getattr(
+            eligibility, "profile_resolver", None
+        )
+        self.eligibility = eligibility or PhaseEligibilityResolver(
+            profile_resolver=selected_profile_resolver
+        )
         self.store = store or ReviewInvocationStore(resolver.repo_root)
         self.last_snapshot: OperationSnapshot | None = None
 
@@ -547,12 +560,17 @@ class RemediationCompleter:
         store: ReviewInvocationStore | None = None,
         checks_gate: DeliveryChecksGate | None = None,
         policy_registry: ProfilePolicyRegistry | None = None,
+        profile_resolver: ProfileResolver | None = None,
     ) -> None:
         self.resolver = resolver
         self.snapshots = OperationSnapshotBuilder(resolver)
         self.policy_registry = policy_registry or DEFAULT_PROFILE_POLICY_REGISTRY
+        self.profile_resolver = profile_resolver or getattr(
+            eligibility, "profile_resolver", None
+        )
         self.eligibility = eligibility or PhaseEligibilityResolver(
-            registry=self.policy_registry
+            registry=self.policy_registry,
+            profile_resolver=profile_resolver,
         )
         self.store = store or ReviewInvocationStore(resolver.repo_root)
         self.checks_gate = checks_gate or DeliveryChecksGate(resolver)
@@ -733,6 +751,7 @@ class RemediationCompleter:
             pr_effect=cast(Any, ReuseExistingOpenPrEffect(self.resolver)),
             checks_gate=self.checks_gate,
             policy_registry=self.policy_registry,
+            profile_resolver=self.profile_resolver,
             require_existing_open_pr=True,
             candidate_recorder=record_candidate,
         )

--- a/tools/agent_workflow/workflow_evidence.py
+++ b/tools/agent_workflow/workflow_evidence.py
@@ -1452,7 +1452,14 @@ def _formal_blockers_gate(
                 unknown_state += 1
                 continue
             profile = profile_resolution.profile
-            contract_check = validate_profile_contract(profile, item)
+            # Task Critical Outcome is a leaf-entry contract, not a dependency
+            # blocker policy. Its dependency semantics remain shared until the
+            # typed blocker migration owned by the follow-up blocker Task.
+            contract_check = (
+                validate_profile_contract(profile, item)
+                if profile.contract_policy is not None
+                else None
+            )
             if contract_check is not None and not contract_check.valid:
                 if contract_check.policy == "bug":
                     bug_contract_unknown += 1


### PR DESCRIPTION
Closes #217

## Summary
Add an explicit injectable leaf policy registry, typed blocker and four-stage profile evidence contracts, and propagate generic candidate evidence through Delivery, Remediation, and receipts while preserving legacy projections.

## Validation
- Critical Outcome: pass
- Formal Delivery validation: pass

## Risks / limitations
Review and completion stages remain intentionally empty for follow-up Task #219; mixed Research dependency blocker semantics remain owned by follow-up Task #220.
