### PR TITLE
[Task] 将 Typed Profile 特有能力移出 LCK Phase Controller

### DIFF
--- a/tests/tools/test_lck_documentation.py
+++ b/tests/tools/test_lck_documentation.py
@@ -28,7 +28,7 @@ from lck_core import (  # type: ignore[import-not-found]  # noqa: E402
     issue_profiles as lck_profiles,
 )
 from lck_core.models import Phase  # type: ignore[import-not-found]  # noqa: E402
-from lck_core.validation import (  # type: ignore[import-not-found]  # noqa: E402
+from lck_core.profile_policies import (  # type: ignore[import-not-found]  # noqa: E402
     DocumentationReclassificationRequired,
     DocumentationValidationGate,
 )
@@ -116,10 +116,7 @@ def test_documentation_profile_uses_shared_lifecycle_without_critical_outcome(
 
     completer = lck_delivery.DeliveryCompleter(
         resolver,
-        documentation_validation=cast(Any, DocumentationGate()),
-    )
-    completer._run_critical_outcome = lambda *_args, **_kwargs: pytest.fail(
-        "Documentation must not invoke Critical Outcome"
+        services=(DocumentationGate(),),
     )
     result = completer._run_profile_gates(
         state,

--- a/tests/tools/test_lck_profile_architecture.py
+++ b/tests/tools/test_lck_profile_architecture.py
@@ -175,7 +175,8 @@ class SyntheticPolicy:
         leaf_contract: Mapping[str, Any],
         completion_input: Mapping[str, Any],
     ) -> ProfileEvidenceRecord:
-        del context, completion_input
+        assert context.runner is None
+        del completion_input
         descriptor = ProfileEffectDescriptor(
             effect_kind="synthetic.noop.v1",
             schema_version=1,
@@ -489,6 +490,11 @@ def test_synthetic_policy_review_completion_and_effect_are_generic_capabilities(
             "review_evidence": review.evidence,
         },
         registry=registry,
+        context=PolicyContext(
+            profile=profile,
+            issue=leaf_contract,
+            runner=object(),
+        ),
     )
     assert completion.effect is not None
     assert completion.profile_evidence is not None
@@ -508,12 +514,42 @@ def test_synthetic_policy_review_completion_and_effect_are_generic_capabilities(
         state=object(),
     )
     assert receipt.action == "executed"
+    assert receipt.is_complete
+    assert not lck_models.EffectReceipt("synthetic.noop.v1", "pending", {}).is_complete
     with pytest.raises(lck_models.LckStopError, match="unknown completion effect"):
         effects.execute(
             replace(completion.effect, effect_kind="synthetic.unknown.v1"),
             resolver=object(),
             state=object(),
         )
+
+
+def test_merge_preflight_propagates_policy_injection_to_default_review_gate(
+    tmp_path: Path,
+) -> None:
+    policy = SyntheticPolicy()
+    registry = ProfilePolicyRegistry.from_policies(policy)
+
+    def resolve_synthetic(_issue: Mapping[str, Any] | None) -> IssueProfileResolution:
+        return IssueProfileResolution(
+            status=IssueProfileResolutionStatus.RESOLVED,
+            profile=replace(
+                issue_profiles.TASK_PROFILE,
+                profile_id=policy.profile_id,
+                canonical_type_label=policy.canonical_type_label,
+            ),
+            type_labels=(policy.canonical_type_label,),
+        )
+
+    preflight = lck_review.MergePreflight(
+        StaticResolver(tmp_path, _review_state()),
+        policy_registry=registry,
+        profile_resolver=resolve_synthetic,
+    )
+
+    assert isinstance(preflight.review_gate, lck_review.ReviewPassGate)
+    assert preflight.review_gate.policy_registry is registry
+    assert preflight.review_gate.profile_resolver is resolve_synthetic
 
 
 def test_synthetic_policy_dispatches_through_delivery_remediation_and_receipts(

--- a/tests/tools/test_lck_profile_architecture.py
+++ b/tests/tools/test_lck_profile_architecture.py
@@ -59,7 +59,7 @@ from lck_test_support import (  # noqa: E402
 
 
 def test_all_phase_controllers_use_only_generic_policy_capabilities() -> None:
-    """Shared lifecycle controllers must not import concrete profile policies."""
+    """Shared lifecycle controllers must not dispatch concrete profile capabilities."""
     controller_names = (
         "delivery.py",
         "review.py",
@@ -72,10 +72,24 @@ def test_all_phase_controllers_use_only_generic_policy_capabilities() -> None:
         "documentation_policy",
         "research_policy",
     }
+    forbidden_capability_names = {
+        "CriticalOutcomeGate",
+        "DocumentationReclassificationRequired",
+        "DocumentationValidationGate",
+        "ResearchOutcomeEffect",
+        "ResearchOutcomeRequired",
+        "ResearchReclassificationRequired",
+        "ResearchValidationGate",
+        "_run_critical_outcome",
+    }
     controller_root = ROOT / "tools" / "agent_workflow" / "lck_core"
 
     for name in controller_names:
-        tree = ast.parse((controller_root / name).read_text(encoding="utf-8"))
+        source = (controller_root / name).read_text(encoding="utf-8")
+        assert not any(
+            capability in source for capability in forbidden_capability_names
+        ), name
+        tree = ast.parse(source)
         for node in ast.walk(tree):
             if isinstance(node, ast.Import):
                 imported = {alias.name.split(".", 1)[0] for alias in node.names}
@@ -83,6 +97,8 @@ def test_all_phase_controllers_use_only_generic_policy_capabilities() -> None:
             elif isinstance(node, ast.ImportFrom):
                 module = (node.module or "").split(".")[-1]
                 assert module not in forbidden_modules, name
+            elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                assert node.name != "__getattr__", name
 
 
 @dataclass(frozen=True)

--- a/tests/tools/test_lck_profile_architecture.py
+++ b/tests/tools/test_lck_profile_architecture.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import ast
 import sys
 from dataclasses import dataclass, replace
 from pathlib import Path
@@ -19,6 +20,7 @@ if AGENT_WORKFLOW not in sys.path:
 
 from lck_core import (  # type: ignore[import-not-found]  # noqa: E402
     delivery as lck_delivery,
+    effects as lck_effects,
     issue_profiles,
     models as lck_models,
     receipts as lck_receipts,
@@ -32,12 +34,15 @@ from lck_core.profile_policies import (  # type: ignore[import-not-found]  # noq
     DEFAULT_PROFILE_POLICY_REGISTRY,
     PolicyBlocker,
     PolicyContext,
+    ProfileEffectDescriptor,
     ProfileEvidenceEnvelope,
     ProfileEvidenceRecord,
     ProfilePolicyRegistry,
     evaluate_profile_blockers,
+    validate_profile_completion,
     validate_profile_candidate,
     validate_profile_contract,
+    validate_profile_review,
     run_profile_delivery_gates,
 )
 from workflow_common import (  # type: ignore[import-not-found]  # noqa: E402
@@ -50,6 +55,33 @@ from lck_test_support import (  # noqa: E402
 )
 
 
+def test_all_phase_controllers_use_only_generic_policy_capabilities() -> None:
+    """Shared lifecycle controllers must not import concrete profile policies."""
+    controller_names = (
+        "delivery.py",
+        "review.py",
+        "review_workspace.py",
+        "validation.py",
+        "closeout.py",
+    )
+    forbidden_modules = {
+        "critical_outcome",
+        "documentation_policy",
+        "research_policy",
+    }
+    controller_root = ROOT / "tools" / "agent_workflow" / "lck_core"
+
+    for name in controller_names:
+        tree = ast.parse((controller_root / name).read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported = {alias.name.split(".", 1)[0] for alias in node.names}
+                assert imported.isdisjoint(forbidden_modules), name
+            elif isinstance(node, ast.ImportFrom):
+                module = (node.module or "").split(".")[-1]
+                assert module not in forbidden_modules, name
+
+
 @dataclass(frozen=True)
 class SyntheticPolicy:
     """A fifth policy proving the injection seam is independent of production."""
@@ -58,6 +90,8 @@ class SyntheticPolicy:
     canonical_type_label: str = "type:synthetic"
     contract_kind: str = "synthetic.contract.v1"
     candidate_kind: str = "synthetic.candidate.v1"
+    review_kind: str = "synthetic.review.v1"
+    completion_kind: str = "synthetic.completion.v1"
 
     def validate_contract(
         self, context: PolicyContext, leaf_contract: Mapping[str, Any]
@@ -110,6 +144,57 @@ class SyntheticPolicy:
             },
         )
 
+    def validate_review(
+        self,
+        context: PolicyContext,
+        leaf_contract: Mapping[str, Any],
+        review_input: Mapping[str, Any],
+    ) -> ProfileEvidenceRecord:
+        del context
+        return ProfileEvidenceRecord(
+            self.review_kind,
+            1,
+            {
+                "policy_id": self.profile_id,
+                "contract_ref": {
+                    "number": leaf_contract["number"],
+                    "body_sha256": leaf_contract["body_sha256"],
+                },
+                "result": {"status": "pass"},
+                "status": "pass",
+                "review_input": dict(review_input),
+            },
+        )
+
+    def validate_completion(
+        self,
+        context: PolicyContext,
+        leaf_contract: Mapping[str, Any],
+        completion_input: Mapping[str, Any],
+    ) -> ProfileEvidenceRecord:
+        del context, completion_input
+        descriptor = ProfileEffectDescriptor(
+            effect_kind="synthetic.noop.v1",
+            schema_version=1,
+            parameters={"value": "complete"},
+            postcondition={"kind": "synthetic.completed", "value": "complete"},
+            receipt={"source": "synthetic-policy"},
+        )
+        return ProfileEvidenceRecord(
+            self.completion_kind,
+            1,
+            {
+                "policy_id": self.profile_id,
+                "contract_ref": {
+                    "number": leaf_contract["number"],
+                    "body_sha256": leaf_contract["body_sha256"],
+                },
+                "result": {"status": "pass"},
+                "status": "pass",
+                "effect": descriptor.to_dict(),
+            },
+        )
+
     def validate_evidence(self, record: ProfileEvidenceRecord) -> bool:
         if (
             record.schema_version != 1
@@ -127,6 +212,19 @@ class SyntheticPolicy:
                 record.payload.get("status") == "pass"
                 and isinstance(result, Mapping)
                 and dict(result) == {"status": "pass"}
+            )
+        if record.kind == self.review_kind:
+            return (
+                record.payload.get("status") == "pass"
+                and isinstance(record.payload.get("result"), Mapping)
+                and record.payload["result"].get("status") == "pass"
+            )
+        if record.kind == self.completion_kind:
+            return (
+                record.payload.get("status") == "pass"
+                and isinstance(record.payload.get("result"), Mapping)
+                and record.payload["result"].get("status") == "pass"
+                and isinstance(record.payload.get("effect"), Mapping)
             )
         return False
 
@@ -279,6 +377,70 @@ def test_profile_registry_rejects_conflicting_canonical_labels() -> None:
     second = SyntheticPolicy(profile_id="synthetic-b")
     with pytest.raises(ValueError, match="duplicate canonical type label"):
         ProfilePolicyRegistry.from_policies(first, second)
+
+
+def test_synthetic_policy_review_completion_and_effect_are_generic_capabilities() -> (
+    None
+):
+    policy = SyntheticPolicy()
+    registry = ProfilePolicyRegistry.from_policies(policy)
+    profile = replace(
+        issue_profiles.TASK_PROFILE,
+        profile_id=policy.profile_id,
+        canonical_type_label=policy.canonical_type_label,
+        candidate_capability="synthetic_candidate",
+        requires_critical_outcome=False,
+    )
+    leaf_contract = {
+        "number": 219,
+        "body": "synthetic lifecycle contract",
+        "body_sha256": "a" * 64,
+    }
+
+    review = validate_profile_review(
+        profile,
+        leaf_contract,
+        {"verdict": "PASS", "review_input": "bounded"},
+        registry=registry,
+    )
+    assert review.evidence is not None
+    assert review.profile_evidence is not None
+    assert review.profile_evidence.review == review.evidence
+
+    completion = validate_profile_completion(
+        profile,
+        leaf_contract,
+        {
+            "task_number": 219,
+            "repository": "PhoenixSss/tracequant",
+            "review_evidence": review.evidence,
+        },
+        registry=registry,
+    )
+    assert completion.effect is not None
+    assert completion.profile_evidence is not None
+    assert completion.profile_evidence.completion == completion.evidence
+
+    def execute_effect(
+        _descriptor: ProfileEffectDescriptor, **_kwargs: Any
+    ) -> lck_models.EffectReceipt:
+        return lck_models.EffectReceipt(
+            "synthetic.noop.v1", "executed", {"source": "test"}
+        )
+
+    effects = lck_effects.EffectExecutorRegistry({"synthetic.noop.v1": execute_effect})
+    receipt = effects.execute(
+        completion.effect,
+        resolver=object(),
+        state=object(),
+    )
+    assert receipt.action == "executed"
+    with pytest.raises(lck_models.LckStopError, match="unknown completion effect"):
+        effects.execute(
+            replace(completion.effect, effect_kind="synthetic.unknown.v1"),
+            resolver=object(),
+            state=object(),
+        )
 
 
 def test_synthetic_policy_dispatches_through_delivery_remediation_and_receipts(

--- a/tests/tools/test_lck_profile_architecture.py
+++ b/tests/tools/test_lck_profile_architecture.py
@@ -19,12 +19,14 @@ if AGENT_WORKFLOW not in sys.path:
     sys.path.insert(0, AGENT_WORKFLOW)
 
 from lck_core import (  # type: ignore[import-not-found]  # noqa: E402
+    closeout as lck_closeout,
     delivery as lck_delivery,
     effects as lck_effects,
     issue_profiles,
     models as lck_models,
     receipts as lck_receipts,
     remediation as lck_remediation,
+    review as lck_review,
 )
 from lck_core.issue_profiles import (  # type: ignore[import-not-found]  # noqa: E402
     IssueProfileResolution,
@@ -227,6 +229,54 @@ class SyntheticPolicy:
                 and isinstance(record.payload.get("effect"), Mapping)
             )
         return False
+
+
+def test_review_and_closeout_propagate_policy_injection_to_eligibility(
+    tmp_path: Path,
+) -> None:
+    policy = SyntheticPolicy()
+    registry = ProfilePolicyRegistry.from_policies(policy)
+    profile = replace(
+        issue_profiles.TASK_PROFILE,
+        profile_id=policy.profile_id,
+        canonical_type_label=policy.canonical_type_label,
+        candidate_capability="synthetic_candidate",
+        requires_critical_outcome=False,
+    )
+
+    def resolve_synthetic(_issue: Mapping[str, Any] | None) -> IssueProfileResolution:
+        return IssueProfileResolution(
+            status=IssueProfileResolutionStatus.RESOLVED,
+            profile=profile,
+            type_labels=(profile.canonical_type_label,),
+        )
+
+    resolver = StaticResolver(tmp_path, _review_state())
+    preparer = lck_review.ReviewPreparer(
+        resolver,
+        policy_registry=registry,
+        profile_resolver=resolve_synthetic,
+    )
+    completer = lck_review.ReviewCompleter(
+        resolver,
+        policy_registry=registry,
+        profile_resolver=resolve_synthetic,
+    )
+    closeout = lck_closeout.CloseoutCompleter(
+        resolver,
+        policy_registry=registry,
+        profile_resolver=resolve_synthetic,
+    )
+
+    for controller, phase in (
+        (preparer, lck_models.Phase.REVIEW_PREPARE),
+        (completer, lck_models.Phase.REVIEW_COMPLETE),
+        (closeout, lck_models.Phase.CLOSEOUT),
+    ):
+        assert controller.eligibility.registry is registry
+        assert controller.eligibility.profile_resolver is resolve_synthetic
+        decision = controller.eligibility.resolve(resolver.state, phase)
+        assert decision.issue_profile["profile"]["profile_id"] == policy.profile_id
 
 
 def test_synthetic_policy_contract_blocker_candidate_use_frozen_registry_and_envelope() -> (

--- a/tests/tools/test_lck_profile_architecture.py
+++ b/tests/tools/test_lck_profile_architecture.py
@@ -39,6 +39,7 @@ from lck_core.profile_policies import (  # type: ignore[import-not-found]  # noq
     ProfileEffectDescriptor,
     ProfileEvidenceEnvelope,
     ProfileEvidenceRecord,
+    ProfilePolicyError,
     ProfilePolicyRegistry,
     evaluate_profile_blockers,
     validate_profile_completion,
@@ -229,6 +230,28 @@ class SyntheticPolicy:
                 and isinstance(record.payload.get("effect"), Mapping)
             )
         return False
+
+
+@pytest.mark.parametrize(
+    "profile",
+    (
+        issue_profiles.TASK_PROFILE,
+        issue_profiles.BUG_PROFILE,
+        issue_profiles.DOCUMENTATION_PROFILE,
+    ),
+)
+def test_non_research_review_rejects_research_outcome_at_generic_policy_boundary(
+    profile: issue_profiles.LeafIssueWorkflowProfile,
+) -> None:
+    with pytest.raises(
+        ProfilePolicyError,
+        match="--research-outcome is supported only for Research Issues",
+    ):
+        validate_profile_review(
+            profile,
+            {"number": 219, "body_sha256": "a" * 64},
+            {"verdict": "PASS", "research_outcome": "IMPLEMENT"},
+        )
 
 
 def test_review_and_closeout_propagate_policy_injection_to_eligibility(

--- a/tests/tools/test_lck_remediation.py
+++ b/tests/tools/test_lck_remediation.py
@@ -21,13 +21,11 @@ from lck_core import (  # type: ignore[import-not-found]  # noqa: E402
     effects as lck_effects,
     eligibility as lck_eligibility,
     models as lck_models,
+    profile_policies as lck_profile_policies,
     remediation as lck_remediation,
     review as lck_review,
     review_workspace as lck_review_workspace,
     validation as lck_validation,
-)
-from workflow_common import (  # type: ignore[import-not-found]  # noqa: E402
-    ProgressReporter,
 )
 from lck_test_support import (  # noqa: E402
     FakeRunner,
@@ -761,15 +759,16 @@ def test_remediation_complete_recovers_exact_owned_partial_effect_candidate(
     )
     calls = {"critical": 0, "validation": 0}
 
-    def critical_outcome(
-        _self: lck_delivery.DeliveryCompleter,
-        _state: lck_models.LiveState,
-        *,
-        progress: ProgressReporter | None = None,
-    ) -> dict[str, Any]:
-        del progress
+    class CriticalResult:
+        status = "pass"
+        exit_code = 0
+
+        def to_dict(self) -> dict[str, Any]:
+            return {"status": self.status, "exit_code": self.exit_code}
+
+    def verify_critical_outcome(*_args: Any, **_kwargs: Any) -> CriticalResult:
         calls["critical"] += 1
-        return {"status": "pass"}
+        return CriticalResult()
 
     def formal_validation(
         _self: lck_validation.FormalValidationGate, base_sha: str
@@ -779,7 +778,7 @@ def test_remediation_complete_recovers_exact_owned_partial_effect_candidate(
         return {"status": "pass"}
 
     monkeypatch.setattr(
-        lck_delivery.DeliveryCompleter, "_run_critical_outcome", critical_outcome
+        lck_profile_policies, "verify_critical_outcome", verify_critical_outcome
     )
     monkeypatch.setattr(lck_validation.FormalValidationGate, "run", formal_validation)
 

--- a/tests/tools/test_lck_research.py
+++ b/tests/tools/test_lck_research.py
@@ -22,6 +22,8 @@ from lck_core import (  # type: ignore[import-not-found]  # noqa: E402
     closeout as lck_closeout,
     delivery as lck_delivery,
     eligibility as lck_eligibility,
+    effects as lck_effects,
+    issue_profiles,
     models as lck_models,
     review as lck_review,
     review_workspace as lck_review_workspace,
@@ -41,6 +43,10 @@ from research_policy import (  # type: ignore[import-not-found]  # noqa: E402
     research_contract_snapshot,
     research_template_contract,
     require_typed_research_outcome,
+)
+from lck_core.profile_policies import (  # type: ignore[import-not-found]  # noqa: E402
+    ProfileEffectDescriptor,
+    validate_profile_completion,
 )
 from workflow_evidence import (  # type: ignore[import-not-found]  # noqa: E402
     _formal_blockers_gate,
@@ -515,6 +521,85 @@ def test_research_profile_binds_typed_outcome_to_reviewed_artifact(
     assert blocker_gate["status"] == "pass"
 
 
+def test_research_completion_rejects_artifact_divergence_from_review_identity(
+    tmp_path: Path,
+) -> None:
+    artifact_path = tmp_path / "docs" / "research" / "report.md"
+    artifact_path.parent.mkdir(parents=True)
+    artifact_path.write_text(
+        "# Research report\n\nResearch Outcome: IMPLEMENT\n",
+        encoding="utf-8",
+    )
+    body_sha = sha256_json({"body": RESEARCH_BODY})
+    head_sha = "c" * 40
+    binding = research_artifact_binding(
+        tmp_path,
+        task_number=199,
+        pr_number=299,
+        base_sha=SHA,
+        head_sha=head_sha,
+        task_body_sha256=body_sha,
+        merge_base_sha=SHA,
+        effective_diff_sha256=DIGEST,
+        changed_files=("docs/research/report.md",),
+    )
+    identity = {
+        "task_number": 199,
+        "pr_number": 299,
+        "base_sha": SHA,
+        "head_sha": head_sha,
+        "task_body_sha256": body_sha,
+        "merge_base_sha": SHA,
+        "effective_diff_sha256": DIGEST,
+        "changed_files": ["docs/research/report.md"],
+        "research_artifact": binding,
+    }
+    issue = {
+        "number": 199,
+        "body_sha256": body_sha,
+        "research_contract": research_contract_snapshot(RESEARCH_BODY),
+    }
+    completion_input = {
+        "task_number": 199,
+        "repository": "owner/repo",
+        "merged_pr": {
+            "number": 299,
+            "baseRefOid": SHA,
+            "headRefOid": head_sha,
+        },
+        "review_record": {
+            "identity": identity,
+            "research_artifact": binding,
+        },
+    }
+
+    result = validate_profile_completion(
+        issue_profiles.RESEARCH_PROFILE,
+        issue,
+        completion_input,
+    )
+    assert result.effect is not None
+
+    tampered = dict(binding)
+    tampered["artifact_sha256"] = "f" * 64
+    tampered_input = {
+        **completion_input,
+        "review_record": {
+            "identity": identity,
+            "research_artifact": tampered,
+        },
+    }
+    with pytest.raises(
+        lck_models.LckStopError,
+        match="diverges from the reviewed identity",
+    ):
+        validate_profile_completion(
+            issue_profiles.RESEARCH_PROFILE,
+            issue,
+            tampered_input,
+        )
+
+
 def test_research_blocker_uses_only_the_canonical_project_outcome() -> None:
     class Runner:
         def run(self, argv: Any, *, command_id: str, **_: Any) -> CommandResult:
@@ -668,6 +753,95 @@ def test_research_outcome_postcondition_paginates_past_first_page() -> None:
     assert outcome == "IMPLEMENT"
     assert len(runner.calls) == 2
     assert "userAfter=cursor-page-1" in runner.calls[1]
+
+
+def test_research_outcome_effect_uses_normalized_state_field_for_idempotency() -> None:
+    class Runner:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, ...]] = []
+
+        def run(self, argv: Any, *, command_id: str, **_: Any) -> CommandResult:
+            command = tuple(str(item) for item in argv)
+            self.calls.append(command)
+            if command[:3] != ("gh", "api", "graphql"):
+                raise AssertionError(f"unexpected Project write: {command}")
+            return CommandResult(
+                command_id,
+                command,
+                0,
+                json.dumps(
+                    {
+                        "data": {
+                            "user": {
+                                "projectV2": {
+                                    "items": {
+                                        "nodes": [
+                                            {
+                                                "content": {
+                                                    "number": 199,
+                                                    "repository": {
+                                                        "nameWithOwner": "owner/repo"
+                                                    },
+                                                },
+                                                "fieldValueByName": {
+                                                    "name": "IMPLEMENT"
+                                                },
+                                            }
+                                        ],
+                                        "pageInfo": {
+                                            "hasNextPage": False,
+                                            "endCursor": None,
+                                        },
+                                    }
+                                }
+                            },
+                            "organization": None,
+                        }
+                    }
+                ),
+                "",
+            )
+
+    descriptor = ProfileEffectDescriptor(
+        effect_kind="project.single_select.set.v1",
+        schema_version=1,
+        parameters={
+            "repository": "owner/repo",
+            "task_number": 199,
+            "project_number": 1,
+            "field": "Research Outcome",
+            "value": "IMPLEMENT",
+        },
+        postcondition={
+            "kind": "project.single_select.equals",
+            "repository": "owner/repo",
+            "task_number": 199,
+            "project_number": 1,
+            "field": "Research Outcome",
+            "value": "IMPLEMENT",
+        },
+        receipt={"outcome": "IMPLEMENT"},
+    )
+    runner = Runner()
+    resolver = type("Resolver", (), {"runner": runner})()
+    state = type(
+        "State",
+        (),
+        {
+            "repository": "owner/repo",
+            "task_number": 199,
+            "issue": {"research_outcome": "IMPLEMENT"},
+        },
+    )()
+
+    receipt = lck_effects.DEFAULT_EFFECT_EXECUTOR_REGISTRY.execute(
+        descriptor,
+        resolver=cast(Any, resolver),
+        state=cast(Any, state),
+    )
+
+    assert receipt.action == "already-set"
+    assert len(runner.calls) == 1
 
 
 def test_research_artifact_binding_rejects_non_utf8_as_policy_error(

--- a/tests/tools/test_lck_research.py
+++ b/tests/tools/test_lck_research.py
@@ -242,7 +242,11 @@ def test_research_profile_binds_typed_outcome_to_reviewed_artifact(
                                                         },
                                                     },
                                                     "fieldValueByName": {
-                                                        "name": "IMPLEMENT"
+                                                        "name": (
+                                                            "IMPLEMENT"
+                                                            if self.project_writes
+                                                            else "DO NOT IMPLEMENT"
+                                                        )
                                                     },
                                                 }
                                             ],
@@ -755,7 +759,7 @@ def test_research_outcome_postcondition_paginates_past_first_page() -> None:
     assert "userAfter=cursor-page-1" in runner.calls[1]
 
 
-def test_research_outcome_effect_uses_normalized_state_field_for_idempotency() -> None:
+def test_research_outcome_effect_uses_canonical_read_for_idempotency() -> None:
     class Runner:
         def __init__(self) -> None:
             self.calls: list[tuple[str, ...]] = []
@@ -830,7 +834,7 @@ def test_research_outcome_effect_uses_normalized_state_field_for_idempotency() -
         {
             "repository": "owner/repo",
             "task_number": 199,
-            "issue": {"research_outcome": "IMPLEMENT"},
+            "issue": {"research_outcome": "DO NOT IMPLEMENT"},
         },
     )()
 
@@ -842,6 +846,104 @@ def test_research_outcome_effect_uses_normalized_state_field_for_idempotency() -
 
     assert receipt.action == "already-set"
     assert len(runner.calls) == 1
+
+
+def test_research_outcome_effect_writes_when_only_noncanonical_state_matches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Runner:
+        def __init__(self) -> None:
+            self.queries = 0
+
+        def run(self, argv: Any, *, command_id: str, **_: Any) -> CommandResult:
+            command = tuple(str(item) for item in argv)
+            assert command[:3] == ("gh", "api", "graphql")
+            self.queries += 1
+            outcome = "DO NOT IMPLEMENT" if self.queries == 1 else "IMPLEMENT"
+            return CommandResult(
+                command_id,
+                command,
+                0,
+                json.dumps(
+                    {
+                        "data": {
+                            "user": {
+                                "projectV2": {
+                                    "items": {
+                                        "nodes": [
+                                            {
+                                                "content": {
+                                                    "number": 199,
+                                                    "repository": {
+                                                        "nameWithOwner": "owner/repo"
+                                                    },
+                                                },
+                                                "fieldValueByName": {"name": outcome},
+                                            }
+                                        ],
+                                        "pageInfo": {
+                                            "hasNextPage": False,
+                                            "endCursor": None,
+                                        },
+                                    }
+                                }
+                            },
+                            "organization": None,
+                        }
+                    }
+                ),
+                "",
+            )
+
+    descriptor = ProfileEffectDescriptor(
+        effect_kind="project.single_select.set.v1",
+        schema_version=1,
+        parameters={
+            "repository": "owner/repo",
+            "task_number": 199,
+            "project_number": 1,
+            "field": "Research Outcome",
+            "value": "IMPLEMENT",
+        },
+        postcondition={
+            "kind": "project.single_select.equals",
+            "repository": "owner/repo",
+            "task_number": 199,
+            "project_number": 1,
+            "field": "Research Outcome",
+            "value": "IMPLEMENT",
+        },
+        receipt={"outcome": "IMPLEMENT"},
+    )
+    writes: list[tuple[str, int, int, str, str]] = []
+    monkeypatch.setattr(
+        lck_effects,
+        "set_project_status_with_runner",
+        lambda _runner, repository, task_number, *, project_number, field, value: (
+            writes.append((repository, task_number, project_number, field, value))
+        ),
+    )
+    runner = Runner()
+    resolver = type("Resolver", (), {"runner": runner})()
+    state = type(
+        "State",
+        (),
+        {
+            "repository": "owner/repo",
+            "task_number": 199,
+            "issue": {"research_outcome": "IMPLEMENT"},
+        },
+    )()
+
+    receipt = lck_effects.DEFAULT_EFFECT_EXECUTOR_REGISTRY.execute(
+        descriptor,
+        resolver=cast(Any, resolver),
+        state=cast(Any, state),
+    )
+
+    assert receipt.action == "updated"
+    assert writes == [("owner/repo", 199, 1, "Research Outcome", "IMPLEMENT")]
+    assert runner.queries == 2
 
 
 def test_research_outcome_pending_receipt_preserves_descriptor_metadata() -> None:

--- a/tests/tools/test_lck_research.py
+++ b/tests/tools/test_lck_research.py
@@ -27,7 +27,6 @@ from lck_core import (  # type: ignore[import-not-found]  # noqa: E402
     models as lck_models,
     review as lck_review,
     review_workspace as lck_review_workspace,
-    validation as lck_validation,
 )
 from lck_test_support import FakeReviewWorkspace  # noqa: E402
 from research_policy import (  # type: ignore[import-not-found]  # noqa: E402
@@ -46,6 +45,7 @@ from research_policy import (  # type: ignore[import-not-found]  # noqa: E402
 )
 from lck_core.profile_policies import (  # type: ignore[import-not-found]  # noqa: E402
     ProfileEffectDescriptor,
+    ResearchValidationGate,
     validate_profile_completion,
 )
 from workflow_evidence import (  # type: ignore[import-not-found]  # noqa: E402
@@ -385,7 +385,7 @@ def test_research_profile_binds_typed_outcome_to_reviewed_artifact(
         pr_effect=cast(Any, PR()),
         status_effect=cast(Any, Status()),
         checks_gate=cast(Any, Checks()),
-        research_validation=lck_validation.ResearchValidationGate(resolver),
+        services=(ResearchValidationGate(resolver),),
     )
     delivery_result = delivery.complete(
         199,
@@ -750,7 +750,9 @@ def test_research_outcome_postcondition_paginates_past_first_page() -> None:
     runner = Runner()
     resolver = type("Resolver", (), {"runner": runner})()
 
-    outcome = lck_closeout.ResearchOutcomeEffect(cast(Any, resolver))._query_outcome(
+    from lck_core.profile_policies import ResearchOutcomeEffect
+
+    outcome = ResearchOutcomeEffect(cast(Any, resolver))._query_outcome(
         "owner/repo", 199
     )
 

--- a/tests/tools/test_lck_research.py
+++ b/tests/tools/test_lck_research.py
@@ -844,6 +844,70 @@ def test_research_outcome_effect_uses_normalized_state_field_for_idempotency() -
     assert len(runner.calls) == 1
 
 
+def test_research_outcome_pending_receipt_preserves_descriptor_metadata() -> None:
+    class Runner:
+        def run(self, argv: Any, *, command_id: str, **_: Any) -> CommandResult:
+            command = tuple(str(item) for item in argv)
+            if command[:3] == ("gh", "project", "item-edit"):
+                return CommandResult(command_id, command, 0, "", "")
+            if command[:3] == ("gh", "api", "graphql"):
+                return CommandResult(
+                    command_id,
+                    command,
+                    0,
+                    json.dumps(
+                        {
+                            "data": {
+                                "user": None,
+                                "organization": None,
+                            }
+                        }
+                    ),
+                    "",
+                )
+            raise AssertionError(f"unexpected command: {command}")
+
+    descriptor = ProfileEffectDescriptor(
+        effect_kind="project.single_select.set.v1",
+        schema_version=1,
+        parameters={
+            "repository": "owner/repo",
+            "task_number": 199,
+            "project_number": 1,
+            "field": "Research Outcome",
+            "value": "IMPLEMENT",
+        },
+        postcondition={
+            "kind": "project.single_select.equals",
+            "repository": "owner/repo",
+            "task_number": 199,
+            "project_number": 1,
+            "field": "Research Outcome",
+            "value": "IMPLEMENT",
+        },
+        receipt={"outcome": "IMPLEMENT"},
+    )
+    resolver = type("Resolver", (), {"runner": Runner()})()
+    state = type(
+        "State",
+        (),
+        {
+            "repository": "owner/repo",
+            "task_number": 199,
+            "issue": {},
+        },
+    )()
+
+    receipt = lck_effects.DEFAULT_EFFECT_EXECUTOR_REGISTRY.execute(
+        descriptor,
+        resolver=cast(Any, resolver),
+        state=cast(Any, state),
+    )
+
+    assert receipt.action == "pending"
+    assert receipt.details["outcome"] == "IMPLEMENT"
+
+
 def test_research_artifact_binding_rejects_non_utf8_as_policy_error(
     tmp_path: Path,
 ) -> None:

--- a/tests/tools/test_lck_review.py
+++ b/tests/tools/test_lck_review.py
@@ -288,6 +288,40 @@ def test_review_complete_acquires_one_fresh_snapshot_and_accepts_unchanged_targe
     assert workspace.removed == [review_root]
 
 
+def test_review_complete_rejects_research_outcome_for_task_profile(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    identity = _review_identity_value()
+    resolver = cast(Any, StaticResolver(tmp_path, _review_state()))
+    monkeypatch.setattr(
+        lck_review, "_review_identity", lambda *_args, **_kwargs: identity
+    )
+    store = lck_review_workspace.ReviewInvocationStore(tmp_path)
+    review_id = store.new_id()
+    review_root = tmp_path / "review-root"
+    review_root.mkdir()
+    store.write_guard(review_id, _review_guard(identity, review_root=review_root))
+
+    with pytest.raises(
+        lck_models.LckStopError,
+        match="--research-outcome is supported only for Research Issues",
+    ):
+        lck_review.ReviewCompleter(
+            resolver,
+            checks_gate=cast(Any, FakeReviewChecks()),
+            store=store,
+            workspace=cast(Any, FakeReviewWorkspace(review_root)),
+        ).complete(
+            159,
+            review_id,
+            verdict="PASS",
+            research_outcome="IMPLEMENT",
+        )
+
+    assert not store.record_path(159, review_id).exists()
+
+
 def test_review_complete_acquires_only_review_complete_fact_profile(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tools/agent_workflow/lck_core/README.md
+++ b/tools/agent_workflow/lck_core/README.md
@@ -10,7 +10,7 @@ maintainer or reviewer can start with the responsibility that owns the behavior.
 | live Git/GitHub facts, Fact Profiles, operation snapshots | `state.py` | `models.py` |
 | lifecycle admission / eligibility | `eligibility.py` | `state.py` |
 | formal validation and required-check gates | `validation.py` | `state.py`, `../documentation_policy.py` |
-| bounded Git/GitHub write effects | `effects.py` | `delivery.py` or `remediation.py` |
+| bounded Git/GitHub write effects and profile effect executors | `effects.py` | `delivery.py`, `remediation.py`, or `closeout.py` |
 | Delivery prepare/complete | `delivery.py` | `eligibility.py`, `validation.py`, `effects.py` |
 | isolated Review workspace and review records | `review_workspace.py` | `review.py` |
 | Independent Review and Merge Preflight | `review.py` | `review_workspace.py`, `validation.py` |
@@ -29,15 +29,20 @@ module mutation to bypass this direction.
 
 `issue_profiles.py` owns canonical label resolution and profile metadata.
 `profile_policies.py` owns the one dispatch boundary from that metadata to the
-Bug, Documentation, Research, and Task-specific candidate hooks. Lifecycle phase
-modules must not add another type-driven dispatch table.
+generic contract/candidate/review/completion capabilities. Lifecycle phase
+modules must not add another type-driven dispatch table. Profile policies may
+return validated, data-only effect descriptors; `effects.py` executes only
+registered effect kinds and proves their postconditions.
 
 The same module owns the immutable production `ProfilePolicyRegistry`, the
 injectable `LeafIssuePolicy` seam, and the frozen four-stage
 `ProfileEvidenceEnvelope` (`contract`, `candidate`, `review`, `completion`).
 Policy blockers and stage payloads are validated by the selected policy before
 the shared kernel transports or records them; the canonical leaf contract is
-referenced by identity/digest rather than copied into the envelope.
+referenced by identity/digest rather than copied into the envelope. Review
+workspace isolation, path containment, and review identity freshness remain
+kernel responsibilities; profile policies only supply bounded artifact
+semantics/evidence.
 
 When diagnosing a lifecycle issue, read this map first and inspect the owner module
 plus at most its direct companion modules before broad repository searches.

--- a/tools/agent_workflow/lck_core/closeout.py
+++ b/tools/agent_workflow/lck_core/closeout.py
@@ -671,7 +671,6 @@ class CloseoutCompleter:
                     profile=profile,
                     phase="completion",
                     issue=state.issue,
-                    runner=self.resolver.runner,
                     review_record=review_record,
                     merged_pr=state.merged_pr,
                 ),
@@ -695,6 +694,7 @@ class CloseoutCompleter:
                     completion.effect.effect_kind,
                     "pending",
                     reason="main synchronization is incomplete",
+                    details=completion.effect.receipt,
                 )
             effects.append(completion_effect)
 
@@ -716,11 +716,7 @@ class CloseoutCompleter:
             and metadata.action in {"updated", "already-converged"}
             and cleanup.action in {"cleaned", "already-clean"}
         )
-        completion_complete = completion_effect is None or completion_effect.action in {
-            "updated",
-            "already-set",
-            "not-applicable",
-        }
+        completion_complete = completion_effect is None or completion_effect.is_complete
         return CloseoutResult(
             task_number=task_number,
             status="BUSINESS_DELIVERY_COMPLETE",

--- a/tools/agent_workflow/lck_core/closeout.py
+++ b/tools/agent_workflow/lck_core/closeout.py
@@ -41,15 +41,6 @@ from .review_workspace import ReviewInvocationStore, _identity_from_mapping
 from .state import LiveStateResolver, OperationSnapshotBuilder
 
 
-def __getattr__(name: str) -> Any:
-    """Resolve the removed Research helper only for legacy callers."""
-    if name == "ResearchOutcomeEffect":
-        from .profile_policies import ResearchOutcomeEffect
-
-        return ResearchOutcomeEffect
-    raise AttributeError(name)
-
-
 def _label_names(issue: Mapping[str, Any] | None) -> set[str]:
     if not isinstance(issue, Mapping):
         return set()

--- a/tools/agent_workflow/lck_core/closeout.py
+++ b/tools/agent_workflow/lck_core/closeout.py
@@ -2,20 +2,15 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, Final
+from typing import Any
 
 from project_status import set_project_status_with_runner
-from research_policy import (
-    RESEARCH_OUTCOME_FIELD,
-    ResearchOutcome,
-    ResearchPolicyError,
-    require_typed_research_outcome,
-)
 from workflow_common import WorkflowToolError, is_sha, read_json_text, safe_text
-from workflow_evidence import CANONICAL_PROJECT_NUMBER, _find_project_status
+from workflow_evidence import _find_project_status
 
+from .effects import DEFAULT_EFFECT_EXECUTOR_REGISTRY, EffectExecutorRegistry
 from .eligibility import PhaseEligibilityResolver
-from .issue_profiles import resolve_issue_profile
+from .issue_profiles import resolve_leaf_issue_profile
 from .models import (
     BASE_BRANCH,
     LCK_SCHEMA_VERSION,
@@ -32,11 +27,27 @@ from .models import (
     branch_matches_profile,
 )
 from .profile_policies import (
+    DEFAULT_PROFILE_POLICY_REGISTRY,
+    PolicyContext,
+    ProfileEvidenceEnvelope,
+    ProfilePolicyError,
+    ProfilePolicyRegistry,
+    ProfileResolver,
     profile_cleanup_label,
-    profile_research_outcome_supported,
+    resolve_issue_policy,
+    validate_profile_completion,
 )
 from .review_workspace import ReviewInvocationStore, _identity_from_mapping
 from .state import LiveStateResolver, OperationSnapshotBuilder
+
+
+def __getattr__(name: str) -> Any:
+    """Resolve the removed Research helper only for legacy callers."""
+    if name == "ResearchOutcomeEffect":
+        from .profile_policies import ResearchOutcomeEffect
+
+        return ResearchOutcomeEffect
+    raise AttributeError(name)
 
 
 def _label_names(issue: Mapping[str, Any] | None) -> set[str]:
@@ -61,48 +72,6 @@ def _pending_receipt(
     if details:
         payload.update(details)
     return EffectReceipt(effect=effect, action=action, details=payload)
-
-
-RESEARCH_OUTCOME_QUERY: Final = r"""
-query($owner:String!, $projectNumber:Int!, $userAfter:String, $organizationAfter:String) {
-  user(login:$owner) {
-    projectV2(number:$projectNumber) {
-      items(first:100, after:$userAfter) {
-        nodes {
-          content {
-            ... on Issue {
-              number
-              repository { nameWithOwner }
-            }
-          }
-          fieldValueByName(name:"Research Outcome") {
-            ... on ProjectV2ItemFieldSingleSelectValue { name }
-          }
-        }
-        pageInfo { hasNextPage endCursor }
-      }
-    }
-  }
-  organization(login:$owner) {
-    projectV2(number:$projectNumber) {
-      items(first:100, after:$organizationAfter) {
-        nodes {
-          content {
-            ... on Issue {
-              number
-              repository { nameWithOwner }
-            }
-          }
-          fieldValueByName(name:"Research Outcome") {
-            ... on ProjectV2ItemFieldSingleSelectValue { name }
-          }
-        }
-        pageInfo { hasNextPage endCursor }
-      }
-    }
-  }
-}
-"""
 
 
 class MainSynchronizationEffect:
@@ -317,234 +286,6 @@ class CloseoutMetadataEffect:
         )
 
 
-class ResearchOutcomeEffect:
-    """Persist the typed Research decision after a reviewed merge."""
-
-    def __init__(self, resolver: LiveStateResolver) -> None:
-        self.resolver = resolver
-
-    def _query_outcome(self, repository: str, task_number: int) -> str | None:
-        owner, separator, _name = repository.partition("/")
-        if not separator or not owner:
-            return None
-        cursors: dict[str, str | None] = {
-            "user": None,
-            "organization": None,
-        }
-        seen_cursors: dict[str, set[str]] = {"user": set(), "organization": set()}
-        complete: set[str] = set()
-
-        while len(complete) < 2:
-            argv = [
-                "gh",
-                "api",
-                "graphql",
-                "-f",
-                f"query={' '.join(RESEARCH_OUTCOME_QUERY.split())}",
-                "-F",
-                f"owner={owner}",
-                "-F",
-                f"projectNumber={CANONICAL_PROJECT_NUMBER}",
-            ]
-            if cursors["user"] is not None:
-                argv.extend(("-F", f"userAfter={cursors['user']}"))
-            if cursors["organization"] is not None:
-                argv.extend(("-F", f"organizationAfter={cursors['organization']}"))
-            result = self.resolver.runner.run(
-                argv,
-                command_id="lck-research-outcome-postcondition",
-                retries=1,
-            )
-            if result.returncode != 0 or not result.stdout.strip():
-                return None
-            value = read_json_text(
-                result.stdout, field="lck-research-outcome-postcondition"
-            )
-            if not isinstance(value, Mapping) or value.get("errors"):
-                return None
-            data = value.get("data")
-            if not isinstance(data, Mapping):
-                return None
-
-            for scope in ("user", "organization"):
-                if scope in complete:
-                    continue
-                if scope not in data:
-                    return None
-                owner_data = data.get(scope)
-                if owner_data is None:
-                    complete.add(scope)
-                    continue
-                if not isinstance(owner_data, Mapping):
-                    return None
-                project = owner_data.get("projectV2")
-                if project is None:
-                    complete.add(scope)
-                    continue
-                if not isinstance(project, Mapping):
-                    return None
-                items = project.get("items")
-                if not isinstance(items, Mapping):
-                    return None
-                nodes = items.get("nodes")
-                page_info = items.get("pageInfo")
-                if not isinstance(nodes, list) or not isinstance(page_info, Mapping):
-                    return None
-                for item in nodes:
-                    if not isinstance(item, Mapping):
-                        continue
-                    content = item.get("content")
-                    if not isinstance(content, Mapping):
-                        continue
-                    content_repository = content.get("repository")
-                    if (
-                        content.get("number") != task_number
-                        or not isinstance(content_repository, Mapping)
-                        or content_repository.get("nameWithOwner") != repository
-                    ):
-                        continue
-                    field_value = item.get("fieldValueByName")
-                    if not isinstance(field_value, Mapping):
-                        return None
-                    return safe_text(field_value.get("name"))
-                has_next_page = page_info.get("hasNextPage")
-                if has_next_page is False:
-                    complete.add(scope)
-                    continue
-                if has_next_page is not True:
-                    return None
-                end_cursor = page_info.get("endCursor")
-                if not isinstance(end_cursor, str) or not end_cursor:
-                    return None
-                if end_cursor in seen_cursors[scope]:
-                    return None
-                seen_cursors[scope].add(end_cursor)
-                cursors[scope] = end_cursor
-        return None
-
-    @staticmethod
-    def _validate_binding(
-        state: LiveState,
-        review_record: Mapping[str, Any],
-        merged_pr: Mapping[str, Any],
-    ) -> ResearchOutcome:
-        raw_identity = review_record.get("identity")
-        binding = review_record.get("research_artifact")
-        if not isinstance(binding, Mapping) and isinstance(raw_identity, Mapping):
-            binding = raw_identity.get("research_artifact")
-        if not isinstance(binding, Mapping):
-            raise LckStopError(
-                "Closeout STOP: Research Review PASS has no artifact binding"
-            )
-        try:
-            outcome = require_typed_research_outcome(binding)
-        except ResearchPolicyError as exc:
-            raise LckStopError(
-                f"Closeout STOP: Research outcome is not typed: {exc}"
-            ) from exc
-        expected = {
-            "task_number": state.task_number,
-            "pr_number": merged_pr.get("number"),
-            "base_sha": _pr_base_sha(merged_pr),
-            "head_sha": _pr_head_sha(merged_pr),
-        }
-        if any(binding.get(key) != value for key, value in expected.items()):
-            raise LckStopError(
-                "Closeout STOP: Research outcome is not bound to the merged PR head/base"
-            )
-        if isinstance(raw_identity, Mapping):
-            for key in (
-                "task_number",
-                "pr_number",
-                "base_sha",
-                "head_sha",
-                "task_body_sha256",
-                "merge_base_sha",
-                "effective_diff_sha256",
-            ):
-                if binding.get(key) != raw_identity.get(key):
-                    raise LckStopError(
-                        "Closeout STOP: Research outcome is not bound to the reviewed artifact"
-                    )
-        return outcome
-
-    def execute(
-        self,
-        state: LiveState,
-        *,
-        review_record: Mapping[str, Any],
-        merged_pr: Mapping[str, Any],
-    ) -> EffectReceipt:
-        profile = resolve_issue_profile(state.issue).profile
-        if profile is None or not profile_research_outcome_supported(profile):
-            return EffectReceipt(
-                effect="set_research_outcome",
-                action="not-applicable",
-                details={},
-            )
-        outcome = self._validate_binding(state, review_record, merged_pr)
-        repository = state.repository
-        if repository is None:
-            raise LckStopError(
-                "Closeout STOP: Research Outcome requires repository identity"
-            )
-        current = (
-            state.issue.get("research_outcome")
-            if isinstance(state.issue, Mapping)
-            else None
-        )
-        if current == outcome.value:
-            action = "already-set"
-        else:
-            try:
-                set_project_status_with_runner(
-                    self.resolver.runner,
-                    repository,
-                    state.task_number,
-                    field=RESEARCH_OUTCOME_FIELD,
-                    value=outcome.value,
-                )
-            except WorkflowToolError as exc:
-                raise LckStopError(f"Research Outcome write failed: {exc}") from exc
-            action = "updated"
-        observed = self._query_outcome(repository, state.task_number)
-        if observed != outcome.value:
-            return _pending_receipt(
-                "set_research_outcome",
-                "pending",
-                reason="Research Outcome postcondition is not proven",
-                details={"outcome": outcome.value},
-            )
-        identity = review_record.get("identity")
-        decision_identity = {
-            key: identity.get(key)
-            for key in (
-                "task_number",
-                "pr_number",
-                "base_sha",
-                "head_sha",
-                "merge_base_sha",
-                "effective_diff_sha256",
-            )
-            if isinstance(identity, Mapping)
-        }
-        return EffectReceipt(
-            effect="set_research_outcome",
-            action=action,
-            details={
-                "field": RESEARCH_OUTCOME_FIELD,
-                "outcome": outcome.value,
-                "decision_identity": decision_identity,
-                "reviewed_artifact": review_record.get("research_artifact")
-                or (
-                    identity.get("research_artifact")
-                    if isinstance(identity, Mapping)
-                    else None
-                ),
-            },
-        )
-
-
 class CleanupTaskRefsEffect:
     """Clean only the verified Task branch and recognize GitHub auto-deletion."""
 
@@ -559,7 +300,7 @@ class CleanupTaskRefsEffect:
         merge_sha: str | None,
     ) -> EffectReceipt:
         branch = state.target_branch
-        profile = resolve_issue_profile(state.issue).profile
+        profile = resolve_leaf_issue_profile(state.issue).profile
         if (
             branch == BASE_BRANCH
             or profile is None
@@ -708,6 +449,7 @@ class CloseoutResult:
     effects: tuple[EffectReceipt, ...]
     operation_snapshot: OperationSnapshot
     research_outcome: str | None = None
+    profile_evidence: ProfileEvidenceEnvelope | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -719,6 +461,9 @@ class CloseoutResult:
             "business_delivery": self.business_delivery,
             "cleanup": self.cleanup,
             "research_outcome": self.research_outcome,
+            "profile_evidence": (
+                self.profile_evidence.to_dict() if self.profile_evidence else None
+            ),
             "effects": [item.to_dict() for item in self.effects],
             "operation_snapshot": self.operation_snapshot.to_dict(),
             "automatic_merge": False,
@@ -737,8 +482,10 @@ class CloseoutCompleter:
         main_effect: MainSynchronizationEffect | None = None,
         metadata_effect: CloseoutMetadataEffect | None = None,
         cleanup_effect: CleanupTaskRefsEffect | None = None,
-        research_outcome_effect: ResearchOutcomeEffect | None = None,
         review_store: ReviewInvocationStore | None = None,
+        effect_registry: EffectExecutorRegistry | None = None,
+        policy_registry: ProfilePolicyRegistry | None = None,
+        profile_resolver: ProfileResolver | None = None,
     ) -> None:
         self.resolver = resolver
         self.snapshots = OperationSnapshotBuilder(resolver)
@@ -746,12 +493,13 @@ class CloseoutCompleter:
         self.main_effect = main_effect or MainSynchronizationEffect(resolver)
         self.metadata_effect = metadata_effect or CloseoutMetadataEffect(resolver)
         self.cleanup_effect = cleanup_effect or CleanupTaskRefsEffect(resolver)
-        self.research_outcome_effect = research_outcome_effect or ResearchOutcomeEffect(
-            resolver
-        )
+        self.effect_registry = effect_registry or DEFAULT_EFFECT_EXECUTOR_REGISTRY
+        self.policy_registry = policy_registry or DEFAULT_PROFILE_POLICY_REGISTRY
+        self.profile_resolver = profile_resolver
         self.review_store = review_store or ReviewInvocationStore(resolver.repo_root)
         self.last_snapshot: OperationSnapshot | None = None
         self.last_effects: list[EffectReceipt] = []
+        self.last_profile_evidence: ProfileEvidenceEnvelope | None = None
 
     @staticmethod
     def _validate_merged_identity(state: LiveState) -> tuple[str, str]:
@@ -870,6 +618,7 @@ class CloseoutCompleter:
         # Keep the same list object while effects run so any effect failure
         # still leaves already-completed effects visible to the failure path.
         self.last_effects = effects
+        self.last_profile_evidence = None
         snapshot = self.snapshots.acquire(task_number, operation="closeout")
         self.last_snapshot = snapshot
         state = snapshot.state
@@ -888,22 +637,59 @@ class CloseoutCompleter:
         metadata = self.metadata_effect.execute(state)
         effects.append(metadata)
 
-        profile = resolve_issue_profile(state.issue).profile
-        research_outcome: EffectReceipt | None = None
-        if profile is not None and profile_research_outcome_supported(profile):
-            if main.action in {"synchronized", "already-synced"}:
-                research_outcome = self.research_outcome_effect.execute(
-                    state,
+        try:
+            profile, _policy = resolve_issue_policy(
+                state.issue or {},
+                registry=self.policy_registry,
+                profile_resolver=self.profile_resolver or resolve_leaf_issue_profile,
+            )
+            raw_envelope = review_record.get("profile_evidence")
+            review_evidence = (
+                raw_envelope.get("review")
+                if isinstance(raw_envelope, Mapping)
+                else None
+            )
+            completion = validate_profile_completion(
+                profile,
+                state.issue or {},
+                {
+                    "task_number": state.task_number,
+                    "repository": state.repository,
+                    "merged_pr": state.merged_pr,
+                    "review_record": review_record,
+                    "review_evidence": review_evidence,
+                },
+                registry=self.policy_registry,
+                context=PolicyContext(
+                    profile=profile,
+                    phase="completion",
+                    issue=state.issue,
+                    runner=self.resolver.runner,
                     review_record=review_record,
                     merged_pr=state.merged_pr,
+                ),
+            )
+        except (ProfilePolicyError, TypeError, ValueError) as exc:
+            raise LckStopError(
+                f"profile completion capability rejected the merge: {exc}"
+            ) from exc
+
+        self.last_profile_evidence = completion.profile_evidence
+        completion_effect: EffectReceipt | None = None
+        if completion.effect is not None:
+            if main.action in {"synchronized", "already-synced"}:
+                completion_effect = self.effect_registry.execute(
+                    completion.effect,
+                    resolver=self.resolver,
+                    state=state,
                 )
             else:
-                research_outcome = _pending_receipt(
-                    "set_research_outcome",
+                completion_effect = _pending_receipt(
+                    completion.effect.effect_kind,
                     "pending",
                     reason="main synchronization is incomplete",
                 )
-            effects.append(research_outcome)
+            effects.append(completion_effect)
 
         if main.action in {"synchronized", "already-synced"}:
             cleanup = self.cleanup_effect.execute(
@@ -923,7 +709,7 @@ class CloseoutCompleter:
             and metadata.action in {"updated", "already-converged"}
             and cleanup.action in {"cleaned", "already-clean"}
         )
-        research_complete = research_outcome is None or research_outcome.action in {
+        completion_complete = completion_effect is None or completion_effect.action in {
             "updated",
             "already-set",
             "not-applicable",
@@ -931,13 +717,14 @@ class CloseoutCompleter:
         return CloseoutResult(
             task_number=task_number,
             status="BUSINESS_DELIVERY_COMPLETE",
-            business_delivery="COMPLETE" if research_complete else "PENDING",
+            business_delivery="COMPLETE" if completion_complete else "PENDING",
             cleanup="COMPLETE" if cleanup_complete else "PENDING",
             effects=tuple(effects),
             operation_snapshot=snapshot,
             research_outcome=(
-                research_outcome.details.get("outcome")
-                if research_outcome is not None
+                completion_effect.details.get("outcome")
+                if completion_effect is not None
                 else None
             ),
+            profile_evidence=completion.profile_evidence,
         )

--- a/tools/agent_workflow/lck_core/closeout.py
+++ b/tools/agent_workflow/lck_core/closeout.py
@@ -489,13 +489,20 @@ class CloseoutCompleter:
     ) -> None:
         self.resolver = resolver
         self.snapshots = OperationSnapshotBuilder(resolver)
-        self.eligibility = eligibility or PhaseEligibilityResolver()
+        self.policy_registry = policy_registry or DEFAULT_PROFILE_POLICY_REGISTRY
+        self.profile_resolver = (
+            profile_resolver
+            or getattr(eligibility, "profile_resolver", None)
+            or resolve_leaf_issue_profile
+        )
+        self.eligibility = eligibility or PhaseEligibilityResolver(
+            registry=self.policy_registry,
+            profile_resolver=self.profile_resolver,
+        )
         self.main_effect = main_effect or MainSynchronizationEffect(resolver)
         self.metadata_effect = metadata_effect or CloseoutMetadataEffect(resolver)
         self.cleanup_effect = cleanup_effect or CleanupTaskRefsEffect(resolver)
         self.effect_registry = effect_registry or DEFAULT_EFFECT_EXECUTOR_REGISTRY
-        self.policy_registry = policy_registry or DEFAULT_PROFILE_POLICY_REGISTRY
-        self.profile_resolver = profile_resolver
         self.review_store = review_store or ReviewInvocationStore(resolver.repo_root)
         self.last_snapshot: OperationSnapshot | None = None
         self.last_effects: list[EffectReceipt] = []

--- a/tools/agent_workflow/lck_core/delivery.py
+++ b/tools/agent_workflow/lck_core/delivery.py
@@ -250,11 +250,6 @@ class DeliveryCompleter:
     Strict check evaluation remains owned by Review Complete and Merge Preflight.
     """
 
-    # Compatibility hook for deterministic callers that used to override the
-    # profile candidate callback.  Normal Delivery leaves this unset; the
-    # selected registry policy owns candidate execution.
-    _run_critical_outcome: Any = None
-
     def __init__(
         self,
         resolver: LiveStateResolver,
@@ -270,7 +265,7 @@ class DeliveryCompleter:
         profile_resolver: ProfileResolver | None = None,
         require_existing_open_pr: bool = False,
         candidate_recorder: Callable[[str, str], None] | None = None,
-        **legacy_profile_services: Any,
+        services: Sequence[Any] = (),
     ) -> None:
         self.resolver = resolver
         self.snapshots = OperationSnapshotBuilder(resolver)
@@ -290,14 +285,7 @@ class DeliveryCompleter:
         self.pr_effect = pr_effect or EnsureOpenPrEffect(resolver)
         self.status_effect = status_effect or SetReviewStatusEffect(resolver)
         self.checks_gate = checks_gate or DeliveryChecksGate(resolver)
-        # Older callers may still inject a deterministic profile service by
-        # keyword.  Keep it as an opaque policy-service seam; no controller
-        # attribute is typed as or dispatches a concrete profile validator.
-        self.profile_services = tuple(
-            value
-            for key, value in legacy_profile_services.items()
-            if key.endswith("_validation") and value is not None
-        )
+        self.services = tuple(services)
         self.require_existing_open_pr = require_existing_open_pr
         self.candidate_recorder = candidate_recorder
         self.last_snapshot: OperationSnapshot | None = None
@@ -353,12 +341,6 @@ class DeliveryCompleter:
         self.last_documentation_validation = None
         self.last_research_validation = None
         self.last_profile_evidence = None
-        legacy_critical = getattr(self, "_run_critical_outcome", None)
-        critical_callback = (
-            (lambda: legacy_critical(state, progress=progress))
-            if callable(legacy_critical)
-            else None
-        )
         try:
             results = run_profile_delivery_gates(
                 profile,
@@ -370,8 +352,7 @@ class DeliveryCompleter:
                 registry=self.policy_registry,
                 repo_root=self.resolver.repo_root,
                 runner=self.resolver.runner,
-                services=self.profile_services,
-                critical_outcome=critical_callback,
+                services=self.services,
             )
         except ProfileGateFailure as exc:
             self.last_profile_evidence = exc.profile_evidence
@@ -379,14 +360,8 @@ class DeliveryCompleter:
                 target = f"last_{field}"
                 if isinstance(field, str) and hasattr(self, target):
                     setattr(self, target, value)
-            self.last_research_validation = getattr(
-                getattr(self, "research_validation", None), "last_result", None
-            )
             raise
         except LckStopError:
-            self.last_research_validation = getattr(
-                getattr(self, "research_validation", None), "last_result", None
-            )
             raise
         self.last_documentation_validation = results.documentation_validation
         self.last_research_validation = results.research_validation

--- a/tools/agent_workflow/lck_core/delivery.py
+++ b/tools/agent_workflow/lck_core/delivery.py
@@ -4,11 +4,6 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
 
-from critical_outcome import (
-    CriticalOutcomeError,
-    contract_from_snapshot,
-    verify_critical_outcome,
-)
 from workflow_common import ProgressReporter, is_sha
 
 from .effects import (
@@ -48,9 +43,7 @@ from .state import (
 )
 from .validation import (
     DeliveryChecksGate,
-    DocumentationValidationGate,
     FormalValidationGate,
-    ResearchValidationGate,
 )
 
 
@@ -257,6 +250,11 @@ class DeliveryCompleter:
     Strict check evaluation remains owned by Review Complete and Merge Preflight.
     """
 
+    # Compatibility hook for deterministic callers that used to override the
+    # profile candidate callback.  Normal Delivery leaves this unset; the
+    # selected registry policy owns candidate execution.
+    _run_critical_outcome: Any = None
+
     def __init__(
         self,
         resolver: LiveStateResolver,
@@ -268,12 +266,11 @@ class DeliveryCompleter:
         pr_effect: EnsureOpenPrEffect | ReuseExistingOpenPrEffect | None = None,
         status_effect: SetReviewStatusEffect | None = None,
         checks_gate: DeliveryChecksGate | None = None,
-        documentation_validation: DocumentationValidationGate | None = None,
-        research_validation: ResearchValidationGate | None = None,
         policy_registry: ProfilePolicyRegistry | None = None,
         profile_resolver: ProfileResolver | None = None,
         require_existing_open_pr: bool = False,
         candidate_recorder: Callable[[str, str], None] | None = None,
+        **legacy_profile_services: Any,
     ) -> None:
         self.resolver = resolver
         self.snapshots = OperationSnapshotBuilder(resolver)
@@ -293,11 +290,13 @@ class DeliveryCompleter:
         self.pr_effect = pr_effect or EnsureOpenPrEffect(resolver)
         self.status_effect = status_effect or SetReviewStatusEffect(resolver)
         self.checks_gate = checks_gate or DeliveryChecksGate(resolver)
-        self.documentation_validation = (
-            documentation_validation or DocumentationValidationGate(resolver)
-        )
-        self.research_validation = research_validation or ResearchValidationGate(
-            resolver
+        # Older callers may still inject a deterministic profile service by
+        # keyword.  Keep it as an opaque policy-service seam; no controller
+        # attribute is typed as or dispatches a concrete profile validator.
+        self.profile_services = tuple(
+            value
+            for key, value in legacy_profile_services.items()
+            if key.endswith("_validation") and value is not None
         )
         self.require_existing_open_pr = require_existing_open_pr
         self.candidate_recorder = candidate_recorder
@@ -317,35 +316,6 @@ class DeliveryCompleter:
             if isinstance(value, Mapping):
                 self.last_checks = dict(value)
                 return
-
-    def _run_critical_outcome(
-        self,
-        state: LiveState,
-        *,
-        progress: ProgressReporter | None = None,
-    ) -> dict[str, Any]:
-        issue = state.issue
-        contract_snapshot = (
-            issue.get("critical_outcome") if isinstance(issue, Mapping) else None
-        )
-        try:
-            contract = contract_from_snapshot(contract_snapshot)
-            result = verify_critical_outcome(
-                self.resolver.repo_root,
-                self.resolver.runner,
-                contract,
-                progress=progress,
-            )
-        except CriticalOutcomeError as exc:
-            raise LckStopError(f"Critical Outcome contract invalid: {exc}") from exc
-        payload = result.to_dict()
-        self.last_critical_outcome = payload
-        if result.status != "pass":
-            raise LckStopError(
-                "Critical Outcome FAIL: "
-                f"{contract.verification_test} exited {result.exit_code}"
-            )
-        return payload
 
     def _run_formal_validation(self, base_sha: str) -> dict[str, Any]:
         """Retain a parsed validation payload when the gate rejects it."""
@@ -383,6 +353,12 @@ class DeliveryCompleter:
         self.last_documentation_validation = None
         self.last_research_validation = None
         self.last_profile_evidence = None
+        legacy_critical = getattr(self, "_run_critical_outcome", None)
+        critical_callback = (
+            (lambda: legacy_critical(state, progress=progress))
+            if callable(legacy_critical)
+            else None
+        )
         try:
             results = run_profile_delivery_gates(
                 profile,
@@ -390,23 +366,26 @@ class DeliveryCompleter:
                 head_sha=head_sha,
                 include_index=include_index,
                 progress=progress,
-                documentation_validation=self.documentation_validation,
-                research_validation=self.research_validation,
-                critical_outcome=lambda: self._run_critical_outcome(
-                    state, progress=progress
-                ),
                 issue=state.issue,
                 registry=self.policy_registry,
+                repo_root=self.resolver.repo_root,
+                runner=self.resolver.runner,
+                services=self.profile_services,
+                critical_outcome=critical_callback,
             )
         except ProfileGateFailure as exc:
             self.last_profile_evidence = exc.profile_evidence
+            for field, value in exc.legacy_results.items():
+                target = f"last_{field}"
+                if isinstance(field, str) and hasattr(self, target):
+                    setattr(self, target, value)
             self.last_research_validation = getattr(
-                self.research_validation, "last_result", None
+                getattr(self, "research_validation", None), "last_result", None
             )
             raise
         except LckStopError:
             self.last_research_validation = getattr(
-                self.research_validation, "last_result", None
+                getattr(self, "research_validation", None), "last_result", None
             )
             raise
         self.last_documentation_validation = results.documentation_validation

--- a/tools/agent_workflow/lck_core/effects.py
+++ b/tools/agent_workflow/lck_core/effects.py
@@ -308,7 +308,12 @@ class ProjectSingleSelectEffectExecutor:
             return _pending_effect(
                 cls.effect_kind,
                 reason="project field effect postcondition is not proven",
-                details={"field": params["field"], "value": params["value"]},
+                details={
+                    "field": params["field"],
+                    "value": params["value"],
+                    "effect_kind": descriptor.effect_kind,
+                    **dict(descriptor.receipt),
+                },
             )
         details = {
             "field": params["field"],

--- a/tools/agent_workflow/lck_core/effects.py
+++ b/tools/agent_workflow/lck_core/effects.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import tempfile
 from collections.abc import Mapping, Sequence
 from pathlib import Path
@@ -275,11 +276,14 @@ class ProjectSingleSelectEffectExecutor:
             raise LckStopError(
                 "project field effect identity does not match live state"
             )
-        current = (
-            state.issue.get(params["field"])
-            if isinstance(state.issue, Mapping)
-            else None
-        )
+        current = None
+        if isinstance(state.issue, Mapping):
+            current = state.issue.get(params["field"])
+            if current is None:
+                normalized_field = re.sub(
+                    r"[^a-z0-9]+", "_", params["field"].strip().lower()
+                ).strip("_")
+                current = state.issue.get(normalized_field)
         action = "already-set" if current == params["value"] else "updated"
         if action == "updated":
             try:

--- a/tools/agent_workflow/lck_core/effects.py
+++ b/tools/agent_workflow/lck_core/effects.py
@@ -3,11 +3,18 @@ from __future__ import annotations
 import tempfile
 from collections.abc import Mapping, Sequence
 from pathlib import Path
+from types import MappingProxyType
 from typing import Any, Final
 
 from pr_resolve import PrResolveError, resolve_or_create_pr
 from project_status import set_project_status_with_runner
-from workflow_common import is_sha, read_json_text, stderr_tail
+from workflow_common import (
+    WorkflowToolError,
+    is_sha,
+    read_json_text,
+    safe_text,
+    stderr_tail,
+)
 from workflow_evidence import _find_project_status
 
 from .models import (
@@ -18,7 +25,307 @@ from .models import (
     _authoritative_remote_main_sha,
     _remote_refs,
 )
+from .profile_policies import ProfileEffectDescriptor
 from .state import LiveStateResolver
+
+
+class EffectExecutorRegistry:
+    """Immutable kernel allowlist for policy-declared effect kinds."""
+
+    def __init__(self, executors: Mapping[str, Any]) -> None:
+        selected: dict[str, Any] = {}
+        for kind, executor in executors.items():
+            if not isinstance(kind, str) or not kind or not callable(executor):
+                raise ValueError("effect executor registry entry is malformed")
+            if kind in selected:
+                raise ValueError(f"duplicate effect executor: {kind}")
+            selected[kind] = executor
+        self._executors = MappingProxyType(selected)
+
+    @property
+    def executors(self) -> Mapping[str, Any]:
+        return self._executors
+
+    def execute(
+        self,
+        descriptor: ProfileEffectDescriptor,
+        *,
+        resolver: LiveStateResolver,
+        state: LiveState,
+    ) -> EffectReceipt:
+        if not isinstance(descriptor, ProfileEffectDescriptor):
+            raise LckStopError("completion effect descriptor is malformed")
+        try:
+            executor = self._executors[descriptor.effect_kind]
+        except KeyError as exc:
+            raise LckStopError(
+                f"unknown completion effect kind: {descriptor.effect_kind}"
+            ) from exc
+        try:
+            receipt = executor(descriptor, resolver=resolver, state=state)
+            if not isinstance(receipt, EffectReceipt):
+                raise LckStopError("completion effect executor returned no receipt")
+            return receipt
+        except LckStopError:
+            raise
+        except Exception as exc:
+            raise LckStopError(f"completion effect execution failed: {exc}") from exc
+
+
+def _pending_effect(
+    effect: str, *, reason: str, details: Mapping[str, Any]
+) -> EffectReceipt:
+    payload = {"reason": reason, **dict(details)}
+    return EffectReceipt(effect=effect, action="pending", details=payload)
+
+
+_PROJECT_FIELD_QUERY: Final = r"""
+query($owner:String!, $projectNumber:Int!, $fieldName:String!, $userAfter:String, $organizationAfter:String) {
+  user(login:$owner) {
+    projectV2(number:$projectNumber) {
+      items(first:100, after:$userAfter) {
+        nodes {
+          content { ... on Issue { number repository { nameWithOwner } } }
+          fieldValueByName(name:$fieldName) {
+            ... on ProjectV2ItemFieldSingleSelectValue { name }
+          }
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+  organization(login:$owner) {
+    projectV2(number:$projectNumber) {
+      items(first:100, after:$organizationAfter) {
+        nodes {
+          content { ... on Issue { number repository { nameWithOwner } } }
+          fieldValueByName(name:$fieldName) {
+            ... on ProjectV2ItemFieldSingleSelectValue { name }
+          }
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}
+"""
+
+
+class ProjectSingleSelectEffectExecutor:
+    """Execute the one generic Project single-select effect kind."""
+
+    effect_kind = "project.single_select.set.v1"
+    schema_version = 1
+
+    @staticmethod
+    def _parameters(descriptor: ProfileEffectDescriptor) -> dict[str, Any]:
+        params = dict(descriptor.parameters)
+        required = {"repository", "task_number", "project_number", "field", "value"}
+        if set(params) != required:
+            raise LckStopError("project field effect parameters are invalid")
+        if (
+            not isinstance(params["repository"], str)
+            or not params["repository"]
+            or not isinstance(params["task_number"], int)
+            or isinstance(params["task_number"], bool)
+            or params["task_number"] <= 0
+            or not isinstance(params["project_number"], int)
+            or isinstance(params["project_number"], bool)
+            or params["project_number"] <= 0
+            or not isinstance(params["field"], str)
+            or not params["field"]
+            or not isinstance(params["value"], str)
+            or not params["value"]
+        ):
+            raise LckStopError("project field effect parameters are invalid")
+        return params
+
+    @classmethod
+    def _validate(cls, descriptor: ProfileEffectDescriptor) -> dict[str, Any]:
+        if (
+            descriptor.effect_kind != cls.effect_kind
+            or descriptor.schema_version != cls.schema_version
+        ):
+            raise LckStopError("unsupported project field effect schema")
+        params = cls._parameters(descriptor)
+        expected_postcondition = {
+            "kind": "project.single_select.equals",
+            **params,
+        }
+        if dict(descriptor.postcondition) != expected_postcondition:
+            raise LckStopError("project field effect postcondition is invalid")
+        return params
+
+    @staticmethod
+    def _query(
+        resolver: LiveStateResolver,
+        *,
+        repository: str,
+        project_number: int,
+        task_number: int,
+        field: str,
+    ) -> str | None:
+        owner, separator, _name = repository.partition("/")
+        if not separator or not owner:
+            return None
+        cursors: dict[str, str | None] = {"user": None, "organization": None}
+        seen: dict[str, set[str]] = {"user": set(), "organization": set()}
+        complete: set[str] = set()
+        while len(complete) < 2:
+            argv = [
+                "gh",
+                "api",
+                "graphql",
+                "-f",
+                f"query={' '.join(_PROJECT_FIELD_QUERY.split())}",
+                "-F",
+                f"owner={owner}",
+                "-F",
+                f"projectNumber={project_number}",
+                "-F",
+                f"fieldName={field}",
+            ]
+            if cursors["user"] is not None:
+                argv.extend(("-F", f"userAfter={cursors['user']}"))
+            if cursors["organization"] is not None:
+                argv.extend(("-F", f"organizationAfter={cursors['organization']}"))
+            result = resolver.runner.run(
+                argv, command_id="lck-profile-effect-postcondition", retries=1
+            )
+            if result.returncode != 0 or not result.stdout.strip():
+                return None
+            value = read_json_text(
+                result.stdout, field="lck-profile-effect-postcondition"
+            )
+            if not isinstance(value, Mapping) or value.get("errors"):
+                return None
+            data = value.get("data")
+            if not isinstance(data, Mapping):
+                return None
+            for scope in ("user", "organization"):
+                if scope in complete:
+                    continue
+                owner_data = data.get(scope)
+                if owner_data is None:
+                    complete.add(scope)
+                    continue
+                if not isinstance(owner_data, Mapping):
+                    return None
+                project = owner_data.get("projectV2")
+                if project is None:
+                    complete.add(scope)
+                    continue
+                if not isinstance(project, Mapping):
+                    return None
+                items = project.get("items")
+                if not isinstance(items, Mapping):
+                    return None
+                nodes = items.get("nodes")
+                page_info = items.get("pageInfo")
+                if not isinstance(nodes, list) or not isinstance(page_info, Mapping):
+                    return None
+                for item in nodes:
+                    if not isinstance(item, Mapping):
+                        continue
+                    content = item.get("content")
+                    repo = (
+                        content.get("repository")
+                        if isinstance(content, Mapping)
+                        else None
+                    )
+                    if (
+                        isinstance(content, Mapping)
+                        and content.get("number") == task_number
+                        and isinstance(repo, Mapping)
+                        and repo.get("nameWithOwner") == repository
+                    ):
+                        field_value = item.get("fieldValueByName")
+                        if not isinstance(field_value, Mapping):
+                            return None
+                        return safe_text(field_value.get("name"))
+                if page_info.get("hasNextPage") is False:
+                    complete.add(scope)
+                elif page_info.get("hasNextPage") is True:
+                    cursor = page_info.get("endCursor")
+                    if (
+                        not isinstance(cursor, str)
+                        or not cursor
+                        or cursor in seen[scope]
+                    ):
+                        return None
+                    seen[scope].add(cursor)
+                    cursors[scope] = cursor
+                else:
+                    return None
+        return None
+
+    @classmethod
+    def execute(
+        cls,
+        descriptor: ProfileEffectDescriptor,
+        *,
+        resolver: LiveStateResolver,
+        state: LiveState,
+    ) -> EffectReceipt:
+        params = cls._validate(descriptor)
+        if (
+            state.repository != params["repository"]
+            or state.task_number != params["task_number"]
+        ):
+            raise LckStopError(
+                "project field effect identity does not match live state"
+            )
+        current = (
+            state.issue.get(params["field"])
+            if isinstance(state.issue, Mapping)
+            else None
+        )
+        action = "already-set" if current == params["value"] else "updated"
+        if action == "updated":
+            try:
+                set_project_status_with_runner(
+                    resolver.runner,
+                    params["repository"],
+                    params["task_number"],
+                    project_number=params["project_number"],
+                    field=params["field"],
+                    value=params["value"],
+                )
+            except WorkflowToolError as exc:
+                raise LckStopError(f"project field effect write failed: {exc}") from exc
+        observed = cls._query(
+            resolver,
+            repository=params["repository"],
+            project_number=params["project_number"],
+            task_number=params["task_number"],
+            field=params["field"],
+        )
+        if observed != params["value"]:
+            return _pending_effect(
+                cls.effect_kind,
+                reason="project field effect postcondition is not proven",
+                details={"field": params["field"], "value": params["value"]},
+            )
+        details = {
+            "field": params["field"],
+            "value": params["value"],
+            "effect_kind": descriptor.effect_kind,
+            **dict(descriptor.receipt),
+        }
+        return EffectReceipt(
+            effect=cls.effect_kind,
+            action=action,
+            details=details,
+        )
+
+
+DEFAULT_EFFECT_EXECUTOR_REGISTRY: Final = EffectExecutorRegistry(
+    {
+        ProjectSingleSelectEffectExecutor.effect_kind: ProjectSingleSelectEffectExecutor.execute
+    }
+)
+PROFILE_EFFECT_EXECUTOR_REGISTRY: Final = DEFAULT_EFFECT_EXECUTOR_REGISTRY
+ProfileEffectExecutorRegistry = EffectExecutorRegistry
 
 
 class CommitCurrentTreeEffect:

--- a/tools/agent_workflow/lck_core/effects.py
+++ b/tools/agent_workflow/lck_core/effects.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import re
 import tempfile
 from collections.abc import Mapping, Sequence
 from pathlib import Path
@@ -276,15 +275,14 @@ class ProjectSingleSelectEffectExecutor:
             raise LckStopError(
                 "project field effect identity does not match live state"
             )
-        current = None
-        if isinstance(state.issue, Mapping):
-            current = state.issue.get(params["field"])
-            if current is None:
-                normalized_field = re.sub(
-                    r"[^a-z0-9]+", "_", params["field"].strip().lower()
-                ).strip("_")
-                current = state.issue.get(normalized_field)
-        action = "already-set" if current == params["value"] else "updated"
+        observed = cls._query(
+            resolver,
+            repository=params["repository"],
+            project_number=params["project_number"],
+            task_number=params["task_number"],
+            field=params["field"],
+        )
+        action = "already-set" if observed == params["value"] else "updated"
         if action == "updated":
             try:
                 set_project_status_with_runner(
@@ -297,13 +295,13 @@ class ProjectSingleSelectEffectExecutor:
                 )
             except WorkflowToolError as exc:
                 raise LckStopError(f"project field effect write failed: {exc}") from exc
-        observed = cls._query(
-            resolver,
-            repository=params["repository"],
-            project_number=params["project_number"],
-            task_number=params["task_number"],
-            field=params["field"],
-        )
+            observed = cls._query(
+                resolver,
+                repository=params["repository"],
+                project_number=params["project_number"],
+                task_number=params["task_number"],
+                field=params["field"],
+            )
         if observed != params["value"]:
             return _pending_effect(
                 cls.effect_kind,

--- a/tools/agent_workflow/lck_core/models.py
+++ b/tools/agent_workflow/lck_core/models.py
@@ -574,6 +574,16 @@ class EffectReceipt:
     action: str
     details: Mapping[str, Any]
 
+    @property
+    def is_complete(self) -> bool:
+        """Whether the effect produced a proven completion receipt.
+
+        Effect actions are executor-specific.  The kernel reserves only
+        ``pending`` for an effect whose postcondition is not proven, so
+        completion controllers must not maintain an action-name allowlist.
+        """
+        return self.action != "pending"
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "effect": self.effect,

--- a/tools/agent_workflow/lck_core/profile_policies.py
+++ b/tools/agent_workflow/lck_core/profile_policies.py
@@ -1929,6 +1929,12 @@ def validate_profile_review(
     context: PolicyContext | None = None,
 ) -> ProfileReviewResult:
     """Dispatch the generic Review capability without profile switches."""
+    if review_input.get(
+        "research_outcome"
+    ) is not None and not profile_research_outcome_supported(profile):
+        raise ProfilePolicyError(
+            "--research-outcome is supported only for Research Issues"
+        )
     policy = resolve_profile_policy(profile, registry=registry)
     execution_context = _policy_context(
         profile,

--- a/tools/agent_workflow/lck_core/profile_policies.py
+++ b/tools/agent_workflow/lck_core/profile_policies.py
@@ -1484,6 +1484,12 @@ class _ResearchPolicy(_BuiltinPolicy):
             raise ResearchOutcomeRequired(
                 "Research completion requires a reviewed artifact binding"
             )
+        self._validate_completion_artifact_binding(
+            artifact,
+            context=context,
+            leaf_contract=leaf_contract,
+            completion_input=completion_input,
+        )
         try:
             outcome = require_typed_research_outcome(artifact)
         except ResearchPolicyError as exc:
@@ -1532,6 +1538,83 @@ class _ResearchPolicy(_BuiltinPolicy):
             status="pass",
             effect=descriptor.to_dict(),
         )
+
+    @staticmethod
+    def _validate_completion_artifact_binding(
+        artifact: Mapping[str, Any],
+        *,
+        context: PolicyContext,
+        leaf_contract: Mapping[str, Any],
+        completion_input: Mapping[str, Any],
+    ) -> None:
+        """Keep a Research completion effect bound to the accepted Review.
+
+        Closeout has already validated the outer Review identity against the
+        merged PR.  The Research policy owns the separate artifact binding and
+        therefore verifies that the artifact selected for the effect matches
+        both that identity and the current merged PR before producing intent.
+        """
+        review_record = completion_input.get("review_record")
+        if not isinstance(review_record, Mapping):
+            raise ResearchOutcomeRequired(
+                "Research completion requires a reviewed identity"
+            )
+        reviewed_identity = review_record.get("identity")
+        if not isinstance(reviewed_identity, Mapping):
+            raise ResearchOutcomeRequired(
+                "Research completion requires a reviewed identity"
+            )
+        identity_artifact = reviewed_identity.get("research_artifact")
+        if not isinstance(identity_artifact, Mapping):
+            raise ResearchOutcomeRequired(
+                "Research completion requires an identity-bound artifact"
+            )
+
+        merged_pr = completion_input.get("merged_pr")
+        if not isinstance(merged_pr, Mapping):
+            merged_pr = context.merged_pr
+        if not isinstance(merged_pr, Mapping):
+            raise ResearchOutcomeRequired(
+                "Research completion requires the current merged PR identity"
+            )
+
+        def first_value(source: Mapping[str, Any], *names: str) -> Any:
+            for name in names:
+                value = source.get(name)
+                if value is not None:
+                    return value
+            return None
+
+        current_identity = {
+            "task_number": completion_input.get("task_number"),
+            "pr_number": merged_pr.get("number"),
+            "base_sha": first_value(merged_pr, "baseRefOid", "base_sha"),
+            "head_sha": first_value(merged_pr, "headRefOid", "head_sha"),
+            "task_body_sha256": leaf_contract.get("body_sha256"),
+        }
+        for field, current_value in current_identity.items():
+            reviewed_value = reviewed_identity.get(field)
+            artifact_value = artifact.get(field)
+            if (
+                current_value is None
+                or reviewed_value != current_value
+                or artifact_value != current_value
+            ):
+                raise ResearchOutcomeRequired(
+                    f"Research completion artifact is not bound to the current {field}"
+                )
+
+        for field in ("merge_base_sha", "effective_diff_sha256"):
+            reviewed_value = reviewed_identity.get(field)
+            if reviewed_value is None or artifact.get(field) != reviewed_value:
+                raise ResearchOutcomeRequired(
+                    f"Research completion artifact is not bound to the reviewed {field}"
+                )
+
+        if dict(identity_artifact) != dict(artifact):
+            raise ResearchOutcomeRequired(
+                "Research completion artifact diverges from the reviewed identity"
+            )
 
     def validate_evidence(self, record: ProfileEvidenceRecord) -> bool:
         if not super().validate_evidence(record):

--- a/tools/agent_workflow/lck_core/profile_policies.py
+++ b/tools/agent_workflow/lck_core/profile_policies.py
@@ -9,6 +9,7 @@ an independent registry without mutating production state.
 from __future__ import annotations
 
 import json
+import math
 import re
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass
@@ -21,6 +22,7 @@ from critical_outcome import (
     CriticalOutcomeError,
     contract_from_snapshot,
     critical_outcome_snapshot,
+    verify_critical_outcome,
 )
 from documentation_policy import (
     DocumentationChangeResult,
@@ -28,9 +30,20 @@ from documentation_policy import (
     evaluate_documentation_changes,
     is_valid_documentation_contract,
 )
-from research_policy import is_valid_research_contract, research_contract_snapshot
-from workflow_common import sha256_json
+from research_policy import (
+    RESEARCH_OUTCOME_FIELD,
+    ResearchPolicyError,
+    bind_research_outcome,
+    evaluate_research_changes,
+    is_valid_research_contract,
+    require_typed_research_outcome,
+    research_artifact_binding,
+    research_artifact_outcome,
+    research_contract_snapshot,
+)
+from workflow_common import read_json_text, safe_text, sha256_json
 
+from .effective_diff import calculate_effective_diff
 from .issue_profiles import (
     IssueProfileResolution,
     LeafIssueWorkflowProfile,
@@ -44,10 +57,115 @@ _KIND_PATTERN: Final = r"^[a-z][a-z0-9_.-]*$"
 _CODE_PATTERN: Final = r"^[A-Z][A-Z0-9_.-]*$"
 _TYPE_LABEL_PATTERN: Final = r"^type:[a-z][a-z0-9_.-]*$"
 _SHA256_PATTERN: Final = r"^[0-9a-f]{64}$"
+_EFFECT_KIND_PATTERN: Final = r"^[a-z][a-z0-9_.-]*$"
 
 
 class ProfilePolicyError(ValueError):
     """A profile policy or its typed evidence cannot be accepted safely."""
+
+
+class ProfileCandidateRejected(ProfilePolicyError):
+    """A candidate failed with a structured, policy-owned result."""
+
+    def __init__(self, detail: str, result: Mapping[str, Any]) -> None:
+        super().__init__(detail)
+        self.result = dict(result)
+
+
+@dataclass(frozen=True)
+class ProfileEffectDescriptor:
+    """A constrained, data-only intent emitted by a profile policy.
+
+    A descriptor is deliberately not executable.  The LCK kernel validates its
+    shape and dispatches the allow-listed ``effect_kind`` through its own
+    executor registry.  Keeping parameters, postconditions, and receipt
+    metadata as JSON data also prevents a policy from smuggling a callable or
+    an unbounded GitHub operation through the profile boundary.
+    """
+
+    effect_kind: str
+    schema_version: int
+    parameters: Mapping[str, Any]
+    postcondition: Mapping[str, Any]
+    receipt: Mapping[str, Any]
+
+    def __post_init__(self) -> None:
+        if (
+            not isinstance(self.effect_kind, str)
+            or re.fullmatch(_EFFECT_KIND_PATTERN, self.effect_kind) is None
+        ):
+            raise ProfilePolicyError("effect descriptor kind is malformed")
+        if (
+            not isinstance(self.schema_version, int)
+            or isinstance(self.schema_version, bool)
+            or self.schema_version != 1
+        ):
+            raise ProfilePolicyError("unsupported effect descriptor schema version")
+        for name, value in (
+            ("parameters", self.parameters),
+            ("postcondition", self.postcondition),
+            ("receipt", self.receipt),
+        ):
+            if not isinstance(value, Mapping):
+                raise ProfilePolicyError(f"effect descriptor {name} must be a mapping")
+            if any(not isinstance(key, str) for key in value):
+                raise ProfilePolicyError(
+                    f"effect descriptor {name} keys must be strings"
+                )
+            try:
+                _validate_json_data(value)
+                _canonical_json(value)
+            except (TypeError, ValueError) as exc:
+                raise ProfilePolicyError(
+                    f"effect descriptor {name} must be JSON data"
+                ) from exc
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "effect_kind": self.effect_kind,
+            "schema_version": self.schema_version,
+            "parameters": _jsonable(self.parameters),
+            "postcondition": _jsonable(self.postcondition),
+            "receipt": _jsonable(self.receipt),
+        }
+
+    def serialize(self) -> str:
+        return _canonical_json(self.to_dict())
+
+
+# Short aliases make the generic contract convenient for policy adapters and
+# for external test-only policies without exposing a second schema.
+EffectDescriptor = ProfileEffectDescriptor
+
+
+class DocumentationReclassificationRequired(LckStopError):
+    """The Documentation policy rejected the candidate file scope."""
+
+    code = "DOCUMENTATION_RECLASSIFICATION_REQUIRED"
+
+    def __init__(
+        self, message: str, *, result: Mapping[str, Any] | None = None
+    ) -> None:
+        super().__init__(message)
+        self.result = dict(result) if isinstance(result, Mapping) else None
+
+
+class ResearchReclassificationRequired(LckStopError):
+    """The Research policy rejected the candidate artifact scope."""
+
+    code = "RESEARCH_RECLASSIFICATION_REQUIRED"
+
+    def __init__(
+        self, message: str, *, result: Mapping[str, Any] | None = None
+    ) -> None:
+        super().__init__(message)
+        self.result = dict(result) if isinstance(result, Mapping) else None
+
+
+class ResearchOutcomeRequired(LckStopError):
+    """A Research completion boundary has no typed outcome."""
+
+    code = "RESEARCH_OUTCOME_REQUIRED"
 
 
 ProfileResolver = Callable[[Mapping[str, Any] | None], IssueProfileResolution]
@@ -59,6 +177,26 @@ def _jsonable(value: Any) -> Any:
     if isinstance(value, (list, tuple)):
         return [_jsonable(item) for item in value]
     return value
+
+
+def _validate_json_data(value: Any) -> None:
+    if value is None or isinstance(value, (str, bool, int)):
+        return
+    if isinstance(value, float):
+        if math.isfinite(value):
+            return
+        raise TypeError("non-finite numbers are not JSON data")
+    if isinstance(value, Mapping):
+        for key, nested in value.items():
+            if not isinstance(key, str):
+                raise TypeError("JSON object keys must be strings")
+            _validate_json_data(nested)
+        return
+    if isinstance(value, (list, tuple)):
+        for nested in value:
+            _validate_json_data(nested)
+        return
+    raise TypeError(f"unsupported JSON data type: {type(value).__name__}")
 
 
 def _canonical_json(value: Any) -> str:
@@ -250,11 +388,21 @@ class PolicyContext:
     issue: Mapping[str, Any] | None = None
     relationships: Mapping[str, Any] | None = None
     repo_root: Path | None = None
+    runner: Any = None
     base_sha: str | None = None
     head_sha: str | None = None
     include_index: bool = False
     changed_files: tuple[str, ...] = ()
     progress: Any = None
+    # ``services`` is a compatibility seam for deterministic test doubles.
+    # Production policies use the bounded inputs above and do not receive
+    # controller-owned concrete validators.
+    services: tuple[Any, ...] = ()
+    review_identity: Mapping[str, Any] | None = None
+    review_record: Mapping[str, Any] | None = None
+    merged_pr: Mapping[str, Any] | None = None
+    review_verdict: str | None = None
+    research_outcome: str | None = None
     critical_outcome: Callable[[], Mapping[str, Any]] | None = None
     documentation_validation: Callable[[], Mapping[str, Any]] | None = None
     research_validation: Callable[[], Mapping[str, Any]] | None = None
@@ -290,6 +438,28 @@ class LeafIssuePolicy(Protocol):
     ) -> ProfileEvidenceRecord: ...
 
     def validate_evidence(self, record: ProfileEvidenceRecord) -> bool: ...
+
+
+class ProfileReviewPolicy(Protocol):
+    """Optional generic review-stage capability supplied by a leaf policy."""
+
+    def validate_review(
+        self,
+        context: PolicyContext,
+        leaf_contract: Mapping[str, Any],
+        review_input: Mapping[str, Any],
+    ) -> ProfileEvidenceRecord: ...
+
+
+class ProfileCompletionPolicy(Protocol):
+    """Optional generic completion-stage capability supplied by a leaf policy."""
+
+    def validate_completion(
+        self,
+        context: PolicyContext,
+        leaf_contract: Mapping[str, Any],
+        completion_input: Mapping[str, Any],
+    ) -> ProfileEvidenceRecord | None: ...
 
 
 class ProfilePolicyRegistry:
@@ -393,19 +563,22 @@ LeafIssuePolicyRegistry = ProfilePolicyRegistry
 
 
 def _contract_reference(leaf_contract: Mapping[str, Any]) -> dict[str, Any]:
-    reference = {
+    body_sha256 = leaf_contract.get("body_sha256")
+    if isinstance(body_sha256, str) and body_sha256:
+        return {
+            "number": leaf_contract.get("number"),
+            "body_sha256": body_sha256,
+        }
+    return {
         "number": leaf_contract.get("number"),
-        "body_sha256": leaf_contract.get("body_sha256"),
-    }
-    if not isinstance(reference["body_sha256"], str) or not reference["body_sha256"]:
-        reference["contract_sha256"] = sha256_json(
+        "contract_sha256": sha256_json(
             {
                 "number": leaf_contract.get("number"),
                 "title": leaf_contract.get("title"),
                 "url": leaf_contract.get("url"),
             }
-        )
-    return reference
+        ),
+    }
 
 
 def _valid_contract_reference(value: Any) -> bool:
@@ -433,7 +606,7 @@ def _valid_contract_reference(value: Any) -> bool:
     return set(value) == (
         {"number", "body_sha256"}
         if body_sha256 is not None
-        else {"number", "body_sha256", "contract_sha256"}
+        else {"number", "contract_sha256"}
     )
 
 
@@ -514,8 +687,14 @@ class _BuiltinPolicy:
     contract_kind: str
     candidate_kind: str
     policy_label: str
+    review_kind: str | None = None
+    completion_kind: str | None = None
     legacy_result_field: str | None = None
     candidate_requires_result: bool = False
+
+    def _kind(self, stage: str) -> str:
+        value = getattr(self, f"{stage}_kind", None)
+        return value if isinstance(value, str) else f"{self.profile_id}.{stage}.v1"
 
     def _validate_contract_payload(self, value: object) -> bool:
         del value
@@ -554,7 +733,12 @@ class _BuiltinPolicy:
     def validate_evidence(self, record: ProfileEvidenceRecord) -> bool:
         if record.schema_version != PROFILE_EVIDENCE_SCHEMA_VERSION:
             return False
-        if record.kind not in {self.contract_kind, self.candidate_kind}:
+        if record.kind not in {
+            self.contract_kind,
+            self.candidate_kind,
+            self._kind("review"),
+            self._kind("completion"),
+        }:
             return False
         payload = record.payload
         if payload.get("policy_id") != self.profile_id or not isinstance(
@@ -572,9 +756,41 @@ class _BuiltinPolicy:
         if status == "fail":
             error = payload.get("error")
             return isinstance(error, str) and bool(error.strip())
-        return not self.candidate_requires_result or (
-            isinstance(result, Mapping) and result.get("status") == "pass"
+        if record.kind == self.candidate_kind and self.candidate_requires_result:
+            return isinstance(result, Mapping) and result.get("status") == "pass"
+        return True
+
+    def validate_review(
+        self,
+        context: PolicyContext,
+        leaf_contract: Mapping[str, Any],
+        review_input: Mapping[str, Any],
+    ) -> ProfileEvidenceRecord:
+        return self._record(
+            self._kind("review"),
+            context,
+            leaf_contract,
+            result={"status": "pass"},
+            status="pass",
+            review=review_input,
         )
+
+    def review_artifact(
+        self,
+        context: PolicyContext,
+        review_input: Mapping[str, Any],
+    ) -> Mapping[str, Any] | None:
+        del context, review_input
+        return None
+
+    def validate_completion(
+        self,
+        context: PolicyContext,
+        leaf_contract: Mapping[str, Any],
+        completion_input: Mapping[str, Any],
+    ) -> ProfileEvidenceRecord | None:
+        del context, leaf_contract, completion_input
+        return None
 
     def evaluate_blockers(
         self,
@@ -612,6 +828,271 @@ class _BuiltinPolicy:
         if self.legacy_result_field is None or result is None:
             return {}
         return {self.legacy_result_field: dict(result)}
+
+    def _service_result(self, context: PolicyContext) -> Mapping[str, Any] | None:
+        """Use an injected test service without making it a controller contract."""
+        if not context.services:
+            return None
+        service = context.services[0]
+        run = getattr(service, "run", None)
+        if not callable(run):
+            raise ProfilePolicyError("injected profile service is not executable")
+        try:
+            result = run(
+                context.base_sha,
+                head_sha=context.head_sha,
+                include_index=context.include_index,
+            )
+        except TypeError:
+            # Keep old test doubles that only accept a positional base SHA.
+            result = run(context.base_sha)
+        if not isinstance(result, Mapping):
+            raise ProfilePolicyError("profile candidate result is malformed")
+        return result
+
+
+def _candidate_effective_diff(context: PolicyContext, *, command_prefix: str) -> Any:
+    if context.runner is None or context.repo_root is None:
+        raise ProfilePolicyError("profile candidate diff context is unavailable")
+    if not isinstance(context.base_sha, str) or not context.base_sha:
+        raise ProfilePolicyError("profile candidate base identity is unavailable")
+    head_ref = "HEAD" if context.include_index else (context.head_sha or "HEAD")
+    return calculate_effective_diff(
+        context.runner,
+        base_sha=context.base_sha,
+        head_ref=head_ref,
+        command_id_prefix=command_prefix,
+        cwd=context.repo_root,
+        include_index=context.include_index,
+    )
+
+
+def _documentation_candidate_result(context: PolicyContext) -> dict[str, Any]:
+    effective_diff = _candidate_effective_diff(
+        context, command_prefix="lck-documentation"
+    )
+    policy = evaluate_documentation_changes(effective_diff.changed_files)
+    payload = policy.to_dict()
+    payload["effective_diff"] = {
+        "merge_base_sha": effective_diff.merge_base_sha,
+        "effective_diff_sha256": effective_diff.effective_diff_sha256,
+        "source": "index" if context.include_index else "head",
+    }
+    return payload
+
+
+def _research_candidate_result(context: PolicyContext) -> dict[str, Any]:
+    effective_diff = _candidate_effective_diff(context, command_prefix="lck-research")
+    policy = evaluate_research_changes(
+        effective_diff.changed_files, repo_root=context.repo_root
+    )
+    payload = policy.to_dict()
+    payload["effective_diff"] = {
+        "merge_base_sha": effective_diff.merge_base_sha,
+        "effective_diff_sha256": effective_diff.effective_diff_sha256,
+        "source": "index" if context.include_index else "head",
+    }
+    try:
+        artifact_outcome = research_artifact_outcome(
+            context.repo_root, policy.artifact_files
+        )
+    except ResearchPolicyError as exc:
+        raise ResearchReclassificationRequired(str(exc)) from exc
+    payload["artifact_outcome"] = (
+        artifact_outcome.value if artifact_outcome is not None else None
+    )
+    return payload
+
+
+class DocumentationValidationGate:
+    """Compatibility adapter; production Delivery uses policy dispatch."""
+
+    def __init__(self, resolver: Any) -> None:
+        self.resolver = resolver
+        self.last_result: dict[str, Any] | None = None
+
+    def run(self, base_sha: str) -> dict[str, Any]:
+        context = PolicyContext(
+            base_sha=base_sha,
+            repo_root=self.resolver.repo_root,
+            runner=self.resolver.runner,
+            include_index=True,
+        )
+        result = _documentation_candidate_result(context)
+        self.last_result = result
+        if result.get("status") != "pass":
+            raise DocumentationReclassificationRequired(
+                "DOCUMENTATION_RECLASSIFICATION_REQUIRED: "
+                + str(
+                    result.get("detail")
+                    or "Documentation policy rejected the candidate"
+                ),
+                result=result,
+            )
+        return result
+
+
+class ResearchValidationGate:
+    """Compatibility adapter; production Delivery uses policy dispatch."""
+
+    def __init__(self, resolver: Any) -> None:
+        self.resolver = resolver
+        self.last_result: dict[str, Any] | None = None
+
+    def run(
+        self,
+        base_sha: str,
+        *,
+        head_sha: str | None = None,
+        include_index: bool = False,
+    ) -> dict[str, Any]:
+        context = PolicyContext(
+            base_sha=base_sha,
+            head_sha=head_sha,
+            repo_root=self.resolver.repo_root,
+            runner=self.resolver.runner,
+            include_index=include_index,
+        )
+        result = _research_candidate_result(context)
+        self.last_result = result
+        if result.get("status") != "pass":
+            raise ResearchReclassificationRequired(
+                "RESEARCH_RECLASSIFICATION_REQUIRED: "
+                + str(result.get("detail") or "Research policy rejected the candidate"),
+                result=result,
+            )
+        return result
+
+
+RESEARCH_OUTCOME_QUERY: Final = r"""
+query($owner:String!, $projectNumber:Int!, $userAfter:String, $organizationAfter:String) {
+  user(login:$owner) {
+    projectV2(number:$projectNumber) {
+      items(first:100, after:$userAfter) {
+        nodes {
+          content { ... on Issue { number repository { nameWithOwner } } }
+          fieldValueByName(name:"Research Outcome") {
+            ... on ProjectV2ItemFieldSingleSelectValue { name }
+          }
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+  organization(login:$owner) {
+    projectV2(number:$projectNumber) {
+      items(first:100, after:$organizationAfter) {
+        nodes {
+          content { ... on Issue { number repository { nameWithOwner } } }
+          fieldValueByName(name:"Research Outcome") {
+            ... on ProjectV2ItemFieldSingleSelectValue { name }
+          }
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}
+"""
+
+
+class ResearchOutcomeEffect:
+    """Legacy read-only adapter retained for callers of the old helper.
+
+    Closeout no longer owns this profile-specific implementation; the generic
+    effect executor in ``effects.py`` owns completion side effects.
+    """
+
+    def __init__(self, resolver: Any) -> None:
+        self.resolver = resolver
+
+    def _query_outcome(self, repository: str, task_number: int) -> str | None:
+        owner, separator, _name = repository.partition("/")
+        if not separator or not owner:
+            return None
+        cursors: dict[str, str | None] = {"user": None, "organization": None}
+        seen: dict[str, set[str]] = {"user": set(), "organization": set()}
+        complete: set[str] = set()
+        while len(complete) < 2:
+            argv = [
+                "gh",
+                "api",
+                "graphql",
+                "-f",
+                f"query={' '.join(RESEARCH_OUTCOME_QUERY.split())}",
+                "-F",
+                f"owner={owner}",
+                "-F",
+                "projectNumber=1",
+            ]
+            if cursors["user"] is not None:
+                argv.extend(("-F", f"userAfter={cursors['user']}"))
+            if cursors["organization"] is not None:
+                argv.extend(("-F", f"organizationAfter={cursors['organization']}"))
+            result = self.resolver.runner.run(
+                argv, command_id="lck-research-outcome-postcondition", retries=1
+            )
+            if result.returncode != 0 or not result.stdout.strip():
+                return None
+            value = read_json_text(
+                result.stdout, field="lck-research-outcome-postcondition"
+            )
+            if not isinstance(value, Mapping) or value.get("errors"):
+                return None
+            data = value.get("data")
+            if not isinstance(data, Mapping):
+                return None
+            for scope in ("user", "organization"):
+                if scope in complete:
+                    continue
+                owner_data = data.get(scope)
+                if owner_data is None:
+                    complete.add(scope)
+                    continue
+                if not isinstance(owner_data, Mapping):
+                    return None
+                project = owner_data.get("projectV2")
+                if project is None:
+                    complete.add(scope)
+                    continue
+                if not isinstance(project, Mapping):
+                    return None
+                items = project.get("items")
+                if not isinstance(items, Mapping):
+                    return None
+                nodes = items.get("nodes")
+                page_info = items.get("pageInfo")
+                if not isinstance(nodes, list) or not isinstance(page_info, Mapping):
+                    return None
+                for item in nodes:
+                    if not isinstance(item, Mapping):
+                        continue
+                    content = item.get("content")
+                    if not isinstance(content, Mapping):
+                        continue
+                    content_repository = content.get("repository")
+                    if (
+                        content.get("number") == task_number
+                        and isinstance(content_repository, Mapping)
+                        and content_repository.get("nameWithOwner") == repository
+                    ):
+                        field_value = item.get("fieldValueByName")
+                        if not isinstance(field_value, Mapping):
+                            return None
+                        return safe_text(field_value.get("name"))
+                if page_info.get("hasNextPage") is False:
+                    complete.add(scope)
+                elif page_info.get("hasNextPage") is True:
+                    end_cursor = page_info.get("endCursor")
+                    if not isinstance(end_cursor, str) or not end_cursor:
+                        return None
+                    if end_cursor in seen[scope]:
+                        return None
+                    seen[scope].add(end_cursor)
+                    cursors[scope] = end_cursor
+                else:
+                    return None
+        return None
 
 
 class _TaskPolicy(_BuiltinPolicy):
@@ -654,19 +1135,46 @@ class _TaskPolicy(_BuiltinPolicy):
         leaf_contract: Mapping[str, Any],
         contract_evidence: ProfileEvidenceRecord,
     ) -> ProfileEvidenceRecord:
-        if context.critical_outcome is None:
-            raise ProfilePolicyError("Task Critical Outcome verifier is unavailable")
         _validate_policy_evidence(
             self,
             contract_evidence,
             stage="contract",
             leaf_contract=leaf_contract,
         )
-        result = context.critical_outcome()
+        if context.critical_outcome is not None:
+            # Compatibility for callers that inject a deterministic candidate
+            # callback.  Production Delivery leaves this unset and uses the
+            # policy-owned verifier below.
+            result = context.critical_outcome()
+        else:
+            if context.repo_root is None or context.runner is None:
+                raise ProfilePolicyError(
+                    "Task Critical Outcome verifier is unavailable"
+                )
+            try:
+                contract = contract_from_snapshot(
+                    contract_evidence.payload.get("contract")
+                )
+                verified = verify_critical_outcome(
+                    context.repo_root,
+                    context.runner,
+                    contract,
+                    progress=context.progress,
+                )
+            except (CriticalOutcomeError, ValueError) as exc:
+                raise ProfilePolicyError(str(exc)) from exc
+            result = verified.to_dict()
         if not isinstance(result, Mapping):
             raise ProfilePolicyError("Task Critical Outcome result is malformed")
         if result.get("status") != "pass":
-            raise ProfilePolicyError("Task Critical Outcome candidate did not pass")
+            detail = "Critical Outcome FAIL"
+            verification_test = contract_evidence.payload.get("verification_test")
+            exit_code = result.get("exit_code")
+            if isinstance(verification_test, str) and verification_test:
+                detail += f": {verification_test}"
+            if isinstance(exit_code, int) and not isinstance(exit_code, bool):
+                detail += f" exited {exit_code}"
+            raise ProfileCandidateRejected(detail, result)
         return self._record(
             self.candidate_kind,
             context,
@@ -753,18 +1261,61 @@ class _DocumentationPolicy(_BuiltinPolicy):
             stage="contract",
             leaf_contract=leaf_contract,
         )
-        if context.documentation_validation is not None:
-            result = context.documentation_validation()
-        else:
-            result = evaluate_documentation_changes(context.changed_files).to_dict()
+        result = self._service_result(context)
+        if result is None:
+            if context.runner is None or context.repo_root is None:
+                result = evaluate_documentation_changes(context.changed_files).to_dict()
+            else:
+                result = _documentation_candidate_result(context)
         if not isinstance(result, Mapping):
             raise ProfilePolicyError("Documentation candidate result is malformed")
+        if result.get("status") != "pass":
+            raise DocumentationReclassificationRequired(
+                "DOCUMENTATION_RECLASSIFICATION_REQUIRED: "
+                + str(
+                    result.get("detail")
+                    or "Documentation policy rejected the candidate"
+                ),
+                result=result,
+            )
         return self._record(
             self.candidate_kind,
             context,
             leaf_contract,
             result=dict(result),
             status=result.get("status"),
+        )
+
+    def validate_review(
+        self,
+        context: PolicyContext,
+        leaf_contract: Mapping[str, Any],
+        review_input: Mapping[str, Any],
+    ) -> ProfileEvidenceRecord:
+        identity = review_input.get("identity", review_input)
+        changed_files = (
+            identity.get("changed_files") if isinstance(identity, Mapping) else None
+        )
+        if not isinstance(changed_files, (list, tuple)):
+            raise DocumentationReclassificationRequired(
+                "DOCUMENTATION_RECLASSIFICATION_REQUIRED: "
+                "Review changed-file inventory is unavailable"
+            )
+        result = evaluate_documentation_changes(changed_files).to_dict()
+        if result.get("status") != "pass":
+            raise DocumentationReclassificationRequired(
+                "DOCUMENTATION_RECLASSIFICATION_REQUIRED: "
+                + str(
+                    result.get("detail")
+                    or "Documentation policy rejected the Review target"
+                )
+            )
+        return self._record(
+            self._kind("review"),
+            context,
+            leaf_contract,
+            result=result,
+            status="pass",
         )
 
 
@@ -806,11 +1357,19 @@ class _ResearchPolicy(_BuiltinPolicy):
             stage="contract",
             leaf_contract=leaf_contract,
         )
-        if context.research_validation is None:
-            raise ProfilePolicyError("Research candidate validator is unavailable")
-        result = context.research_validation()
+        result = self._service_result(context)
+        if result is None:
+            if context.runner is None or context.repo_root is None:
+                raise ProfilePolicyError("Research candidate validator is unavailable")
+            result = _research_candidate_result(context)
         if not isinstance(result, Mapping):
             raise ProfilePolicyError("Research candidate result is malformed")
+        if result.get("status") != "pass":
+            raise ResearchReclassificationRequired(
+                "RESEARCH_RECLASSIFICATION_REQUIRED: "
+                + str(result.get("detail") or "Research policy rejected the candidate"),
+                result=result,
+            )
         return self._record(
             self.candidate_kind,
             context,
@@ -818,6 +1377,184 @@ class _ResearchPolicy(_BuiltinPolicy):
             result=dict(result),
             status=result.get("status"),
         )
+
+    def review_artifact(
+        self,
+        context: PolicyContext,
+        review_input: Mapping[str, Any],
+    ) -> Mapping[str, Any] | None:
+        if context.repo_root is None:
+            raise ResearchPolicyError("Research Review workspace is unavailable")
+        identity = review_input.get("identity", review_input)
+        if not isinstance(identity, Mapping):
+            raise ResearchPolicyError("Research Review identity is unavailable")
+        required = {
+            key: identity.get(key)
+            for key in (
+                "task_number",
+                "pr_number",
+                "base_sha",
+                "head_sha",
+                "task_body_sha256",
+                "merge_base_sha",
+                "effective_diff_sha256",
+                "changed_files",
+            )
+        }
+        if not isinstance(required["changed_files"], (list, tuple)):
+            raise ResearchPolicyError(
+                "Research Review changed-file inventory is unavailable"
+            )
+        try:
+            return research_artifact_binding(
+                context.repo_root,
+                task_number=required["task_number"],
+                pr_number=required["pr_number"],
+                base_sha=required["base_sha"],
+                head_sha=required["head_sha"],
+                task_body_sha256=required["task_body_sha256"],
+                merge_base_sha=required["merge_base_sha"],
+                effective_diff_sha256=required["effective_diff_sha256"],
+                changed_files=required["changed_files"],
+            )
+        except (ResearchPolicyError, TypeError, ValueError) as exc:
+            raise ResearchPolicyError(str(exc)) from exc
+
+    def validate_review(
+        self,
+        context: PolicyContext,
+        leaf_contract: Mapping[str, Any],
+        review_input: Mapping[str, Any],
+    ) -> ProfileEvidenceRecord:
+        artifact = review_input.get("artifact")
+        if not isinstance(artifact, Mapping):
+            artifact = self.review_artifact(context, review_input)
+        verdict = str(review_input.get("verdict") or "PASS").upper()
+        outcome = review_input.get("research_outcome")
+        if outcome is not None:
+            if not isinstance(artifact, Mapping):
+                raise ResearchOutcomeRequired(
+                    "Research Review Complete requires a reviewed artifact binding"
+                )
+            try:
+                artifact = bind_research_outcome(artifact, outcome)
+            except ResearchPolicyError as exc:
+                raise ResearchOutcomeRequired(str(exc)) from exc
+        if verdict == "PASS":
+            if not isinstance(artifact, Mapping):
+                raise ResearchOutcomeRequired(
+                    "Research Review Complete requires a reviewed artifact binding"
+                )
+            try:
+                require_typed_research_outcome(artifact)
+            except ResearchPolicyError as exc:
+                raise ResearchOutcomeRequired(
+                    f"Research Review Complete requires a typed outcome: {exc}"
+                ) from exc
+        payload: dict[str, Any] = {
+            "result": {"status": "pass"},
+            "status": "pass",
+            "verdict": verdict,
+        }
+        if isinstance(artifact, Mapping):
+            payload["artifact"] = dict(artifact)
+        return self._record(self._kind("review"), context, leaf_contract, **payload)
+
+    def validate_completion(
+        self,
+        context: PolicyContext,
+        leaf_contract: Mapping[str, Any],
+        completion_input: Mapping[str, Any],
+    ) -> ProfileEvidenceRecord:
+        review_record = completion_input.get("review_record")
+        artifact: Mapping[str, Any] | None = None
+        if isinstance(review_record, Mapping):
+            raw_artifact = review_record.get("research_artifact")
+            if not isinstance(raw_artifact, Mapping):
+                raw_identity = review_record.get("identity")
+                if isinstance(raw_identity, Mapping):
+                    raw_artifact = raw_identity.get("research_artifact")
+            if isinstance(raw_artifact, Mapping):
+                artifact = raw_artifact
+        if artifact is None:
+            raw_artifact = completion_input.get("artifact")
+            if isinstance(raw_artifact, Mapping):
+                artifact = raw_artifact
+        if artifact is None:
+            raise ResearchOutcomeRequired(
+                "Research completion requires a reviewed artifact binding"
+            )
+        try:
+            outcome = require_typed_research_outcome(artifact)
+        except ResearchPolicyError as exc:
+            raise ResearchOutcomeRequired(
+                f"Research completion requires a typed outcome: {exc}"
+            ) from exc
+        repository = completion_input.get("repository") or (
+            context.issue.get("repository")
+            if isinstance(context.issue, Mapping)
+            else None
+        )
+        task_number = completion_input.get("task_number")
+        if not isinstance(repository, str) or not repository:
+            raise ProfilePolicyError("Research completion repository is unavailable")
+        if (
+            not isinstance(task_number, int)
+            or isinstance(task_number, bool)
+            or task_number <= 0
+        ):
+            raise ProfilePolicyError("Research completion Task number is unavailable")
+        descriptor = ProfileEffectDescriptor(
+            effect_kind="project.single_select.set.v1",
+            schema_version=1,
+            parameters={
+                "repository": repository,
+                "task_number": task_number,
+                "project_number": 1,
+                "field": RESEARCH_OUTCOME_FIELD,
+                "value": outcome.value,
+            },
+            postcondition={
+                "kind": "project.single_select.equals",
+                "repository": repository,
+                "task_number": task_number,
+                "project_number": 1,
+                "field": RESEARCH_OUTCOME_FIELD,
+                "value": outcome.value,
+            },
+            receipt={"outcome": outcome.value},
+        )
+        return self._record(
+            self._kind("completion"),
+            context,
+            leaf_contract,
+            result={"status": "pass", "outcome": outcome.value},
+            status="pass",
+            effect=descriptor.to_dict(),
+        )
+
+    def validate_evidence(self, record: ProfileEvidenceRecord) -> bool:
+        if not super().validate_evidence(record):
+            return False
+        if record.kind == self._kind("review"):
+            artifact = record.payload.get("artifact")
+            if artifact is not None and not isinstance(artifact, Mapping):
+                return False
+        if record.kind == self._kind("completion"):
+            effect = record.payload.get("effect")
+            if not isinstance(effect, Mapping):
+                return False
+            try:
+                ProfileEffectDescriptor(
+                    effect_kind=effect.get("effect_kind"),
+                    schema_version=effect.get("schema_version"),
+                    parameters=effect.get("parameters"),
+                    postcondition=effect.get("postcondition"),
+                    receipt=effect.get("receipt"),
+                )
+            except (ProfilePolicyError, TypeError, ValueError):
+                return False
+        return True
 
 
 DEFAULT_PROFILE_POLICY_REGISTRY: Final = ProfilePolicyRegistry(
@@ -860,6 +1597,7 @@ class ProfileGateFailure(LckStopError):
 
     detail: str
     profile_evidence: ProfileEvidenceEnvelope | None = None
+    legacy_results: Mapping[str, Any] = MappingProxyType({})
 
     def __str__(self) -> str:
         return self.detail
@@ -1036,6 +1774,211 @@ def validate_profile_candidate(
     return candidate
 
 
+@dataclass(frozen=True)
+class ProfileReviewResult:
+    """Generic Review-stage output, including the optional workspace artifact."""
+
+    evidence: ProfileEvidenceRecord | None
+    artifact: Mapping[str, Any] | None = None
+    profile_evidence: ProfileEvidenceEnvelope | None = None
+
+
+@dataclass(frozen=True)
+class ProfileCompletionResult:
+    """Generic completion-stage output and its data-only effect intent."""
+
+    evidence: ProfileEvidenceRecord | None
+    effect: ProfileEffectDescriptor | None = None
+    profile_evidence: ProfileEvidenceEnvelope | None = None
+
+
+def _policy_context(
+    profile: LeafIssueWorkflowProfile,
+    issue: Mapping[str, Any],
+    *,
+    context: PolicyContext | None = None,
+    **updates: Any,
+) -> PolicyContext:
+    if context is not None:
+        values = {**context.__dict__, **updates}
+        return PolicyContext(**values)
+    return PolicyContext(profile=profile, issue=issue, **updates)
+
+
+def build_profile_review_artifact(
+    profile: LeafIssueWorkflowProfile,
+    issue: Mapping[str, Any],
+    review_input: Mapping[str, Any],
+    *,
+    repo_root: Path | None,
+    registry: ProfilePolicyRegistry = DEFAULT_PROFILE_POLICY_REGISTRY,
+) -> Mapping[str, Any] | None:
+    """Ask the selected policy for artifact semantics inside a review clone."""
+    policy = resolve_profile_policy(profile, registry=registry)
+    method = getattr(policy, "review_artifact", None)
+    if not callable(method):
+        return None
+    context = PolicyContext(
+        profile=profile,
+        phase="review",
+        issue=issue,
+        repo_root=repo_root,
+        review_identity=(
+            review_input.get("identity")
+            if isinstance(review_input.get("identity"), Mapping)
+            else review_input
+        ),
+    )
+    value = method(context, review_input)
+    if value is None:
+        return None
+    if not isinstance(value, Mapping):
+        raise ProfilePolicyError("policy returned malformed Review artifact")
+    return dict(value)
+
+
+def validate_profile_review(
+    profile: LeafIssueWorkflowProfile,
+    issue: Mapping[str, Any],
+    review_input: Mapping[str, Any],
+    *,
+    registry: ProfilePolicyRegistry = DEFAULT_PROFILE_POLICY_REGISTRY,
+    context: PolicyContext | None = None,
+) -> ProfileReviewResult:
+    """Dispatch the generic Review capability without profile switches."""
+    policy = resolve_profile_policy(profile, registry=registry)
+    execution_context = _policy_context(
+        profile,
+        issue,
+        context=context,
+        phase="review",
+        review_identity=(
+            review_input.get("identity")
+            if isinstance(review_input.get("identity"), Mapping)
+            else review_input
+        ),
+        review_verdict=review_input.get("verdict"),
+        research_outcome=review_input.get("research_outcome"),
+    )
+    normalized_input = dict(review_input)
+    artifact = normalized_input.get("artifact")
+    identity = normalized_input.get("identity")
+    if not isinstance(artifact, Mapping) and isinstance(identity, Mapping):
+        identity_artifact = identity.get("research_artifact")
+        if isinstance(identity_artifact, Mapping):
+            artifact = identity_artifact
+            normalized_input["artifact"] = dict(identity_artifact)
+    if not isinstance(artifact, Mapping):
+        artifact = build_profile_review_artifact(
+            profile,
+            issue,
+            normalized_input,
+            repo_root=execution_context.repo_root,
+            registry=registry,
+        )
+        if artifact is not None:
+            normalized_input["artifact"] = dict(artifact)
+    method = getattr(policy, "validate_review", None)
+    evidence: ProfileEvidenceRecord | None = None
+    if callable(method):
+        evidence = _coerce_evidence(method(execution_context, issue, normalized_input))
+        _validate_policy_evidence(policy, evidence, stage="review", leaf_contract=issue)
+    artifact = normalized_input.get("artifact")
+    check = validate_profile_contract(
+        profile, issue, registry=registry, context=execution_context
+    )
+    if not check.valid or check.evidence is None:
+        raise ProfilePolicyError(check.failure_reason)
+    envelope = ProfileEvidenceEnvelope(
+        profile_id=profile.profile_id,
+        contract=check.evidence,
+        review=evidence,
+    ).validated(registry, leaf_contract=issue)
+    return ProfileReviewResult(
+        evidence=evidence,
+        artifact=dict(artifact) if isinstance(artifact, Mapping) else None,
+        profile_evidence=envelope,
+    )
+
+
+def validate_profile_completion(
+    profile: LeafIssueWorkflowProfile,
+    issue: Mapping[str, Any],
+    completion_input: Mapping[str, Any],
+    *,
+    registry: ProfilePolicyRegistry = DEFAULT_PROFILE_POLICY_REGISTRY,
+    context: PolicyContext | None = None,
+) -> ProfileCompletionResult:
+    """Dispatch and validate one profile's generic completion capability."""
+    policy = resolve_profile_policy(profile, registry=registry)
+    execution_context = _policy_context(
+        profile,
+        issue,
+        context=context,
+        phase="completion",
+        review_record=completion_input.get("review_record")
+        if isinstance(completion_input.get("review_record"), Mapping)
+        else None,
+        merged_pr=completion_input.get("merged_pr")
+        if isinstance(completion_input.get("merged_pr"), Mapping)
+        else None,
+    )
+    method = getattr(policy, "validate_completion", None)
+    evidence: ProfileEvidenceRecord | None = None
+    if callable(method):
+        result = method(execution_context, issue, completion_input)
+        if result is not None:
+            evidence = _coerce_evidence(result)
+            _validate_policy_evidence(
+                policy, evidence, stage="completion", leaf_contract=issue
+            )
+    effect: ProfileEffectDescriptor | None = None
+    if evidence is not None:
+        raw_effect = evidence.payload.get("effect")
+        if raw_effect is not None:
+            if not isinstance(raw_effect, Mapping):
+                raise ProfilePolicyError("completion effect descriptor is malformed")
+            try:
+                effect = ProfileEffectDescriptor(
+                    effect_kind=raw_effect.get("effect_kind"),
+                    schema_version=raw_effect.get("schema_version"),
+                    parameters=raw_effect.get("parameters"),
+                    postcondition=raw_effect.get("postcondition"),
+                    receipt=raw_effect.get("receipt"),
+                )
+            except (ProfilePolicyError, TypeError, ValueError) as exc:
+                raise ProfilePolicyError(str(exc)) from exc
+    if evidence is None:
+        # Completion is an optional capability.  Profiles without a completion
+        # policy must not acquire or re-validate a profile-specific contract at
+        # this generic lifecycle boundary.
+        return ProfileCompletionResult(
+            evidence=None, effect=None, profile_evidence=None
+        )
+    check = validate_profile_contract(
+        profile, issue, registry=registry, context=execution_context
+    )
+    if not check.valid or check.evidence is None:
+        raise ProfilePolicyError(check.failure_reason)
+    review_record = completion_input.get("review_evidence")
+    review_evidence = (
+        _coerce_evidence(review_record) if review_record is not None else None
+    )
+    if review_evidence is not None:
+        _validate_policy_evidence(
+            policy, review_evidence, stage="review", leaf_contract=issue
+        )
+    envelope = ProfileEvidenceEnvelope(
+        profile_id=profile.profile_id,
+        contract=check.evidence,
+        review=review_evidence,
+        completion=evidence,
+    ).validated(registry, leaf_contract=issue)
+    return ProfileCompletionResult(
+        evidence=evidence, effect=effect, profile_evidence=envelope
+    )
+
+
 def _result_from_candidate(
     record: ProfileEvidenceRecord | None,
 ) -> dict[str, Any] | None:
@@ -1052,11 +1995,14 @@ def run_profile_delivery_gates(
     head_sha: str | None,
     include_index: bool,
     progress: Any,
-    documentation_validation: Any,
-    research_validation: Any,
-    critical_outcome: Callable[[], dict[str, Any]],
+    documentation_validation: Any = None,
+    research_validation: Any = None,
+    critical_outcome: Callable[[], dict[str, Any]] | None = None,
     issue: Mapping[str, Any] | None = None,
     registry: ProfilePolicyRegistry = DEFAULT_PROFILE_POLICY_REGISTRY,
+    repo_root: Path | None = None,
+    runner: Any = None,
+    services: Sequence[Any] = (),
 ) -> ProfileGateResults:
     """Run contract and candidate stages through the selected policy."""
     policy = resolve_profile_policy(profile, registry=registry)
@@ -1106,13 +2052,22 @@ def run_profile_delivery_gates(
         profile=profile,
         phase="delivery",
         issue=issue,
+        repo_root=repo_root,
+        runner=runner,
         base_sha=base_sha,
         head_sha=head_sha,
         include_index=include_index,
         progress=progress,
-        critical_outcome=run_critical,
-        documentation_validation=run_documentation,
-        research_validation=run_research,
+        critical_outcome=run_critical if critical_outcome is not None else None,
+        documentation_validation=(
+            run_documentation if documentation_validation is not None else None
+        ),
+        research_validation=run_research if research_validation is not None else None,
+        services=tuple(
+            item
+            for item in (*services, documentation_validation, research_validation)
+            if item is not None
+        ),
     )
     if not isinstance(issue, Mapping):
         raise LckStopError("current leaf Issue contract is unavailable")
@@ -1143,12 +2098,24 @@ def run_profile_delivery_gates(
             if callable(failure_builder)
             else None
         )
+        structured_result = getattr(exc, "result", None)
+        if isinstance(structured_result, Mapping):
+            observed_result = dict(structured_result)
+            if callable(failure_builder):
+                failure = failure_builder(
+                    context,
+                    issue,
+                    check.evidence,
+                    observed_result,
+                    str(exc),
+                )
         envelope = ProfileEvidenceEnvelope(
             profile_id=profile.profile_id,
             contract=check.evidence,
             candidate=failure,
         ).validated(registry, leaf_contract=issue)
-        raise ProfileGateFailure(str(exc), envelope) from exc
+        legacy = getattr(policy, "legacy_result", lambda _result: {})(observed_result)
+        raise ProfileGateFailure(str(exc), envelope, legacy_results=legacy) from exc
 
     envelope = ProfileEvidenceEnvelope(
         profile_id=profile.profile_id,

--- a/tools/agent_workflow/lck_core/profile_policies.py
+++ b/tools/agent_workflow/lck_core/profile_policies.py
@@ -2005,6 +2005,9 @@ def validate_profile_completion(
         issue,
         context=context,
         phase="completion",
+        # Completion policies may declare effect intent only.  Do not allow a
+        # caller-provided command runner to cross the Kernel effect boundary.
+        runner=None,
         review_record=completion_input.get("review_record")
         if isinstance(completion_input.get("review_record"), Mapping)
         else None,

--- a/tools/agent_workflow/lck_core/receipts.py
+++ b/tools/agent_workflow/lck_core/receipts.py
@@ -256,6 +256,7 @@ def _agent_view_for_result(value: Any) -> dict[str, Any]:
             "issue_profile": _issue_profile_agent_view(value),
             "task_contract": _jsonable(value.task_contract),
             "review_target": value.identity.to_dict(),
+            "profile_evidence": _profile_evidence(value.profile_evidence),
             "checks": _checks_agent_view(value.checks),
             "validation": _validation_agent_view(value.validation),
             "review_root": str(value.review_root),
@@ -276,6 +277,7 @@ def _agent_view_for_result(value: Any) -> dict[str, Any]:
             "status": value.status,
             "issue_profile": _issue_profile_agent_view(value),
             "review_target": value.identity.to_dict(),
+            "profile_evidence": _profile_evidence(value.profile_evidence),
             "human_boundary": (
                 "STOP; run deterministic Merge Preflight before any manual merge"
                 if value.verdict == "PASS"
@@ -344,6 +346,7 @@ def _agent_view_for_result(value: Any) -> dict[str, Any]:
             "business_delivery": value.business_delivery,
             "cleanup": value.cleanup,
             "research_outcome": value.research_outcome,
+            "profile_evidence": _profile_evidence(value.profile_evidence),
             "effects": _effect_agent_view(value.effects),
             "automatic_merge": False,
             "manual_issue_close": False,

--- a/tools/agent_workflow/lck_core/review.py
+++ b/tools/agent_workflow/lck_core/review.py
@@ -142,13 +142,20 @@ class ReviewPreparer:
     ) -> None:
         self.resolver = resolver
         self.snapshots = OperationSnapshotBuilder(resolver)
-        self.eligibility = eligibility or PhaseEligibilityResolver()
+        self.policy_registry = policy_registry or DEFAULT_PROFILE_POLICY_REGISTRY
+        self.profile_resolver = (
+            profile_resolver
+            or getattr(eligibility, "profile_resolver", None)
+            or resolve_leaf_issue_profile
+        )
+        self.eligibility = eligibility or PhaseEligibilityResolver(
+            registry=self.policy_registry,
+            profile_resolver=self.profile_resolver,
+        )
         self.validation = validation or ReviewValidationGate(resolver)
         self.checks_gate = checks_gate or DeliveryChecksGate(resolver)
         self.workspace = workspace or ReviewWorkspaceManager(resolver)
         self.store = store or ReviewInvocationStore(resolver.repo_root)
-        self.policy_registry = policy_registry or DEFAULT_PROFILE_POLICY_REGISTRY
-        self.profile_resolver = profile_resolver
         self.last_snapshot: OperationSnapshot | None = None
         self.last_validation: dict[str, Any] | None = None
         self.last_documentation_validation: dict[str, Any] | None = None
@@ -413,12 +420,19 @@ class ReviewCompleter:
     ) -> None:
         self.resolver = resolver
         self.snapshots = OperationSnapshotBuilder(resolver)
-        self.eligibility = eligibility or PhaseEligibilityResolver()
+        self.policy_registry = policy_registry or DEFAULT_PROFILE_POLICY_REGISTRY
+        self.profile_resolver = (
+            profile_resolver
+            or getattr(eligibility, "profile_resolver", None)
+            or resolve_leaf_issue_profile
+        )
+        self.eligibility = eligibility or PhaseEligibilityResolver(
+            registry=self.policy_registry,
+            profile_resolver=self.profile_resolver,
+        )
         self.checks_gate = checks_gate or DeliveryChecksGate(resolver)
         self.store = store or ReviewInvocationStore(resolver.repo_root)
         self.workspace = workspace or ReviewWorkspaceManager(resolver)
-        self.policy_registry = policy_registry or DEFAULT_PROFILE_POLICY_REGISTRY
-        self.profile_resolver = profile_resolver
         self.last_snapshot: OperationSnapshot | None = None
         self.last_checks: dict[str, Any] | None = None
         self.last_documentation_validation: dict[str, Any] | None = None

--- a/tools/agent_workflow/lck_core/review.py
+++ b/tools/agent_workflow/lck_core/review.py
@@ -795,10 +795,18 @@ class MergePreflight:
         *,
         review_gate: ReviewPassGate | None = None,
         checks_gate: DeliveryChecksGate | None = None,
+        policy_registry: ProfilePolicyRegistry | None = None,
+        profile_resolver: ProfileResolver | None = None,
     ) -> None:
         self.resolver = resolver
         self.snapshots = OperationSnapshotBuilder(resolver)
-        self.review_gate = review_gate or ReviewPassGate(resolver)
+        self.policy_registry = policy_registry or DEFAULT_PROFILE_POLICY_REGISTRY
+        self.profile_resolver = profile_resolver
+        self.review_gate = review_gate or ReviewPassGate(
+            resolver,
+            policy_registry=self.policy_registry,
+            profile_resolver=self.profile_resolver,
+        )
         self.checks_gate = checks_gate or DeliveryChecksGate(resolver)
         self.last_snapshot: OperationSnapshot | None = None
         self.last_checks: dict[str, Any] | None = None

--- a/tools/agent_workflow/lck_core/review.py
+++ b/tools/agent_workflow/lck_core/review.py
@@ -7,16 +7,11 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any, cast
 
-from research_policy import (
-    ResearchPolicyError,
-    bind_research_outcome,
-    require_typed_research_outcome,
-)
 from workflow_common import ProgressReporter, is_sha, safe_text
 from workflow_evidence import _formal_blockers_gate
 
 from .eligibility import PhaseEligibilityResolver
-from .issue_profiles import resolve_issue_profile
+from .issue_profiles import resolve_leaf_issue_profile
 from .models import (
     BASE_BRANCH,
     LCK_SCHEMA_VERSION,
@@ -31,8 +26,14 @@ from .models import (
     _pr_head_sha,
 )
 from .profile_policies import (
-    evaluate_profile_changes,
-    profile_research_outcome_supported,
+    DEFAULT_PROFILE_POLICY_REGISTRY,
+    PolicyContext,
+    ProfileEvidenceEnvelope,
+    ProfilePolicyError,
+    ProfilePolicyRegistry,
+    ProfileResolver,
+    resolve_issue_policy,
+    validate_profile_review,
 )
 from .review_workspace import (
     ReviewIdentity,
@@ -51,7 +52,6 @@ from .state import (
 )
 from .validation import (
     DeliveryChecksGate,
-    DocumentationReclassificationRequired,
     ReviewValidationGate,
 )
 
@@ -65,6 +65,7 @@ class ReviewContext:
     validation: Mapping[str, Any]
     review_root: Path
     issue_profile: Mapping[str, Any] | None = None
+    profile_evidence: ProfileEvidenceEnvelope | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -77,6 +78,9 @@ class ReviewContext:
             "review_target": self.identity.to_dict(),
             "checks": _jsonable(self.checks),
             "validation": _jsonable(self.validation),
+            "profile_evidence": (
+                self.profile_evidence.to_dict() if self.profile_evidence else None
+            ),
             "review_root": str(self.review_root),
             "workspace_mode": "implementation-read-only",
             "agent_role": ["Inspect", "Reason", "Judge", "Report"],
@@ -133,6 +137,8 @@ class ReviewPreparer:
         checks_gate: DeliveryChecksGate | None = None,
         workspace: ReviewWorkspaceManager | None = None,
         store: ReviewInvocationStore | None = None,
+        policy_registry: ProfilePolicyRegistry | None = None,
+        profile_resolver: ProfileResolver | None = None,
     ) -> None:
         self.resolver = resolver
         self.snapshots = OperationSnapshotBuilder(resolver)
@@ -141,9 +147,12 @@ class ReviewPreparer:
         self.checks_gate = checks_gate or DeliveryChecksGate(resolver)
         self.workspace = workspace or ReviewWorkspaceManager(resolver)
         self.store = store or ReviewInvocationStore(resolver.repo_root)
+        self.policy_registry = policy_registry or DEFAULT_PROFILE_POLICY_REGISTRY
+        self.profile_resolver = profile_resolver
         self.last_snapshot: OperationSnapshot | None = None
         self.last_validation: dict[str, Any] | None = None
         self.last_documentation_validation: dict[str, Any] | None = None
+        self.last_profile_evidence: ProfileEvidenceEnvelope | None = None
 
     def prepare(self, task_number: int) -> ReviewContext:
         self.last_validation = None
@@ -237,20 +246,29 @@ class ReviewPreparer:
                 state,
                 task_contract,
                 repo_root=review_root,
+                policy_registry=self.policy_registry,
+                profile_resolver=self.profile_resolver,
             )
-            profile = resolve_issue_profile(state.issue).profile
-            documentation_policy: dict[str, Any] | None = None
-            if profile is not None:
-                policy = evaluate_profile_changes(profile, identity.changed_files)
-            else:
-                policy = None
-            if policy is not None:
-                documentation_policy = policy.to_dict()
-                self.last_documentation_validation = documentation_policy
-                if policy.status.value != "pass":
-                    raise DocumentationReclassificationRequired(
-                        "DOCUMENTATION_RECLASSIFICATION_REQUIRED: " + policy.detail
-                    )
+            profile, _policy = resolve_issue_policy(
+                state.issue or {},
+                registry=self.policy_registry,
+                profile_resolver=self.profile_resolver or resolve_leaf_issue_profile,
+            )
+            review_stage = validate_profile_review(
+                profile,
+                state.issue or {},
+                {"identity": identity.to_dict(), "verdict": "PREPARE"},
+                registry=self.policy_registry,
+                context=PolicyContext(
+                    profile=profile,
+                    phase="review",
+                    issue=state.issue,
+                    repo_root=review_root,
+                    runner=self.resolver.runner,
+                    review_identity=identity.to_dict(),
+                ),
+            )
+            self.last_profile_evidence = review_stage.profile_evidence
             mark(
                 "review-target-derived",
                 identity=identity.to_dict(),
@@ -260,9 +278,6 @@ class ReviewPreparer:
             validation = self.validation.run(
                 review_root, identity.base_sha, identity.head_sha
             )
-            if documentation_policy is not None:
-                validation = dict(validation)
-                validation["documentation_policy"] = documentation_policy
             # Preserve the structured validation result before applying the
             # pass gate so a rejected Review Prepare has complete evidence.
             self.last_validation = validation
@@ -290,6 +305,11 @@ class ReviewPreparer:
                 "review_root": str(review_root),
                 "validation": validation,
                 "checks": checks,
+                "profile_evidence": (
+                    review_stage.profile_evidence.to_dict()
+                    if review_stage.profile_evidence
+                    else None
+                ),
                 "snapshot": snapshot.to_dict(),
                 "authority": (
                     "sealed Review Prepare target; historical identity for Review Complete "
@@ -312,6 +332,7 @@ class ReviewPreparer:
                 validation=validation,
                 review_root=review_root,
                 issue_profile=state.issue_profile,
+                profile_evidence=review_stage.profile_evidence,
             )
             invocation.release_lock()
         except BaseException as exc:
@@ -341,6 +362,7 @@ class ReviewCompletionResult:
     identity: ReviewIdentity
     record_path: Path
     issue_profile: Mapping[str, Any] | None = None
+    profile_evidence: ProfileEvidenceEnvelope | None = None
 
     def to_dict(self) -> dict[str, Any]:
         human_boundary = (
@@ -359,6 +381,9 @@ class ReviewCompletionResult:
             "review_target": self.identity.to_dict(),
             "research_artifact": _jsonable(self.identity.research_artifact),
             "record_path": str(self.record_path),
+            "profile_evidence": (
+                self.profile_evidence.to_dict() if self.profile_evidence else None
+            ),
             "human_boundary": human_boundary,
             "automatic_remediation": False,
         }
@@ -383,6 +408,8 @@ class ReviewCompleter:
         checks_gate: DeliveryChecksGate | None = None,
         store: ReviewInvocationStore | None = None,
         workspace: ReviewWorkspaceManager | None = None,
+        policy_registry: ProfilePolicyRegistry | None = None,
+        profile_resolver: ProfileResolver | None = None,
     ) -> None:
         self.resolver = resolver
         self.snapshots = OperationSnapshotBuilder(resolver)
@@ -390,9 +417,12 @@ class ReviewCompleter:
         self.checks_gate = checks_gate or DeliveryChecksGate(resolver)
         self.store = store or ReviewInvocationStore(resolver.repo_root)
         self.workspace = workspace or ReviewWorkspaceManager(resolver)
+        self.policy_registry = policy_registry or DEFAULT_PROFILE_POLICY_REGISTRY
+        self.profile_resolver = profile_resolver
         self.last_snapshot: OperationSnapshot | None = None
         self.last_checks: dict[str, Any] | None = None
         self.last_documentation_validation: dict[str, Any] | None = None
+        self.last_profile_evidence: ProfileEvidenceEnvelope | None = None
 
     def _capture_checks_from_gate(self) -> None:
         """Retain a check gate's result when strict evaluation raises."""
@@ -493,50 +523,48 @@ class ReviewCompleter:
                 state,
                 current_contract,
                 repo_root=review_root,
+                policy_registry=self.policy_registry,
+                profile_resolver=self.profile_resolver,
             )
             _assert_review_applicable(reviewed_identity, current_identity)
-            profile = resolve_issue_profile(state.issue).profile
-            research_artifact = current_identity.research_artifact
-            if profile is not None and profile_research_outcome_supported(profile):
-                if verdict == "PASS":
-                    if not isinstance(research_artifact, Mapping):
-                        raise LckStopError(
-                            "Research Review Complete requires a reviewed artifact binding"
-                        )
-                    try:
-                        if research_outcome is not None:
-                            research_artifact = bind_research_outcome(
-                                research_artifact, research_outcome
-                            )
-                        require_typed_research_outcome(research_artifact)
-                    except ResearchPolicyError as exc:
-                        raise LckStopError(
-                            f"Research Review Complete requires a typed outcome: {exc}"
-                        ) from exc
-                    current_identity = replace(
-                        current_identity, research_artifact=research_artifact
-                    )
-                elif research_outcome is not None:
-                    try:
-                        bind_research_outcome(research_artifact or {}, research_outcome)
-                    except ResearchPolicyError as exc:
-                        raise LckStopError(f"invalid Research Outcome: {exc}") from exc
-            elif research_outcome is not None:
+            try:
+                profile, _policy = resolve_issue_policy(
+                    state.issue or {},
+                    registry=self.policy_registry,
+                    profile_resolver=self.profile_resolver
+                    or resolve_leaf_issue_profile,
+                )
+                review_input: dict[str, Any] = {
+                    "identity": current_identity.to_dict(),
+                    "verdict": verdict,
+                }
+                if research_outcome is not None:
+                    review_input["research_outcome"] = research_outcome
+                review_stage = validate_profile_review(
+                    profile,
+                    state.issue or {},
+                    review_input,
+                    registry=self.policy_registry,
+                    context=PolicyContext(
+                        profile=profile,
+                        phase="review",
+                        issue=state.issue,
+                        repo_root=review_root,
+                        runner=self.resolver.runner,
+                        review_identity=current_identity.to_dict(),
+                        review_verdict=verdict,
+                        research_outcome=research_outcome,
+                    ),
+                )
+            except (ProfilePolicyError, TypeError, ValueError) as exc:
                 raise LckStopError(
-                    "--research-outcome is supported only for Research Issues"
+                    f"profile Review capability rejected the verdict: {exc}"
+                ) from exc
+            if review_stage.artifact is not None:
+                current_identity = replace(
+                    current_identity, research_artifact=review_stage.artifact
                 )
-            if profile is not None:
-                policy = evaluate_profile_changes(
-                    profile, current_identity.changed_files
-                )
-            else:
-                policy = None
-            if policy is not None:
-                self.last_documentation_validation = policy.to_dict()
-                if policy.status.value != "pass":
-                    raise DocumentationReclassificationRequired(
-                        "DOCUMENTATION_RECLASSIFICATION_REQUIRED: " + policy.detail
-                    )
+            self.last_profile_evidence = review_stage.profile_evidence
             if verdict == "PASS":
                 completion_snapshot = self.snapshots.bind_required_checks(
                     completion_snapshot, repo_root=review_root
@@ -580,6 +608,11 @@ class ReviewCompleter:
                 "validation": validation,
                 "checks": dict(prepared_checks),
                 "completion_checks": completion_checks,
+                "profile_evidence": (
+                    review_stage.profile_evidence.to_dict()
+                    if review_stage.profile_evidence
+                    else None
+                ),
                 "review_snapshot": dict(prepared_snapshot),
                 "completion_snapshot": completion_snapshot.to_dict(),
                 "authority_note": (
@@ -600,6 +633,7 @@ class ReviewCompleter:
                 identity=current_identity,
                 record_path=record_path,
                 issue_profile=completion_snapshot.state.issue_profile,
+                profile_evidence=review_stage.profile_evidence,
             )
         except ReviewStaleError:
             # Stale is a formal terminal outcome for this prepared target.  It
@@ -629,9 +663,13 @@ class ReviewPassGate:
         resolver: LiveStateResolver,
         *,
         store: ReviewInvocationStore | None = None,
+        policy_registry: ProfilePolicyRegistry | None = None,
+        profile_resolver: ProfileResolver | None = None,
     ) -> None:
         self.resolver = resolver
         self.store = store or ReviewInvocationStore(resolver.repo_root)
+        self.policy_registry = policy_registry or DEFAULT_PROFILE_POLICY_REGISTRY
+        self.profile_resolver = profile_resolver
 
     def run(self, task_number: int, state: LiveState) -> dict[str, Any]:
         latest = self.store.read_latest_review(task_number)
@@ -663,18 +701,29 @@ class ReviewPassGate:
             )
         except ReviewStaleError as exc:
             raise LckStopError(f"Review PASS is stale: {exc}") from exc
-        profile = resolve_issue_profile(state.issue).profile
-        if profile is not None:
-            policy = evaluate_profile_changes(profile, recorded.changed_files)
-        else:
-            policy = None
-        if policy is not None:
-            if policy.status.value != "pass":
-                raise DocumentationReclassificationRequired(
-                    "Documentation Review PASS is outside the safe-change policy: "
-                    + policy.detail
-                )
-
+        try:
+            profile, _policy = resolve_issue_policy(
+                state.issue or {},
+                registry=self.policy_registry,
+                profile_resolver=self.profile_resolver or resolve_leaf_issue_profile,
+            )
+            validate_profile_review(
+                profile,
+                state.issue or {},
+                {"identity": recorded.to_dict(), "verdict": "PASS"},
+                registry=self.policy_registry,
+                context=PolicyContext(
+                    profile=profile,
+                    phase="review",
+                    issue=state.issue,
+                    review_identity=recorded.to_dict(),
+                    review_verdict="PASS",
+                ),
+            )
+        except (ProfilePolicyError, TypeError, ValueError) as exc:
+            raise LckStopError(
+                f"Review PASS profile evidence is invalid: {exc}"
+            ) from exc
         # Git commit objects are content-addressed. Once current PR/base/head and
         # Task Contract identity still match the accepted Review receipt, the
         # recorded merge-base/effective-diff identity remains mechanically bound

--- a/tools/agent_workflow/lck_core/review_workspace.py
+++ b/tools/agent_workflow/lck_core/review_workspace.py
@@ -12,11 +12,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Final, cast
 
-from research_policy import ResearchPolicyError, research_artifact_binding
 from workflow_common import WorkflowToolError, atomic_write_json, is_sha, read_json_file
 
 from .effective_diff import calculate_effective_diff
-from .issue_profiles import resolve_issue_profile
+from .issue_profiles import resolve_leaf_issue_profile
 from .models import (
     LCK_SCHEMA_VERSION,
     LckStopError,
@@ -25,7 +24,14 @@ from .models import (
     _pr_base_sha,
     _pr_head_sha,
 )
-from .profile_policies import profile_has_research_artifacts
+from .profile_policies import (
+    DEFAULT_PROFILE_POLICY_REGISTRY,
+    ProfilePolicyError,
+    ProfilePolicyRegistry,
+    ProfileResolver,
+    build_profile_review_artifact,
+    resolve_issue_policy,
+)
 from .state import LiveStateResolver
 
 
@@ -110,6 +116,8 @@ def _review_identity(
     task_contract: Mapping[str, Any],
     *,
     repo_root: Path,
+    policy_registry: ProfilePolicyRegistry = DEFAULT_PROFILE_POLICY_REGISTRY,
+    profile_resolver: ProfileResolver | None = None,
 ) -> ReviewIdentity:
     """Derive the effective diff from frozen refs inside a materialized repository.
 
@@ -126,25 +134,33 @@ def _review_identity(
         command_id_prefix="lck-review",
         cwd=repo_root,
     )
-    research_artifact = None
-    profile = resolve_issue_profile(state.issue).profile
-    if profile is not None and profile_has_research_artifacts(profile):
-        try:
-            research_artifact = research_artifact_binding(
-                repo_root,
-                task_number=target.task_number,
-                pr_number=target.pr_number,
-                base_sha=target.base_sha,
-                head_sha=target.head_sha,
-                task_body_sha256=target.task_body_sha256,
-                merge_base_sha=effective_diff.merge_base_sha,
-                effective_diff_sha256=effective_diff.effective_diff_sha256,
-                changed_files=effective_diff.changed_files,
-            )
-        except ResearchPolicyError as exc:
-            raise LckStopError(
-                f"Research artifact policy rejected the Review target: {exc}"
-            ) from exc
+    artifact_input = {
+        "task_number": target.task_number,
+        "pr_number": target.pr_number,
+        "base_sha": target.base_sha,
+        "head_sha": target.head_sha,
+        "task_body_sha256": target.task_body_sha256,
+        "merge_base_sha": effective_diff.merge_base_sha,
+        "effective_diff_sha256": effective_diff.effective_diff_sha256,
+        "changed_files": effective_diff.changed_files,
+    }
+    try:
+        profile, _policy = resolve_issue_policy(
+            state.issue or {},
+            registry=policy_registry,
+            profile_resolver=profile_resolver or resolve_leaf_issue_profile,
+        )
+        research_artifact = build_profile_review_artifact(
+            profile,
+            state.issue or {},
+            artifact_input,
+            repo_root=repo_root,
+            registry=policy_registry,
+        )
+    except (ProfilePolicyError, ValueError) as exc:
+        raise LckStopError(
+            f"Research artifact policy rejected the Review target: {exc}"
+        ) from exc
     return ReviewIdentity(
         task_number=target.task_number,
         pr_number=target.pr_number,

--- a/tools/agent_workflow/lck_core/validation.py
+++ b/tools/agent_workflow/lck_core/validation.py
@@ -7,17 +7,6 @@ from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import Any, Final
 
-from documentation_policy import (
-    DocumentationChangeResult,
-    DocumentationPolicyStatus,
-    evaluate_documentation_changes,
-)
-from research_policy import (
-    ResearchPolicyError,
-    ResearchPolicyStatus,
-    evaluate_research_changes,
-    research_artifact_outcome,
-)
 from workflow_common import (
     ProgressReporter,
     WorkflowToolError,
@@ -28,7 +17,6 @@ from workflow_common import (
 )
 from workflow_evidence import _normalize_checks
 
-from .effective_diff import calculate_effective_diff
 from .models import (
     LCK_SCHEMA_VERSION,
     LckStopError,
@@ -43,22 +31,21 @@ from .state import (
 )
 
 
-class DocumentationReclassificationRequired(LckStopError):
-    """The candidate is outside the Documentation profile's safe scope."""
+# Backward-compatible names for callers that imported the old adapters from
+# this module.  They are resolved lazily so the shared validation controller
+# does not import or hold any concrete profile implementation.
+def __getattr__(name: str) -> Any:
+    if name in {
+        "DocumentationReclassificationRequired",
+        "DocumentationValidationGate",
+        "ResearchReclassificationRequired",
+        "ResearchOutcomeRequired",
+        "ResearchValidationGate",
+    }:
+        from . import profile_policies
 
-    code = "DOCUMENTATION_RECLASSIFICATION_REQUIRED"
-
-
-class ResearchReclassificationRequired(LckStopError):
-    """The candidate is outside the Research artifact policy."""
-
-    code = "RESEARCH_RECLASSIFICATION_REQUIRED"
-
-
-class ResearchOutcomeRequired(LckStopError):
-    """A Research decision boundary has no typed outcome."""
-
-    code = "RESEARCH_OUTCOME_REQUIRED"
+        return getattr(profile_policies, name)
+    raise AttributeError(name)
 
 
 class FormalValidationGate:
@@ -128,92 +115,6 @@ class FormalValidationGate:
             reporter.failed("formal-validation")
             raise
         reporter.completed("formal-validation")
-        return payload
-
-
-class DocumentationValidationGate:
-    """Apply the fixed repository-owned Documentation change policy."""
-
-    def __init__(self, resolver: LiveStateResolver) -> None:
-        self.resolver = resolver
-        self.last_result: dict[str, Any] | None = None
-
-    def run(self, base_sha: str) -> dict[str, Any]:
-        if not is_sha(base_sha):
-            raise LckStopError("Documentation validation base SHA is unavailable")
-        effective_diff = calculate_effective_diff(
-            self.resolver.runner,
-            base_sha=base_sha,
-            head_ref="HEAD",
-            command_id_prefix="lck-documentation",
-            cwd=self.resolver.repo_root,
-            include_index=True,
-        )
-        policy: DocumentationChangeResult = evaluate_documentation_changes(
-            effective_diff.changed_files
-        )
-        payload = policy.to_dict()
-        payload["effective_diff"] = {
-            "merge_base_sha": effective_diff.merge_base_sha,
-            "effective_diff_sha256": effective_diff.effective_diff_sha256,
-            "source": "index",
-        }
-        self.last_result = payload
-        if policy.status is not DocumentationPolicyStatus.PASS:
-            raise DocumentationReclassificationRequired(
-                "DOCUMENTATION_RECLASSIFICATION_REQUIRED: " + policy.detail
-            )
-        return payload
-
-
-class ResearchValidationGate:
-    """Apply the repository-owned Research artifact policy to one candidate."""
-
-    def __init__(self, resolver: LiveStateResolver) -> None:
-        self.resolver = resolver
-        self.last_result: dict[str, Any] | None = None
-
-    def run(
-        self,
-        base_sha: str,
-        *,
-        head_sha: str | None = None,
-        include_index: bool = False,
-    ) -> dict[str, Any]:
-        if not is_sha(base_sha):
-            raise LckStopError("Research validation base SHA is unavailable")
-        effective_diff = calculate_effective_diff(
-            self.resolver.runner,
-            base_sha=base_sha,
-            head_ref="HEAD" if include_index else (head_sha or ""),
-            command_id_prefix="lck-research",
-            cwd=self.resolver.repo_root,
-            include_index=include_index,
-        )
-        policy = evaluate_research_changes(
-            effective_diff.changed_files, repo_root=self.resolver.repo_root
-        )
-        payload = policy.to_dict()
-        payload["effective_diff"] = {
-            "merge_base_sha": effective_diff.merge_base_sha,
-            "effective_diff_sha256": effective_diff.effective_diff_sha256,
-            "source": "index" if include_index else "head",
-        }
-        try:
-            artifact_outcome = research_artifact_outcome(
-                self.resolver.repo_root, policy.artifact_files
-            )
-        except ResearchPolicyError as exc:
-            raise ResearchReclassificationRequired(str(exc)) from exc
-        payload["artifact_outcome"] = (
-            artifact_outcome.value if artifact_outcome is not None else None
-        )
-        self.last_result = payload
-        if policy.status is not ResearchPolicyStatus.PASS:
-            raise ResearchReclassificationRequired(
-                "RESEARCH_RECLASSIFICATION_REQUIRED: "
-                + (policy.detail or "Research artifact policy rejected the candidate")
-            )
         return payload
 
 

--- a/tools/agent_workflow/lck_core/validation.py
+++ b/tools/agent_workflow/lck_core/validation.py
@@ -31,23 +31,6 @@ from .state import (
 )
 
 
-# Backward-compatible names for callers that imported the old adapters from
-# this module.  They are resolved lazily so the shared validation controller
-# does not import or hold any concrete profile implementation.
-def __getattr__(name: str) -> Any:
-    if name in {
-        "DocumentationReclassificationRequired",
-        "DocumentationValidationGate",
-        "ResearchReclassificationRequired",
-        "ResearchOutcomeRequired",
-        "ResearchValidationGate",
-    }:
-        from . import profile_policies
-
-        return getattr(profile_policies, name)
-    raise AttributeError(name)
-
-
 class FormalValidationGate:
     """Run the repository-owned deterministic Delivery validation plan."""
 


### PR DESCRIPTION
Closes #219

## Summary
Move typed profile candidate, Review, completion, and effect behavior behind the registry and frozen evidence envelope; keep workspace safety and lifecycle mechanics in shared LCK controllers; add synthetic policy/effect coverage.

## Validation
- Critical Outcome: pass
- Formal Delivery validation: pass

## Risks / limitations
No intended lifecycle behavior change; existing compatibility projections remain for legacy receipts and test injection seams.
