### PR TITLE
[Bug] LCK 关系快照截断 typed dependency 正文导致合法合同被误判

### DIFF
--- a/tests/tools/test_lck_typed_dependency_contracts.py
+++ b/tests/tools/test_lck_typed_dependency_contracts.py
@@ -1,0 +1,314 @@
+# ruff: noqa: E402, I001
+
+"""Regression coverage for complete typed dependency contracts."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+ROOT = Path(__file__).parents[2]
+AGENT_WORKFLOW = str(ROOT / "tools" / "agent_workflow")
+if AGENT_WORKFLOW not in sys.path:
+    sys.path.insert(0, AGENT_WORKFLOW)
+
+from lck_core import eligibility, models, shared_facts  # type: ignore[import-not-found]  # noqa: E402
+from lck_core.issue_profiles import resolve_leaf_issue_profile  # type: ignore[import-not-found]  # noqa: E402
+from lck_core.profile_policies import validate_profile_contract  # type: ignore[import-not-found]  # noqa: E402
+from workflow_common import CommandResult, bounded_list, sha256_json  # type: ignore[import-not-found]  # noqa: E402
+from workflow_evidence import _relationship_snapshot as audit_relationship_snapshot  # type: ignore[import-not-found]  # noqa: E402
+
+
+BUG_BODY = (
+    """### Observed
+
+The long Bug contract remains readable.
+
+### Expected
+
+LCK should evaluate the complete Bug contract.
+
+### Reproduction / Evidence
+
+"""
+    + ("Evidence prefix. " * 45)
+    + """
+
+### Acceptance Criteria
+
+- The complete Bug contract is accepted.
+"""
+)
+
+DOCUMENTATION_BODY = (
+    """### Documentation Goal
+
+The long Documentation contract remains readable.
+
+### Requirements
+
+"""
+    + ("Document the supported behavior. " * 45)
+    + """
+
+### Acceptance Criteria
+
+- The complete Documentation contract is accepted.
+"""
+)
+
+RESEARCH_BODY = (
+    """### Question / Decision Needed
+
+Should the supported path be adopted?
+
+### Context
+
+The long Research contract remains readable.
+
+### Scope
+
+- Repository-backed workflow behavior.
+
+### Non-goals
+
+- No unrelated runtime changes.
+
+### Evidence / Evaluation Criteria
+
+"""
+    + ("Evaluate the repository-backed evidence. " * 45)
+    + """
+
+### Expected Outcome / Artifact
+
+Adopt the repository-backed workflow contract.
+"""
+)
+
+DEPENDENCY_PROJECT = {
+    "nodes": [
+        {
+            "project": {"number": 1, "owner": {"login": "owner"}},
+            "fieldValues": {
+                "nodes": [
+                    {
+                        "name": "ARCHITECTURE DECISION",
+                        "field": {"name": "Research Outcome"},
+                    }
+                ],
+                "pageInfo": {"hasNextPage": False},
+            },
+        }
+    ],
+    "pageInfo": {"hasNextPage": False},
+}
+
+
+def _raw_dependency(
+    *,
+    number: int,
+    label: str,
+    body: str,
+    project_items: Any = None,
+) -> dict[str, Any]:
+    return {
+        "number": number,
+        "title": f"[{label}] long dependency",
+        "state": "CLOSED",
+        "body": body,
+        "labels": {
+            "nodes": [{"name": label}],
+            "pageInfo": {"hasNextPage": False},
+        },
+        "projectItems": project_items
+        or {"nodes": [], "pageInfo": {"hasNextPage": False}},
+    }
+
+
+def _bounded_dependency(raw: dict[str, Any]) -> dict[str, Any]:
+    normalized = shared_facts._normalize_relationship_item(raw)
+    assert normalized is not None
+    value = bounded_list([normalized])
+    return cast(dict[str, Any], value["items"][0])
+
+
+def _relationship_payload(dependency: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "data": {
+            "repository": {
+                "issue": {
+                    "number": 300,
+                    "title": "Task with typed dependency",
+                    "state": "OPEN",
+                    "blockedBy": {
+                        "nodes": [dependency],
+                        "pageInfo": {"hasNextPage": False},
+                    },
+                    "blocking": {
+                        "nodes": [],
+                        "pageInfo": {"hasNextPage": False},
+                    },
+                    "subIssues": {
+                        "nodes": [],
+                        "pageInfo": {"hasNextPage": False},
+                    },
+                    "issueType": {"name": "Task"},
+                    "parent": None,
+                }
+            }
+        }
+    }
+
+
+class _GraphQLRunner:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.payload = payload
+
+    def run(self, argv: Any, *, command_id: str, **_: Any) -> CommandResult:
+        return CommandResult(
+            command_id,
+            tuple(str(item) for item in argv),
+            0,
+            json.dumps(self.payload),
+            "",
+        )
+
+
+@pytest.mark.parametrize(
+    ("label", "body", "contract_key"),
+    [
+        ("type:bug", BUG_BODY, "bug_contract"),
+        ("type:documentation", DOCUMENTATION_BODY, "documentation_contract"),
+        ("type:research", RESEARCH_BODY, "research_contract"),
+    ],
+)
+def test_lck_policy_uses_complete_dependency_contract(
+    label: str,
+    body: str,
+    contract_key: str,
+) -> None:
+    dependency = _bounded_dependency(
+        _raw_dependency(
+            number=191,
+            label=label,
+            body=body,
+            project_items=DEPENDENCY_PROJECT if label == "type:research" else None,
+        )
+    )
+    assert len(dependency["body"]) < len(body)
+    assert dependency["contract"]["body"] == body
+    assert dependency["contract"]["body_characters"] == len(body)
+
+    resolution = resolve_leaf_issue_profile({"labels": [label]})
+    assert resolution.resolved and resolution.profile is not None
+    check = validate_profile_contract(resolution.profile, dependency)
+    assert check.valid, check.detail
+    assert check.evidence is not None
+    assert check.evidence.payload["contract"]["status"] == "pass"
+    assert check.evidence.payload["contract"]["required_sections"]
+
+
+def test_lck_eligibility_accepts_long_research_architecture_dependency() -> None:
+    dependency = _bounded_dependency(
+        _raw_dependency(
+            number=191,
+            label="type:research",
+            body=RESEARCH_BODY,
+            project_items=DEPENDENCY_PROJECT,
+        )
+    )
+    downstream_body = (
+        "### Decision Contract\n\nAdopt the repository-backed workflow contract.\n"
+    )
+    target = {
+        "number": 239,
+        "title": "[Task] downstream",
+        "state": "OPEN",
+        "labels": ["type:task", "codex:ready"],
+    }
+    state = models.LiveState(
+        issue_number=239,
+        repository="owner/repo",
+        issue=target,
+        leaf_contract={
+            "number": 239,
+            "body": downstream_body,
+            "body_sha256": sha256_json({"body": downstream_body}),
+        },
+        relationships={
+            "available": True,
+            "blocked_by": {
+                "items": [dependency],
+                "count": 1,
+                "truncated": False,
+            },
+        },
+    )
+
+    reasons = eligibility.PhaseEligibilityResolver().blocker_reasons(
+        state, phase=models.Phase.REVIEW_PREPARE
+    )
+    assert reasons == ()
+
+
+@pytest.mark.parametrize(
+    ("label", "body", "contract_key"),
+    [
+        ("type:bug", BUG_BODY, "bug_contract"),
+        ("type:documentation", DOCUMENTATION_BODY, "documentation_contract"),
+        ("type:research", RESEARCH_BODY, "research_contract"),
+    ],
+)
+def test_feature_audit_parses_complete_typed_dependency_contract(
+    label: str,
+    body: str,
+    contract_key: str,
+) -> None:
+    raw = _raw_dependency(
+        number=191,
+        label=label,
+        body=body,
+        project_items=DEPENDENCY_PROJECT if label == "type:research" else None,
+    )
+    relationships = audit_relationship_snapshot(
+        _GraphQLRunner(_relationship_payload(raw)), "owner/repo", 300, []
+    )
+    dependency = relationships["blocked_by"]["items"][0]
+    assert len(dependency["body"]) < len(body)
+    assert dependency[contract_key]["status"] == "pass"
+    if label == "type:research":
+        assert dependency["research_outcome"] == "ARCHITECTURE DECISION"
+        assert dependency["research_outcome_is_canonical"] is True
+        assert dependency["decision_contract"]["status"] == "pass"
+    assert "contract" not in dependency
+
+
+def test_relationship_contract_fails_closed_on_truncation_and_identity_mismatch() -> (
+    None
+):
+    dependency = _bounded_dependency(
+        _raw_dependency(number=201, label="type:bug", body=BUG_BODY)
+    )
+    assert shared_facts.relationship_contract(dependency) is not None
+
+    invalid_body = dict(dependency["contract"])
+    invalid_body["body"] = BUG_BODY[:512]
+    dependency["contract"] = invalid_body
+    assert shared_facts.relationship_contract(dependency) is None
+    profile = resolve_leaf_issue_profile({"labels": ["type:bug"]}).profile
+    assert profile is not None
+    assert not validate_profile_contract(profile, dependency).valid
+
+    dependency = _bounded_dependency(
+        _raw_dependency(number=201, label="type:bug", body=BUG_BODY)
+    )
+    invalid_identity = dict(dependency["contract"])
+    invalid_identity["number"] = 999
+    dependency["contract"] = invalid_identity
+    assert shared_facts.relationship_contract(dependency) is None
+    assert not validate_profile_contract(profile, dependency).valid

--- a/tools/agent_workflow/lck_core/profile_policies.py
+++ b/tools/agent_workflow/lck_core/profile_policies.py
@@ -54,7 +54,7 @@ from .issue_profiles import (
     resolve_leaf_issue_profile,
 )
 from .models import LckStopError
-from .shared_facts import canonical_project_field
+from .shared_facts import canonical_project_field, relationship_contract
 
 PROFILE_EVIDENCE_SCHEMA_VERSION: Final = 1
 PROFILE_EVIDENCE_STAGES: Final = ("contract", "candidate", "review", "completion")
@@ -731,11 +731,14 @@ class _BuiltinPolicy:
         field_name: str,
         snapshot: Callable[[str | None], Mapping[str, Any]],
     ) -> Mapping[str, Any]:
+        # Relationship metadata may expose a bounded legacy body. Typed
+        # policy parsers must use the separately verified complete contract.
+        if "contract" in leaf_contract:
+            return snapshot(_contract_body(leaf_contract))
         value = leaf_contract.get(field_name)
         if isinstance(value, Mapping):
             return value
-        body = leaf_contract.get("body")
-        return snapshot(body if isinstance(body, str) else None)
+        return snapshot(_contract_body(leaf_contract))
 
     def validate_evidence(self, record: ProfileEvidenceRecord) -> bool:
         if record.schema_version != PROFILE_EVIDENCE_SCHEMA_VERSION:
@@ -1389,10 +1392,8 @@ class _ResearchPolicy(_BuiltinPolicy):
         if parsed.value == "ARCHITECTURE DECISION":
             decision_contract = leaf_contract.get("decision_contract")
             if not isinstance(decision_contract, Mapping):
-                body = leaf_contract.get("body")
                 decision_contract = decision_contract_snapshot(
-                    body if isinstance(body, str) else None,
-                    research=True,
+                    _contract_body(leaf_contract), research=True
                 )
             if not architecture_decision_is_consistent(
                 decision_contract,
@@ -1808,6 +1809,17 @@ def _context_for(
     if context is not None:
         return context
     return PolicyContext(profile=profile, issue=issue, **updates)
+
+
+def _contract_body(leaf_contract: Mapping[str, Any]) -> str | None:
+    """Select only an identity-verified complete body for policy parsing."""
+
+    if "contract" in leaf_contract:
+        complete = relationship_contract(leaf_contract)
+        body = complete.get("body") if isinstance(complete, Mapping) else None
+        return body if isinstance(body, str) else None
+    body = leaf_contract.get("body")
+    return body if isinstance(body, str) else None
 
 
 def _raw_contract_snapshot(

--- a/tools/agent_workflow/lck_core/shared_facts.py
+++ b/tools/agent_workflow/lck_core/shared_facts.py
@@ -906,14 +906,87 @@ def _normalize_relationship_item(item: Any) -> dict[str, Any] | None:
         ]
         page = raw_labels.get("pageInfo")
         labels_complete = isinstance(page, Mapping) and page.get("hasNextPage") is False
+    number = item.get("number")
+    title = safe_text(item.get("title"))
+    state = safe_text(item.get("state"))
+    body = item.get("body") if isinstance(item.get("body"), str) else None
+    body_sha256 = sha256_json({"body": body}) if body is not None else None
+    # Relationship metadata is intentionally bounded below.  Keep the full
+    # canonical Issue contract in a separate, explicitly named value so the
+    # bounded display projection can never become semantic parser input.
+    contract = (
+        {
+            "number": number,
+            "title": title,
+            "state": state,
+            "body": body,
+            "body_sha256": body_sha256,
+            "body_characters": len(body),
+        }
+        if body is not None
+        else None
+    )
     return {
-        "number": item.get("number"),
-        "title": safe_text(item.get("title")),
-        "state": safe_text(item.get("state")),
+        "number": number,
+        "title": title,
+        "state": state,
         "labels": sorted(labels),
         "labels_complete": labels_complete,
-        "body": item.get("body") if isinstance(item.get("body"), str) else None,
+        "body": body,
+        "body_sha256": body_sha256,
+        "body_characters": len(body) if body is not None else None,
+        "contract": contract,
         "project_items": _normalize_project_items(item.get("projectItems")),
+    }
+
+
+def relationship_contract(item: Mapping[str, Any]) -> Mapping[str, Any] | None:
+    """Return a verified complete raw contract from one relationship item.
+
+    Relationship items expose a bounded top-level metadata projection.  The
+    nested contract is the only value that may contain the complete Issue
+    body.  Verify both the relationship identity and body digest before any
+    profile policy is allowed to interpret it.
+    """
+
+    raw_contract = item.get("contract")
+    if not isinstance(raw_contract, Mapping):
+        return None
+    number = item.get("number")
+    contract_number = raw_contract.get("number")
+    if (
+        not isinstance(number, int)
+        or isinstance(number, bool)
+        or number <= 0
+        or contract_number != number
+    ):
+        return None
+    body = raw_contract.get("body")
+    body_sha256 = raw_contract.get("body_sha256")
+    if not isinstance(body, str) or not isinstance(body_sha256, str):
+        return None
+    if sha256_json({"body": body}) != body_sha256:
+        return None
+    item_sha256 = item.get("body_sha256")
+    if item_sha256 is not None and item_sha256 != body_sha256:
+        return None
+    body_characters = raw_contract.get("body_characters")
+    if (
+        not isinstance(body_characters, int)
+        or isinstance(body_characters, bool)
+        or body_characters != len(body)
+    ):
+        return None
+    item_characters = item.get("body_characters")
+    if item_characters is not None and item_characters != body_characters:
+        return None
+    return {
+        "number": number,
+        "title": raw_contract.get("title"),
+        "state": raw_contract.get("state"),
+        "body": body,
+        "body_sha256": body_sha256,
+        "body_characters": body_characters,
     }
 
 

--- a/tools/agent_workflow/workflow_evidence.py
+++ b/tools/agent_workflow/workflow_evidence.py
@@ -273,7 +273,16 @@ def _audit_relationship_snapshot(
             labels = item.get("labels") if isinstance(item.get("labels"), list) else []
             resolution = resolve_leaf_issue_profile({"labels": labels})
             profile = resolution.profile if resolution.resolved else None
-            body = item.get("body") if isinstance(item.get("body"), str) else None
+            complete_contract = shared_facts.relationship_contract(item)
+            if "contract" in item:
+                body = (
+                    complete_contract.get("body")
+                    if isinstance(complete_contract, Mapping)
+                    else None
+                )
+            else:
+                # Compatibility for already-normalized historical callers.
+                body = item.get("body") if isinstance(item.get("body"), str) else None
             is_bug = profile is not None and profile.contract_policy == "bug"
             is_documentation = (
                 profile is not None and profile.contract_policy == "documentation"
@@ -301,6 +310,9 @@ def _audit_relationship_snapshot(
             item["research_outcome_is_canonical"] = (
                 item["research_outcome"] is not None if is_research else None
             )
+            # The audit projection retains bounded metadata and typed contract
+            # snapshots, not the raw full Issue body used to derive them.
+            item.pop("contract", None)
     return result
 
 


### PR DESCRIPTION
Closes #239

## Summary
Preserve identity-verified complete dependency contracts beside bounded relationship metadata and parse them in LCK eligibility and Feature-audit paths.

## Validation
- Formal Delivery validation: pass

## Risks / limitations
Relationship facts retain complete dependency bodies in a separate contract projection; unavailable or mismatched contract evidence fails closed.
