### PR TITLE
[Task] 建立 Issue-neutral LCK Shared Model

### DIFF
--- a/tests/tools/test_lck_profile_architecture.py
+++ b/tests/tools/test_lck_profile_architecture.py
@@ -413,6 +413,53 @@ class SyntheticPolicy:
         return False
 
 
+def test_leaf_contract_is_canonical_input_not_profile_evidence_envelope() -> None:
+    """Keep acquired Issue input separate from #217 lifecycle evidence."""
+    policy = SyntheticPolicy()
+    registry = ProfilePolicyRegistry.from_policies(policy)
+    profile = replace(
+        issue_profiles.TASK_PROFILE,
+        profile_id=policy.profile_id,
+        canonical_type_label=policy.canonical_type_label,
+        requires_critical_outcome=False,
+    )
+    leaf_contract = {
+        "number": 217,
+        "title": "Synthetic leaf Issue",
+        "body": "the acquired Issue body is not lifecycle evidence",
+        "body_sha256": "a" * 64,
+    }
+    state = lck_models.LiveState(
+        issue_number=217,
+        issue={"number": 217, "body_sha256": leaf_contract["body_sha256"]},
+        target_branch="synthetic/217-leaf-contract",
+        leaf_contract=leaf_contract,
+    )
+    snapshot = lck_models.OperationSnapshot(operation="test", state=state)
+
+    contract_result = validate_profile_contract(
+        profile,
+        snapshot.leaf_contract or {},
+        registry=registry,
+        context=PolicyContext(profile=profile, issue=snapshot.leaf_contract),
+    )
+    assert contract_result.valid
+    assert contract_result.evidence is not None
+    envelope = ProfileEvidenceEnvelope(
+        profile_id=policy.profile_id,
+        contract=contract_result.evidence,
+    ).validated(registry, leaf_contract=snapshot.leaf_contract)
+
+    assert snapshot.issue_number == 217
+    assert snapshot.leaf_contract == leaf_contract
+    assert "body" not in envelope.to_dict()["contract"]["payload"]
+    assert "leaf_contract" not in envelope.to_dict()
+    assert envelope.to_dict()["contract"]["payload"]["contract_ref"] == {
+        "number": 217,
+        "body_sha256": "a" * 64,
+    }
+
+
 @pytest.mark.parametrize(
     "profile",
     (

--- a/tests/tools/test_lck_state.py
+++ b/tests/tools/test_lck_state.py
@@ -39,6 +39,7 @@ from lck_test_support import (  # noqa: E402
     _issue,
     _open_pr,
     _relationships,
+    _review_state,
     _resolver,
     _task_contract,
 )
@@ -709,3 +710,44 @@ def test_delivery_history_query_requests_only_merged_detection_fields() -> None:
 
     command = fake.commands[-1]
     assert command[command.index("--json") + 1] == "number,state"
+
+
+def test_live_state_uses_neutral_storage_with_legacy_projections() -> None:
+    state = _review_state()
+    payload = state.to_dict()
+
+    assert state.issue_number == state.task_number == 159
+    assert state.local_issue_branch == state.local_task_branch
+    assert state.local_issue_head == state.local_task_head
+    assert state.remote_issue_branch == state.remote_task_branch
+    assert state.remote_issue_oid == state.remote_task_oid
+    assert state.leaf_contract == state.task_contract
+    assert "task_number" not in state.__dict__
+    assert "task_contract" not in state.__dict__
+    assert payload["issue_number"] == payload["task_number"] == 159
+    assert payload["leaf_contract"]["body"] == "Task Contract"
+    assert payload["task_contract"]["body_sha256"] == "d" * 64
+
+    restored = lck_models.LiveState.from_dict(payload)
+    assert restored == state
+    snapshot = lck_models.OperationSnapshot(operation="test", state=state)
+    restored_snapshot = lck_models.OperationSnapshot.from_dict(snapshot.to_dict())
+    assert restored_snapshot.issue_number == restored_snapshot.task_number == 159
+    assert restored_snapshot.leaf_contract == state.leaf_contract
+
+
+def test_live_state_compatibility_conflicts_fail_closed() -> None:
+    with pytest.raises(ValueError, match="issue_number/task_number"):
+        lck_models.LiveState(issue_number=1, task_number=2)
+
+    payload = _review_state().to_dict()
+    payload["remote_task_oid"] = "b" * 40
+    with pytest.raises(ValueError, match="remote_issue_oid/remote_task_oid"):
+        lck_models.LiveState.from_dict(payload)
+
+    payload = _review_state().to_dict()
+    legacy_contract = dict(cast(dict[str, Any], payload["task_contract"]))
+    legacy_contract["body_sha256"] = "f" * 64
+    payload["task_contract"] = legacy_contract
+    with pytest.raises(ValueError, match="leaf_contract/task_contract"):
+        lck_models.LiveState.from_dict(payload)

--- a/tools/agent_workflow/lck_core/README.md
+++ b/tools/agent_workflow/lck_core/README.md
@@ -48,6 +48,12 @@ workspace isolation, path containment, and review identity freshness remain
 kernel responsibilities; profile policies only supply bounded artifact
 semantics/evidence.
 
+`LiveState` and `OperationSnapshot` store Issue-neutral identity, branch, and
+`leaf_contract` fields. The historical `task_*` names remain read-only or
+serialized projections for compatibility; they are never a second canonical
+source. `leaf_contract` is the acquired Issue contract input, while
+`ProfileEvidenceEnvelope` remains lifecycle-stage evidence.
+
 When diagnosing a lifecycle issue, read this map first and inspect the owner module
 plus at most its direct companion modules before broad repository searches.
 

--- a/tools/agent_workflow/lck_core/closeout.py
+++ b/tools/agent_workflow/lck_core/closeout.py
@@ -223,7 +223,7 @@ class CloseoutMetadataEffect:
                 set_project_status_with_runner(
                     self.resolver.runner,
                     state.repository,
-                    state.task_number,
+                    state.issue_number,
                     value="Done",
                 )
                 actions.append("project-status-done")
@@ -234,7 +234,7 @@ class CloseoutMetadataEffect:
                         "gh",
                         "issue",
                         "edit",
-                        str(state.task_number),
+                        str(state.issue_number),
                         "--repo",
                         state.repository,
                         "--add-label",
@@ -260,7 +260,7 @@ class CloseoutMetadataEffect:
                 details={"actions": actions},
             )
         final_state, final_project_status, final_labels = self._query_metadata(
-            state.repository, state.task_number
+            state.repository, state.issue_number
         )
         if (
             str(final_state or "").upper() != "CLOSED"
@@ -299,7 +299,7 @@ class CleanupTaskRefsEffect:
         if (
             branch == BASE_BRANCH
             or profile is None
-            or not branch_matches_profile(branch, state.task_number, profile)
+            or not branch_matches_profile(branch, state.issue_number, profile)
         ):
             label = (
                 profile_cleanup_label(profile) if profile is not None else "leaf Issue"
@@ -340,13 +340,13 @@ class CleanupTaskRefsEffect:
                 "Cleanup STOP: PR head tree does not equal squash merge tree"
             )
 
-        if state.local_task_branch is None and state.remote_task_branch is None:
+        if state.local_issue_branch is None and state.remote_issue_branch is None:
             return EffectReceipt(
                 effect="cleanup_task_refs",
                 action="already-clean",
                 details={"branch": branch, "remote_branch": "already-deleted"},
             )
-        if state.local_task_branch is not None:
+        if state.local_issue_branch is not None:
             local_result = self.resolver.runner.run(
                 ["git", "rev-parse", f"refs/heads/{branch}"],
                 command_id="lck-closeout-local-branch-tip",
@@ -371,8 +371,8 @@ class CleanupTaskRefsEffect:
                     "pending",
                     reason="verified local Task branch could not be deleted",
                 )
-        if state.remote_task_branch is not None:
-            if state.remote_task_oid != expected_head_sha:
+        if state.remote_issue_branch is not None:
+            if state.remote_issue_oid != expected_head_sha:
                 raise LckStopError(
                     "Cleanup STOP: remote Task branch diverges from merged PR head"
                 )
@@ -541,7 +541,7 @@ class CloseoutCompleter:
             for item in closing
             if isinstance(item, Mapping) and isinstance(item.get("number"), int)
         ]
-        if len(closing_numbers) != 1 or closing_numbers[0] != state.task_number:
+        if len(closing_numbers) != 1 or closing_numbers[0] != state.issue_number:
             raise LckStopError(
                 "Closeout STOP: merged PR does not close exactly this Task"
             )
@@ -561,11 +561,17 @@ class CloseoutCompleter:
                 raise LckStopError(
                     "Closeout STOP: closed Task is not proven closed by the merged PR"
                 )
-        if state.local_task_head is not None and state.local_task_head != expected_head:
+        if (
+            state.local_issue_head is not None
+            and state.local_issue_head != expected_head
+        ):
             raise LckStopError(
                 "Closeout STOP: local Task branch diverges from merged PR head"
             )
-        if state.remote_task_oid is not None and state.remote_task_oid != expected_head:
+        if (
+            state.remote_issue_oid is not None
+            and state.remote_issue_oid != expected_head
+        ):
             raise LckStopError(
                 "Closeout STOP: remote Task branch diverges from merged PR head"
             )
@@ -574,7 +580,7 @@ class CloseoutCompleter:
     def _validate_reviewed_identity(
         self, state: LiveState, merged_pr: Mapping[str, Any]
     ) -> Mapping[str, Any]:
-        latest = self.review_store.read_latest_review(state.task_number)
+        latest = self.review_store.read_latest_review(state.issue_number)
         if not isinstance(latest, Mapping) or latest.get("verdict") != "PASS":
             raise LckStopError(
                 "Closeout STOP: latest Independent Review PASS is unavailable"
@@ -582,9 +588,9 @@ class CloseoutCompleter:
         review_id = latest.get("review_id")
         if not isinstance(review_id, str):
             raise LckStopError("Closeout STOP: latest Review PASS has no review id")
-        record = self.review_store.read_record(state.task_number, review_id)
+        record = self.review_store.read_record(state.issue_number, review_id)
         if (
-            record.get("task_number") != state.task_number
+            record.get("task_number") != state.issue_number
             or record.get("review_id") != review_id
             or record.get("verdict") != "PASS"
             or record.get("status") != "READY_FOR_MERGE_PREFLIGHT"
@@ -594,7 +600,7 @@ class CloseoutCompleter:
         if not isinstance(raw_identity, Mapping):
             raise LckStopError("Closeout STOP: Review PASS identity is unavailable")
         reviewed = _identity_from_mapping(raw_identity)
-        current_contract = state.task_contract
+        current_contract = state.leaf_contract
         current_body_sha256 = (
             current_contract.get("body_sha256")
             if isinstance(current_contract, Mapping)
@@ -605,7 +611,7 @@ class CloseoutCompleter:
                 "Closeout STOP: Review PASS is stale: Task Contract changed"
             )
         if (
-            reviewed.task_number != state.task_number
+            reviewed.task_number != state.issue_number
             or reviewed.pr_number != merged_pr.get("number")
             or reviewed.base_sha != _pr_base_sha(merged_pr)
             or reviewed.head_sha != _pr_head_sha(merged_pr)
@@ -655,7 +661,7 @@ class CloseoutCompleter:
                 profile,
                 _policy_issue_from_state(state),
                 {
-                    "task_number": state.task_number,
+                    "task_number": state.issue_number,
                     "repository": state.repository,
                     "merged_pr": state.merged_pr,
                     "review_record": review_record,

--- a/tools/agent_workflow/lck_core/delivery.py
+++ b/tools/agent_workflow/lck_core/delivery.py
@@ -39,8 +39,8 @@ from .profile_policies import (
 from .state import (
     LiveStateResolver,
     OperationSnapshotBuilder,
+    _leaf_contract_from_state,
     _policy_issue_from_state,
-    _task_contract_from_state,
 )
 from .validation import (
     DeliveryChecksGate,
@@ -72,7 +72,7 @@ class DeliveryContext:
             "base_sha": self.base_sha,
             "action": self.action,
             "issue_profile": _jsonable(self.state.issue_profile),
-            "task_contract": _jsonable(_task_contract_from_state(self.state)),
+            "task_contract": _jsonable(_leaf_contract_from_state(self.state)),
             "operation_snapshot": self.operation_snapshot.to_dict(),
             "eligibility": self.eligibility.to_dict(),
         }
@@ -151,7 +151,7 @@ class DeliveryPreparer:
         clean = state.git.get("clean") is True
         base_sha = state.git.get("local_main_sha")
         action = "already-prepared"
-        local_exists = state.local_task_branch is not None
+        local_exists = state.local_issue_branch is not None
 
         if local_exists:
             if current_branch != branch:
@@ -164,7 +164,7 @@ class DeliveryPreparer:
                     "lck-select-existing-task-branch",
                 )
                 action = "selected-existing"
-        elif state.remote_task_branch is not None:
+        elif state.remote_issue_branch is not None:
             if current_branch != BASE_BRANCH or not clean:
                 raise LckStopError(
                     "restoring a remote Task branch requires a clean main worktree"
@@ -187,10 +187,10 @@ class DeliveryPreparer:
             action = "created-from-main"
 
         expected_head = (
-            state.local_task_head
+            state.local_issue_head
             if local_exists
-            else state.remote_task_oid
-            if state.remote_task_branch is not None
+            else state.remote_issue_oid
+            if state.remote_issue_branch is not None
             else base_sha
         )
         self._verify_workspace(branch, expected_head)
@@ -428,7 +428,7 @@ class DeliveryCompleter:
         progress: ProgressReporter,
     ) -> DeliveryCompletionResult:
         state = snapshot.state
-        task_number = state.task_number
+        task_number = state.issue_number
         effects: list[EffectReceipt] = []
         self.last_effects = effects
         self.last_critical_outcome = None
@@ -479,7 +479,7 @@ class DeliveryCompleter:
                 state,
                 base_sha,
                 progress=progress,
-                head_sha=state.local_task_head,
+                head_sha=state.local_issue_head,
             )
             progress.running("formal-validation")
             validation = self._run_formal_validation(base_sha)
@@ -487,7 +487,7 @@ class DeliveryCompleter:
                 validation = dict(validation)
                 validation["documentation_policy"] = self.last_documentation_validation
                 self.last_validation = validation
-            validated_head = state.local_task_head
+            validated_head = state.local_issue_head
             if not is_sha(validated_head):
                 raise LckStopError("current Task head is unavailable")
             self.commit_effect.verify_tree_unchanged(
@@ -510,7 +510,7 @@ class DeliveryCompleter:
                 base_sha,
                 progress=progress,
                 include_index=True,
-                head_sha=state.local_task_head,
+                head_sha=state.local_issue_head,
             )
             progress.running("formal-validation")
             validation = self._run_formal_validation(base_sha)
@@ -520,12 +520,12 @@ class DeliveryCompleter:
                 self.last_validation = validation
             self.commit_effect.verify_tree_unchanged(
                 validated_tree,
-                expected_head_sha=state.local_task_head,
+                expected_head_sha=state.local_issue_head,
             )
             commit = self.commit_effect.execute(
                 validated_tree,
                 commit_message,
-                expected_parent_sha=state.local_task_head,
+                expected_parent_sha=state.local_issue_head,
             )
             effects.append(commit)
             head = commit.details.get("head_sha")
@@ -644,7 +644,7 @@ class DeliveryCompleter:
                 operation=phase.value,
             )
             self.last_snapshot = snapshot
-            if snapshot.state.task_number != task_number:
+            if snapshot.state.issue_number != task_number:
                 raise LckStopError("operation snapshot belongs to another Task")
             result = self._complete_from_snapshot(
                 snapshot,

--- a/tools/agent_workflow/lck_core/effects.py
+++ b/tools/agent_workflow/lck_core/effects.py
@@ -22,6 +22,7 @@ from .models import (
     LckStopError,
     LiveState,
     _authoritative_remote_main_sha,
+    _issue_number_from_state,
     _remote_refs,
 )
 from .profile_policies import ProfileEffectDescriptor
@@ -270,7 +271,7 @@ class ProjectSingleSelectEffectExecutor:
         params = cls._validate(descriptor)
         if (
             state.repository != params["repository"]
-            or state.task_number != params["task_number"]
+            or _issue_number_from_state(state) != params["task_number"]
         ):
             raise LckStopError(
                 "project field effect identity does not match live state"
@@ -737,7 +738,7 @@ class EnsureOpenPrEffect:
                 f"- Critical Outcome: {critical_outcome.get('status')}",
             )
         body = (
-            f"Closes #{state.task_number}\n\n"
+            f"Closes #{state.issue_number}\n\n"
             "## Summary\n"
             f"{summary.strip()}\n\n"
             "## Validation\n" + "\n".join(validation_lines) + "\n\n"
@@ -945,10 +946,10 @@ class SetReviewStatusEffect:
         set_project_status_with_runner(
             self.resolver.runner,
             state.repository,
-            state.task_number,
+            state.issue_number,
             value="Review",
         )
-        observed = self._query_project_status(state.repository, state.task_number)
+        observed = self._query_project_status(state.repository, state.issue_number)
         if observed == "Review":
             return EffectReceipt(
                 effect="set_review_status",
@@ -960,7 +961,7 @@ class SetReviewStatusEffect:
             set_project_status_with_runner(
                 self.resolver.runner,
                 state.repository,
-                state.task_number,
+                state.issue_number,
                 value=previous_status,
             )
         except Exception as restore_exc:
@@ -968,7 +969,7 @@ class SetReviewStatusEffect:
                 "Project Status postcondition failed and compensation could not "
                 f"restore {previous_status!r}"
             ) from restore_exc
-        restored = self._query_project_status(state.repository, state.task_number)
+        restored = self._query_project_status(state.repository, state.issue_number)
         if restored != previous_status:
             raise LckStopError(
                 "Project Status postcondition failed and compensation did not "

--- a/tools/agent_workflow/lck_core/eligibility.py
+++ b/tools/agent_workflow/lck_core/eligibility.py
@@ -128,10 +128,10 @@ class PhaseEligibilityResolver:
         target_contract: Mapping[str, Any] | None = None
         if isinstance(issue, Mapping):
             target_contract = dict(issue)
-            if isinstance(state.task_contract, Mapping):
-                target_contract.update(state.task_contract)
+            if isinstance(state.leaf_contract, Mapping):
+                target_contract.update(state.leaf_contract)
         downstream_contract = (
-            state.task_contract if isinstance(state.task_contract, Mapping) else issue
+            state.leaf_contract if isinstance(state.leaf_contract, Mapping) else issue
         )
         if profile is not None and isinstance(target_contract, Mapping):
             try:
@@ -316,21 +316,21 @@ class PhaseEligibilityResolver:
             if state.merged is True:
                 reasons.append("Task already has a merged PR")
             if (
-                state.local_task_branch is not None
-                and state.git.get("branch") == state.local_task_branch
+                state.local_issue_branch is not None
+                and state.git.get("branch") == state.local_issue_branch
                 and state.git.get("clean") is not True
             ):
                 reasons.append("existing Task branch reuse requires a clean worktree")
-            if state.local_task_head and state.remote_task_oid:
-                if state.local_task_head != state.remote_task_oid:
+            if state.local_issue_head and state.remote_issue_oid:
+                if state.local_issue_head != state.remote_issue_oid:
                     reasons.append("Task branch has divergent local and remote tips")
-            if state.open_pr is not None and state.local_task_head is not None:
+            if state.open_pr is not None and state.local_issue_head is not None:
                 pr_head = state.open_pr.get("headRefOid")
-                if is_sha(pr_head) and state.local_task_head != pr_head:
+                if is_sha(pr_head) and state.local_issue_head != pr_head:
                     reasons.append(
                         "current OPEN PR head OID differs from local Task branch tip"
                     )
-            if not state.local_task_branch and not state.remote_task_branch:
+            if not state.local_issue_branch and not state.remote_issue_branch:
                 if not _is_clean_current_main(state.git):
                     reasons.append(
                         "new workspace bootstrap requires clean main with "
@@ -340,13 +340,13 @@ class PhaseEligibilityResolver:
         elif phase is Phase.DELIVERY_COMPLETE:
             if state.merged is True:
                 reasons.append("Task already has a merged PR")
-            if state.local_task_branch is None:
+            if state.local_issue_branch is None:
                 reasons.append("Delivery Complete requires a local Task branch")
             if state.git.get("branch") != state.target_branch:
                 reasons.append(
                     "Delivery Complete requires the resolved Task branch selected"
                 )
-            if not is_sha(state.local_task_head):
+            if not is_sha(state.local_issue_head):
                 reasons.append("Delivery Complete requires a current local Task head")
             if state.open_pr is not None and state.open_pr.get("isDraft") is not False:
                 reasons.append("Delivery Complete cannot continue with a Draft OPEN PR")
@@ -393,11 +393,11 @@ class PhaseEligibilityResolver:
             remote_main = _authoritative_remote_main_sha(state.git)
             if not is_sha(pr_base) or not is_sha(remote_main) or pr_base != remote_main:
                 reasons.append("current OPEN PR base must match current origin/main")
-            if state.remote_task_oid != pr_head:
+            if state.remote_issue_oid != pr_head:
                 reasons.append("remote Task branch must match current OPEN PR head")
             if (
-                state.local_task_head is not None
-                and state.local_task_head != pr_head
+                state.local_issue_head is not None
+                and state.local_issue_head != pr_head
                 and not (
                     phase is Phase.REMEDIATION_COMPLETE and owned_remediation_candidate
                 )
@@ -406,7 +406,7 @@ class PhaseEligibilityResolver:
             if phase is Phase.REMEDIATION_PREPARE:
                 capabilities = ("prepare_task_workspace", "load_review_findings")
             else:
-                if state.local_task_branch is None:
+                if state.local_issue_branch is None:
                     reasons.append(f"{phase.value} requires a local Task branch")
                 if state.git.get("branch") != state.target_branch:
                     reasons.append(

--- a/tools/agent_workflow/lck_core/models.py
+++ b/tools/agent_workflow/lck_core/models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import re
 from collections.abc import Mapping
 from dataclasses import dataclass
@@ -52,18 +53,32 @@ class FactProfile:
     name: str
     include_comments: bool = False
     include_issue_closure: bool = False
-    include_task_contract: bool = True
+    include_leaf_contract: bool = True
     include_git: bool = True
     include_workspace_inventory: bool = False
-    include_local_task_branches: bool = True
-    include_remote_task_branches: bool = True
+    include_local_issue_branches: bool = True
+    include_remote_issue_branches: bool = True
     include_open_pr: bool = True
     include_pr_history: bool = False
     include_pr_history_details: bool = False
     include_checks: bool = False
     include_mergeability: bool = False
 
+    # Stable compatibility spellings for persisted fact-profile consumers.
+    @property
+    def include_task_contract(self) -> bool:
+        return self.include_leaf_contract
+
+    @property
+    def include_local_task_branches(self) -> bool:
+        return self.include_local_issue_branches
+
+    @property
+    def include_remote_task_branches(self) -> bool:
+        return self.include_remote_issue_branches
+
     def facts(self) -> tuple[str, ...]:
+        """Return the stable legacy fact names used by persisted snapshots."""
         enabled = []
         for name in (
             "comments",
@@ -82,16 +97,36 @@ class FactProfile:
                 enabled.append(name)
         return tuple(enabled)
 
+    def neutral_facts(self) -> tuple[str, ...]:
+        """Return the canonical neutral names for new in-memory consumers."""
+        enabled = []
+        for name in (
+            "comments",
+            "issue_closure",
+            "leaf_contract",
+            "git",
+            "workspace_inventory",
+            "local_issue_branches",
+            "remote_issue_branches",
+            "open_pr",
+            "pr_history",
+            "checks",
+            "mergeability",
+        ):
+            if getattr(self, f"include_{name}"):
+                enabled.append(name)
+        return tuple(enabled)
+
 
 _DIAGNOSTIC_FACT_PROFILE: Final = FactProfile(
     name="diagnostic",
     include_comments=True,
     include_issue_closure=True,
-    include_task_contract=True,
+    include_leaf_contract=True,
     include_git=True,
     include_workspace_inventory=True,
-    include_local_task_branches=True,
-    include_remote_task_branches=True,
+    include_local_issue_branches=True,
+    include_remote_issue_branches=True,
     include_open_pr=True,
     include_pr_history=True,
     include_pr_history_details=True,
@@ -112,24 +147,24 @@ _OPERATION_FACT_PROFILES: Final = {
     "review-prepare": FactProfile(
         name="review-prepare",
         include_git=False,
-        include_local_task_branches=False,
+        include_local_issue_branches=False,
         include_checks=True,
     ),
     "review-complete": FactProfile(
         name="review-complete",
         include_git=False,
-        include_local_task_branches=False,
+        include_local_issue_branches=False,
         include_checks=True,
     ),
     # All phases that run eligibility need the current Issue contract so
     # Documentation remains valid through its terminal lifecycle paths.
     "remediation-prepare": FactProfile(
         name="remediation-prepare",
-        include_task_contract=True,
+        include_leaf_contract=True,
     ),
     "remediation-no-change": FactProfile(
         name="remediation-no-change",
-        include_task_contract=True,
+        include_leaf_contract=True,
     ),
     "remediation-complete": FactProfile(
         name="remediation-complete",
@@ -138,14 +173,14 @@ _OPERATION_FACT_PROFILES: Final = {
     "merge-preflight": FactProfile(
         name="merge-preflight",
         include_git=False,
-        include_local_task_branches=False,
+        include_local_issue_branches=False,
         include_checks=True,
         include_mergeability=True,
     ),
     "closeout": FactProfile(
         name="closeout",
         include_issue_closure=True,
-        include_task_contract=True,
+        include_leaf_contract=True,
         include_pr_history=True,
         include_pr_history_details=True,
     ),
@@ -411,20 +446,128 @@ def _pr_base_sha(pr: Mapping[str, Any] | None) -> str | None:
     return value if is_sha(value) else None
 
 
-@dataclass(frozen=True)
-class LiveState:
-    """Current mechanical facts acquired from Git and GitHub for one Issue."""
+def _called_from_dataclasses_replace() -> bool:
+    """Recognize Python's reconstruction path for legacy alias updates."""
+    frame = inspect.currentframe()
+    try:
+        while frame is not None:
+            if (
+                frame.f_globals.get("__name__") == "dataclasses"
+                and frame.f_code.co_name == "_replace"
+            ):
+                return True
+            frame = frame.f_back
+    finally:
+        del frame
+    return False
 
-    task_number: int
+
+def _coalesce_compatibility_value(
+    canonical_name: str,
+    canonical: Any,
+    legacy_name: str,
+    legacy: Any,
+) -> Any:
+    """Normalize one canonical value and its optional legacy projection.
+
+    Legacy serialized contracts historically contained a bounded projection of
+    the full contract.  Mapping values therefore use an overlap comparison so
+    that a complete canonical value and an older bounded projection can be
+    read together without creating a second source of truth.
+    """
+    if canonical is None:
+        return legacy
+    if legacy is None:
+        return canonical
+    if isinstance(canonical, Mapping) and isinstance(legacy, Mapping):
+        conflicts = [
+            key
+            for key, value in legacy.items()
+            if key in canonical and canonical[key] != value
+        ]
+        if conflicts:
+            if _called_from_dataclasses_replace():
+                return legacy
+            raise ValueError(
+                f"conflicting {canonical_name}/{legacy_name} values: "
+                + ", ".join(sorted(str(key) for key in conflicts))
+            )
+        return canonical
+    if canonical != legacy:
+        # ``dataclasses.replace`` reconstructs an object by passing every
+        # stored field plus the requested change.  A legacy property is not a
+        # stored field, but callers may still use the historical alias in a
+        # replace call.  Let that explicit replacement win while keeping all
+        # ordinary constructors and deserializers fail-closed below.
+        if _called_from_dataclasses_replace():
+            return legacy
+        raise ValueError(f"conflicting {canonical_name}/{legacy_name} values")
+    return canonical
+
+
+def _legacy_contract_projection(
+    leaf_contract: Mapping[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Return the bounded pre-neutralization ``task_contract`` projection."""
+    if not isinstance(leaf_contract, Mapping):
+        return None
+    return {
+        key: leaf_contract.get(key)
+        for key in (
+            "number",
+            "title",
+            "url",
+            "body_sha256",
+            "critical_outcome",
+            "bug_contract",
+            "documentation_contract",
+            "research_contract",
+            "research_outcome",
+        )
+    }
+
+
+def _contract_agent_view(
+    leaf_contract: Mapping[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Return a bounded contract projection without exposing the Issue body."""
+    if not isinstance(leaf_contract, Mapping):
+        return None
+    return _legacy_contract_projection(leaf_contract)
+
+
+def _issue_number_from_state(value: Any) -> int | None:
+    """Read an Issue number from canonical state with a legacy adapter fallback."""
+    issue_number = getattr(value, "issue_number", None)
+    if isinstance(issue_number, int) and not isinstance(issue_number, bool):
+        return issue_number
+    task_number = getattr(value, "task_number", None)
+    return (
+        task_number
+        if isinstance(task_number, int) and not isinstance(task_number, bool)
+        else None
+    )
+
+
+@dataclass(frozen=True, init=False)
+class LiveState:
+    """Current mechanical facts acquired from Git and GitHub for one Issue.
+
+    The neutral fields are the only stored identity, branch, and contract
+    values.  ``task_*`` names remain constructor and property compatibility
+    projections for existing Task callers and persisted consumers.
+    """
+
+    issue_number: int
     repository: str | None
     issue: Mapping[str, Any] | None
     relationships: Mapping[str, Any]
     git: Mapping[str, Any]
     target_branch: str
-    local_task_branch: str | None
-    local_task_head: str | None
-    remote_task_branch: str | None
-    remote_task_oid: str | None
+    local_issue_branch: str | None
+    local_issue_head: str | None
+    remote_issue_branch: str | None
+    remote_issue_oid: str | None
     open_pr: Mapping[str, Any] | None
     merged_pr_numbers: tuple[int, ...]
     merged: bool | None
@@ -434,8 +577,132 @@ class LiveState:
     stop_reasons: tuple[str, ...] = ()
     warnings: tuple[Mapping[str, Any], ...] = ()
     merged_pr: Mapping[str, Any] | None = None
-    task_contract: Mapping[str, Any] | None = None
+    leaf_contract: Mapping[str, Any] | None = None
     issue_profile: Mapping[str, Any] | None = None
+
+    def __init__(
+        self,
+        issue_number: int | None = None,
+        repository: str | None = None,
+        issue: Mapping[str, Any] | None = None,
+        relationships: Mapping[str, Any] | None = None,
+        git: Mapping[str, Any] | None = None,
+        target_branch: str = "",
+        local_issue_branch: str | None = None,
+        local_issue_head: str | None = None,
+        remote_issue_branch: str | None = None,
+        remote_issue_oid: str | None = None,
+        open_pr: Mapping[str, Any] | None = None,
+        merged_pr_numbers: tuple[int, ...] | list[int] = (),
+        merged: bool | None = None,
+        checks: Mapping[str, Any] | None = None,
+        cleanup: Mapping[str, Any] | None = None,
+        status: ResolutionStatus = ResolutionStatus.RESOLVED,
+        stop_reasons: tuple[str, ...] | list[str] = (),
+        warnings: tuple[Mapping[str, Any], ...] | list[Mapping[str, Any]] = (),
+        merged_pr: Mapping[str, Any] | None = None,
+        leaf_contract: Mapping[str, Any] | None = None,
+        issue_profile: Mapping[str, Any] | None = None,
+        *,
+        task_number: int | None = None,
+        local_task_branch: str | None = None,
+        local_task_head: str | None = None,
+        remote_task_branch: str | None = None,
+        remote_task_oid: str | None = None,
+        task_contract: Mapping[str, Any] | None = None,
+    ) -> None:
+        resolved_number = _coalesce_compatibility_value(
+            "issue_number", issue_number, "task_number", task_number
+        )
+        if not isinstance(resolved_number, int) or isinstance(resolved_number, bool):
+            raise TypeError("LiveState issue_number must be an integer")
+
+        values = (
+            (
+                "local_issue_branch",
+                local_issue_branch,
+                "local_task_branch",
+                local_task_branch,
+            ),
+            (
+                "local_issue_head",
+                local_issue_head,
+                "local_task_head",
+                local_task_head,
+            ),
+            (
+                "remote_issue_branch",
+                remote_issue_branch,
+                "remote_task_branch",
+                remote_task_branch,
+            ),
+            (
+                "remote_issue_oid",
+                remote_issue_oid,
+                "remote_task_oid",
+                remote_task_oid,
+            ),
+        )
+        resolved_values = {
+            name: _coalesce_compatibility_value(name, canonical, legacy_name, legacy)
+            for name, canonical, legacy_name, legacy in values
+        }
+        resolved_contract = _coalesce_compatibility_value(
+            "leaf_contract", leaf_contract, "task_contract", task_contract
+        )
+        if resolved_contract is not None and not isinstance(resolved_contract, Mapping):
+            raise TypeError("LiveState leaf_contract must be a mapping or None")
+
+        if isinstance(status, str):
+            status = ResolutionStatus(status)
+        if not isinstance(status, ResolutionStatus):
+            raise TypeError("LiveState status must be a ResolutionStatus")
+        object.__setattr__(self, "issue_number", resolved_number)
+        object.__setattr__(self, "repository", repository)
+        object.__setattr__(self, "issue", issue)
+        object.__setattr__(self, "relationships", relationships or {})
+        object.__setattr__(self, "git", git or {})
+        object.__setattr__(self, "target_branch", target_branch)
+        for name, value in resolved_values.items():
+            object.__setattr__(self, name, value)
+        object.__setattr__(self, "open_pr", open_pr)
+        object.__setattr__(self, "merged_pr_numbers", tuple(merged_pr_numbers))
+        object.__setattr__(self, "merged", merged)
+        object.__setattr__(self, "checks", checks or {})
+        object.__setattr__(self, "cleanup", cleanup or {})
+        object.__setattr__(self, "status", status)
+        object.__setattr__(self, "stop_reasons", tuple(stop_reasons))
+        object.__setattr__(self, "warnings", tuple(warnings))
+        object.__setattr__(self, "merged_pr", merged_pr)
+        object.__setattr__(self, "leaf_contract", resolved_contract)
+        object.__setattr__(self, "issue_profile", issue_profile)
+
+    # Read-only legacy projections.  They intentionally do not appear in the
+    # dataclass storage or in ``__dict__`` and can never diverge from neutral
+    # state.
+    @property
+    def task_number(self) -> int:
+        return self.issue_number
+
+    @property
+    def local_task_branch(self) -> str | None:
+        return self.local_issue_branch
+
+    @property
+    def local_task_head(self) -> str | None:
+        return self.local_issue_head
+
+    @property
+    def remote_task_branch(self) -> str | None:
+        return self.remote_issue_branch
+
+    @property
+    def remote_task_oid(self) -> str | None:
+        return self.remote_issue_oid
+
+    @property
+    def task_contract(self) -> Mapping[str, Any] | None:
+        return self.leaf_contract
 
     @property
     def project_status(self) -> str | None:
@@ -461,40 +728,26 @@ class LiveState:
             _jsonable(
                 {
                     "schema_version": LCK_SCHEMA_VERSION,
-                    "task_number": self.task_number,
+                    # Neutral fields are canonical.  The task_* entries below
+                    # are retained as additive compatibility projections.
+                    "issue_number": self.issue_number,
+                    "local_issue_branch": self.local_issue_branch,
+                    "local_issue_head": self.local_issue_head,
+                    "remote_issue_branch": self.remote_issue_branch,
+                    "remote_issue_oid": self.remote_issue_oid,
+                    "leaf_contract": self.leaf_contract,
+                    "task_number": self.issue_number,
                     "repository": self.repository,
                     "issue": self.issue,
-                    "task_contract": (
-                        {
-                            "number": self.task_contract.get("number"),
-                            "title": self.task_contract.get("title"),
-                            "url": self.task_contract.get("url"),
-                            "body_sha256": self.task_contract.get("body_sha256"),
-                            "critical_outcome": self.task_contract.get(
-                                "critical_outcome"
-                            ),
-                            "bug_contract": self.task_contract.get("bug_contract"),
-                            "documentation_contract": self.task_contract.get(
-                                "documentation_contract"
-                            ),
-                            "research_contract": self.task_contract.get(
-                                "research_contract"
-                            ),
-                            "research_outcome": self.task_contract.get(
-                                "research_outcome"
-                            ),
-                        }
-                        if isinstance(self.task_contract, Mapping)
-                        else None
-                    ),
+                    "task_contract": _legacy_contract_projection(self.leaf_contract),
                     "issue_profile": self.issue_profile,
                     "relationships": self.relationships,
                     "git": self.git,
                     "target_branch": self.target_branch,
-                    "local_task_branch": self.local_task_branch,
-                    "local_task_head": self.local_task_head,
-                    "remote_task_branch": self.remote_task_branch,
-                    "remote_task_oid": self.remote_task_oid,
+                    "local_task_branch": self.local_issue_branch,
+                    "local_task_head": self.local_issue_head,
+                    "remote_task_branch": self.remote_issue_branch,
+                    "remote_task_oid": self.remote_issue_oid,
                     "open_pr": self.open_pr,
                     "merged_pr_numbers": self.merged_pr_numbers,
                     "merged": self.merged,
@@ -508,23 +761,77 @@ class LiveState:
             ),
         )
 
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> LiveState:
+        """Deserialize canonical or legacy state into one neutral model.
+
+        Both schemas may be present in an additive receipt.  The constructor
+        performs overlap conflict detection and stores only the neutral form.
+        """
+        if not isinstance(value, Mapping):
+            raise TypeError("LiveState payload must be a mapping")
+        merged_numbers = value.get("merged_pr_numbers", ())
+        if not isinstance(merged_numbers, (list, tuple)):
+            raise TypeError("LiveState merged_pr_numbers must be a sequence")
+        stop_reasons = value.get("stop_reasons", ())
+        if not isinstance(stop_reasons, (list, tuple)):
+            raise TypeError("LiveState stop_reasons must be a sequence")
+        warnings = value.get("warnings", ())
+        if not isinstance(warnings, (list, tuple)):
+            raise TypeError("LiveState warnings must be a sequence")
+        return cls(
+            issue_number=value.get("issue_number"),
+            task_number=value.get("task_number"),
+            repository=value.get("repository"),
+            issue=value.get("issue"),
+            relationships=value.get("relationships"),
+            git=value.get("git"),
+            target_branch=value.get("target_branch", ""),
+            local_issue_branch=value.get("local_issue_branch"),
+            local_task_branch=value.get("local_task_branch"),
+            local_issue_head=value.get("local_issue_head"),
+            local_task_head=value.get("local_task_head"),
+            remote_issue_branch=value.get("remote_issue_branch"),
+            remote_task_branch=value.get("remote_task_branch"),
+            remote_issue_oid=value.get("remote_issue_oid"),
+            remote_task_oid=value.get("remote_task_oid"),
+            open_pr=value.get("open_pr"),
+            merged_pr_numbers=merged_numbers,
+            merged=value.get("merged"),
+            checks=value.get("checks"),
+            cleanup=value.get("cleanup"),
+            status=value.get("status", ResolutionStatus.RESOLVED),
+            stop_reasons=stop_reasons,
+            warnings=warnings,
+            merged_pr=value.get("merged_pr"),
+            leaf_contract=value.get("leaf_contract"),
+            task_contract=value.get("task_contract"),
+            issue_profile=value.get("issue_profile"),
+        )
+
     def agent_view(self) -> dict[str, Any]:
         """Return the compact result intended for the invoking Agent."""
         return {
             "schema_version": LCK_SCHEMA_VERSION,
             "kind": "lck-agent-view",
             "operation": "status",
-            "task_number": self.task_number,
+            "issue_number": self.issue_number,
+            "task_number": self.issue_number,
             "repository": self.repository,
             "status": self.status,
             "issue": _issue_agent_view(self.issue),
             "issue_profile": self.issue_profile,
             "target_branch": self.target_branch,
+            "local_issue_branch": self.local_issue_branch,
+            "local_issue_head": self.local_issue_head,
+            "remote_issue_branch": self.remote_issue_branch,
+            "remote_issue_oid": self.remote_issue_oid,
+            "leaf_contract": _contract_agent_view(self.leaf_contract),
             "task_branch": {
-                "local": self.local_task_branch,
-                "local_head_sha": self.local_task_head,
-                "remote": self.remote_task_branch,
-                "remote_head_sha": self.remote_task_oid,
+                "local": self.local_issue_branch,
+                "local_head_sha": self.local_issue_head,
+                "remote": self.remote_issue_branch,
+                "remote_head_sha": self.remote_issue_oid,
             },
             "pr": _pr_agent_view(self.open_pr or self.merged_pr),
             "checks": _checks_agent_view(self.checks),
@@ -556,16 +863,142 @@ class OperationSnapshot:
     fact_profile: str = "diagnostic"
     acquired_facts: tuple[str, ...] = ()
 
+    # The snapshot owns one LiveState object; these accessors expose its
+    # canonical neutral model without copying identity/branch/contract data.
+    @property
+    def issue_number(self) -> int:
+        return self.state.issue_number
+
+    @property
+    def local_issue_branch(self) -> str | None:
+        return self.state.local_issue_branch
+
+    @property
+    def local_issue_head(self) -> str | None:
+        return self.state.local_issue_head
+
+    @property
+    def remote_issue_branch(self) -> str | None:
+        return self.state.remote_issue_branch
+
+    @property
+    def remote_issue_oid(self) -> str | None:
+        return self.state.remote_issue_oid
+
+    @property
+    def leaf_contract(self) -> Mapping[str, Any] | None:
+        return self.state.leaf_contract
+
+    # Legacy names are read-only projections of the same snapshot state.
+    @property
+    def task_number(self) -> int:
+        return self.issue_number
+
+    @property
+    def local_task_branch(self) -> str | None:
+        return self.local_issue_branch
+
+    @property
+    def local_task_head(self) -> str | None:
+        return self.local_issue_head
+
+    @property
+    def remote_task_branch(self) -> str | None:
+        return self.remote_issue_branch
+
+    @property
+    def remote_task_oid(self) -> str | None:
+        return self.remote_issue_oid
+
+    @property
+    def task_contract(self) -> Mapping[str, Any] | None:
+        return self.leaf_contract
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "schema_version": LCK_SCHEMA_VERSION,
             "operation": self.operation,
+            # These are projections of ``state`` for consumers that read the
+            # operation envelope without unpacking its nested LiveState.
+            "issue_number": self.issue_number,
+            "local_issue_branch": self.local_issue_branch,
+            "local_issue_head": self.local_issue_head,
+            "remote_issue_branch": self.remote_issue_branch,
+            "remote_issue_oid": self.remote_issue_oid,
+            "leaf_contract": _jsonable(self.leaf_contract),
+            "task_number": self.issue_number,
+            "local_task_branch": self.local_issue_branch,
+            "local_task_head": self.local_issue_head,
+            "remote_task_branch": self.remote_issue_branch,
+            "remote_task_oid": self.remote_issue_oid,
+            "task_contract": _jsonable(_legacy_contract_projection(self.leaf_contract)),
             "state": self.state.to_dict(),
             "required_checks": _jsonable(self.required_checks),
             "acquisition_warnings": _jsonable(self.acquisition_warnings),
             "fact_profile": self.fact_profile,
             "acquired_facts": list(self.acquired_facts),
         }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> OperationSnapshot:
+        """Deserialize a snapshot through the canonical LiveState adapter."""
+        if not isinstance(value, Mapping):
+            raise TypeError("OperationSnapshot payload must be a mapping")
+        state = value.get("state")
+        if not isinstance(state, Mapping):
+            raise TypeError("OperationSnapshot state payload must be a mapping")
+        restored_state = LiveState.from_dict(state)
+        for canonical_name, legacy_name, expected in (
+            ("issue_number", "task_number", restored_state.issue_number),
+            (
+                "local_issue_branch",
+                "local_task_branch",
+                restored_state.local_issue_branch,
+            ),
+            (
+                "local_issue_head",
+                "local_task_head",
+                restored_state.local_issue_head,
+            ),
+            (
+                "remote_issue_branch",
+                "remote_task_branch",
+                restored_state.remote_issue_branch,
+            ),
+            ("remote_issue_oid", "remote_task_oid", restored_state.remote_issue_oid),
+            ("leaf_contract", "task_contract", restored_state.leaf_contract),
+        ):
+            if canonical_name not in value and legacy_name not in value:
+                continue
+            observed = _coalesce_compatibility_value(
+                canonical_name,
+                value.get(canonical_name),
+                legacy_name,
+                value.get(legacy_name),
+            )
+            _coalesce_compatibility_value(
+                canonical_name,
+                expected,
+                "serialized_" + canonical_name,
+                observed,
+            )
+        warnings = value.get("acquisition_warnings", ())
+        facts = value.get("acquired_facts", ())
+        if not isinstance(warnings, (list, tuple)):
+            raise TypeError("OperationSnapshot acquisition_warnings must be a sequence")
+        if not isinstance(facts, (list, tuple)):
+            raise TypeError("OperationSnapshot acquired_facts must be a sequence")
+        operation = value.get("operation")
+        if not isinstance(operation, str) or not operation:
+            raise TypeError("OperationSnapshot operation must be a non-empty string")
+        return cls(
+            operation=operation,
+            state=restored_state,
+            required_checks=value.get("required_checks"),
+            acquisition_warnings=tuple(warnings),
+            fact_profile=str(value.get("fact_profile", "diagnostic")),
+            acquired_facts=tuple(str(fact) for fact in facts),
+        )
 
 
 @dataclass(frozen=True)

--- a/tools/agent_workflow/lck_core/receipts.py
+++ b/tools/agent_workflow/lck_core/receipts.py
@@ -39,7 +39,7 @@ from .remediation import (
 )
 from .review import MergePreflightResult, ReviewCompletionResult, ReviewContext
 from .review_workspace import ReviewInvocationStore
-from .state import _task_contract_from_state
+from .state import _leaf_contract_from_state
 
 
 @dataclass(frozen=True)
@@ -237,7 +237,7 @@ def _agent_view_for_result(value: Any) -> dict[str, Any]:
             "branch": value.branch,
             "base_sha": value.base_sha,
             "action": value.action,
-            "task_contract": _jsonable(_task_contract_from_state(value.state)),
+            "task_contract": _jsonable(_leaf_contract_from_state(value.state)),
             "eligibility": {
                 "eligible": value.eligibility.eligible,
                 "reasons": list(value.eligibility.reasons),

--- a/tools/agent_workflow/lck_core/remediation.py
+++ b/tools/agent_workflow/lck_core/remediation.py
@@ -30,7 +30,7 @@ from .review_workspace import ReviewInvocationStore, _identity_from_mapping
 from .state import (
     LiveStateResolver,
     OperationSnapshotBuilder,
-    _task_contract_from_state,
+    _leaf_contract_from_state,
 )
 from .validation import DeliveryChecksGate
 
@@ -51,7 +51,7 @@ class RemediationContext:
     @property
     def task_contract(self) -> dict[str, Any]:
         """Return the contract bound to this Remediation Prepare snapshot."""
-        return _task_contract_from_state(self.state)
+        return _leaf_contract_from_state(self.state)
 
     def to_dict(self) -> dict[str, Any]:
         pr = self.state.open_pr or {}
@@ -237,12 +237,12 @@ class RemediationPreparer:
         current = state.git.get("branch")
         clean = state.git.get("clean") is True
         action = "already-prepared"
-        if state.local_task_branch is None:
+        if state.local_issue_branch is None:
             if not clean:
                 raise LckStopError(
                     "restoring Remediation workspace requires a clean current worktree"
                 )
-            if state.remote_task_branch != branch:
+            if state.remote_issue_branch != branch:
                 raise LckStopError(
                     "current OPEN PR has no restorable remote Task branch"
                 )
@@ -392,8 +392,8 @@ class RemediationNoChangeCompleter:
             pr.get("number") != pr_number
             or pr.get("headRefOid") != head_sha
             or pr.get("baseRefOid") != base_sha
-            or state.local_task_head != head_sha
-            or state.remote_task_oid != head_sha
+            or state.local_issue_head != head_sha
+            or state.remote_issue_oid != head_sha
         ):
             raise LckStopError(
                 "Remediation No Change target no longer matches the prepared session"
@@ -631,8 +631,8 @@ class RemediationCompleter:
             and pr.get("number") == session.get("pr_number")
             and pr.get("baseRefOid") == session.get("base_sha")
             and pr.get("headRefOid") == start_head
-            and state.remote_task_oid == start_head
-            and state.local_task_head == candidate_head
+            and state.remote_issue_oid == start_head
+            and state.local_issue_head == candidate_head
             and state.git.get("branch") == state.target_branch
             and state.git.get("clean") is True
         )
@@ -709,7 +709,7 @@ class RemediationCompleter:
         if (
             session is not None
             and session.get("candidate") is not None
-            and state.local_task_head != pr_head
+            and state.local_issue_head != pr_head
         ):
             owned_candidate = self._owned_candidate_recovery(
                 session,
@@ -727,7 +727,7 @@ class RemediationCompleter:
                 f"Remediation Complete STOP for Task #{task_number}: "
                 + "; ".join(decision.reasons)
             )
-        if state.git.get("clean") is True and state.local_task_head == start_head:
+        if state.git.get("clean") is True and state.local_issue_head == start_head:
             raise LckStopError(
                 "Remediation Complete requires a repaired head or uncommitted repair changes"
             )

--- a/tools/agent_workflow/lck_core/review.py
+++ b/tools/agent_workflow/lck_core/review.py
@@ -47,8 +47,8 @@ from .review_workspace import (
 from .state import (
     LiveStateResolver,
     OperationSnapshotBuilder,
+    _leaf_contract_from_state,
     _policy_issue_from_state,
-    _task_contract_from_state,
 )
 from .validation import (
     DeliveryChecksGate,
@@ -227,7 +227,7 @@ class ReviewPreparer:
                     f"Review Prepare STOP for Task #{task_number}: "
                     + "; ".join(decision.reasons)
                 )
-            task_contract = _task_contract_from_state(state)
+            task_contract = _leaf_contract_from_state(state)
             target = _review_target_refs(state, task_contract)
             review_root = self.workspace.path_for(task_number, invocation.operation_id)
             mark(
@@ -523,7 +523,7 @@ class ReviewCompleter:
                     f"Review Complete STOP for Task #{task_number}: "
                     + "; ".join(decision.reasons)
                 )
-            current_contract = _task_contract_from_state(state)
+            current_contract = _leaf_contract_from_state(state)
             _assert_review_target_facts_applicable(
                 reviewed_identity,
                 state,
@@ -706,7 +706,7 @@ class ReviewPassGate:
         if not isinstance(raw_identity, Mapping):
             raise LckStopError("Independent Review PASS has no identity")
         recorded = _identity_from_mapping(raw_identity)
-        current_contract = _task_contract_from_state(state)
+        current_contract = _leaf_contract_from_state(state)
         try:
             _assert_review_target_facts_applicable(
                 recorded,
@@ -851,11 +851,11 @@ class MergePreflight:
         base_sha = _pr_base_sha(pr)
         if head_sha is None or base_sha is None:
             raise LckStopError("Merge Preflight PR head/base identity is unavailable")
-        if state.remote_task_oid != head_sha:
+        if state.remote_issue_oid != head_sha:
             raise LckStopError(
                 "Merge Preflight remote Task branch diverges from PR head"
             )
-        if state.local_task_head is not None and state.local_task_head != head_sha:
+        if state.local_issue_head is not None and state.local_issue_head != head_sha:
             raise LckStopError(
                 "Merge Preflight local Task branch diverges from PR head"
             )

--- a/tools/agent_workflow/lck_core/review_workspace.py
+++ b/tools/agent_workflow/lck_core/review_workspace.py
@@ -102,7 +102,7 @@ def _review_target_refs(
     if not isinstance(task_body_sha256, str) or not task_body_sha256:
         raise LckStopError("Review target Task Contract identity is unavailable")
     return ReviewTargetRefs(
-        task_number=state.task_number,
+        task_number=state.issue_number,
         pr_number=pr_number,
         base_sha=str(base_sha),
         head_sha=str(head_sha),

--- a/tools/agent_workflow/lck_core/state.py
+++ b/tools/agent_workflow/lck_core/state.py
@@ -292,17 +292,17 @@ class LiveStateResolver:
         reasons: list[str] = []
         repository = _repository_slug(self.runner, self.repository, warnings)
         issue: Mapping[str, Any] | None = None
-        task_contract: Mapping[str, Any] | None = None
+        leaf_contract: Mapping[str, Any] | None = None
         relationships: Mapping[str, Any] = {"available": False}
         if repository is not None:
-            issue, task_contract = _issue_view_with_contract(
+            issue, leaf_contract = _issue_view_with_contract(
                 self.runner,
                 repository,
                 task_number,
                 warnings,
                 profile.include_comments,
                 profile.include_issue_closure,
-                profile.include_task_contract,
+                profile.include_leaf_contract,
             )
             relationships = _relationship_snapshot(
                 self.runner, repository, task_number, warnings
@@ -358,8 +358,8 @@ class LiveStateResolver:
             # from preserving compatibility with resolver doubles, this makes
             # the shared branch inventory helper's default behavior explicit.
             if (
-                profile.include_local_task_branches
-                and profile.include_remote_task_branches
+                profile.include_local_issue_branches
+                and profile.include_remote_issue_branches
             ):
                 local_branches, remote_branches, remote_available = self._task_branches(
                     task_number, warnings
@@ -368,15 +368,15 @@ class LiveStateResolver:
                 local_branches, remote_branches, remote_available = self._task_branches(
                     task_number,
                     warnings,
-                    include_local=profile.include_local_task_branches,
-                    include_remote=profile.include_remote_task_branches,
+                    include_local=profile.include_local_issue_branches,
+                    include_remote=profile.include_remote_issue_branches,
                 )
         else:
             local_branches, remote_branches, remote_available = self._task_branches(
                 task_number,
                 warnings,
-                include_local=profile.include_local_task_branches,
-                include_remote=profile.include_remote_task_branches,
+                include_local=profile.include_local_issue_branches,
+                include_remote=profile.include_remote_issue_branches,
                 profile=branch_match_profile,
             )
         if len(warnings) > branch_warning_count:
@@ -541,17 +541,17 @@ class LiveStateResolver:
         }
         status = ResolutionStatus.STOP if reasons else ResolutionStatus.RESOLVED
         return LiveState(
-            task_number=task_number,
+            issue_number=task_number,
             repository=repository,
             issue=issue,
-            task_contract=task_contract,
+            leaf_contract=leaf_contract,
             relationships=relationships,
             git=git,
             target_branch=target_branch,
-            local_task_branch=local_branch,
-            local_task_head=local_head,
-            remote_task_branch=remote_branch,
-            remote_task_oid=remote_oid,
+            local_issue_branch=local_branch,
+            local_issue_head=local_head,
+            remote_issue_branch=remote_branch,
+            remote_issue_oid=remote_oid,
             open_pr=open_pr,
             merged_pr_numbers=merged_numbers,
             merged=merged,
@@ -862,29 +862,36 @@ def _policy_issue_from_state(state: LiveState) -> dict[str, Any]:
     interpret profile semantics.
     """
     result = dict(state.issue) if isinstance(state.issue, Mapping) else {}
-    if isinstance(state.task_contract, Mapping):
-        result.update(state.task_contract)
+    if isinstance(state.leaf_contract, Mapping):
+        result.update(state.leaf_contract)
     return result
 
 
-def _task_contract_from_state(state: LiveState) -> dict[str, Any]:
-    """Return the Task contract captured by the operation-start live snapshot."""
+def _leaf_contract_from_state(state: LiveState) -> dict[str, Any]:
+    """Return the Issue contract captured by the operation-start snapshot."""
     if state.status is not ResolutionStatus.RESOLVED:
-        raise LckStopError("cannot read Task Contract from unresolved live state")
-    value = state.task_contract
+        raise LckStopError("cannot read Issue Contract from unresolved live state")
+    value = state.leaf_contract
     if not isinstance(value, Mapping):
-        raise LckStopError("current Task Contract is unavailable in operation snapshot")
+        raise LckStopError(
+            "current Issue Contract is unavailable in operation snapshot"
+        )
     body = value.get("body")
     body_sha256 = value.get("body_sha256")
     if not isinstance(body, str) or not isinstance(body_sha256, str):
-        raise LckStopError("current Task Contract body is unavailable")
+        raise LckStopError("current Issue Contract body is unavailable")
     issue = state.issue
     if (
         not isinstance(issue, Mapping)
         or issue.get("body_sha256") != body_sha256
-        or value.get("number") != state.task_number
+        or value.get("number") != state.issue_number
         or value.get("title") != issue.get("title")
         or str(issue.get("state", "")).upper() != "OPEN"
     ):
-        raise LckStopError("Task Contract is inconsistent inside operation snapshot")
+        raise LckStopError("Issue Contract is inconsistent inside operation snapshot")
     return dict(value)
+
+
+def _task_contract_from_state(state: LiveState) -> dict[str, Any]:
+    """Compatibility adapter for callers that still use the Task spelling."""
+    return _leaf_contract_from_state(state)


### PR DESCRIPTION
Closes #222

## Summary
Freeze LiveState and OperationSnapshot around Issue-neutral canonical identity, branch, and leaf contract fields while preserving one-way task_* compatibility projections and strict legacy conflict handling.

## Validation
- Critical Outcome: pass
- Formal Delivery validation: pass

## Risks / limitations
Legacy task_* callers remain supported through read-only projections and additive serialization; no repository-wide rename or breaking schema migration was performed.
