### PR TITLE
[Documentation] Publish Corrected LCK Preview and Synchronize Public OSS Entry Points

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,13 +116,13 @@ flowchart LR
 
 ### LCK releases and manual adoption
 
-LCK is actively developed within TraceQuant. The current corrected preview is
-[`lck-v0.1.0-preview.2`](https://github.com/PhoenixSss/tracequant/releases/tag/lck-v0.1.0-preview.2),
-a manifest-backed source snapshot for manual evaluation and adaptation. The
-earlier [`preview.1`](https://github.com/PhoenixSss/tracequant/releases/tag/lck-v0.1.0-preview.1)
-remains an immutable historical release and is superseded by `preview.2`.
-Before selecting the versioned path, verify the exact source commit, manifest,
-archive digest, release metadata, and compatibility guidance in the [release
+LCK is actively developed within TraceQuant. The [GitHub Releases
+page](https://github.com/PhoenixSss/tracequant/releases) lists the versioned
+LCK previews; select the current supported preview rather than relying on an
+unversioned branch or arbitrary commit. Each supported preview is a
+manifest-backed source snapshot for manual evaluation and adaptation. Before
+adopting one, verify its exact tag, source commit, manifest, archive digest,
+release metadata, and compatibility guidance in the [release
 policy](docs/guides/release-policy.md) and [LCK adoption guide](docs/guides/LCK-adoption.md).
 
 For manual evaluation and repository-specific adaptation, see the [LCK

--- a/README.md
+++ b/README.md
@@ -117,12 +117,14 @@ flowchart LR
 ### LCK releases and manual adoption
 
 LCK is actively developed within TraceQuant. The [GitHub Releases
-page](https://github.com/PhoenixSss/tracequant/releases) lists the versioned
-LCK previews; select the current supported preview rather than relying on an
-unversioned branch or arbitrary commit. Each supported preview is a
-manifest-backed source snapshot for manual evaluation and adaptation. Before
-adopting one, verify its exact tag, source commit, manifest, archive digest,
-release metadata, and compatibility guidance in the [release
+page](https://github.com/PhoenixSss/tracequant/releases) is the authority for
+whether a named LCK archive has actually been published. The corrected
+`lck-v0.1.0-preview.2` archive is not published yet; until a named Release is
+listed, use the repository-copy path in the [LCK adoption
+guide](docs/guides/LCK-adoption.md) rather than relying on an unversioned
+branch, arbitrary commit, or nonexistent archive. Before adopting a published
+preview, verify its exact tag, source commit, manifest, archive digest, release
+metadata, and compatibility guidance in the [release
 policy](docs/guides/release-policy.md) and [LCK adoption guide](docs/guides/LCK-adoption.md).
 
 For manual evaluation and repository-specific adaptation, see the [LCK

--- a/README.md
+++ b/README.md
@@ -116,13 +116,14 @@ flowchart LR
 
 ### LCK releases and manual adoption
 
-LCK is actively developed within TraceQuant. The [GitHub Releases
-page](https://github.com/PhoenixSss/tracequant/releases) records versioned LCK
-release entries, but this README does not establish that a supported archive is
-currently available or pin a version. Before selecting a versioned distribution
-path, verify its live release status, exact tag, artifact integrity, and
-compatibility guidance in the [release policy](docs/guides/release-policy.md)
-and [LCK adoption guide](docs/guides/LCK-adoption.md).
+LCK is actively developed within TraceQuant. The current corrected preview is
+[`lck-v0.1.0-preview.2`](https://github.com/PhoenixSss/tracequant/releases/tag/lck-v0.1.0-preview.2),
+a manifest-backed source snapshot for manual evaluation and adaptation. The
+earlier [`preview.1`](https://github.com/PhoenixSss/tracequant/releases/tag/lck-v0.1.0-preview.1)
+remains an immutable historical release and is superseded by `preview.2`.
+Before selecting the versioned path, verify the exact source commit, manifest,
+archive digest, release metadata, and compatibility guidance in the [release
+policy](docs/guides/release-policy.md) and [LCK adoption guide](docs/guides/LCK-adoption.md).
 
 For manual evaluation and repository-specific adaptation, see the [LCK
 adoption guide](docs/guides/LCK-adoption.md). LCK is not a standalone product,

--- a/docs/guides/LCK-adoption.md
+++ b/docs/guides/LCK-adoption.md
@@ -310,10 +310,12 @@ with future TraceQuant main.
 
 ### Future portability work
 
-A separately published archive, standalone LCK repository, package extraction,
-one-click installer, zero-configuration setup, universal compatibility, and
-automatic external adoption are not provided by this guide. They remain future
-portability or distribution work, not current implementation facts.
+The separately published `preview.2` archive is available through the
+versioned path described above. A standalone LCK repository, package
+extraction, one-click installer, zero-configuration setup, universal
+compatibility, and automatic external adoption are not provided by this guide.
+They remain future portability or distribution work, not current implementation
+facts.
 
 Manual adoption also does not decouple LCK core from TraceQuant, change
 TraceQuant's product identity, or grant an adopting repository any of

--- a/docs/guides/LCK-adoption.md
+++ b/docs/guides/LCK-adoption.md
@@ -33,14 +33,14 @@ implications:
 | Path | Current status | What it means |
 | --- | --- | --- |
 | Repository copy | Available for manual evaluation and adaptation | Inspect a chosen TraceQuant revision, copy the coherent LCK source and workflow material, then adapt every repository-specific integration point. |
-| Versioned release archive | Available: [`lck-v0.1.0-preview.2`](https://github.com/PhoenixSss/tracequant/releases/tag/lck-v0.1.0-preview.2) | Use the corrected, manifest-backed preview for manual evaluation and adaptation. The release record contains the exact source commit, manifest, archive digest, compatibility information, and validation summary. |
+| Corrected versioned release archive | Not yet published: `lck-v0.1.0-preview.2` | The corrected archive path is planned, but no supported `preview.2` archive is available before its named GitHub Release is published. Until then, use the repository-copy path; the existing `preview.1` is historical and is not the corrected candidate. |
 
-The versioned path is a supported LCK source snapshot, not a generic GitHub
-source archive for an arbitrary commit or tag. `preview.1` remains immutable
-and is clearly superseded; do not replace its tag or assets. Use the exact
-`preview.2` release identity, record its source commit and archive digest,
-extract that snapshot into the adopting repository, and follow its
-compatibility and upgrade notes.
+An eventual versioned path is a supported LCK source snapshot, not a generic
+GitHub source archive for an arbitrary commit or tag. The existing
+[`lck-v0.1.0-preview.1`](https://github.com/PhoenixSss/tracequant/releases/tag/lck-v0.1.0-preview.1)
+release remains immutable historical evidence. Do not represent it as
+`preview.2`, replace its tag or assets, or download a corrected archive before
+the named `preview.2` Release is actually listed.
 
 ## Path A: repository-copy adoption
 
@@ -114,12 +114,14 @@ alternate LCK lifecycle entry point.
 
 ## Path B: versioned release-archive adoption
 
-The current supported archive is the pre-release
-[`lck-v0.1.0-preview.2`](https://github.com/PhoenixSss/tracequant/releases/tag/lck-v0.1.0-preview.2).
-Its archive is a fixed source snapshot, not a floating view of `main`. Use the
-following manual sequence:
+The corrected `preview.2` archive is not yet published. This path becomes
+available only after a named `preview.2` GitHub Release is actually listed;
+until then, stop at the availability check and use Path A. Once the Release is
+listed, its archive is a fixed source snapshot, not a floating view of `main`.
+Use the following manual sequence:
 
-1. Select `preview.2` rather than an unversioned branch or arbitrary commit.
+1. Select the named `preview.2` Release rather than an unversioned branch or
+   arbitrary commit.
 2. Download its named archive and metadata assets; verify and record the tag,
    exact source commit, manifest digest, archive digest, and pre-release status.
 3. Extract the archive into a controlled location in the adopting repository.
@@ -310,8 +312,8 @@ with future TraceQuant main.
 
 ### Future portability work
 
-The separately published `preview.2` archive is available through the
-versioned path described above. A standalone LCK repository, package
+No separately published corrected `preview.2` archive is currently available
+through this guide. A standalone LCK repository, package
 extraction, one-click installer, zero-configuration setup, universal
 compatibility, and automatic external adoption are not provided by this guide.
 They remain future portability or distribution work, not current implementation

--- a/docs/guides/LCK-adoption.md
+++ b/docs/guides/LCK-adoption.md
@@ -33,14 +33,14 @@ implications:
 | Path | Current status | What it means |
 | --- | --- | --- |
 | Repository copy | Available for manual evaluation and adaptation | Inspect a chosen TraceQuant revision, copy the coherent LCK source and workflow material, then adapt every repository-specific integration point. |
-| Versioned release archive | Planned / unavailable | No supported LCK release archive was listed for `PhoenixSss/tracequant` when this guide was checked on 2026-09-02. Re-check the repository's [GitHub Releases](https://github.com/PhoenixSss/tracequant/releases) before using this path. |
+| Versioned release archive | Available: [`lck-v0.1.0-preview.2`](https://github.com/PhoenixSss/tracequant/releases/tag/lck-v0.1.0-preview.2) | Use the corrected, manifest-backed preview for manual evaluation and adaptation. The release record contains the exact source commit, manifest, archive digest, compatibility information, and validation summary. |
 
-The absence of a supported release archive is intentional in this guide. A
-GitHub-generated source archive for an arbitrary commit or tag is not by itself
-a supported LCK distribution. When a supported archive is eventually
-published, use its exact release version, record the tag and archive digest,
-extract that version into the adopting repository, and follow its compatibility
-and upgrade notes. Do not imply that an archive exists before it is published.
+The versioned path is a supported LCK source snapshot, not a generic GitHub
+source archive for an arbitrary commit or tag. `preview.1` remains immutable
+and is clearly superseded; do not replace its tag or assets. Use the exact
+`preview.2` release identity, record its source commit and archive digest,
+extract that snapshot into the adopting repository, and follow its
+compatibility and upgrade notes.
 
 ## Path A: repository-copy adoption
 
@@ -114,22 +114,23 @@ alternate LCK lifecycle entry point.
 
 ## Path B: versioned release-archive adoption
 
-This path is conditional on a supported archive being published in a GitHub
-Release. Once available, the manual sequence is:
+The current supported archive is the pre-release
+[`lck-v0.1.0-preview.2`](https://github.com/PhoenixSss/tracequant/releases/tag/lck-v0.1.0-preview.2).
+Its archive is a fixed source snapshot, not a floating view of `main`. Use the
+following manual sequence:
 
-1. Select a named supported release rather than an unversioned branch or
-   arbitrary commit.
-2. Download the archive from that release's assets or documented release
-   location; verify and record the release tag, version, and digest.
+1. Select `preview.2` rather than an unversioned branch or arbitrary commit.
+2. Download its named archive and metadata assets; verify and record the tag,
+   exact source commit, manifest digest, archive digest, and pre-release status.
 3. Extract the archive into a controlled location in the adopting repository.
 4. Read the archive's compatibility and upgrade guidance before replacing an
    earlier snapshot.
 5. Adapt the repository integration points listed in the matrix below and run
    non-destructive validation before any lifecycle write.
 
-Until such a release is actually listed, this path stops at availability
-checking. It does not authorize downloading a nonexistent LCK artifact, and it
-does not turn TraceQuant's current source snapshot into a standalone product.
+The archive does not authorize automatic installation, and it does not turn
+TraceQuant's current source snapshot into a standalone product. A later
+correction or changed digest requires a new immutable release identity.
 
 ## Reuse and adaptation matrix
 

--- a/docs/guides/release-policy.md
+++ b/docs/guides/release-policy.md
@@ -1,13 +1,14 @@
 # TraceQuant and LCK release policy
 
-> **Status:** Current policy for future releases
-> **First LCK preview:** `lck-v0.1.0-preview.1`
-> **Last repository-state check:** 2026-09-02
+> **Status:** Current release policy and LCK preview record
+> **Current LCK preview:** `lck-v0.1.0-preview.2`
+> **Last repository-state check:** 2026-09-03
 
 This policy defines how releases of the TraceQuant project and previews of the
 Local Control Kernel (LCK) are identified, checked, documented, and kept
 traceable. It is a release decision and record-keeping policy, not release
-automation and not a promise that an artifact currently exists.
+automation. The GitHub Release record and its named assets are the authority
+for the exact source commit, manifest, and digest of each published preview.
 
 ## 1. One repository, two release tracks
 
@@ -34,11 +35,14 @@ other track's stability claim.
 | TraceQuant project | A reviewed TraceQuant repository state and, when applicable, its project package | `tracequant-v<MAJOR>.<MINOR>.<PATCH>`; the package version remains the value in `pyproject.toml` | A project release. It must not imply that planned quantitative or trading capabilities are implemented. |
 | LCK component preview | A deliberately scoped, manifest-backed LCK source archive, if one is published | `lck-v<MAJOR>.<MINOR>.<PATCH>-preview.<N>` | A versioned LCK snapshot for manual evaluation and adaptation inside TraceQuant's project context. |
 
-The first proposed LCK identity is `lck-v0.1.0-preview.1`. Preview number
-`N` increases for another published candidate in the same preview series. A
-stable LCK identity removes the `-preview.N` suffix only after the stable
-criteria in Section 8 are met. A version or tag is never reused for a
-different commit, manifest, or archive digest.
+The first LCK preview, [`lck-v0.1.0-preview.1`](https://github.com/PhoenixSss/tracequant/releases/tag/lck-v0.1.0-preview.1),
+was published and remains an immutable historical release. The corrected
+current preview is [`lck-v0.1.0-preview.2`](https://github.com/PhoenixSss/tracequant/releases/tag/lck-v0.1.0-preview.2),
+which supersedes `preview.1` without reusing its tag, source commit, manifest,
+or archive. Preview number `N` increases for another published candidate in
+the same preview series. A stable LCK identity removes the `-preview.N` suffix
+only after the stable criteria in Section 8 are met. A version or tag is never
+reused for a different commit, manifest, or archive digest.
 
 The `version = "0.1.0"` value currently in `pyproject.toml` identifies the
 `tracequant` Python project. It is not automatically the LCK version, and
@@ -47,16 +51,19 @@ preview.
 
 ## 2. Current availability and source-of-truth boundaries
 
-At the state check recorded above, the repository has no Git tag, no GitHub
-Release, and no supported LCK release archive. The repository-copy adoption
-path is therefore the available path: a maintainer or adopter selects a
-coherent commit and manually adapts it. A GitHub-generated source archive for
-an arbitrary branch, commit, or tag is not by itself an LCK release archive.
+At the state check recorded above, `preview.1` and the corrected `preview.2`
+are distinct GitHub pre-releases. `preview.2` is the current supported LCK
+source archive for manual evaluation and adaptation; `preview.1` remains an
+immutable historical release and is clearly marked as superseded. The
+repository-copy path remains available as an alternative. A GitHub-generated
+source archive for an arbitrary commit, branch, or tag is not by itself an LCK
+release archive.
 
-Before preparing any release, re-check the live tags, GitHub Releases, and
-candidate commit. The dated statement above is an audit point, not a permanent
-inventory. This documentation change does not create a tag, GitHub Release, or
-release asset.
+The live [GitHub Release record](https://github.com/PhoenixSss/tracequant/releases/tag/lck-v0.1.0-preview.2)
+is authoritative for `preview.2`'s exact source commit, included-path
+manifest, manifest digest, archive digest, metadata, checksums, and validation
+records. This policy records the meaning and continuity of those facts; it
+does not silently replace or rewrite the `preview.1` tag or assets.
 
 The documents have deliberately different responsibilities:
 
@@ -276,10 +283,11 @@ evidence of those outcomes.
 
 ## 8. Preview and stable status
 
-The initial LCK release is a **pre-release**: `lck-v0.1.0-preview.1` must be
-marked as a GitHub pre-release and described as actively evolving. Its public
-adoption surface is a manually copied and adapted source snapshot, not yet a
-stable universal interface.
+The LCK preview series remains **pre-release** and actively evolving.
+`lck-v0.1.0-preview.2` is the current corrected preview and its public
+adoption surface is a fixed source snapshot for manual copying and adaptation,
+not a stable universal interface. `preview.1` remains visible as an immutable
+historical release and is superseded by `preview.2`.
 
 An LCK stable release requires, at minimum:
 

--- a/docs/guides/release-policy.md
+++ b/docs/guides/release-policy.md
@@ -72,7 +72,7 @@ The documents have deliberately different responsibilities:
 - The [LCK overview](LCK-overview.md) explains what LCK is, how the lifecycle
   is divided, and where LCK stops.
 - The [manual adoption guide](LCK-adoption.md) explains repository-copy
-  adoption, adaptation points, and the conditional archive-adoption path.
+  adoption, adaptation points, and the versioned archive-adoption path.
 - The [technical baseline](../architecture/technical-baseline.md) is the
   authority for current TraceQuant implementation facts and deferred product
   boundaries.

--- a/docs/guides/release-policy.md
+++ b/docs/guides/release-policy.md
@@ -1,7 +1,8 @@
 # TraceQuant and LCK release policy
 
-> **Status:** Current release policy and LCK preview record
-> **Current LCK preview:** `lck-v0.1.0-preview.2`
+> **Status:** Current release policy and pre-publication LCK preview record
+> **Published LCK preview:** `lck-v0.1.0-preview.1`
+> **Corrected preview:** `lck-v0.1.0-preview.2` (not yet published)
 > **Last repository-state check:** 2026-09-03
 
 This policy defines how releases of the TraceQuant project and previews of the
@@ -37,12 +38,13 @@ other track's stability claim.
 
 The first LCK preview, [`lck-v0.1.0-preview.1`](https://github.com/PhoenixSss/tracequant/releases/tag/lck-v0.1.0-preview.1),
 was published and remains an immutable historical release. The corrected
-current preview is [`lck-v0.1.0-preview.2`](https://github.com/PhoenixSss/tracequant/releases/tag/lck-v0.1.0-preview.2),
-which supersedes `preview.1` without reusing its tag, source commit, manifest,
-or archive. Preview number `N` increases for another published candidate in
-the same preview series. A stable LCK identity removes the `-preview.N` suffix
-only after the stable criteria in Section 8 are met. A version or tag is never
-reused for a different commit, manifest, or archive digest.
+`lck-v0.1.0-preview.2` identity is planned but has not yet been published. If
+published, it will supersede `preview.1` without reusing its tag, source
+commit, manifest, or archive. Preview number `N` increases for another
+published candidate in the same preview series. A stable LCK identity removes
+the `-preview.N` suffix only after the stable criteria in Section 8 are met. A
+version or tag is never reused for a different commit, manifest, or archive
+digest.
 
 The `version = "0.1.0"` value currently in `pyproject.toml` identifies the
 `tracequant` Python project. It is not automatically the LCK version, and
@@ -51,19 +53,20 @@ preview.
 
 ## 2. Current availability and source-of-truth boundaries
 
-At the state check recorded above, `preview.1` and the corrected `preview.2`
-are distinct GitHub pre-releases. `preview.2` is the current supported LCK
-source archive for manual evaluation and adaptation; `preview.1` remains an
-immutable historical release and is clearly marked as superseded. The
-repository-copy path remains available as an alternative. A GitHub-generated
-source archive for an arbitrary commit, branch, or tag is not by itself an LCK
-release archive.
+At the state check recorded above, `preview.1` is the only published LCK
+pre-release listed. The corrected `preview.2` is planned but not yet
+published, so no supported `preview.2` source archive or Release record exists
+for manual evaluation. The repository-copy path remains available. A
+GitHub-generated source archive for an arbitrary commit, branch, or tag is not
+by itself an LCK release archive.
 
-The live [GitHub Release record](https://github.com/PhoenixSss/tracequant/releases/tag/lck-v0.1.0-preview.2)
-is authoritative for `preview.2`'s exact source commit, included-path
-manifest, manifest digest, archive digest, metadata, checksums, and validation
-records. This policy records the meaning and continuity of those facts; it
-does not silently replace or rewrite the `preview.1` tag or assets.
+The live [GitHub Release record](https://github.com/PhoenixSss/tracequant/releases/tag/lck-v0.1.0-preview.1)
+is authoritative for the published `preview.1` identity and any recorded
+source commit, included-path manifest, digests, metadata, checksums, and
+validation records. When `preview.2` is later published, its own Release
+record will be authoritative for those facts. This policy records the meaning
+and continuity of those facts; it does not silently replace or rewrite the
+`preview.1` tag or assets.
 
 The documents have deliberately different responsibilities:
 
@@ -284,10 +287,10 @@ evidence of those outcomes.
 ## 8. Preview and stable status
 
 The LCK preview series remains **pre-release** and actively evolving.
-`lck-v0.1.0-preview.2` is the current corrected preview and its public
-adoption surface is a fixed source snapshot for manual copying and adaptation,
-not a stable universal interface. `preview.1` remains visible as an immutable
-historical release and is superseded by `preview.2`.
+`lck-v0.1.0-preview.1` is the only published preview and remains an immutable
+historical release. The corrected `lck-v0.1.0-preview.2` is planned but not yet
+published; when published, its adoption surface must be a fixed source
+snapshot for manual copying and adaptation, not a stable universal interface.
 
 An LCK stable release requires, at minimum:
 


### PR DESCRIPTION
Closes #244

## Summary
Synchronize README, adoption guidance, and release policy with the corrected LCK preview. Preserve preview.1 as immutable history, identify preview.2 as the current manual-adoption snapshot, and retain TraceQuant-first and provider-neutral boundaries.

## Validation
- Formal Delivery validation: pass

## Risks / limitations
GitHub preview.2 publication, preview.1 release-record correction, and repository About metadata remain external publication facts to verify at the required human boundary; no runtime or package behavior changed.
