### PR TITLE
[Documentation] Reorganize Public README and Prepare LCK Overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,30 @@
 # TraceQuant
 
-TraceQuant is intended to become an auditable research-to-live quantitative
-trading system for cryptocurrency perpetual futures. The current repository is
-the Research MVP foundation: it contains a small, validated Python package and
-the engineering documentation around it. It does not contain a trading system
-or an executable strategy yet.
+TraceQuant is an actively developed open-source project intended to become an
+auditable research-to-live quantitative trading system for cryptocurrency
+perpetual futures. The current repository is the Research MVP foundation: it
+contains a small, validated Python package and the engineering documentation
+around it. It does not contain a trading system or an executable strategy yet.
+
+## LCK: an engineering capability within TraceQuant
+
+While building and maintaining TraceQuant, the project is developing the Local
+Control Kernel (LCK): an engineering capability for making Codex-centered,
+AI-assisted development deterministic, auditable, and human-controlled. LCK
+separates semantic Agent work—understanding, designing, implementing, and
+reviewing—from deterministic lifecycle control such as resolving current
+repository and GitHub state, validating a candidate, and carrying out bounded
+delivery effects.
+
+LCK is part of TraceQuant. It is not an independent product, general Agent
+platform, trading module, or risk authority, and it does not make the current
+repository a trading system. LCK is provider-neutral by design: Codex is a
+primary use case, while other supported Agent providers can use the same
+lifecycle contract. The capability is intended to offer reusable engineering
+value to other open-source projects, but this repository does not claim
+drop-in installation, external adoption, or unsupported portability. See the
+[public LCK overview](docs/guides/LCK-overview.md) for the lifecycle and
+boundaries.
 
 ## Current capability and boundary
 
@@ -301,6 +321,8 @@ backfilled or replayed typed lifecycle receipts.
 
 ## Documentation map
 
+- [LCK overview](docs/guides/LCK-overview.md): public explanation of the LCK
+  engineering capability, lifecycle, responsibilities, and reuse boundaries.
 - [Technical baseline](docs/architecture/technical-baseline.md): current
   implementation facts and explicitly deferred research/trading architecture.
 - [Repository structure](docs/architecture/repository-structure.md): current
@@ -311,8 +333,13 @@ backfilled or replayed typed lifecycle receipts.
   navigation, not proof that planned capabilities are implemented.
 - [Issue workflow](docs/development/issue-workflow.md): repository lifecycle
   semantics for implementation work.
+- [Independent PR Review](docs/development/pr-review.md): fresh Review,
+  remediation, and merge-preflight semantics.
 - [Agent workflow Skills](docs/workflows/agent-skills.md): current workflow
   controls, separate from the business architecture.
+- [LCK v1 Design Charter](docs/workflows/LCK-v1-Design-Charter.md): design
+  baseline and responsibility model; it is not evidence of completed product
+  capability.
 - [WSL2 Codex environment](docs/workflows/wsl2-codex-environment/README.md):
   environment-specific setup and diagnostics.
 

--- a/docs/guides/LCK-overview.md
+++ b/docs/guides/LCK-overview.md
@@ -1,0 +1,122 @@
+# LCK overview
+
+This page is a public orientation to the Local Control Kernel (LCK) as it is
+used within TraceQuant. It distinguishes current workflow behavior from design
+intentions. The [LCK v1 Design Charter](../workflows/LCK-v1-Design-Charter.md)
+is a design baseline; it is not proof that TraceQuant has completed its
+quantitative roadmap or that every future capability described there exists.
+
+## What LCK is
+
+TraceQuant is an actively developed open-source project whose long-term goal is
+an auditable research-to-live quantitative trading system for cryptocurrency
+perpetual futures. The current repository is a Research MVP foundation. It has
+no exchange client, research data pipeline, backtester, strategy, model,
+execution service, risk engine, or Live runtime. LCK does not change that
+boundary.
+
+LCK was developed within TraceQuant while constructing and maintaining it. It
+is an engineering capability for making AI-assisted software delivery deterministic,
+auditable, and human-controlled. It addresses a practical problem: an Agent
+can reason about a change, but conversational context alone should not decide
+which branch, commit, pull request, lifecycle state, or recovery action is
+currently safe.
+
+LCK is an on-demand local control layer, not a long-running daemon, standalone
+Agent platform, trading module, or risk authority. Its purpose is to control
+the deterministic parts of the repository workflow while leaving semantic
+judgment with people and Agents.
+
+## Semantic work and deterministic control
+
+The responsibilities are deliberately separated:
+
+| Responsibility | Primary owner |
+| --- | --- |
+| Define intent, resolve genuine ambiguity, and manually approve the merge | Human maintainer |
+| Understand the change, design it, implement it, diagnose it, and explain it | Implementation Agent |
+| Independently inspect, reason about, judge, and report on a candidate | Fresh Review Agent |
+| Resolve current Git/GitHub identity, evaluate lifecycle gates, run formal validation, commit, push, resolve the PR, and record bounded lifecycle evidence | LCK |
+| Store current repository, Issue, PR, branch, commit, and check state | Git and GitHub |
+
+Codex is a primary use case, and the workflow is provider-neutral by design.
+Codex and other supported providers, including Claude in the current workflow
+documentation, can perform the semantic Agent roles under the same LCK
+contract. Provider-specific prompts, tools, or sandbox details must not decide
+the actionable branch, SHA, PR, push destination, merge state, or recovery
+state.
+
+## The controlled lifecycle
+
+The normal path is:
+
+1. **Issue and Delivery.** A maintainer starts from the current Issue
+   contract. LCK resolves live readiness facts and prepares the correct
+   profile-owned workspace. The Implementation Agent performs the scoped
+   semantic work. LCK Delivery Complete runs the applicable gates and formal
+   validation, commits the validated tree, synchronizes the branch, resolves
+   or creates the open PR, and moves the lifecycle to Review.
+
+2. **Human stop and Independent Review.** Delivery stops at a human boundary.
+   A fresh Review invocation independently resolves the current open PR,
+   base, head, checks, and applicable contract. The Review Agent works
+   read-only and does not inherit the Delivery Agent's correctness judgment.
+
+3. **Review PASS and manual merge.** A passing Review is followed by a fresh
+   merge preflight. Only after that preflight is the change ready for the
+   maintainer's manual Squash Merge. No Agent, Skill, or LCK operation
+   automatically merges a PR.
+
+4. **Review FAIL and explicit remediation.** A failed Review stops with
+   findings. It does not automatically start repair. A maintainer must
+   explicitly start remediation using the failed Review identity. LCK then
+   reacquires live state, the Implementation Agent repairs the scoped defect,
+   and LCK validates and updates the existing PR. The repaired head must go
+   through a fresh Independent Review; the old Review result cannot authorize
+   the new head.
+
+5. **Closeout.** After the maintainer has merged the PR, a separate LCK
+   Closeout operation reacquires the merge identity and converges the Issue,
+   Project, canonical `main`, and exact leaf-Issue branch lifecycle. Closeout is
+   separate from the merge decision and does not turn a planned quantitative
+   capability into a completed one.
+
+```text
+Issue → Delivery → HUMAN STOP → Independent Review
+                                  ├─ FAIL → HUMAN STOP → explicit remediation → fresh Review
+                                  └─ PASS → merge preflight → HUMAN SQUASH MERGE → Closeout
+```
+
+## Fresh state, recovery, and auditability
+
+Each LCK lifecycle operation resolves a fresh phase-specific snapshot from
+current Git and GitHub facts. A previous Agent message, expected SHA, PR
+number, validation snapshot, or audit receipt is not authority for a later
+operation. LCK checks freshness at operation boundaries and fails closed when
+identity is ambiguous, state has diverged, or a required fact cannot be
+trusted. It does not guess, force-push, automatically repair a failed Review,
+or wait in a background polling loop for the world to change.
+
+LCK records bounded operation results, validation, effect receipts, and other
+diagnostic evidence so that a maintainer can understand what happened. That
+audit evidence is not a permission token: current live state is resolved again
+before a later lifecycle effect. This separation makes recovery from an
+interrupted or stale operation an explicit state-resolution problem rather
+than a request to trust conversational memory.
+
+## Relationship to TraceQuant and reuse
+
+LCK remains an engineering capability within TraceQuant, whose product identity
+and quantitative-system goal remain primary. LCK governs repository delivery
+and review mechanics; it does not make trading decisions, submit exchange
+orders, or replace a future risk authority. Its provider-neutral control ideas
+are intended to have reuse value for other open-source projects that need
+auditable, human-controlled Agent-assisted maintenance. That is an intended
+reuse direction, not a claim of drop-in installation, external adoption, or
+capabilities that this repository does not currently support.
+
+For the normative current workflow, see the [Issue workflow](../development/issue-workflow.md)
+and [Independent PR Review](../development/pr-review.md). The [Agent Workflow
+Skills registry](../workflows/agent-skills.md) is a navigation document, while
+the [technical baseline](../architecture/technical-baseline.md) remains the
+authority for TraceQuant's current product capabilities.


### PR DESCRIPTION
Closes #232

## Summary
Reorganize the TraceQuant README and add a public LCK overview describing current boundaries, lifecycle responsibilities, remediation, auditability, and provider-neutral reuse.

## Validation
- Formal Delivery validation: pass

## Risks / limitations
Documentation-only wording change; no runtime behavior, tests, CI, or LCK controls were modified.
