### PR TITLE
[Task] 建立 Review Eval 双 Authority 与三平面 Harness

### DIFF
--- a/tests/tools/test_lck_review_eval.py
+++ b/tests/tools/test_lck_review_eval.py
@@ -1,0 +1,232 @@
+# ruff: noqa: E402, I001
+
+"""Acceptance tests for the isolated Review Eval Harness boundary."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+AGENT_WORKFLOW = str(Path(__file__).parents[2] / "tools" / "agent_workflow")
+if AGENT_WORKFLOW not in sys.path:
+    sys.path.insert(0, AGENT_WORKFLOW)
+
+from lck_core.review_authority import (  # type: ignore[import-not-found]
+    FrozenReviewAuthority,
+    LiveReviewAuthority,
+    require_frozen_review_authority,
+    require_live_review_authority,
+)
+from lck_core.review_eval import (  # type: ignore[import-not-found]
+    GitFrozenSubjectMaterializer,
+    ReviewEvalRunner,
+    ReviewEvalWorkspaceManager,
+)
+from lck_core.review_workspace import _review_target_refs  # type: ignore[import-not-found]
+from lck_test_support import _review_state
+
+
+SHA = "a" * 40
+
+
+def test_review_eval_keeps_harness_and_frozen_subject_authorities_separate(
+    tmp_path: Path,
+) -> None:
+    harness = tmp_path / "harness"
+    fixture_source = tmp_path / "fixture-source"
+    harness.mkdir()
+    fixture_source.mkdir()
+    (harness / "review_harness.py").write_text(
+        "CURRENT CANDIDATE HARNESS\n", encoding="utf-8"
+    )
+    old_workflow = fixture_source / "tools" / "agent_workflow"
+    old_workflow.mkdir(parents=True)
+    (old_workflow / "review.py").write_text(
+        "HISTORICAL SUBJECT WORKFLOW\n", encoding="utf-8"
+    )
+
+    authority = FrozenReviewAuthority(
+        fixture_id="historical-subject",
+        base_sha=SHA,
+        head_sha="b" * 40,
+    )
+    workspace = ReviewEvalWorkspaceManager(tmp_path / "runs")
+    runner = ReviewEvalRunner(harness, workspace=workspace)
+
+    def materialize(supplied: FrozenReviewAuthority, destination: Path) -> None:
+        assert supplied is authority
+        shutil.copytree(fixture_source, destination, dirs_exist_ok=True)
+
+    def evaluate(run: Any) -> dict[str, Any]:
+        assert run.authority is authority
+        assert run.harness_root == harness.resolve()
+        assert run.subject_root != run.harness_root
+        assert run.execution_cwd == run.harness_root
+        assert (run.harness_root / "review_harness.py").read_text(
+            encoding="utf-8"
+        ) == "CURRENT CANDIDATE HARNESS\n"
+        assert (run.subject_root / "tools/agent_workflow/review.py").read_text(
+            encoding="utf-8"
+        ) == "HISTORICAL SUBJECT WORKFLOW\n"
+        return {
+            "harness_file": (run.harness_root / "review_harness.py").read_text(
+                encoding="utf-8"
+            ),
+            "subject_file": (
+                run.subject_root / "tools/agent_workflow/review.py"
+            ).read_text(encoding="utf-8"),
+        }
+
+    execution = runner.run(authority, materialize, evaluate)
+    assert execution.run_id
+    assert execution.value["harness_file"] == "CURRENT CANDIDATE HARNESS\n"
+    assert execution.value["subject_file"] == "HISTORICAL SUBJECT WORKFLOW\n"
+    assert execution.run.to_dict()["planes"] == {
+        "harness": "current-checkout",
+        "subject": "frozen-fixture-materialization",
+        "run": "operation-owned-isolated-state",
+    }
+    assert execution.run.result_path("receipt.json").parent == execution.run.result_root
+    assert execution.run.run_root.is_dir()
+    execution.close()
+    assert not execution.run.run_root.exists()
+    assert (harness / "review_harness.py").read_text(encoding="utf-8") == (
+        "CURRENT CANDIDATE HARNESS\n"
+    )
+
+
+def test_review_eval_rejects_live_authority_and_production_uses_live_pr() -> None:
+    frozen = FrozenReviewAuthority(
+        fixture_id="fixture",
+        base_sha=SHA,
+        head_sha=SHA,
+    )
+    state = _review_state()
+    live = LiveReviewAuthority.from_state(state, state.task_contract or {})
+
+    assert require_live_review_authority(live) is live
+    assert require_frozen_review_authority(frozen) is frozen
+    with pytest.raises(TypeError, match="FrozenReviewAuthority"):
+        require_frozen_review_authority(live)
+    with pytest.raises(TypeError, match="LiveReviewAuthority"):
+        require_live_review_authority(frozen)
+
+    production_target = _review_target_refs(state, state.task_contract or {})
+    assert production_target.pr_number == live.pr_number
+    assert production_target.base_sha == live.base_sha
+    assert production_target.head_sha == live.head_sha
+
+
+def test_review_eval_command_runs_from_harness_checkout_without_subject_import_path(
+    tmp_path: Path,
+) -> None:
+    harness = tmp_path / "harness"
+    fixture_source = tmp_path / "fixture-source"
+    harness.mkdir()
+    fixture_source.mkdir()
+    (fixture_source / "old_runner.py").write_text(
+        "raise RuntimeError('subject runner must not execute')\n", encoding="utf-8"
+    )
+    authority = FrozenReviewAuthority("fixture", SHA, SHA)
+    runner = ReviewEvalRunner(
+        harness,
+        workspace=ReviewEvalWorkspaceManager(tmp_path / "runs"),
+    )
+
+    def materialize(_authority: FrozenReviewAuthority, destination: Path) -> None:
+        shutil.copytree(fixture_source, destination, dirs_exist_ok=True)
+
+    execution = runner.execute_command(
+        authority,
+        materialize,
+        [
+            sys.executable,
+            "-c",
+            "import os, pathlib; print(pathlib.Path.cwd()); print(os.getenv('PYTHONPATH', '')); print(os.getenv('TRACEQUANT_REVIEW_EVAL_SUBJECT_ROOT', ''))",
+        ],
+    )
+    try:
+        assert execution.value.returncode == 0
+        lines = execution.value.stdout.splitlines()
+        assert lines[0] == str(harness.resolve())
+        assert str(execution.run.subject_root) not in lines[1]
+        assert lines[2] == str(execution.run.subject_root)
+    finally:
+        execution.close()
+
+
+def test_review_eval_closes_run_when_harness_entrypoint_fails(tmp_path: Path) -> None:
+    harness = tmp_path / "harness"
+    fixture_source = tmp_path / "fixture-source"
+    harness.mkdir()
+    fixture_source.mkdir()
+    authority = FrozenReviewAuthority("fixture", SHA, SHA)
+    runner = ReviewEvalRunner(
+        harness,
+        workspace=ReviewEvalWorkspaceManager(tmp_path / "runs"),
+    )
+
+    with pytest.raises(RuntimeError, match="entrypoint failed"):
+        runner.run(
+            authority,
+            lambda _authority, destination: destination.mkdir(exist_ok=True),
+            lambda _run: (_ for _ in ()).throw(RuntimeError("entrypoint failed")),
+        )
+    assert not list((tmp_path / "runs").iterdir())
+
+
+def test_git_subject_materializer_uses_explicit_frozen_head(tmp_path: Path) -> None:
+    source = tmp_path / "historical-source"
+    harness = tmp_path / "harness"
+    source.mkdir()
+    harness.mkdir()
+
+    def git(*args: str) -> str:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=source,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout.strip()
+
+    git("init", "--quiet")
+    git("config", "user.name", "Review Eval Test")
+    git("config", "user.email", "review-eval@example.invalid")
+    (source / "subject.txt").write_text("base\n", encoding="utf-8")
+    git("add", "subject.txt")
+    git("commit", "--quiet", "-m", "base")
+    base_sha = git("rev-parse", "HEAD")
+    (source / "subject.txt").write_text("historical head\n", encoding="utf-8")
+    git("commit", "--quiet", "-am", "head")
+    head_sha = git("rev-parse", "HEAD")
+
+    authority = FrozenReviewAuthority("fixture", base_sha, head_sha)
+    runner = ReviewEvalRunner(
+        harness,
+        workspace_root=tmp_path / "runs",
+    )
+    execution = runner.run(
+        authority,
+        GitFrozenSubjectMaterializer(source),
+        lambda run: (
+            (run.subject_root / "subject.txt").read_text(encoding="utf-8"),
+            subprocess.run(
+                ["git", "branch", "--show-current"],
+                cwd=run.subject_root,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip(),
+        ),
+    )
+    try:
+        assert execution.value == ("historical head\n", "")
+    finally:
+        execution.close()

--- a/tools/agent_workflow/lck_core/README.md
+++ b/tools/agent_workflow/lck_core/README.md
@@ -15,6 +15,7 @@ maintainer or reviewer can start with the responsibility that owns the behavior.
 | Delivery prepare/complete | `delivery.py` | `eligibility.py`, `validation.py`, `effects.py` |
 | isolated Review workspace and review records | `review_workspace.py` | `review.py` |
 | Independent Review and Merge Preflight | `review.py` | `review_workspace.py`, `validation.py` |
+| Review Eval authority and Harness / Subject / Run isolation | `review_authority.py`, `review_eval.py` | none |
 | remediation and owned-candidate recovery | `remediation.py` | `eligibility.py`, `delivery.py`, `effects.py` |
 | post-merge Closeout | `closeout.py` | `eligibility.py`, `profile_policies.py` |
 | Agent View, Audit Receipt, failure evidence/replay | `receipts.py` | affected phase module |

--- a/tools/agent_workflow/lck_core/review_authority.py
+++ b/tools/agent_workflow/lck_core/review_authority.py
@@ -1,0 +1,229 @@
+"""Nominal authority contracts for production Review and Review Eval.
+
+The two authority types intentionally live next to, rather than inside, the
+phase controllers.  A production Review target is derived from the current
+GitHub PR.  An Eval target is supplied by a frozen fixture and never comes
+from the live-state resolver.  Keeping these as unrelated dataclasses makes a
+wrong authority source visible at the API boundary instead of silently
+coercing one into the other.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from workflow_common import is_sha
+
+from .models import LckStopError, LiveState
+
+
+def _required_sha(value: Any, *, field: str) -> str:
+    if not is_sha(value):
+        raise LckStopError(f"Review authority {field} is unavailable")
+    return str(value)
+
+
+def _optional_digest(value: Any, *, field: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or len(value) != 64:
+        raise LckStopError(f"Review authority {field} is not a SHA-256 digest")
+    try:
+        int(value, 16)
+    except ValueError as exc:
+        raise LckStopError(f"Review authority {field} is not a SHA-256 digest") from exc
+    return value.lower()
+
+
+@dataclass(frozen=True, slots=True)
+class LiveReviewAuthority:
+    """The production Review authority derived from one current OPEN PR."""
+
+    repository: str
+    task_number: int
+    pr_number: int
+    base_sha: str
+    head_sha: str
+    task_body_sha256: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.repository, str) or not self.repository.strip():
+            raise ValueError("live Review authority requires repository")
+        if (
+            not isinstance(self.task_number, int)
+            or isinstance(self.task_number, bool)
+            or self.task_number <= 0
+        ):
+            raise ValueError("live Review authority requires a positive Task number")
+        if (
+            not isinstance(self.pr_number, int)
+            or isinstance(self.pr_number, bool)
+            or self.pr_number <= 0
+        ):
+            raise ValueError("live Review authority requires a positive PR number")
+        object.__setattr__(
+            self,
+            "base_sha",
+            _required_sha(self.base_sha, field="base SHA"),
+        )
+        object.__setattr__(
+            self,
+            "head_sha",
+            _required_sha(self.head_sha, field="head SHA"),
+        )
+        if not isinstance(self.task_body_sha256, str) or not self.task_body_sha256:
+            raise ValueError("live Review authority requires Task Contract identity")
+
+    @classmethod
+    def from_state(
+        cls,
+        state: LiveState,
+        task_contract: Mapping[str, Any],
+    ) -> LiveReviewAuthority:
+        """Derive production authority from live-resolved state only."""
+        if not isinstance(state, LiveState):
+            raise TypeError("production Review authority requires LiveState")
+        pr = state.open_pr
+        if not isinstance(pr, Mapping):
+            raise LckStopError("Review target has no current OPEN PR")
+        pr_number = pr.get("number")
+        if (
+            not isinstance(pr_number, int)
+            or isinstance(pr_number, bool)
+            or pr_number <= 0
+        ):
+            raise LckStopError("Review target PR number is unavailable")
+        base_sha = _required_sha(pr.get("baseRefOid"), field="base SHA")
+        head_sha = _required_sha(pr.get("headRefOid"), field="head SHA")
+        task_body_sha256 = task_contract.get("body_sha256")
+        if not isinstance(task_body_sha256, str) or not task_body_sha256:
+            raise LckStopError("Review target Task Contract identity is unavailable")
+        if not isinstance(state.repository, str) or not state.repository:
+            raise LckStopError("Review target repository identity is unavailable")
+        return cls(
+            repository=state.repository,
+            task_number=state.issue_number,
+            pr_number=pr_number,
+            base_sha=base_sha,
+            head_sha=head_sha,
+            task_body_sha256=task_body_sha256,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "authority_kind": "live-pr",
+            "repository": self.repository,
+            "task_number": self.task_number,
+            "pr_number": self.pr_number,
+            "base_sha": self.base_sha,
+            "head_sha": self.head_sha,
+            "task_body_sha256": self.task_body_sha256,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class FrozenReviewAuthority:
+    """Explicit authority for one frozen Review Eval Subject.
+
+    Fixture packaging and manifest semantics deliberately remain outside this
+    contract.  The current Task only needs a stable fixture identifier and
+    explicit historical base/head identities.  Optional digests reserve
+    identity slots for the fixture Task without allowing a live PR to fill
+    them implicitly.
+    """
+
+    fixture_id: str
+    base_sha: str
+    head_sha: str
+    effective_diff_sha256: str | None = None
+    task_contract_sha256: str | None = None
+    evidence_sha256: str | None = None
+    repository_artifact_sha256: str | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.fixture_id, str) or not self.fixture_id.strip():
+            raise ValueError("frozen Review Eval authority requires fixture_id")
+        object.__setattr__(
+            self,
+            "base_sha",
+            _required_sha(self.base_sha, field="frozen base SHA"),
+        )
+        object.__setattr__(
+            self,
+            "head_sha",
+            _required_sha(self.head_sha, field="frozen head SHA"),
+        )
+        for field in (
+            "effective_diff_sha256",
+            "task_contract_sha256",
+            "evidence_sha256",
+            "repository_artifact_sha256",
+        ):
+            object.__setattr__(
+                self,
+                field,
+                _optional_digest(getattr(self, field), field=field),
+            )
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> FrozenReviewAuthority:
+        """Parse only a frozen authority mapping; never a live PR mapping."""
+        if not isinstance(value, Mapping):
+            raise TypeError("frozen Review Eval authority must be a mapping")
+        return cls(
+            fixture_id=value.get("fixture_id", ""),
+            base_sha=value.get("base_sha", ""),
+            head_sha=value.get("head_sha", ""),
+            effective_diff_sha256=value.get("effective_diff_sha256"),
+            task_contract_sha256=value.get("task_contract_sha256"),
+            evidence_sha256=value.get("evidence_sha256"),
+            repository_artifact_sha256=value.get("repository_artifact_sha256"),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "authority_kind": "frozen-fixture",
+            "fixture_id": self.fixture_id,
+            "base_sha": self.base_sha,
+            "head_sha": self.head_sha,
+        }
+        for field in (
+            "effective_diff_sha256",
+            "task_contract_sha256",
+            "evidence_sha256",
+            "repository_artifact_sha256",
+        ):
+            value = getattr(self, field)
+            if value is not None:
+                result[field] = value
+        return result
+
+
+def require_frozen_review_authority(value: Any) -> FrozenReviewAuthority:
+    """Enforce the Eval entry boundary without accepting live authority."""
+    if type(value) is not FrozenReviewAuthority:
+        raise TypeError(
+            "Review Eval requires FrozenReviewAuthority; live PR authority "
+            "cannot be used as a frozen fixture"
+        )
+    return value
+
+
+def require_live_review_authority(value: Any) -> LiveReviewAuthority:
+    """Enforce the production entry boundary without accepting frozen authority."""
+    if type(value) is not LiveReviewAuthority:
+        raise TypeError(
+            "production Review requires LiveReviewAuthority; frozen fixture "
+            "authority cannot replace a current PR"
+        )
+    return value
+
+
+__all__ = [
+    "FrozenReviewAuthority",
+    "LiveReviewAuthority",
+    "require_frozen_review_authority",
+    "require_live_review_authority",
+]

--- a/tools/agent_workflow/lck_core/review_eval.py
+++ b/tools/agent_workflow/lck_core/review_eval.py
@@ -1,0 +1,511 @@
+"""Execution boundary for Review Eval's Harness / Subject / Run planes.
+
+Review Eval deliberately does not reuse :mod:`lck_core.review`'s live-state
+resolver.  The caller supplies a :class:`FrozenReviewAuthority`, the current
+checkout remains the Harness, and only a fresh Run-owned Subject workspace is
+materialized for inspection.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+import uuid
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Final, Protocol, TypeVar
+
+from workflow_common import (
+    CommandResult,
+    CommandRunner,
+    WorkflowToolError,
+    atomic_write_json,
+    read_json_file,
+)
+
+from .models import LCK_SCHEMA_VERSION, LckStopError
+from .review_authority import (
+    FrozenReviewAuthority,
+    require_frozen_review_authority,
+)
+
+T = TypeVar("T")
+
+
+class SubjectMaterializer(Protocol):
+    """Materialize one frozen Subject below the supplied destination only."""
+
+    def materialize(
+        self, authority: FrozenReviewAuthority, destination: Path
+    ) -> None: ...
+
+
+SubjectMaterializerCallable = Callable[[FrozenReviewAuthority, Path], None]
+
+
+def _within(path: Path, root: Path) -> bool:
+    try:
+        path.resolve(strict=False).relative_to(root.resolve(strict=False))
+    except ValueError:
+        return False
+    return True
+
+
+def _assert_distinct_workspaces(harness_root: Path, subject_root: Path) -> None:
+    harness = harness_root.resolve(strict=False)
+    subject = subject_root.resolve(strict=False)
+    if harness == subject or _within(harness, subject) or _within(subject, harness):
+        raise LckStopError(
+            "Review Eval Harness and Subject workspaces must be independent"
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewEvalRunContext:
+    """Immutable identity and paths for one isolated Review Eval Run."""
+
+    run_id: str
+    authority: FrozenReviewAuthority
+    harness_root: Path
+    run_root: Path
+    subject_root: Path
+    result_root: Path
+    _workspace: ReviewEvalWorkspaceManager = field(repr=False, compare=False)
+
+    @property
+    def execution_cwd(self) -> Path:
+        """The current Harness checkout used to invoke the Eval entrypoint."""
+        return self.harness_root
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": LCK_SCHEMA_VERSION,
+            "kind": "review-eval-run",
+            "status": "READY_FOR_EVAL",
+            "run_id": self.run_id,
+            "authority": self.authority.to_dict(),
+            "harness_root": str(self.harness_root),
+            "run_root": str(self.run_root),
+            "subject_root": str(self.subject_root),
+            "result_root": str(self.result_root),
+            "planes": {
+                "harness": "current-checkout",
+                "subject": "frozen-fixture-materialization",
+                "run": "operation-owned-isolated-state",
+            },
+            "execution_cwd": str(self.harness_root),
+            "subject_on_import_path": False,
+            "mechanical_authority": "explicit FrozenReviewAuthority",
+            "forbidden_authority": [
+                "current GitHub PR resolution",
+                "production Review live PR authority",
+            ],
+        }
+
+    def result_path(self, name: str) -> Path:
+        """Return a safe path for future Run-owned result storage."""
+        candidate = (self.result_root / name).resolve(strict=False)
+        if not _within(candidate, self.result_root) or candidate == self.result_root:
+            raise LckStopError("Review Eval result path must remain inside the Run")
+        return candidate
+
+    def close(self) -> None:
+        self._workspace.close(self)
+
+    def __enter__(self) -> ReviewEvalRunContext:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewEvalExecution[T]:
+    """Result of running the current Harness against one Eval Subject."""
+
+    run: ReviewEvalRunContext
+    value: T
+
+    @property
+    def run_id(self) -> str:
+        return self.run.run_id
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": LCK_SCHEMA_VERSION,
+            "kind": "review-eval-execution",
+            "status": "COMPLETED",
+            "run": self.run.to_dict(),
+            "value": self.value,
+        }
+
+    def close(self) -> None:
+        self.run.close()
+
+
+class ReviewEvalWorkspaceManager:
+    """Create and clean only Run-owned temporary Eval workspaces."""
+
+    OWNER_FILE: Final = ".review-eval-owner.json"
+    RUN_PREFIX: Final = "tracequant-lck-review-eval-"
+
+    def __init__(self, root: Path | None = None) -> None:
+        default_root = Path(tempfile.gettempdir()) / "tracequant-lck-review-eval-runs"
+        self.root = (root or default_root).resolve(strict=False)
+        if self.root == Path("/") or self.root.name in {"", ".", ".."}:
+            raise LckStopError("Review Eval workspace root is too broad")
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    def reserve(
+        self,
+        authority: FrozenReviewAuthority,
+        harness_root: Path,
+    ) -> ReviewEvalRunContext:
+        authority = require_frozen_review_authority(authority)
+        harness_root = harness_root.resolve()
+        if not harness_root.is_dir():
+            raise LckStopError("Review Eval Harness checkout is unavailable")
+
+        run_id = uuid.uuid4().hex
+        run_root = (self.root / f"{self.RUN_PREFIX}{run_id}").resolve()
+        if run_root.exists():
+            raise LckStopError("Review Eval Run workspace identity already exists")
+        subject_root = run_root / "subject"
+        result_root = run_root / "results"
+        _assert_distinct_workspaces(harness_root, subject_root)
+        run_root.mkdir(parents=True)
+        subject_root.mkdir()
+        result_root.mkdir()
+        atomic_write_json(
+            run_root / self.OWNER_FILE,
+            {
+                "schema_version": LCK_SCHEMA_VERSION,
+                "kind": "review-eval-run-owner",
+                "run_id": run_id,
+                "authority": authority.to_dict(),
+                "harness_root": str(harness_root),
+                "run_root": str(run_root),
+                "subject_root": str(subject_root),
+                "result_root": str(result_root),
+                "authority_note": (
+                    "frozen Eval authority only; never a production Review target"
+                ),
+            },
+        )
+        return ReviewEvalRunContext(
+            run_id=run_id,
+            authority=authority,
+            harness_root=harness_root,
+            run_root=run_root,
+            subject_root=subject_root,
+            result_root=result_root,
+            _workspace=self,
+        )
+
+    def _assert_owned(self, run: ReviewEvalRunContext) -> None:
+        root = run.run_root.resolve(strict=False)
+        if not _within(root, self.root) or root == self.root:
+            raise LckStopError("Review Eval Run cleanup path is not Run-owned")
+        owner_path = root / self.OWNER_FILE
+        try:
+            owner = read_json_file(owner_path)
+        except WorkflowToolError as exc:
+            raise LckStopError(
+                "Review Eval Run ownership marker is unavailable"
+            ) from exc
+        if not isinstance(owner, Mapping):
+            raise LckStopError("Review Eval Run ownership marker is invalid")
+        if (
+            owner.get("kind") != "review-eval-run-owner"
+            or owner.get("run_id") != run.run_id
+            or owner.get("run_root") != str(root)
+        ):
+            raise LckStopError("Review Eval Run ownership marker does not match")
+
+    @staticmethod
+    def _make_removable(path: Path) -> None:
+        if not path.exists():
+            return
+        os.chmod(path, 0o755)
+        for root, dirs, files in os.walk(path, topdown=True, followlinks=False):
+            root_path = Path(root)
+            os.chmod(root_path, 0o755)
+            for name in dirs:
+                target = root_path / name
+                if not target.is_symlink():
+                    os.chmod(target, 0o755)
+            for name in files:
+                target = root_path / name
+                if not target.is_symlink():
+                    os.chmod(target, 0o644)
+
+    def close(self, run: ReviewEvalRunContext) -> None:
+        if run._workspace is not self:
+            raise LckStopError("Review Eval Run belongs to another workspace manager")
+        if not run.run_root.exists():
+            return
+        self._assert_owned(run)
+        self._make_removable(run.run_root)
+        shutil.rmtree(run.run_root, ignore_errors=True)
+        if run.run_root.exists():
+            raise LckStopError("failed to remove Review Eval Run workspace")
+
+
+class GitFrozenSubjectMaterializer:
+    """Materialize explicit frozen commits from a local Git source.
+
+    This adapter is intentionally source-oriented, not GitHub-oriented.  It
+    never resolves a PR and it checks out the frozen head in a detached
+    Subject clone while the caller continues executing from the Harness.
+    """
+
+    def __init__(
+        self,
+        source_repository: Path,
+        *,
+        runner: CommandRunner | None = None,
+    ) -> None:
+        self.source_repository = source_repository.resolve()
+        self.runner = runner or CommandRunner(self.source_repository)
+
+    def _ensure_commit(self, destination: Path, sha: str, label: str) -> None:
+        available = self.runner.run(
+            ["git", "cat-file", "-e", f"{sha}^{{commit}}"],
+            command_id=f"review-eval-subject-{label}-available",
+            cwd=destination,
+        )
+        if available.returncode == 0:
+            return
+        fetched = self.runner.run(
+            ["git", "fetch", "--no-tags", "origin", sha],
+            command_id=f"review-eval-subject-{label}-fetch",
+            cwd=destination,
+            retries=1,
+        )
+        if fetched.returncode != 0:
+            raise LckStopError(
+                f"frozen Subject {label} commit is unavailable: "
+                + (fetched.stderr.strip() or f"exit {fetched.returncode}")
+            )
+        verified = self.runner.run(
+            ["git", "cat-file", "-e", f"{sha}^{{commit}}"],
+            command_id=f"review-eval-subject-{label}-verified",
+            cwd=destination,
+        )
+        if verified.returncode != 0:
+            raise LckStopError(f"frozen Subject does not contain its {label} commit")
+
+    def materialize(
+        self,
+        authority: FrozenReviewAuthority,
+        destination: Path,
+    ) -> None:
+        authority = require_frozen_review_authority(authority)
+        source = self.source_repository
+        destination = destination.resolve()
+        if not source.is_dir() or not (source / ".git").exists():
+            raise LckStopError("frozen Subject source repository is unavailable")
+        if (
+            source == destination
+            or _within(destination, source)
+            or _within(source, destination)
+        ):
+            raise LckStopError(
+                "frozen Subject destination must not be inside its source"
+            )
+        clone = self.runner.run(
+            [
+                "git",
+                "clone",
+                "--no-checkout",
+                "--no-hardlinks",
+                str(source),
+                str(destination),
+            ],
+            command_id="review-eval-subject-clone",
+        )
+        if clone.returncode != 0:
+            shutil.rmtree(destination, ignore_errors=True)
+            raise LckStopError(
+                "cannot create frozen Review Eval Subject: "
+                + (clone.stderr.strip() or f"exit {clone.returncode}")
+            )
+        try:
+            self._ensure_commit(destination, authority.base_sha, "base")
+            self._ensure_commit(destination, authority.head_sha, "head")
+            checkout = self.runner.run(
+                ["git", "checkout", "--detach", authority.head_sha],
+                command_id="review-eval-subject-checkout",
+                cwd=destination,
+            )
+            if checkout.returncode != 0:
+                raise LckStopError(
+                    "cannot checkout frozen Review Eval Subject HEAD: "
+                    + (checkout.stderr.strip() or f"exit {checkout.returncode}")
+                )
+            status = self.runner.run(
+                ["git", "status", "--porcelain=v1", "--untracked-files=all"],
+                command_id="review-eval-subject-clean",
+                cwd=destination,
+            )
+            head = self.runner.run(
+                ["git", "rev-parse", "HEAD"],
+                command_id="review-eval-subject-head",
+                cwd=destination,
+            )
+            if status.returncode != 0 or head.returncode != 0:
+                raise LckStopError("cannot verify frozen Review Eval Subject")
+            if status.stdout.strip() or head.stdout.strip() != authority.head_sha:
+                raise LckStopError("frozen Review Eval Subject is not clean and exact")
+        except BaseException:
+            ReviewEvalWorkspaceManager._make_removable(destination)
+            shutil.rmtree(destination, ignore_errors=True)
+            raise
+
+
+def _call_materializer(
+    materializer: SubjectMaterializer | SubjectMaterializerCallable,
+    authority: FrozenReviewAuthority,
+    destination: Path,
+) -> None:
+    method = getattr(materializer, "materialize", None)
+    if callable(method):
+        method(authority, destination)
+    elif callable(materializer):
+        materializer(authority, destination)
+    else:
+        raise TypeError("Review Eval Subject materializer is not callable")
+
+
+class ReviewEvalRunner:
+    """Run a current Harness entrypoint against a frozen Subject workspace."""
+
+    def __init__(
+        self,
+        harness_root: Path | None = None,
+        *,
+        workspace: ReviewEvalWorkspaceManager | None = None,
+        workspace_root: Path | None = None,
+        command_runner: CommandRunner | None = None,
+    ) -> None:
+        self.harness_root = (harness_root or Path.cwd()).resolve()
+        if not self.harness_root.is_dir():
+            raise LckStopError("Review Eval Harness checkout is unavailable")
+        if workspace is not None and workspace_root is not None:
+            raise ValueError("provide workspace or workspace_root, not both")
+        self.workspace = workspace or ReviewEvalWorkspaceManager(workspace_root)
+        self.command_runner = command_runner or CommandRunner(self.harness_root)
+
+    def start(
+        self,
+        authority: FrozenReviewAuthority,
+        materializer: SubjectMaterializer | SubjectMaterializerCallable,
+    ) -> ReviewEvalRunContext:
+        authority = require_frozen_review_authority(authority)
+        run = self.workspace.reserve(authority, self.harness_root)
+        try:
+            _call_materializer(materializer, authority, run.subject_root)
+            subject = run.subject_root.resolve()
+            _assert_distinct_workspaces(run.harness_root, subject)
+            if subject != run.subject_root or not run.subject_root.is_dir():
+                raise LckStopError(
+                    "Review Eval Subject materializer escaped its Run workspace"
+                )
+            return run
+        except BaseException:
+            self.workspace.close(run)
+            raise
+
+    def prepare(
+        self,
+        authority: FrozenReviewAuthority,
+        materializer: SubjectMaterializer | SubjectMaterializerCallable,
+    ) -> ReviewEvalRunContext:
+        """Named entrypoint for callers that separate prepare from execution."""
+        return self.start(authority, materializer)
+
+    def run(
+        self,
+        authority: FrozenReviewAuthority,
+        materializer: SubjectMaterializer | SubjectMaterializerCallable,
+        evaluator: Callable[[ReviewEvalRunContext], T],
+    ) -> ReviewEvalExecution[T]:
+        """Materialize a Subject, then invoke the evaluator from the Harness."""
+        if not callable(evaluator):
+            raise TypeError("Review Eval evaluator is not callable")
+        run = self.start(authority, materializer)
+        try:
+            value = evaluator(run)
+        except BaseException:
+            self.workspace.close(run)
+            raise
+        return ReviewEvalExecution(run=run, value=value)
+
+    def execute_command(
+        self,
+        authority: FrozenReviewAuthority,
+        materializer: SubjectMaterializer | SubjectMaterializerCallable,
+        argv: Sequence[str],
+        *,
+        env: Mapping[str, str] | None = None,
+    ) -> ReviewEvalExecution[CommandResult]:
+        """Execute a Harness-owned command with the Subject as explicit input.
+
+        The command's working directory is always the current Harness.  The
+        Subject is not added to ``PYTHONPATH`` and never becomes the process
+        checkout, so historical workflow files cannot replace the candidate
+        Harness implementation.
+        """
+        if not argv:
+            raise ValueError("Review Eval command argv cannot be empty")
+        run = self.start(authority, materializer)
+        command_env = dict(env or {})
+        command_env.update(
+            {
+                "TRACEQUANT_REVIEW_EVAL_RUN_ID": run.run_id,
+                "TRACEQUANT_REVIEW_EVAL_FIXTURE_ID": run.authority.fixture_id,
+                "TRACEQUANT_REVIEW_EVAL_BASE_SHA": run.authority.base_sha,
+                "TRACEQUANT_REVIEW_EVAL_HEAD_SHA": run.authority.head_sha,
+                "TRACEQUANT_REVIEW_EVAL_SUBJECT_ROOT": str(run.subject_root),
+                "TRACEQUANT_REVIEW_EVAL_HARNESS_ROOT": str(run.harness_root),
+            }
+        )
+        existing_pythonpath = command_env.get("PYTHONPATH") or os.environ.get(
+            "PYTHONPATH"
+        )
+        if existing_pythonpath:
+            allowed = [
+                item
+                for item in existing_pythonpath.split(os.pathsep)
+                if not _within(
+                    Path(item) if Path(item).is_absolute() else run.harness_root / item,
+                    run.subject_root,
+                )
+            ]
+            if allowed:
+                command_env["PYTHONPATH"] = os.pathsep.join(allowed)
+            else:
+                command_env.pop("PYTHONPATH", None)
+        try:
+            result = self.command_runner.run(
+                list(argv),
+                command_id="review-eval-harness-entrypoint",
+                cwd=run.harness_root,
+                env=command_env,
+            )
+        except BaseException:
+            self.workspace.close(run)
+            raise
+        return ReviewEvalExecution(run=run, value=result)
+
+
+__all__ = [
+    "GitFrozenSubjectMaterializer",
+    "ReviewEvalExecution",
+    "ReviewEvalRunContext",
+    "ReviewEvalRunner",
+    "ReviewEvalWorkspaceManager",
+    "SubjectMaterializer",
+]

--- a/tools/agent_workflow/lck_core/review_workspace.py
+++ b/tools/agent_workflow/lck_core/review_workspace.py
@@ -32,6 +32,7 @@ from .profile_policies import (
     build_profile_review_artifact,
     resolve_issue_policy,
 )
+from .review_authority import LiveReviewAuthority
 from .state import LiveStateResolver
 
 
@@ -88,25 +89,13 @@ def _review_target_refs(
     task_contract: Mapping[str, Any],
 ) -> ReviewTargetRefs:
     """Extract immutable Git/GitHub identities without requiring local Git objects."""
-    pr = state.open_pr
-    if not isinstance(pr, Mapping):
-        raise LckStopError("Review target has no current OPEN PR")
-    pr_number = pr.get("number")
-    base_sha = pr.get("baseRefOid")
-    head_sha = pr.get("headRefOid")
-    task_body_sha256 = task_contract.get("body_sha256")
-    if not isinstance(pr_number, int) or isinstance(pr_number, bool) or pr_number <= 0:
-        raise LckStopError("Review target PR number is unavailable")
-    if not is_sha(base_sha) or not is_sha(head_sha):
-        raise LckStopError("Review target base/head identity is unavailable")
-    if not isinstance(task_body_sha256, str) or not task_body_sha256:
-        raise LckStopError("Review target Task Contract identity is unavailable")
+    authority = LiveReviewAuthority.from_state(state, task_contract)
     return ReviewTargetRefs(
-        task_number=state.issue_number,
-        pr_number=pr_number,
-        base_sha=str(base_sha),
-        head_sha=str(head_sha),
-        task_body_sha256=task_body_sha256,
+        task_number=authority.task_number,
+        pr_number=authority.pr_number,
+        base_sha=authority.base_sha,
+        head_sha=authority.head_sha,
+        task_body_sha256=authority.task_body_sha256,
     )
 
 


### PR DESCRIPTION
Closes #251

## Summary
Add strict live-versus-frozen Review authority contracts and an isolated Harness/Subject/Run Eval runner with local Git materialization and run-owned result workspace.

## Validation
- Critical Outcome: pass
- Formal Delivery validation: pass

## Risks / limitations
Fixture manifest and digest packaging remain out of scope for the follow-up fixture Task; Eval callers must supply a frozen authority and subject materializer.
