### PR TITLE
[Task] 定义 Binance 公共历史数据请求与来源契约

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ The currently implemented public package is `tracequant` under `src/`:
   and formatting;
 - `tracequant.domain`: the initial immutable `InstrumentId`, `TimeRange`, and
   `OHLCVBar` models with validation and JSON-compatible serialization.
+- `tracequant.data`: typed Binance USDⓈ-M public-history request and source
+  identity contracts; it performs no network, file, or data-parsing work.
 
 The `apps/`, `packages/`, and `deploy/` directories currently establish future
 boundaries through small README files. They are not implemented product
@@ -123,6 +125,7 @@ src/tracequant/                 implemented bootstrap package
   logging.py                    structured JSON logging
   core/time.py                  UTC utilities
   domain/models.py              initial domain models
+  data/public_history.py        Binance public-history contracts
 tests/                          package and workflow tests
   fixtures/domain.py            deterministic domain factories, test-only
 apps/                           future research/runtime/console boundaries

--- a/docs/architecture/domain-models.md
+++ b/docs/architecture/domain-models.md
@@ -75,6 +75,28 @@ reject naive values; callers remain responsible for validating external event
 time semantics before constructing a model. No domain model consults the
 machine's local timezone.
 
+## Binance public-history boundary
+
+`tracequant.data` adds the first venue-specific data contract without changing
+the generic domain models. `BinancePublicHistoryRequest` reuses
+`InstrumentId` and `TimeRange`, and admits only the four currently scoped
+Binance USDⓈ-M instruments and data families:
+
+- 1m contract, mark-price, and index-price Klines;
+- settled funding-rate records, which have no Kline interval.
+
+`BinanceArchiveObjectBoundary` identifies an upstream UTC calendar day or
+month. It is serialized separately from the caller's `[start, end)`
+`request_range`; an archive object boundary is not a claim about the request's
+actual coverage. Daily archive sources are limited to the three Kline
+families, while monthly archive and REST sources also represent settled
+funding.
+
+The request and its `source_identity` have deterministic JSON-compatible
+serialization. The module contains only value validation and serialization;
+URL resolution, HTTP, archive parsing, persistence, and completeness checks
+remain outside this contract.
+
 ## Test-factory boundary
 
 One-off values stay in the owning test. Deterministic factories reused across

--- a/docs/architecture/repository-structure.md
+++ b/docs/architecture/repository-structure.md
@@ -13,6 +13,7 @@ src/tracequant/
   logging.py
   core/time.py
   domain/models.py
+  data/public_history.py
 tests/
   test_config.py
   test_logging.py
@@ -54,6 +55,8 @@ Python standard library
 
 tracequant.domain.models ──> tracequant.core.time
 
+tracequant.data.public_history ──> tracequant.domain
+
 tests ──> tracequant public APIs
 tests ──> tests/fixtures/domain.py ──> tracequant.domain
 ```
@@ -76,6 +79,9 @@ primitives; test factories remain a separate test-support layer.
 - `tracequant.domain` owns immutable, risk-independent initial market-data
   value models. It may depend on `core.time`, but not on exchanges, network
   clients, logging setup, UI code, deployment code, or test fixtures.
+- `tracequant.data` owns typed source/request contracts at the data boundary.
+  It may depend on `tracequant.domain`, but does not perform network I/O,
+  filesystem I/O, archive parsing, persistence, or exchange-client work.
 - `tests` may import public production APIs and test-only factories. Fixtures
   must remain deterministic, function-scoped where exposed by `conftest.py`,
   and independent of production runtime imports.

--- a/src/tracequant/data/__init__.py
+++ b/src/tracequant/data/__init__.py
@@ -1,0 +1,25 @@
+"""Typed public-history contracts for the first Binance USDⓈ-M sources."""
+
+from tracequant.data.public_history import (
+    BinanceArchiveObjectBoundary,
+    BinanceArchiveObjectGranularity,
+    BinanceKlineInterval,
+    BinanceMarket,
+    BinancePublicHistoryDataType,
+    BinancePublicHistoryRequest,
+    BinancePublicHistorySourceIdentity,
+    BinancePublicHistorySourceKind,
+    PublicHistoryContractError,
+)
+
+__all__ = [
+    "BinanceArchiveObjectBoundary",
+    "BinanceArchiveObjectGranularity",
+    "BinanceKlineInterval",
+    "BinanceMarket",
+    "BinancePublicHistoryDataType",
+    "BinancePublicHistoryRequest",
+    "BinancePublicHistorySourceIdentity",
+    "BinancePublicHistorySourceKind",
+    "PublicHistoryContractError",
+]

--- a/src/tracequant/data/public_history.py
+++ b/src/tracequant/data/public_history.py
@@ -1,0 +1,552 @@
+"""Immutable contracts for Binance USDⓈ-M public historical data.
+
+This module describes source intent only.  It does not resolve archive URLs,
+call REST endpoints, read files, or parse exchange data.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import date
+from enum import StrEnum
+from typing import Final, Self
+
+from tracequant.domain import DomainValidationError, InstrumentId, TimeRange
+
+__all__ = [
+    "BinanceArchiveObjectBoundary",
+    "BinanceArchiveObjectGranularity",
+    "BinanceKlineInterval",
+    "BinanceMarket",
+    "BinancePublicHistoryDataType",
+    "BinancePublicHistoryRequest",
+    "BinancePublicHistorySourceIdentity",
+    "BinancePublicHistorySourceKind",
+    "PublicHistoryContractError",
+]
+
+_BINANCE_VENUE: Final = "binance"
+_SUPPORTED_INSTRUMENT_VALUES: Final = frozenset(
+    {"BTCUSDT", "ETHUSDT", "BTCUSDC", "ETHUSDC"}
+)
+
+
+class PublicHistoryContractError(DomainValidationError):
+    """Raised when a public-history request violates its typed contract."""
+
+
+class BinanceMarket(StrEnum):
+    """The Binance market covered by this first contract."""
+
+    USD_M = "um"
+
+
+class BinancePublicHistoryDataType(StrEnum):
+    """Distinct raw data families supported by the first public-history slice."""
+
+    CONTRACT_KLINE = "contract_kline"
+    MARK_PRICE_KLINE = "mark_price_kline"
+    INDEX_PRICE_KLINE = "index_price_kline"
+    SETTLED_FUNDING_RATE = "settled_funding_rate"
+
+
+class BinancePublicHistorySourceKind(StrEnum):
+    """The source boundary used to obtain a public-history object."""
+
+    ARCHIVE_DAILY = "archive_daily"
+    ARCHIVE_MONTHLY = "archive_monthly"
+    REST = "rest"
+
+
+class BinanceKlineInterval(StrEnum):
+    """Kline intervals admitted by the first implementation contract."""
+
+    ONE_MINUTE = "1m"
+
+
+class BinanceArchiveObjectGranularity(StrEnum):
+    """Calendar granularity of an upstream archive object."""
+
+    DAY = "day"
+    MONTH = "month"
+
+
+def _require_exact_fields(
+    value: object, *, expected: frozenset[str], model: str
+) -> Mapping[str, object]:
+    if not isinstance(value, dict):
+        raise TypeError(f"{model} serialized value must be a JSON object")
+    if any(not isinstance(key, str) for key in value):
+        raise TypeError(f"{model} serialized field names must be strings")
+
+    actual = set(value)
+    missing = expected - actual
+    extra = actual - expected
+    if missing or extra:
+        details: list[str] = []
+        if missing:
+            details.append(f"missing fields: {', '.join(sorted(missing))}")
+        if extra:
+            details.append(f"extra fields: {', '.join(sorted(extra))}")
+        raise PublicHistoryContractError(
+            f"invalid {model} fields ({'; '.join(details)})"
+        )
+    return value
+
+
+def _require_string(value: object, *, field: str) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{field} must be a string")
+    return value
+
+
+def _coerce_enum[EnumT: StrEnum](
+    value: object, enum_type: type[EnumT], *, field: str
+) -> EnumT:
+    if isinstance(value, enum_type):
+        return value
+    if not isinstance(value, str):
+        raise TypeError(f"{field} must be a supported string value")
+    try:
+        return enum_type(value)
+    except ValueError as error:
+        raise PublicHistoryContractError(
+            f"{field} has unsupported value {value!r}"
+        ) from error
+
+
+@dataclass(frozen=True, slots=True)
+class BinanceArchiveObjectBoundary:
+    """UTC calendar boundary for one daily or monthly archive object.
+
+    ``period_start`` is a calendar date, not a caller request timestamp.  A
+    daily object names one UTC calendar day; a monthly object must start on the
+    first day of its UTC calendar month.
+    """
+
+    granularity: BinanceArchiveObjectGranularity
+    period_start: date
+
+    def __post_init__(self) -> None:
+        granularity = _coerce_enum(
+            self.granularity,
+            BinanceArchiveObjectGranularity,
+            field="archive object granularity",
+        )
+        if type(self.period_start) is not date:
+            raise TypeError("archive object period_start must be a date")
+        if (
+            granularity is BinanceArchiveObjectGranularity.MONTH
+            and self.period_start.day != 1
+        ):
+            raise PublicHistoryContractError(
+                "monthly archive object period_start must be the first day of a month"
+            )
+        object.__setattr__(self, "granularity", granularity)
+
+    @classmethod
+    def day(cls, period_start: date) -> Self:
+        """Create a boundary for one UTC daily archive object."""
+        return cls(BinanceArchiveObjectGranularity.DAY, period_start)
+
+    @classmethod
+    def month(cls, year: int, month: int) -> Self:
+        """Create a boundary for one UTC monthly archive object."""
+        return cls(
+            BinanceArchiveObjectGranularity.MONTH,
+            date(year=year, month=month, day=1),
+        )
+
+    @classmethod
+    def daily(cls, period_start: date) -> Self:
+        """Alias for :meth:`day` using the source terminology."""
+        return cls.day(period_start)
+
+    @classmethod
+    def monthly(cls, year: int, month: int) -> Self:
+        """Alias for :meth:`month` using the source terminology."""
+        return cls.month(year, month)
+
+    @property
+    def kind(self) -> BinanceArchiveObjectGranularity:
+        """Return the calendar granularity without exposing a second field."""
+        return self.granularity
+
+    def to_dict(self) -> dict[str, str]:
+        """Return a stable JSON-compatible object boundary."""
+        return {
+            "granularity": self.granularity.value,
+            "period_start": self.period_start.isoformat(),
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> Self:
+        """Create a boundary from exact serialized fields."""
+        fields = _require_exact_fields(
+            value,
+            expected=frozenset({"granularity", "period_start"}),
+            model="BinanceArchiveObjectBoundary",
+        )
+        period_start_text = _require_string(
+            fields["period_start"], field="period_start"
+        )
+        try:
+            period_start = date.fromisoformat(period_start_text)
+        except ValueError as error:
+            raise PublicHistoryContractError(
+                "period_start must be an ISO 8601 calendar date"
+            ) from error
+        return cls(
+            granularity=_coerce_enum(
+                fields["granularity"],
+                BinanceArchiveObjectGranularity,
+                field="archive object granularity",
+            ),
+            period_start=period_start,
+        )
+
+
+def _normalize_components(
+    *,
+    market: BinanceMarket | str,
+    instrument: InstrumentId,
+    data_type: BinancePublicHistoryDataType | str,
+    interval: BinanceKlineInterval | str | None,
+    source_kind: BinancePublicHistorySourceKind | str,
+    archive_object_boundary: BinanceArchiveObjectBoundary | None,
+) -> tuple[
+    BinanceMarket,
+    BinancePublicHistoryDataType,
+    BinanceKlineInterval | None,
+    BinancePublicHistorySourceKind,
+    BinanceArchiveObjectBoundary | None,
+]:
+    normalized_market = _coerce_enum(market, BinanceMarket, field="market")
+    if not isinstance(instrument, InstrumentId):
+        raise TypeError("instrument must be an InstrumentId")
+    if str(instrument) not in _SUPPORTED_INSTRUMENT_VALUES:
+        raise PublicHistoryContractError(
+            f"instrument {instrument!s} is outside the supported Binance USDⓈ-M set"
+        )
+
+    normalized_data_type = _coerce_enum(
+        data_type, BinancePublicHistoryDataType, field="data type"
+    )
+    normalized_interval: BinanceKlineInterval | None
+    if interval is None:
+        normalized_interval = None
+    else:
+        try:
+            normalized_interval = _coerce_enum(
+                interval, BinanceKlineInterval, field="interval"
+            )
+        except PublicHistoryContractError as error:
+            raise PublicHistoryContractError(
+                "supported Kline interval must be 1m"
+            ) from error
+    normalized_source_kind = _coerce_enum(
+        source_kind, BinancePublicHistorySourceKind, field="source kind"
+    )
+
+    if archive_object_boundary is not None and not isinstance(
+        archive_object_boundary, BinanceArchiveObjectBoundary
+    ):
+        raise TypeError(
+            "archive_object_boundary must be a BinanceArchiveObjectBoundary"
+        )
+
+    is_funding = (
+        normalized_data_type is BinancePublicHistoryDataType.SETTLED_FUNDING_RATE
+    )
+    if is_funding:
+        if normalized_interval is not None:
+            raise PublicHistoryContractError(
+                "settled funding rate does not use a Kline interval"
+            )
+    elif normalized_interval is not BinanceKlineInterval.ONE_MINUTE:
+        raise PublicHistoryContractError("supported Kline interval must be 1m")
+
+    if normalized_source_kind is BinancePublicHistorySourceKind.ARCHIVE_DAILY:
+        if is_funding:
+            raise PublicHistoryContractError(
+                "settled funding rate has no daily archive source"
+            )
+        if archive_object_boundary is None:
+            raise PublicHistoryContractError(
+                "daily archive source requires a day object boundary"
+            )
+        if (
+            archive_object_boundary.granularity
+            is not BinanceArchiveObjectGranularity.DAY
+        ):
+            raise PublicHistoryContractError(
+                "daily archive source requires a day object boundary"
+            )
+    elif normalized_source_kind is BinancePublicHistorySourceKind.ARCHIVE_MONTHLY:
+        if archive_object_boundary is None:
+            raise PublicHistoryContractError(
+                "monthly archive source requires a month object boundary"
+            )
+        if (
+            archive_object_boundary.granularity
+            is not BinanceArchiveObjectGranularity.MONTH
+        ):
+            raise PublicHistoryContractError(
+                "monthly archive source requires a month object boundary"
+            )
+    elif archive_object_boundary is not None:
+        raise PublicHistoryContractError(
+            "REST source must not include an archive object boundary"
+        )
+
+    return (
+        normalized_market,
+        normalized_data_type,
+        normalized_interval,
+        normalized_source_kind,
+        archive_object_boundary,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class BinancePublicHistorySourceIdentity:
+    """Stable source identity independent of the caller's request range."""
+
+    instrument: InstrumentId
+    data_type: BinancePublicHistoryDataType
+    source_kind: BinancePublicHistorySourceKind
+    interval: BinanceKlineInterval | None
+    archive_object_boundary: BinanceArchiveObjectBoundary | None
+    market: BinanceMarket = BinanceMarket.USD_M
+
+    def __post_init__(self) -> None:
+        (
+            market,
+            data_type,
+            interval,
+            source_kind,
+            archive_object_boundary,
+        ) = _normalize_components(
+            market=self.market,
+            instrument=self.instrument,
+            data_type=self.data_type,
+            interval=self.interval,
+            source_kind=self.source_kind,
+            archive_object_boundary=self.archive_object_boundary,
+        )
+        object.__setattr__(self, "market", market)
+        object.__setattr__(self, "data_type", data_type)
+        object.__setattr__(self, "interval", interval)
+        object.__setattr__(self, "source_kind", source_kind)
+        object.__setattr__(self, "archive_object_boundary", archive_object_boundary)
+
+    def to_dict(self) -> dict[str, object]:
+        """Return stable JSON-compatible source identity fields."""
+        return {
+            "venue": _BINANCE_VENUE,
+            "market": self.market.value,
+            "instrument": self.instrument.to_dict(),
+            "data_type": self.data_type.value,
+            "interval": self.interval.value if self.interval is not None else None,
+            "source_kind": self.source_kind.value,
+            "archive_object_boundary": (
+                self.archive_object_boundary.to_dict()
+                if self.archive_object_boundary is not None
+                else None
+            ),
+        }
+
+    def to_json(self) -> str:
+        """Return canonical JSON for logs, manifests, and comparisons."""
+        return json.dumps(
+            self.to_dict(),
+            allow_nan=False,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+
+    @classmethod
+    def from_dict(cls, value: object) -> Self:
+        """Create a source identity from exact serialized fields."""
+        fields = _require_exact_fields(
+            value,
+            expected=frozenset(
+                {
+                    "venue",
+                    "market",
+                    "instrument",
+                    "data_type",
+                    "interval",
+                    "source_kind",
+                    "archive_object_boundary",
+                }
+            ),
+            model="BinancePublicHistorySourceIdentity",
+        )
+        venue = _require_string(fields["venue"], field="venue")
+        if venue != _BINANCE_VENUE:
+            raise PublicHistoryContractError(f"venue must be {_BINANCE_VENUE!r}")
+        boundary_value = fields["archive_object_boundary"]
+        boundary = (
+            None
+            if boundary_value is None
+            else BinanceArchiveObjectBoundary.from_dict(boundary_value)
+        )
+        interval_value = fields["interval"]
+        interval = (
+            None
+            if interval_value is None
+            else _coerce_enum(interval_value, BinanceKlineInterval, field="interval")
+        )
+        return cls(
+            instrument=InstrumentId.from_dict(fields["instrument"]),
+            data_type=_coerce_enum(
+                fields["data_type"],
+                BinancePublicHistoryDataType,
+                field="data type",
+            ),
+            source_kind=_coerce_enum(
+                fields["source_kind"],
+                BinancePublicHistorySourceKind,
+                field="source kind",
+            ),
+            interval=interval,
+            archive_object_boundary=boundary,
+            market=_coerce_enum(fields["market"], BinanceMarket, field="market"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class BinancePublicHistoryRequest:
+    """A typed Binance USDⓈ-M public-history acquisition request.
+
+    ``request_range`` is the caller's UTC half-open range.  An archive
+    ``archive_object_boundary`` is the upstream day/month object boundary;
+    keeping them as separate fields prevents an archive filename from being
+    mistaken for the requested or observed data range.
+    """
+
+    instrument: InstrumentId
+    data_type: BinancePublicHistoryDataType
+    request_range: TimeRange
+    source_kind: BinancePublicHistorySourceKind
+    interval: BinanceKlineInterval | None = None
+    archive_object_boundary: BinanceArchiveObjectBoundary | None = None
+    market: BinanceMarket = BinanceMarket.USD_M
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.request_range, TimeRange):
+            raise TypeError("request_range must be a TimeRange")
+        (
+            market,
+            data_type,
+            interval,
+            source_kind,
+            archive_object_boundary,
+        ) = _normalize_components(
+            market=self.market,
+            instrument=self.instrument,
+            data_type=self.data_type,
+            interval=self.interval,
+            source_kind=self.source_kind,
+            archive_object_boundary=self.archive_object_boundary,
+        )
+        object.__setattr__(self, "market", market)
+        object.__setattr__(self, "data_type", data_type)
+        object.__setattr__(self, "interval", interval)
+        object.__setattr__(self, "source_kind", source_kind)
+        object.__setattr__(self, "archive_object_boundary", archive_object_boundary)
+
+    @property
+    def time_range(self) -> TimeRange:
+        """Alias exposing the request's existing domain range terminology."""
+        return self.request_range
+
+    @property
+    def source_object_boundary(self) -> BinanceArchiveObjectBoundary | None:
+        """Return the archive boundary, distinct from ``request_range``."""
+        return self.archive_object_boundary
+
+    @property
+    def source_identity(self) -> BinancePublicHistorySourceIdentity:
+        """Return the stable source identity for this request."""
+        return BinancePublicHistorySourceIdentity(
+            instrument=self.instrument,
+            data_type=self.data_type,
+            source_kind=self.source_kind,
+            interval=self.interval,
+            archive_object_boundary=self.archive_object_boundary,
+            market=self.market,
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        """Return stable JSON-compatible request and source fields."""
+        return {
+            **self.source_identity.to_dict(),
+            "request_range": self.request_range.to_dict(),
+        }
+
+    def to_json(self) -> str:
+        """Return canonical JSON for the complete request identity."""
+        return json.dumps(
+            self.to_dict(),
+            allow_nan=False,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+
+    @classmethod
+    def from_dict(cls, value: object) -> Self:
+        """Create a request from exact serialized fields."""
+        fields = _require_exact_fields(
+            value,
+            expected=frozenset(
+                {
+                    "venue",
+                    "market",
+                    "instrument",
+                    "data_type",
+                    "interval",
+                    "source_kind",
+                    "archive_object_boundary",
+                    "request_range",
+                }
+            ),
+            model="BinancePublicHistoryRequest",
+        )
+        venue = _require_string(fields["venue"], field="venue")
+        if venue != _BINANCE_VENUE:
+            raise PublicHistoryContractError(f"venue must be {_BINANCE_VENUE!r}")
+        boundary_value = fields["archive_object_boundary"]
+        boundary = (
+            None
+            if boundary_value is None
+            else BinanceArchiveObjectBoundary.from_dict(boundary_value)
+        )
+        interval_value = fields["interval"]
+        interval = (
+            None
+            if interval_value is None
+            else _coerce_enum(interval_value, BinanceKlineInterval, field="interval")
+        )
+        return cls(
+            instrument=InstrumentId.from_dict(fields["instrument"]),
+            data_type=_coerce_enum(
+                fields["data_type"],
+                BinancePublicHistoryDataType,
+                field="data type",
+            ),
+            request_range=TimeRange.from_dict(fields["request_range"]),
+            source_kind=_coerce_enum(
+                fields["source_kind"],
+                BinancePublicHistorySourceKind,
+                field="source kind",
+            ),
+            interval=interval,
+            archive_object_boundary=boundary,
+            market=_coerce_enum(fields["market"], BinanceMarket, field="market"),
+        )

--- a/tests/data/test_public_history_contracts.py
+++ b/tests/data/test_public_history_contracts.py
@@ -1,0 +1,218 @@
+import json
+from dataclasses import replace
+from datetime import UTC, date, datetime, timedelta, timezone
+
+import pytest
+
+from tracequant.data import (
+    BinanceArchiveObjectBoundary,
+    BinanceArchiveObjectGranularity,
+    BinanceKlineInterval,
+    BinanceMarket,
+    BinancePublicHistoryDataType,
+    BinancePublicHistoryRequest,
+    BinancePublicHistorySourceIdentity,
+    BinancePublicHistorySourceKind,
+    PublicHistoryContractError,
+)
+from tracequant.domain import InstrumentId, TimeRange
+
+
+def _request(
+    *,
+    data_type: BinancePublicHistoryDataType = (
+        BinancePublicHistoryDataType.CONTRACT_KLINE
+    ),
+    source_kind: BinancePublicHistorySourceKind = (
+        BinancePublicHistorySourceKind.ARCHIVE_DAILY
+    ),
+    interval: BinanceKlineInterval | None = BinanceKlineInterval.ONE_MINUTE,
+    archive_object_boundary: BinanceArchiveObjectBoundary | None = None,
+) -> BinancePublicHistoryRequest:
+    if (
+        archive_object_boundary is None
+        and source_kind is not BinancePublicHistorySourceKind.REST
+    ):
+        archive_object_boundary = BinanceArchiveObjectBoundary.day(date(2024, 2, 29))
+    return BinancePublicHistoryRequest(
+        instrument=InstrumentId("BTCUSDT"),
+        data_type=data_type,
+        request_range=TimeRange(
+            start=datetime(2024, 2, 29, 23, 45, tzinfo=UTC),
+            end=datetime(2024, 3, 1, 0, 15, tzinfo=UTC),
+        ),
+        source_kind=source_kind,
+        interval=interval,
+        archive_object_boundary=archive_object_boundary,
+    )
+
+
+def test_public_history_request_has_stable_utc_source_identity() -> None:
+    first = BinancePublicHistoryRequest(
+        instrument=InstrumentId(" btcusdt "),
+        data_type=BinancePublicHistoryDataType.CONTRACT_KLINE,
+        request_range=TimeRange(
+            start=datetime(2024, 3, 1, 7, 45, tzinfo=timezone(timedelta(hours=8))),
+            end=datetime(2024, 3, 1, 8, 15, tzinfo=timezone(timedelta(hours=8))),
+        ),
+        source_kind=BinancePublicHistorySourceKind.ARCHIVE_DAILY,
+        interval=BinanceKlineInterval.ONE_MINUTE,
+        archive_object_boundary=BinanceArchiveObjectBoundary.day(date(2024, 2, 29)),
+    )
+    second = BinancePublicHistoryRequest(
+        instrument=InstrumentId("BTCUSDT"),
+        data_type=BinancePublicHistoryDataType.CONTRACT_KLINE,
+        request_range=TimeRange(
+            start=datetime(2024, 2, 29, 23, 45, tzinfo=UTC),
+            end=datetime(2024, 3, 1, 0, 15, tzinfo=UTC),
+        ),
+        source_kind=BinancePublicHistorySourceKind.ARCHIVE_DAILY,
+        interval=BinanceKlineInterval.ONE_MINUTE,
+        archive_object_boundary=BinanceArchiveObjectBoundary.daily(date(2024, 2, 29)),
+    )
+
+    assert first == second
+    assert first.source_identity == second.source_identity
+    assert first.to_json() == second.to_json()
+    payload = first.to_dict()
+    assert json.loads(first.to_json()) == payload
+    assert json.dumps(payload, allow_nan=False) == json.dumps(
+        second.to_dict(), allow_nan=False
+    )
+    assert payload["request_range"] != payload["archive_object_boundary"]
+    assert BinancePublicHistoryRequest.from_dict(payload) == first
+    assert (
+        BinancePublicHistorySourceIdentity.from_dict(first.source_identity.to_dict())
+        == first.source_identity
+    )
+
+
+@pytest.mark.parametrize("instrument", ["BTCUSDT", "ETHUSDT", "BTCUSDC", "ETHUSDC"])
+def test_first_binance_instrument_set_is_expressible(instrument: str) -> None:
+    request = BinancePublicHistoryRequest(
+        instrument=InstrumentId(instrument),
+        data_type=BinancePublicHistoryDataType.CONTRACT_KLINE,
+        request_range=TimeRange(
+            start=datetime(2024, 1, 1, tzinfo=UTC),
+            end=datetime(2024, 1, 1, 0, 1, tzinfo=UTC),
+        ),
+        source_kind=BinancePublicHistorySourceKind.REST,
+        interval=BinanceKlineInterval.ONE_MINUTE,
+    )
+
+    assert request.instrument == InstrumentId(instrument)
+    assert request.archive_object_boundary is None
+
+
+@pytest.mark.parametrize(
+    "data_type",
+    [
+        BinancePublicHistoryDataType.CONTRACT_KLINE,
+        BinancePublicHistoryDataType.MARK_PRICE_KLINE,
+        BinancePublicHistoryDataType.INDEX_PRICE_KLINE,
+    ],
+)
+def test_each_kline_family_is_typed_as_one_minute(
+    data_type: BinancePublicHistoryDataType,
+) -> None:
+    request = _request(data_type=data_type)
+
+    assert request.interval is BinanceKlineInterval.ONE_MINUTE
+    assert request.data_type is data_type
+    assert request.source_identity.to_dict()["data_type"] == data_type.value
+
+
+def test_settled_funding_is_not_a_kline() -> None:
+    request = _request(
+        data_type=BinancePublicHistoryDataType.SETTLED_FUNDING_RATE,
+        source_kind=BinancePublicHistorySourceKind.ARCHIVE_MONTHLY,
+        interval=None,
+        archive_object_boundary=BinanceArchiveObjectBoundary.month(2024, 2),
+    )
+
+    assert request.interval is None
+    assert request.data_type is BinancePublicHistoryDataType.SETTLED_FUNDING_RATE
+    assert request.source_kind is BinancePublicHistorySourceKind.ARCHIVE_MONTHLY
+
+
+def test_monthly_archive_boundary_is_explicit_and_utc_calendar_based() -> None:
+    boundary = BinanceArchiveObjectBoundary.monthly(2024, 2)
+
+    assert boundary.granularity is BinanceArchiveObjectGranularity.MONTH
+    assert boundary.period_start == date(2024, 2, 1)
+    assert boundary.to_dict() == {
+        "granularity": "month",
+        "period_start": "2024-02-01",
+    }
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        (
+            {"interval": "5m"},
+            "supported Kline interval must be 1m",
+        ),
+        (
+            {"interval": None},
+            "supported Kline interval must be 1m",
+        ),
+        (
+            {
+                "data_type": BinancePublicHistoryDataType.SETTLED_FUNDING_RATE,
+                "interval": BinanceKlineInterval.ONE_MINUTE,
+                "source_kind": BinancePublicHistorySourceKind.ARCHIVE_MONTHLY,
+                "archive_object_boundary": BinanceArchiveObjectBoundary.month(2024, 2),
+            },
+            "does not use a Kline interval",
+        ),
+        (
+            {
+                "data_type": BinancePublicHistoryDataType.SETTLED_FUNDING_RATE,
+                "source_kind": BinancePublicHistorySourceKind.ARCHIVE_DAILY,
+                "interval": None,
+                "archive_object_boundary": BinanceArchiveObjectBoundary.day(
+                    date(2024, 2, 29)
+                ),
+            },
+            "has no daily archive source",
+        ),
+        (
+            {
+                "source_kind": BinancePublicHistorySourceKind.REST,
+                "archive_object_boundary": BinanceArchiveObjectBoundary.day(
+                    date(2024, 2, 29)
+                ),
+            },
+            "REST source must not include",
+        ),
+        (
+            {
+                "source_kind": BinancePublicHistorySourceKind.ARCHIVE_DAILY,
+                "archive_object_boundary": BinanceArchiveObjectBoundary.month(2024, 2),
+            },
+            "daily archive source requires a day",
+        ),
+        (
+            {"instrument": InstrumentId("SOLUSDT")},
+            "outside the supported",
+        ),
+        (
+            {"market": "spot"},
+            "market has unsupported value",
+        ),
+    ],
+)
+def test_unsupported_public_history_combinations_fail(
+    kwargs: dict[str, object], message: str
+) -> None:
+    with pytest.raises(PublicHistoryContractError, match=message):
+        replace(_request(), **kwargs)  # type: ignore[arg-type]
+
+
+def test_request_uses_the_existing_instrument_and_time_range_models() -> None:
+    request = _request()
+
+    assert isinstance(request.instrument, InstrumentId)
+    assert isinstance(request.request_range, TimeRange)
+    assert request.market is BinanceMarket.USD_M


### PR DESCRIPTION
Closes #192

## Summary
Add the typed tracequant.data boundary for Binance USDⓈ-M public-history requests, archive day/month source boundaries, stable identities, and explicit validation for the first supported data families and instruments.

## Validation
- Critical Outcome: pass
- Formal Delivery validation: pass

## Risks / limitations
No network, archive parsing, persistence, or data-quality implementation is included; source coverage remains limited to the Research #191 first-slice contract.:w
