### PR TITLE
[Documentation] Synchronize Public LCK Documentation After preview.2 Publication

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,14 +118,20 @@ flowchart LR
 
 LCK is actively developed within TraceQuant. The [GitHub Releases
 page](https://github.com/PhoenixSss/tracequant/releases) is the authority for
-whether a named LCK archive has actually been published. The corrected
-`lck-v0.1.0-preview.2` archive is not published yet; until a named Release is
-listed, use the repository-copy path in the [LCK adoption
-guide](docs/guides/LCK-adoption.md) rather than relying on an unversioned
-branch, arbitrary commit, or nonexistent archive. Before adopting a published
-preview, verify its exact tag, source commit, manifest, archive digest, release
-metadata, and compatibility guidance in the [release
-policy](docs/guides/release-policy.md) and [LCK adoption guide](docs/guides/LCK-adoption.md).
+whether a named LCK archive has actually been published. The current corrected
+preview is the published [`lck-v0.1.0-preview.2`
+Release](https://github.com/PhoenixSss/tracequant/releases/tag/lck-v0.1.0-preview.2),
+a pre-release fixed to source commit
+`850ce58c24646c69379d83d79c13d39b145280b5`. Its Release record and named
+assets are authoritative for the manifest, archive digest, publication state,
+and compatibility guidance; the snapshot does not float with later changes on
+`main`. The historical `preview.1` is superseded and remains immutable.
+
+Public LCK guidance is organized as the [LCK overview](docs/guides/LCK-overview.md),
+[manual adoption guide](docs/guides/LCK-adoption.md), and [release
+policy](docs/guides/release-policy.md). Before adopting a preview, use those
+guides and the exact Release record to verify its tag, source commit, manifest,
+archive digest, release metadata, and compatibility guidance.
 
 For manual evaluation and repository-specific adaptation, see the [LCK
 adoption guide](docs/guides/LCK-adoption.md). LCK is not a standalone product,

--- a/docs/guides/LCK-adoption.md
+++ b/docs/guides/LCK-adoption.md
@@ -33,14 +33,32 @@ implications:
 | Path | Current status | What it means |
 | --- | --- | --- |
 | Repository copy | Available for manual evaluation and adaptation | Inspect a chosen TraceQuant revision, copy the coherent LCK source and workflow material, then adapt every repository-specific integration point. |
-| Corrected versioned release archive | Not yet published: `lck-v0.1.0-preview.2` | The corrected archive path is planned, but no supported `preview.2` archive is available before its named GitHub Release is published. Until then, use the repository-copy path; the existing `preview.1` is historical and is not the corrected candidate. |
+| Corrected versioned release archive | Available: [`lck-v0.1.0-preview.2`](https://github.com/PhoenixSss/tracequant/releases/tag/lck-v0.1.0-preview.2) | Use the named Release and its fixed assets as the supported `preview.2` source snapshot. The existing `preview.1` is historical and superseded. |
 
-An eventual versioned path is a supported LCK source snapshot, not a generic
-GitHub source archive for an arbitrary commit or tag. The existing
+The versioned path is a supported LCK source snapshot, not a generic GitHub
+source archive for an arbitrary commit or tag. The current
+[`lck-v0.1.0-preview.2` Release](https://github.com/PhoenixSss/tracequant/releases/tag/lck-v0.1.0-preview.2)
+is a GitHub pre-release, not a draft. It records source commit
+`850ce58c24646c69379d83d79c13d39b145280b5`, manifest digest
+`d5107429c1379bc608bb5f9ea7d5bae11f68abf48016b5fd4efb36735c32494e`, and
+archive digest
+`acb626d0e31073a9431dbd7a7d24a3fa9af8040e6cd10222e40c5564103d5d87` for
+`lck-v0.1.0-preview.2.tar.gz` (286,496 bytes). The [manifest.json
+asset](https://github.com/PhoenixSss/tracequant/releases/download/lck-v0.1.0-preview.2/manifest.json),
+[metadata.json
+asset](https://github.com/PhoenixSss/tracequant/releases/download/lck-v0.1.0-preview.2/metadata.json),
+and [SHA256SUMS
+asset](https://github.com/PhoenixSss/tracequant/releases/download/lck-v0.1.0-preview.2/SHA256SUMS)
+are part of the same Release record. Verify those live assets rather than
+copying values from a branch or stale snapshot.
+
+The historical
 [`lck-v0.1.0-preview.1`](https://github.com/PhoenixSss/tracequant/releases/tag/lck-v0.1.0-preview.1)
 release remains immutable historical evidence. Do not represent it as
-`preview.2`, replace its tag or assets, or download a corrected archive before
-the named `preview.2` Release is actually listed.
+`preview.2`, replace its tag or assets, or treat its archive as the current
+supported snapshot. `preview.2` is fixed to its published source commit and
+does not follow current `main`; a later source change requires a new release
+identity.
 
 ## Path A: repository-copy adoption
 
@@ -114,16 +132,16 @@ alternate LCK lifecycle entry point.
 
 ## Path B: versioned release-archive adoption
 
-The corrected `preview.2` archive is not yet published. This path becomes
-available only after a named `preview.2` GitHub Release is actually listed;
-until then, stop at the availability check and use Path A. Once the Release is
-listed, its archive is a fixed source snapshot, not a floating view of `main`.
-Use the following manual sequence:
+The corrected `preview.2` archive is available through its named [GitHub
+Release](https://github.com/PhoenixSss/tracequant/releases/tag/lck-v0.1.0-preview.2).
+It is a fixed source snapshot, not a floating view of `main`. Use the
+following manual sequence:
 
-1. Select the named `preview.2` Release rather than an unversioned branch or
-   arbitrary commit.
+1. Select the named `preview.2` Release rather than an unversioned branch,
+   arbitrary commit, or GitHub-generated archive.
 2. Download its named archive and metadata assets; verify and record the tag,
-   exact source commit, manifest digest, archive digest, and pre-release status.
+   exact source commit, manifest digest, archive digest, asset identities, and
+   GitHub pre-release status.
 3. Extract the archive into a controlled location in the adopting repository.
 4. Read the archive's compatibility and upgrade guidance before replacing an
    earlier snapshot.
@@ -312,8 +330,8 @@ with future TraceQuant main.
 
 ### Future portability work
 
-No separately published corrected `preview.2` archive is currently available
-through this guide. A standalone LCK repository, package
+The `preview.2` archive is the current supported versioned path, but it remains
+a manually adopted source snapshot. A standalone LCK repository, package
 extraction, one-click installer, zero-configuration setup, universal
 compatibility, and automatic external adoption are not provided by this guide.
 They remain future portability or distribution work, not current implementation

--- a/docs/guides/release-policy.md
+++ b/docs/guides/release-policy.md
@@ -1,8 +1,8 @@
 # TraceQuant and LCK release policy
 
-> **Status:** Current release policy and pre-publication LCK preview record
-> **Published LCK preview:** `lck-v0.1.0-preview.1`
-> **Corrected preview:** `lck-v0.1.0-preview.2` (not yet published)
+> **Status:** Current release policy and published LCK preview record
+> **Published LCK previews:** `lck-v0.1.0-preview.1`, `lck-v0.1.0-preview.2`
+> **Current corrected preview:** `lck-v0.1.0-preview.2` (GitHub pre-release)
 > **Last repository-state check:** 2026-09-03
 
 This policy defines how releases of the TraceQuant project and previews of the
@@ -38,13 +38,13 @@ other track's stability claim.
 
 The first LCK preview, [`lck-v0.1.0-preview.1`](https://github.com/PhoenixSss/tracequant/releases/tag/lck-v0.1.0-preview.1),
 was published and remains an immutable historical release. The corrected
-`lck-v0.1.0-preview.2` identity is planned but has not yet been published. If
-published, it will supersede `preview.1` without reusing its tag, source
-commit, manifest, or archive. Preview number `N` increases for another
-published candidate in the same preview series. A stable LCK identity removes
-the `-preview.N` suffix only after the stable criteria in Section 8 are met. A
-version or tag is never reused for a different commit, manifest, or archive
-digest.
+[`lck-v0.1.0-preview.2`](https://github.com/PhoenixSss/tracequant/releases/tag/lck-v0.1.0-preview.2)
+is the current GitHub pre-release. It supersedes `preview.1` with a new
+immutable identity and does not reuse its tag, source commit, manifest, or
+archive. Preview number `N` increases for another published candidate in the
+same preview series. A stable LCK identity removes the `-preview.N` suffix only
+after the stable criteria in Section 8 are met. A version or tag is never reused
+for a different commit, manifest, or archive digest.
 
 The `version = "0.1.0"` value currently in `pyproject.toml` identifies the
 `tracequant` Python project. It is not automatically the LCK version, and
@@ -53,20 +53,35 @@ preview.
 
 ## 2. Current availability and source-of-truth boundaries
 
-At the state check recorded above, `preview.1` is the only published LCK
-pre-release listed. The corrected `preview.2` is planned but not yet
-published, so no supported `preview.2` source archive or Release record exists
-for manual evaluation. The repository-copy path remains available. A
-GitHub-generated source archive for an arbitrary commit, branch, or tag is not
-by itself an LCK release archive.
+At the state check recorded above, both previews are published GitHub
+pre-releases. `preview.1` is historical and superseded; `preview.2` is the
+current corrected pre-release and the supported versioned path for manual
+evaluation and repository-specific adaptation. The repository-copy path also
+remains available. A GitHub-generated source archive for an arbitrary commit,
+branch, or tag is not by itself an LCK release archive.
 
-The live [GitHub Release record](https://github.com/PhoenixSss/tracequant/releases/tag/lck-v0.1.0-preview.1)
-is authoritative for the published `preview.1` identity and any recorded
-source commit, included-path manifest, digests, metadata, checksums, and
-validation records. When `preview.2` is later published, its own Release
-record will be authoritative for those facts. This policy records the meaning
-and continuity of those facts; it does not silently replace or rewrite the
-`preview.1` tag or assets.
+The live [`preview.2` Release record](https://github.com/PhoenixSss/tracequant/releases/tag/lck-v0.1.0-preview.2)
+is authoritative for the exact current identity: it is not a draft, has
+GitHub `publishedAt` `2026-09-03T08:12:20Z`, and records tag
+`lck-v0.1.0-preview.2`, source commit
+`850ce58c24646c69379d83d79c13d39b145280b5`, manifest digest
+`d5107429c1379bc608bb5f9ea7d5bae11f68abf48016b5fd4efb36735c32494e`, and
+archive digest
+`acb626d0e31073a9431dbd7a7d24a3fa9af8040e6cd10222e40c5564103d5d87` for
+`lck-v0.1.0-preview.2.tar.gz` (286,496 bytes). Its [manifest.json
+asset](https://github.com/PhoenixSss/tracequant/releases/download/lck-v0.1.0-preview.2/manifest.json),
+[metadata.json
+asset](https://github.com/PhoenixSss/tracequant/releases/download/lck-v0.1.0-preview.2/metadata.json),
+[release-notes.md
+asset](https://github.com/PhoenixSss/tracequant/releases/download/lck-v0.1.0-preview.2/release-notes.md),
+[validation-summary.json
+asset](https://github.com/PhoenixSss/tracequant/releases/download/lck-v0.1.0-preview.2/validation-summary.json),
+and [SHA256SUMS
+asset](https://github.com/PhoenixSss/tracequant/releases/download/lck-v0.1.0-preview.2/SHA256SUMS)
+are relevant named assets in that same Release record. `preview.2` is a fixed
+snapshot at its source commit; it does not change when `main` advances. The
+historical [preview.1 Release record](https://github.com/PhoenixSss/tracequant/releases/tag/lck-v0.1.0-preview.1)
+remains authoritative for its own immutable identity and is not rewritten.
 
 The documents have deliberately different responsibilities:
 
@@ -190,6 +205,48 @@ the archive expands to the recorded manifest, and that a fresh digest matches
 the published value. Rebuilding an artifact with a different digest requires
 a new release identity; the old identity is not silently replaced.
 
+### Publication metadata and order
+
+`metadata.json` is prepared before publication and records only identity and
+compatibility facts known at that point: the version and tag, pinned source
+commit, manifest and archive identities, validation inputs, and intended
+preview classification. It must not be rewritten merely to add the eventual
+publication time. GitHub Release `publishedAt` is authoritative for the actual
+publication time; for `preview.2`, the published metadata asset intentionally
+retains `publication_date: null` while the Release record supplies
+`2026-09-03T08:12:20Z`.
+
+If a machine-readable post-publication record is needed, define it as a
+separate additive record (for example, `publication-record.json`) containing
+the GitHub Release identity, `publishedAt`, and read-only verification facts.
+It must not require replacement of the published `metadata.json`,
+`SHA256SUMS`, archive, or any other immutable asset.
+
+The safe publication order is:
+
+1. Pin the exact source commit and freeze the manifest.
+2. Generate the final archive and every accompanying asset from that source;
+   validate the manifest expansion, all asset digests, archive contents,
+   compatibility, and secret hygiene.
+3. Create the Release at the exact tag as a draft and upload the complete named
+   asset set.
+4. Verify the remote draft asset set, including names, sizes, media types, and
+   digests, against the locally validated set.
+5. Publish the draft once, changing only its publication state.
+6. After publication, perform only read-only Release/tag/asset verification
+   and tracked documentation synchronization.
+
+Post-publication asset replacement, deletion, tag reuse, and `--clobber` are
+prohibited. A correction requires a new immutable preview or patch identity.
+
+Archive generation must be deterministic: use a stable normalized path order
+(with `/` separators), normalized archive metadata such as fixed UTC
+timestamps, UID/GID, owner names, permissions, and gzip header metadata, and
+fixed compression settings. Exclude `.git`, local workflow state, caches,
+generated output, and other unmanifested files. Rebuilding the same source SHA
+and manifest must produce the same archive bytes and digest; any different
+file set or digest requires a new release identity.
+
 ## 6. Release entry gates
 
 Publication is allowed only after every applicable gate below has a recorded
@@ -287,10 +344,10 @@ evidence of those outcomes.
 ## 8. Preview and stable status
 
 The LCK preview series remains **pre-release** and actively evolving.
-`lck-v0.1.0-preview.1` is the only published preview and remains an immutable
-historical release. The corrected `lck-v0.1.0-preview.2` is planned but not yet
-published; when published, its adoption surface must be a fixed source
-snapshot for manual copying and adaptation, not a stable universal interface.
+`lck-v0.1.0-preview.1` is an immutable historical release and is superseded by
+the current corrected `lck-v0.1.0-preview.2` pre-release. `preview.2` is a
+fixed source snapshot for manual copying and adaptation, not a stable
+universal interface and not a floating view of current `main`.
 
 An LCK stable release requires, at minimum:
 


### PR DESCRIPTION
Closes #246

## Summary
Synchronize README, adoption guidance, and release policy with the live lck-v0.1.0-preview.2 Release, including immutable asset identity and deterministic publication rules.

## Validation
- Formal Delivery validation: pass

## Risks / limitations
Documentation-only change; live Release facts and asset identities are time-sensitive and should be rechecked before future release updates.
