### PR TITLE
[Task] 建立不可变 Review Fixture、身份校验与 Fresh Run 隔离

### DIFF
--- a/tests/tools/test_lck_review_eval.py
+++ b/tests/tools/test_lck_review_eval.py
@@ -165,6 +165,26 @@ def test_review_eval_command_runs_from_harness_checkout_without_subject_import_p
         execution.close()
 
 
+def test_review_eval_detection_rejects_explicit_writable_subject(
+    tmp_path: Path,
+) -> None:
+    harness = tmp_path / "harness"
+    harness.mkdir()
+    authority = FrozenReviewAuthority("fixture", SHA, SHA)
+    runner = ReviewEvalRunner(
+        harness,
+        workspace=ReviewEvalWorkspaceManager(tmp_path / "runs"),
+    )
+
+    with pytest.raises(LckStopError, match="Detection Run Subject must be read-only"):
+        runner.start(
+            authority,
+            lambda _authority, destination: destination.mkdir(exist_ok=True),
+            writable=True,
+        )
+    assert not list((tmp_path / "runs").iterdir())
+
+
 def test_review_eval_closes_run_when_harness_entrypoint_fails(tmp_path: Path) -> None:
     harness = tmp_path / "harness"
     fixture_source = tmp_path / "fixture-source"
@@ -290,6 +310,14 @@ def test_fixture_digest_and_fresh_run_isolation_are_fail_closed(tmp_path: Path) 
         assert receipt["fixture_digest"] == fixture_digest
         assert receipt["run_identity"]["run_id"] == first.run.run_id
         assert receipt["harness_sha"] == harness_sha
+        with pytest.raises(LckStopError, match="reserved"):
+            first.run.write_result("run-receipt.json", {"tampered": True})
+        with pytest.raises(LckStopError, match="reserved"):
+            first.run.write_result("nested/../run-receipt.json", {"tampered": True})
+        assert json.loads(first.run.receipt_path.read_text(encoding="utf-8")) == receipt
+        first.run.receipt_path.write_text('{"tampered": true}\n', encoding="utf-8")
+        with pytest.raises(LckStopError, match="receipt identity does not match"):
+            first.run.write_receipt()
         assert json.loads(
             first.run.result_path("eval-result.json").read_text(encoding="utf-8")
         ) == {"result": "ok"}
@@ -319,6 +347,12 @@ def test_fixture_digest_and_fresh_run_isolation_are_fail_closed(tmp_path: Path) 
         ) == "frozen head\n"
     finally:
         second.close()
+
+    mismatched_authority = FrozenReviewAuthority(
+        "different-fixture", base_sha, head_sha
+    )
+    with pytest.raises(LckStopError, match="fixture authorities do not match"):
+        materializer.materialize(mismatched_authority, tmp_path / "mismatched-subject")
 
     fixture.repository_bundle_path.write_bytes(
         fixture.repository_bundle_path.read_bytes() + b"tampered"

--- a/tests/tools/test_lck_review_eval.py
+++ b/tests/tools/test_lck_review_eval.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import json
 import shutil
 import subprocess
 import sys
@@ -22,10 +23,14 @@ from lck_core.review_authority import (  # type: ignore[import-not-found]
     require_frozen_review_authority,
     require_live_review_authority,
 )
+from lck_core.models import LckStopError  # type: ignore[import-not-found]
 from lck_core.review_eval import (  # type: ignore[import-not-found]
     GitFrozenSubjectMaterializer,
     ReviewEvalRunner,
     ReviewEvalWorkspaceManager,
+)
+from lck_core.review_fixture import (  # type: ignore[import-not-found]
+    ReviewFixtureBuilder,
 )
 from lck_core.review_workspace import _review_target_refs  # type: ignore[import-not-found]
 from lck_test_support import _review_state
@@ -230,3 +235,93 @@ def test_git_subject_materializer_uses_explicit_frozen_head(tmp_path: Path) -> N
         assert execution.value == ("historical head\n", "")
     finally:
         execution.close()
+
+
+def test_fixture_digest_and_fresh_run_isolation_are_fail_closed(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    harness = tmp_path / "harness"
+    source.mkdir()
+    harness.mkdir()
+
+    def git(root: Path, *args: str) -> str:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=root,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout.strip()
+
+    for root in (source, harness):
+        git(root, "init", "--quiet")
+        git(root, "config", "user.name", "Review Eval Test")
+        git(root, "config", "user.email", "review-eval@example.invalid")
+    (source / "subject.txt").write_text("base\n", encoding="utf-8")
+    git(source, "add", "subject.txt")
+    git(source, "commit", "--quiet", "-m", "base")
+    base_sha = git(source, "rev-parse", "HEAD")
+    (source / "subject.txt").write_text("frozen head\n", encoding="utf-8")
+    git(source, "commit", "--quiet", "-am", "head")
+    head_sha = git(source, "rev-parse", "HEAD")
+    (harness / "harness.py").write_text("candidate\n", encoding="utf-8")
+    git(harness, "add", "harness.py")
+    git(harness, "commit", "--quiet", "-m", "harness")
+    harness_sha = git(harness, "rev-parse", "HEAD")
+
+    fixture = ReviewFixtureBuilder(source).create(
+        tmp_path / "fixture",
+        fixture_id="fixture-252",
+        base_sha=base_sha,
+        head_sha=head_sha,
+        task_contract={"task": 252},
+        deterministic_evidence={"checks": ["deterministic"]},
+    )
+    fixture_digest = fixture.fixture_digest
+    shutil.rmtree(source)
+    runner = ReviewEvalRunner(harness, workspace_root=tmp_path / "runs")
+    materializer = GitFrozenSubjectMaterializer(fixture=fixture)
+    first = runner.run(fixture, materializer, lambda _run: {"result": "ok"})
+    try:
+        assert first.run.run_id
+        assert first.run.harness_sha == harness_sha
+        receipt = json.loads(first.run.receipt_path.read_text(encoding="utf-8"))
+        assert receipt["fixture_id"] == "fixture-252"
+        assert receipt["fixture_digest"] == fixture_digest
+        assert receipt["run_identity"]["run_id"] == first.run.run_id
+        assert receipt["harness_sha"] == harness_sha
+        assert json.loads(
+            first.run.result_path("eval-result.json").read_text(encoding="utf-8")
+        ) == {"result": "ok"}
+        assert (first.run.subject_root / "subject.txt").read_text(
+            encoding="utf-8"
+        ) == "frozen head\n"
+        with pytest.raises(PermissionError):
+            (first.run.subject_root / "subject.txt").write_text(
+                "must not mutate\n", encoding="utf-8"
+            )
+
+        remediation = first.run.materialize_remediation(materializer)
+        (remediation / "subject.txt").write_text("remediation copy\n", encoding="utf-8")
+        assert (first.run.subject_root / "subject.txt").read_text(
+            encoding="utf-8"
+        ) == "frozen head\n"
+        assert fixture.verify().fixture_digest == fixture_digest
+    finally:
+        first.close()
+
+    second = runner.run(fixture, materializer, lambda run: run)
+    try:
+        assert second.run.run_id != first.run.run_id
+        assert second.run.run_root != first.run.run_root
+        assert (second.run.subject_root / "subject.txt").read_text(
+            encoding="utf-8"
+        ) == "frozen head\n"
+    finally:
+        second.close()
+
+    fixture.repository_bundle_path.write_bytes(
+        fixture.repository_bundle_path.read_bytes() + b"tampered"
+    )
+    with pytest.raises(LckStopError, match="digest mismatch"):
+        runner.start(fixture, materializer)

--- a/tests/tools/test_lck_review_eval.py
+++ b/tests/tools/test_lck_review_eval.py
@@ -31,9 +31,11 @@ from lck_core.review_eval import (  # type: ignore[import-not-found]
 )
 from lck_core.review_fixture import (  # type: ignore[import-not-found]
     ReviewFixtureBuilder,
+    load_frozen_review_fixture,
 )
 from lck_core.review_workspace import _review_target_refs  # type: ignore[import-not-found]
 from lck_test_support import _review_state
+from workflow_common import sha256_json  # type: ignore[import-not-found]
 
 
 SHA = "a" * 40
@@ -298,6 +300,69 @@ def test_fixture_digest_and_fresh_run_isolation_are_fail_closed(tmp_path: Path) 
         deterministic_evidence={"checks": ["deterministic"]},
     )
     fixture_digest = fixture.fixture_digest
+    loaded = load_frozen_review_fixture(
+        fixture.root,
+        expected_fixture_digest=fixture_digest,
+    )
+    assert loaded.fixture_digest == fixture_digest
+
+    manifest_path = fixture.root / "fixture-manifest.json"
+    forged_manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    forged_manifest["fixture_id"] = "forged-fixture"
+    manifest_payload = {
+        key: value
+        for key, value in forged_manifest.items()
+        if key not in {"fixture_manifest_sha256", "fixture_digest"}
+    }
+    forged_manifest["fixture_manifest_sha256"] = sha256_json(manifest_payload)
+    identity = {
+        key: forged_manifest[key]
+        for key in (
+            "fixture_schema_version",
+            "fixture_id",
+            "base_sha",
+            "head_sha",
+            "effective_diff_sha256",
+            "task_contract_sha256",
+            "deterministic_evidence_sha256",
+            "repository_artifact_sha256",
+            "fixture_manifest_sha256",
+        )
+    }
+    forged_manifest["fixture_digest"] = sha256_json(identity)
+    manifest_path.write_text(
+        json.dumps(forged_manifest, ensure_ascii=False, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(LckStopError, match="independently trusted digest"):
+        load_frozen_review_fixture(
+            fixture.root,
+            expected_fixture_digest=fixture_digest,
+        )
+    with pytest.raises(LckStopError, match="independently trusted"):
+        load_frozen_review_fixture(fixture.root)
+
+    evaluator_started = False
+
+    def evaluate_forged_fixture(_run: Any) -> dict[str, Any]:
+        nonlocal evaluator_started
+        evaluator_started = True
+        return {"unexpected": "started"}
+
+    runner = ReviewEvalRunner(source, workspace_root=tmp_path / "runs")
+    with pytest.raises(LckStopError, match="independently trusted digest"):
+        runner.run(
+            fixture.root,
+            None,
+            evaluate_forged_fixture,
+            expected_fixture_digest=fixture_digest,
+        )
+    assert not evaluator_started
+
+    manifest_path.write_text(
+        json.dumps(fixture.to_manifest(), ensure_ascii=False, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
     shutil.rmtree(source)
     runner = ReviewEvalRunner(harness, workspace_root=tmp_path / "runs")
     materializer = GitFrozenSubjectMaterializer(fixture=fixture)
@@ -357,5 +422,10 @@ def test_fixture_digest_and_fresh_run_isolation_are_fail_closed(tmp_path: Path) 
     fixture.repository_bundle_path.write_bytes(
         fixture.repository_bundle_path.read_bytes() + b"tampered"
     )
+    with pytest.raises(LckStopError, match="digest mismatch"):
+        load_frozen_review_fixture(
+            fixture.root,
+            expected_fixture_digest=fixture_digest,
+        )
     with pytest.raises(LckStopError, match="digest mismatch"):
         runner.start(fixture, materializer)

--- a/tools/agent_workflow/lck_core/README.md
+++ b/tools/agent_workflow/lck_core/README.md
@@ -15,7 +15,7 @@ maintainer or reviewer can start with the responsibility that owns the behavior.
 | Delivery prepare/complete | `delivery.py` | `eligibility.py`, `validation.py`, `effects.py` |
 | isolated Review workspace and review records | `review_workspace.py` | `review.py` |
 | Independent Review and Merge Preflight | `review.py` | `review_workspace.py`, `validation.py` |
-| Review Eval authority and Harness / Subject / Run isolation | `review_authority.py`, `review_eval.py` | none |
+| Review Eval fixture identity, artifact recovery, and Harness / Subject / Run isolation | `review_authority.py`, `review_fixture.py`, `review_eval.py` | none |
 | remediation and owned-candidate recovery | `remediation.py` | `eligibility.py`, `delivery.py`, `effects.py` |
 | post-merge Closeout | `closeout.py` | `eligibility.py`, `profile_policies.py` |
 | Agent View, Audit Receipt, failure evidence/replay | `receipts.py` | affected phase module |

--- a/tools/agent_workflow/lck_core/review_authority.py
+++ b/tools/agent_workflow/lck_core/review_authority.py
@@ -14,7 +14,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
 
-from workflow_common import is_sha
+from workflow_common import is_sha, sha256_json
 
 from .models import LckStopError, LiveState
 
@@ -127,11 +127,11 @@ class LiveReviewAuthority:
 class FrozenReviewAuthority:
     """Explicit authority for one frozen Review Eval Subject.
 
-    Fixture packaging and manifest semantics deliberately remain outside this
-    contract.  The current Task only needs a stable fixture identifier and
-    explicit historical base/head identities.  Optional digests reserve
-    identity slots for the fixture Task without allowing a live PR to fill
-    them implicitly.
+    The complete fixture package is represented by
+    :class:`FrozenReviewFixture`; this compact authority is the value passed
+    across the Eval boundary.  The legacy optional digest spellings remain
+    accepted for callers that only exercise the authority separation, while a
+    strict fixture identity supplies every digest and schema field.
     """
 
     fixture_id: str
@@ -141,6 +141,10 @@ class FrozenReviewAuthority:
     task_contract_sha256: str | None = None
     evidence_sha256: str | None = None
     repository_artifact_sha256: str | None = None
+    fixture_schema_version: int | None = None
+    deterministic_evidence_sha256: str | None = None
+    fixture_manifest_sha256: str | None = None
+    fixture_digest: str | None = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.fixture_id, str) or not self.fixture_id.strip():
@@ -160,12 +164,61 @@ class FrozenReviewAuthority:
             "task_contract_sha256",
             "evidence_sha256",
             "repository_artifact_sha256",
+            "deterministic_evidence_sha256",
+            "fixture_manifest_sha256",
+            "fixture_digest",
         ):
             object.__setattr__(
                 self,
                 field,
                 _optional_digest(getattr(self, field), field=field),
             )
+        if (
+            self.evidence_sha256 is not None
+            and self.deterministic_evidence_sha256 is not None
+            and self.evidence_sha256 != self.deterministic_evidence_sha256
+        ):
+            raise LckStopError("frozen Review authority evidence digests do not match")
+        if self.fixture_schema_version is not None and (
+            not isinstance(self.fixture_schema_version, int)
+            or isinstance(self.fixture_schema_version, bool)
+            or self.fixture_schema_version <= 0
+        ):
+            raise ValueError(
+                "frozen Review authority requires a fixture schema version"
+            )
+
+    @property
+    def effective_deterministic_evidence_sha256(self) -> str | None:
+        """Return the canonical spelling for deterministic evidence identity."""
+        return self.deterministic_evidence_sha256 or self.evidence_sha256
+
+    @property
+    def identity_payload(self) -> dict[str, Any]:
+        """Return the content identity that a fixture must bind."""
+        return {
+            "fixture_schema_version": self.fixture_schema_version,
+            "fixture_id": self.fixture_id,
+            "base_sha": self.base_sha,
+            "head_sha": self.head_sha,
+            "effective_diff_sha256": self.effective_diff_sha256,
+            "task_contract_sha256": self.task_contract_sha256,
+            "deterministic_evidence_sha256": (
+                self.effective_deterministic_evidence_sha256
+            ),
+            "repository_artifact_sha256": self.repository_artifact_sha256,
+            "fixture_manifest_sha256": self.fixture_manifest_sha256,
+        }
+
+    @property
+    def computed_fixture_digest(self) -> str:
+        """Compute the digest of the complete frozen identity.
+
+        A strict fixture compares this value with its recorded digest before
+        any semantic evaluator is started.  The property remains available for
+        the earlier minimal authority form used by production boundary tests.
+        """
+        return sha256_json(self.identity_payload)
 
     @classmethod
     def from_mapping(cls, value: Mapping[str, Any]) -> FrozenReviewAuthority:
@@ -180,6 +233,10 @@ class FrozenReviewAuthority:
             task_contract_sha256=value.get("task_contract_sha256"),
             evidence_sha256=value.get("evidence_sha256"),
             repository_artifact_sha256=value.get("repository_artifact_sha256"),
+            fixture_schema_version=value.get("fixture_schema_version"),
+            deterministic_evidence_sha256=value.get("deterministic_evidence_sha256"),
+            fixture_manifest_sha256=value.get("fixture_manifest_sha256"),
+            fixture_digest=value.get("fixture_digest"),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -194,10 +251,20 @@ class FrozenReviewAuthority:
             "task_contract_sha256",
             "evidence_sha256",
             "repository_artifact_sha256",
+            "fixture_schema_version",
+            "deterministic_evidence_sha256",
+            "fixture_manifest_sha256",
+            "fixture_digest",
         ):
             value = getattr(self, field)
             if value is not None:
                 result[field] = value
+        if (
+            self.deterministic_evidence_sha256 is not None
+            and "evidence_sha256" in result
+        ):
+            # Keep old readers useful while making the new spelling explicit.
+            result["deterministic_evidence_sha256"] = self.deterministic_evidence_sha256
         return result
 
 

--- a/tools/agent_workflow/lck_core/review_eval.py
+++ b/tools/agent_workflow/lck_core/review_eval.py
@@ -39,6 +39,8 @@ from .review_fixture import (
 )
 
 T = TypeVar("T")
+_RECEIPT_NAME: Final = "run-receipt.json"
+_RECEIPT_STATUSES: Final = frozenset({"READY_FOR_EVAL", "COMPLETED"})
 
 
 class SubjectMaterializer(Protocol):
@@ -171,14 +173,25 @@ class ReviewEvalRunContext:
         candidate = (self.result_root / name).resolve(strict=False)
         if not _within(candidate, self.result_root) or candidate == self.result_root:
             raise LckStopError("Review Eval result path must remain inside the Run")
+        if candidate == self.receipt_path.resolve(strict=False):
+            raise LckStopError(
+                "Review Eval result path is reserved for the Run receipt"
+            )
         return candidate
 
     @property
     def receipt_path(self) -> Path:
-        return self.result_root / "run-receipt.json"
+        return self.result_root / _RECEIPT_NAME
 
     def write_receipt(self, *, status: str = "COMPLETED") -> Path:
         """Persist bounded identity evidence in the Run result area."""
+        self._workspace._assert_owned(self)
+        if status not in _RECEIPT_STATUSES:
+            raise LckStopError("Review Eval Run receipt status is invalid")
+        if self.receipt_path.is_symlink() or (
+            self.receipt_path.exists() and not self.receipt_path.is_file()
+        ):
+            raise LckStopError("Review Eval Run receipt path is unavailable")
         fixture_digest = self.authority.fixture_digest
         if fixture_digest is None:
             fixture_digest = self.authority.computed_fixture_digest
@@ -201,11 +214,36 @@ class ReviewEvalRunContext:
             "subject_root": str(self.subject_root),
             "result_root": str(self.result_root),
         }
+        if self.receipt_path.exists():
+            try:
+                existing = read_json_file(self.receipt_path)
+            except WorkflowToolError as exc:
+                raise LckStopError("Review Eval Run receipt cannot be read") from exc
+            if not isinstance(existing, Mapping):
+                raise LckStopError("Review Eval Run receipt identity does not match")
+            immutable_payload = {
+                key: item for key, item in payload.items() if key != "status"
+            }
+            existing_immutable = {
+                key: item for key, item in existing.items() if key != "status"
+            }
+            if existing_immutable != immutable_payload:
+                raise LckStopError("Review Eval Run receipt identity does not match")
+            existing_status = existing.get("status")
+            if (
+                existing_status not in _RECEIPT_STATUSES
+                or existing_status == "COMPLETED"
+                and status != "COMPLETED"
+            ):
+                raise LckStopError(
+                    "Review Eval Run receipt status transition is invalid"
+                )
         atomic_write_json(self.receipt_path, payload)
         return self.receipt_path
 
     def write_result(self, name: str, value: Mapping[str, Any]) -> Path:
         """Write an Eval result without granting access to fixture or Subject."""
+        self._workspace._assert_owned(self)
         path = self.result_path(name)
         atomic_write_json(path, value)
         return path
@@ -461,6 +499,12 @@ class GitFrozenSubjectMaterializer:
             raise LckStopError("Review Eval fixture authorities do not match")
         fixture = fixture or fixture_input
         if fixture is not None:
+            expected_authority = fixture.authority
+            if (
+                authority.identity_payload != expected_authority.identity_payload
+                or authority.fixture_digest != expected_authority.fixture_digest
+            ):
+                raise LckStopError("Review Eval fixture authorities do not match")
             fixture.verify(self.runner)
         source = self.source_repository
         destination = destination.resolve()
@@ -587,6 +631,8 @@ class ReviewEvalRunner:
         authority, fixture = _authority_input(authority)
         if run_kind not in {"detection", "remediation"}:
             raise ValueError("Review Eval run_kind must be detection or remediation")
+        if run_kind == "detection" and writable is True:
+            raise LckStopError("Detection Run Subject must be read-only")
         if writable is None:
             writable = run_kind == "remediation"
         if fixture is not None and materializer is None:

--- a/tools/agent_workflow/lck_core/review_eval.py
+++ b/tools/agent_workflow/lck_core/review_eval.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import os
 import shutil
+import stat
 import tempfile
 import uuid
 from collections.abc import Callable, Mapping, Sequence
@@ -22,6 +23,7 @@ from workflow_common import (
     CommandRunner,
     WorkflowToolError,
     atomic_write_json,
+    is_sha,
     read_json_file,
 )
 
@@ -29,6 +31,11 @@ from .models import LCK_SCHEMA_VERSION, LckStopError
 from .review_authority import (
     FrozenReviewAuthority,
     require_frozen_review_authority,
+)
+from .review_fixture import (
+    FrozenReviewFixture,
+    ReviewFixtureBuilder,
+    load_frozen_review_fixture,
 )
 
 T = TypeVar("T")
@@ -62,6 +69,57 @@ def _assert_distinct_workspaces(harness_root: Path, subject_root: Path) -> None:
         )
 
 
+def _assert_contained_symlinks(root: Path) -> None:
+    """Reject a Subject symlink that could write outside its Run."""
+    resolved_root = root.resolve(strict=False)
+    for current, dirs, files in os.walk(root, topdown=True, followlinks=False):
+        current_path = Path(current)
+        for name in (*dirs, *files):
+            candidate = current_path / name
+            if candidate.is_symlink() and not _within(
+                candidate.resolve(), resolved_root
+            ):
+                raise LckStopError("Review Eval Subject contains an escaping symlink")
+
+
+def _make_read_only(root: Path) -> None:
+    """Seal a Detection Subject while leaving its Run results writable."""
+    for current, dirs, files in os.walk(root, topdown=False, followlinks=False):
+        current_path = Path(current)
+        for name in (*files, *dirs):
+            target = current_path / name
+            if not target.is_symlink():
+                mode = stat.S_IMODE(target.stat().st_mode)
+                os.chmod(target, mode & ~0o222)
+    mode = stat.S_IMODE(root.stat().st_mode)
+    os.chmod(root, mode & ~0o222)
+
+
+def _authority_input(
+    value: FrozenReviewAuthority | FrozenReviewFixture | Path,
+) -> tuple[FrozenReviewAuthority, FrozenReviewFixture | None]:
+    if isinstance(value, Path):
+        value = load_frozen_review_fixture(value)
+    if isinstance(value, FrozenReviewFixture):
+        value.verify()
+        return value.authority, value
+    authority = require_frozen_review_authority(value)
+    if authority.fixture_schema_version is not None:
+        required = (
+            authority.effective_diff_sha256,
+            authority.task_contract_sha256,
+            authority.effective_deterministic_evidence_sha256,
+            authority.repository_artifact_sha256,
+            authority.fixture_manifest_sha256,
+            authority.fixture_digest,
+        )
+        if any(item is None for item in required):
+            raise LckStopError("strict Review Eval fixture identity is incomplete")
+        if authority.fixture_digest != authority.computed_fixture_digest:
+            raise LckStopError("Review Eval fixture identity digest mismatch")
+    return authority, None
+
+
 @dataclass(frozen=True, slots=True)
 class ReviewEvalRunContext:
     """Immutable identity and paths for one isolated Review Eval Run."""
@@ -72,6 +130,8 @@ class ReviewEvalRunContext:
     run_root: Path
     subject_root: Path
     result_root: Path
+    harness_sha: str | None
+    run_kind: str
     _workspace: ReviewEvalWorkspaceManager = field(repr=False, compare=False)
 
     @property
@@ -90,6 +150,8 @@ class ReviewEvalRunContext:
             "run_root": str(self.run_root),
             "subject_root": str(self.subject_root),
             "result_root": str(self.result_root),
+            "harness_sha": self.harness_sha,
+            "run_kind": self.run_kind,
             "planes": {
                 "harness": "current-checkout",
                 "subject": "frozen-fixture-materialization",
@@ -110,6 +172,66 @@ class ReviewEvalRunContext:
         if not _within(candidate, self.result_root) or candidate == self.result_root:
             raise LckStopError("Review Eval result path must remain inside the Run")
         return candidate
+
+    @property
+    def receipt_path(self) -> Path:
+        return self.result_root / "run-receipt.json"
+
+    def write_receipt(self, *, status: str = "COMPLETED") -> Path:
+        """Persist bounded identity evidence in the Run result area."""
+        fixture_digest = self.authority.fixture_digest
+        if fixture_digest is None:
+            fixture_digest = self.authority.computed_fixture_digest
+        payload = {
+            "schema_version": LCK_SCHEMA_VERSION,
+            "kind": "review-eval-run-receipt",
+            "status": status,
+            "run_id": self.run_id,
+            "run_identity": {
+                "run_id": self.run_id,
+                "fixture_id": self.authority.fixture_id,
+                "fixture_digest": fixture_digest,
+                "base_sha": self.authority.base_sha,
+                "head_sha": self.authority.head_sha,
+            },
+            "fixture_id": self.authority.fixture_id,
+            "fixture_digest": fixture_digest,
+            "harness_sha": self.harness_sha,
+            "run_kind": self.run_kind,
+            "subject_root": str(self.subject_root),
+            "result_root": str(self.result_root),
+        }
+        atomic_write_json(self.receipt_path, payload)
+        return self.receipt_path
+
+    def write_result(self, name: str, value: Mapping[str, Any]) -> Path:
+        """Write an Eval result without granting access to fixture or Subject."""
+        path = self.result_path(name)
+        atomic_write_json(path, value)
+        return path
+
+    def materialize_remediation(
+        self,
+        materializer: SubjectMaterializer | SubjectMaterializerCallable,
+    ) -> Path:
+        """Create a unique writable, Run-owned remediation copy."""
+        self._workspace._assert_owned(self)
+        remediation_root = self.run_root / "remediation"
+        remediation_root.mkdir(exist_ok=True)
+        destination = remediation_root / uuid.uuid4().hex
+        destination.mkdir()
+        try:
+            _call_materializer(materializer, self.authority, destination)
+            if not _within(destination.resolve(), self.run_root.resolve()):
+                raise LckStopError(
+                    "Review Eval remediation copy escaped its Run workspace"
+                )
+            _assert_contained_symlinks(destination)
+            return destination
+        except BaseException:
+            ReviewEvalWorkspaceManager._make_removable(destination)
+            shutil.rmtree(destination, ignore_errors=True)
+            raise
 
     def close(self) -> None:
         self._workspace.close(self)
@@ -162,6 +284,9 @@ class ReviewEvalWorkspaceManager:
         self,
         authority: FrozenReviewAuthority,
         harness_root: Path,
+        *,
+        harness_sha: str | None = None,
+        run_kind: str = "detection",
     ) -> ReviewEvalRunContext:
         authority = require_frozen_review_authority(authority)
         harness_root = harness_root.resolve()
@@ -189,6 +314,8 @@ class ReviewEvalWorkspaceManager:
                 "run_root": str(run_root),
                 "subject_root": str(subject_root),
                 "result_root": str(result_root),
+                "harness_sha": harness_sha,
+                "run_kind": run_kind,
                 "authority_note": (
                     "frozen Eval authority only; never a production Review target"
                 ),
@@ -201,6 +328,8 @@ class ReviewEvalWorkspaceManager:
             run_root=run_root,
             subject_root=subject_root,
             result_root=result_root,
+            harness_sha=harness_sha,
+            run_kind=run_kind,
             _workspace=self,
         )
 
@@ -263,14 +392,32 @@ class GitFrozenSubjectMaterializer:
 
     def __init__(
         self,
-        source_repository: Path,
+        source_repository: Path | None = None,
         *,
         runner: CommandRunner | None = None,
+        fixture: FrozenReviewFixture | Path | None = None,
     ) -> None:
-        self.source_repository = source_repository.resolve()
-        self.runner = runner or CommandRunner(self.source_repository)
+        if source_repository is None and fixture is None:
+            raise ValueError("provide source_repository or frozen fixture")
+        if source_repository is not None and fixture is not None:
+            raise ValueError("provide source_repository or frozen fixture, not both")
+        if isinstance(fixture, Path):
+            fixture = load_frozen_review_fixture(fixture)
+        self.fixture = fixture
+        self.source_repository = (
+            source_repository.resolve() if source_repository is not None else None
+        )
+        if self.source_repository is not None:
+            runner_root = self.source_repository
+        elif fixture is not None:
+            runner_root = fixture.root
+        else:
+            raise ValueError("provide source_repository or frozen fixture")
+        self.runner = runner or CommandRunner(runner_root)
 
-    def _ensure_commit(self, destination: Path, sha: str, label: str) -> None:
+    def _ensure_commit(
+        self, destination: Path, sha: str, label: str, *, allow_fetch: bool = True
+    ) -> None:
         available = self.runner.run(
             ["git", "cat-file", "-e", f"{sha}^{{commit}}"],
             command_id=f"review-eval-subject-{label}-available",
@@ -278,6 +425,8 @@ class GitFrozenSubjectMaterializer:
         )
         if available.returncode == 0:
             return
+        if not allow_fetch:
+            raise LckStopError(f"frozen Subject does not contain its {label} commit")
         fetched = self.runner.run(
             ["git", "fetch", "--no-tags", "origin", sha],
             command_id=f"review-eval-subject-{label}-fetch",
@@ -299,15 +448,27 @@ class GitFrozenSubjectMaterializer:
 
     def materialize(
         self,
-        authority: FrozenReviewAuthority,
+        authority: FrozenReviewAuthority | FrozenReviewFixture,
         destination: Path,
     ) -> None:
-        authority = require_frozen_review_authority(authority)
+        authority, fixture_input = _authority_input(authority)
+        fixture = self.fixture
+        if (
+            fixture is not None
+            and fixture_input is not None
+            and fixture != fixture_input
+        ):
+            raise LckStopError("Review Eval fixture authorities do not match")
+        fixture = fixture or fixture_input
+        if fixture is not None:
+            fixture.verify(self.runner)
         source = self.source_repository
         destination = destination.resolve()
-        if not source.is_dir() or not (source / ".git").exists():
+        if source is not None and (
+            not source.is_dir() or not (source / ".git").exists()
+        ):
             raise LckStopError("frozen Subject source repository is unavailable")
-        if (
+        if source is not None and (
             source == destination
             or _within(destination, source)
             or _within(source, destination)
@@ -315,13 +476,19 @@ class GitFrozenSubjectMaterializer:
             raise LckStopError(
                 "frozen Subject destination must not be inside its source"
             )
+        if fixture is not None:
+            clone_source = str(fixture.repository_bundle_path)
+        elif source is not None:
+            clone_source = str(source)
+        else:
+            raise LckStopError("frozen Subject source repository is unavailable")
         clone = self.runner.run(
             [
                 "git",
                 "clone",
                 "--no-checkout",
                 "--no-hardlinks",
-                str(source),
+                clone_source,
                 str(destination),
             ],
             command_id="review-eval-subject-clone",
@@ -333,8 +500,18 @@ class GitFrozenSubjectMaterializer:
                 + (clone.stderr.strip() or f"exit {clone.returncode}")
             )
         try:
-            self._ensure_commit(destination, authority.base_sha, "base")
-            self._ensure_commit(destination, authority.head_sha, "head")
+            self._ensure_commit(
+                destination,
+                authority.base_sha,
+                "base",
+                allow_fetch=fixture is None,
+            )
+            self._ensure_commit(
+                destination,
+                authority.head_sha,
+                "head",
+                allow_fetch=fixture is None,
+            )
             checkout = self.runner.run(
                 ["git", "checkout", "--detach", authority.head_sha],
                 command_id="review-eval-subject-checkout",
@@ -359,6 +536,7 @@ class GitFrozenSubjectMaterializer:
                 raise LckStopError("cannot verify frozen Review Eval Subject")
             if status.stdout.strip() or head.stdout.strip() != authority.head_sha:
                 raise LckStopError("frozen Review Eval Subject is not clean and exact")
+            _assert_contained_symlinks(destination)
         except BaseException:
             ReviewEvalWorkspaceManager._make_removable(destination)
             shutil.rmtree(destination, ignore_errors=True)
@@ -400,11 +578,32 @@ class ReviewEvalRunner:
 
     def start(
         self,
-        authority: FrozenReviewAuthority,
-        materializer: SubjectMaterializer | SubjectMaterializerCallable,
+        authority: FrozenReviewAuthority | FrozenReviewFixture | Path,
+        materializer: SubjectMaterializer | SubjectMaterializerCallable | None = None,
+        *,
+        run_kind: str = "detection",
+        writable: bool | None = None,
     ) -> ReviewEvalRunContext:
-        authority = require_frozen_review_authority(authority)
-        run = self.workspace.reserve(authority, self.harness_root)
+        authority, fixture = _authority_input(authority)
+        if run_kind not in {"detection", "remediation"}:
+            raise ValueError("Review Eval run_kind must be detection or remediation")
+        if writable is None:
+            writable = run_kind == "remediation"
+        if fixture is not None and materializer is None:
+            materializer = GitFrozenSubjectMaterializer(
+                fixture=fixture, runner=self.command_runner
+            )
+        if materializer is None:
+            raise TypeError("Review Eval Subject materializer is required")
+        harness_sha = self._harness_sha()
+        if fixture is not None and harness_sha is None:
+            raise LckStopError("Review Eval Harness SHA is unavailable")
+        run = self.workspace.reserve(
+            authority,
+            self.harness_root,
+            harness_sha=harness_sha,
+            run_kind=run_kind,
+        )
         try:
             _call_materializer(materializer, authority, run.subject_root)
             subject = run.subject_root.resolve()
@@ -413,6 +612,12 @@ class ReviewEvalRunner:
                 raise LckStopError(
                     "Review Eval Subject materializer escaped its Run workspace"
                 )
+            _assert_contained_symlinks(run.subject_root)
+            if fixture is not None:
+                fixture.verify(self.command_runner)
+            if not writable:
+                _make_read_only(run.subject_root)
+            run.write_receipt(status="READY_FOR_EVAL")
             return run
         except BaseException:
             self.workspace.close(run)
@@ -420,36 +625,57 @@ class ReviewEvalRunner:
 
     def prepare(
         self,
-        authority: FrozenReviewAuthority,
-        materializer: SubjectMaterializer | SubjectMaterializerCallable,
+        authority: FrozenReviewAuthority | FrozenReviewFixture | Path,
+        materializer: SubjectMaterializer | SubjectMaterializerCallable | None = None,
+        *,
+        run_kind: str = "detection",
+        writable: bool | None = None,
     ) -> ReviewEvalRunContext:
         """Named entrypoint for callers that separate prepare from execution."""
-        return self.start(authority, materializer)
+        return self.start(
+            authority,
+            materializer,
+            run_kind=run_kind,
+            writable=writable,
+        )
 
     def run(
         self,
-        authority: FrozenReviewAuthority,
-        materializer: SubjectMaterializer | SubjectMaterializerCallable,
+        authority: FrozenReviewAuthority | FrozenReviewFixture | Path,
+        materializer: SubjectMaterializer | SubjectMaterializerCallable | None,
         evaluator: Callable[[ReviewEvalRunContext], T],
+        *,
+        run_kind: str = "detection",
+        writable: bool | None = None,
     ) -> ReviewEvalExecution[T]:
         """Materialize a Subject, then invoke the evaluator from the Harness."""
         if not callable(evaluator):
             raise TypeError("Review Eval evaluator is not callable")
-        run = self.start(authority, materializer)
+        run = self.start(
+            authority,
+            materializer,
+            run_kind=run_kind,
+            writable=writable,
+        )
         try:
             value = evaluator(run)
         except BaseException:
             self.workspace.close(run)
             raise
+        run.write_receipt(status="COMPLETED")
+        if isinstance(value, Mapping):
+            run.write_result("eval-result.json", value)
         return ReviewEvalExecution(run=run, value=value)
 
     def execute_command(
         self,
-        authority: FrozenReviewAuthority,
-        materializer: SubjectMaterializer | SubjectMaterializerCallable,
+        authority: FrozenReviewAuthority | FrozenReviewFixture | Path,
+        materializer: SubjectMaterializer | SubjectMaterializerCallable | None,
         argv: Sequence[str],
         *,
         env: Mapping[str, str] | None = None,
+        run_kind: str = "detection",
+        writable: bool | None = None,
     ) -> ReviewEvalExecution[CommandResult]:
         """Execute a Harness-owned command with the Subject as explicit input.
 
@@ -460,7 +686,12 @@ class ReviewEvalRunner:
         """
         if not argv:
             raise ValueError("Review Eval command argv cannot be empty")
-        run = self.start(authority, materializer)
+        run = self.start(
+            authority,
+            materializer,
+            run_kind=run_kind,
+            writable=writable,
+        )
         command_env = dict(env or {})
         command_env.update(
             {
@@ -472,6 +703,9 @@ class ReviewEvalRunner:
                 "TRACEQUANT_REVIEW_EVAL_HARNESS_ROOT": str(run.harness_root),
             }
         )
+        if run.run_kind == "detection":
+            command_env.setdefault("PYTHONDONTWRITEBYTECODE", "1")
+            command_env.setdefault("GIT_OPTIONAL_LOCKS", "0")
         existing_pythonpath = command_env.get("PYTHONPATH") or os.environ.get(
             "PYTHONPATH"
         )
@@ -498,7 +732,17 @@ class ReviewEvalRunner:
         except BaseException:
             self.workspace.close(run)
             raise
+        run.write_receipt(status="COMPLETED")
         return ReviewEvalExecution(run=run, value=result)
+
+    def _harness_sha(self) -> str | None:
+        result = self.command_runner.run(
+            ["git", "rev-parse", "HEAD"],
+            command_id="review-eval-harness-head",
+            cwd=self.harness_root,
+        )
+        value = result.stdout.strip()
+        return value if result.returncode == 0 and is_sha(value) else None
 
 
 __all__ = [
@@ -508,4 +752,6 @@ __all__ = [
     "ReviewEvalRunner",
     "ReviewEvalWorkspaceManager",
     "SubjectMaterializer",
+    "FrozenReviewFixture",
+    "ReviewFixtureBuilder",
 ]

--- a/tools/agent_workflow/lck_core/review_eval.py
+++ b/tools/agent_workflow/lck_core/review_eval.py
@@ -99,11 +99,16 @@ def _make_read_only(root: Path) -> None:
 
 def _authority_input(
     value: FrozenReviewAuthority | FrozenReviewFixture | Path,
+    *,
+    expected_fixture_digest: str | None = None,
 ) -> tuple[FrozenReviewAuthority, FrozenReviewFixture | None]:
     if isinstance(value, Path):
-        value = load_frozen_review_fixture(value)
+        value = load_frozen_review_fixture(
+            value,
+            expected_fixture_digest=expected_fixture_digest,
+        )
     if isinstance(value, FrozenReviewFixture):
-        value.verify()
+        value.verify(expected_fixture_digest=expected_fixture_digest)
         return value.authority, value
     authority = require_frozen_review_authority(value)
     if authority.fixture_schema_version is not None:
@@ -434,14 +439,19 @@ class GitFrozenSubjectMaterializer:
         *,
         runner: CommandRunner | None = None,
         fixture: FrozenReviewFixture | Path | None = None,
+        expected_fixture_digest: str | None = None,
     ) -> None:
         if source_repository is None and fixture is None:
             raise ValueError("provide source_repository or frozen fixture")
         if source_repository is not None and fixture is not None:
             raise ValueError("provide source_repository or frozen fixture, not both")
         if isinstance(fixture, Path):
-            fixture = load_frozen_review_fixture(fixture)
+            fixture = load_frozen_review_fixture(
+                fixture,
+                expected_fixture_digest=expected_fixture_digest,
+            )
         self.fixture = fixture
+        self.expected_fixture_digest = expected_fixture_digest
         self.source_repository = (
             source_repository.resolve() if source_repository is not None else None
         )
@@ -489,7 +499,10 @@ class GitFrozenSubjectMaterializer:
         authority: FrozenReviewAuthority | FrozenReviewFixture,
         destination: Path,
     ) -> None:
-        authority, fixture_input = _authority_input(authority)
+        authority, fixture_input = _authority_input(
+            authority,
+            expected_fixture_digest=self.expected_fixture_digest,
+        )
         fixture = self.fixture
         if (
             fixture is not None
@@ -505,7 +518,10 @@ class GitFrozenSubjectMaterializer:
                 or authority.fixture_digest != expected_authority.fixture_digest
             ):
                 raise LckStopError("Review Eval fixture authorities do not match")
-            fixture.verify(self.runner)
+            fixture.verify(
+                self.runner,
+                expected_fixture_digest=self.expected_fixture_digest,
+            )
         source = self.source_repository
         destination = destination.resolve()
         if source is not None and (
@@ -627,8 +643,12 @@ class ReviewEvalRunner:
         *,
         run_kind: str = "detection",
         writable: bool | None = None,
+        expected_fixture_digest: str | None = None,
     ) -> ReviewEvalRunContext:
-        authority, fixture = _authority_input(authority)
+        authority, fixture = _authority_input(
+            authority,
+            expected_fixture_digest=expected_fixture_digest,
+        )
         if run_kind not in {"detection", "remediation"}:
             raise ValueError("Review Eval run_kind must be detection or remediation")
         if run_kind == "detection" and writable is True:
@@ -637,7 +657,9 @@ class ReviewEvalRunner:
             writable = run_kind == "remediation"
         if fixture is not None and materializer is None:
             materializer = GitFrozenSubjectMaterializer(
-                fixture=fixture, runner=self.command_runner
+                fixture=fixture,
+                runner=self.command_runner,
+                expected_fixture_digest=expected_fixture_digest,
             )
         if materializer is None:
             raise TypeError("Review Eval Subject materializer is required")
@@ -676,6 +698,7 @@ class ReviewEvalRunner:
         *,
         run_kind: str = "detection",
         writable: bool | None = None,
+        expected_fixture_digest: str | None = None,
     ) -> ReviewEvalRunContext:
         """Named entrypoint for callers that separate prepare from execution."""
         return self.start(
@@ -683,6 +706,7 @@ class ReviewEvalRunner:
             materializer,
             run_kind=run_kind,
             writable=writable,
+            expected_fixture_digest=expected_fixture_digest,
         )
 
     def run(
@@ -693,6 +717,7 @@ class ReviewEvalRunner:
         *,
         run_kind: str = "detection",
         writable: bool | None = None,
+        expected_fixture_digest: str | None = None,
     ) -> ReviewEvalExecution[T]:
         """Materialize a Subject, then invoke the evaluator from the Harness."""
         if not callable(evaluator):
@@ -702,6 +727,7 @@ class ReviewEvalRunner:
             materializer,
             run_kind=run_kind,
             writable=writable,
+            expected_fixture_digest=expected_fixture_digest,
         )
         try:
             value = evaluator(run)
@@ -722,6 +748,7 @@ class ReviewEvalRunner:
         env: Mapping[str, str] | None = None,
         run_kind: str = "detection",
         writable: bool | None = None,
+        expected_fixture_digest: str | None = None,
     ) -> ReviewEvalExecution[CommandResult]:
         """Execute a Harness-owned command with the Subject as explicit input.
 
@@ -737,6 +764,7 @@ class ReviewEvalRunner:
             materializer,
             run_kind=run_kind,
             writable=writable,
+            expected_fixture_digest=expected_fixture_digest,
         )
         command_env = dict(env or {})
         command_env.update(

--- a/tools/agent_workflow/lck_core/review_fixture.py
+++ b/tools/agent_workflow/lck_core/review_fixture.py
@@ -2,7 +2,8 @@
 
 The fixture is the authority for Eval.  A branch or tag may help a human find
 the package, but the manifest, its digests, and the self-contained Git bundle
-are the only inputs accepted by the materializer.
+are only accepted after a Path load is checked against an independently
+retained fixture digest.
 """
 
 from __future__ import annotations
@@ -94,6 +95,24 @@ def _manifest_payload(value: Mapping[str, Any]) -> dict[str, Any]:
         for key, item in value.items()
         if key not in {"fixture_manifest_sha256", "fixture_digest"}
     }
+
+
+def _expected_fixture_digest(value: Any) -> str:
+    if value is None:
+        raise LckStopError(
+            "Review fixture requires an independently trusted expected fixture digest"
+        )
+    return _required_digest(value, field="expected fixture digest")
+
+
+def _verify_expected_fixture_digest(
+    fixture: FrozenReviewFixture, expected_fixture_digest: Any
+) -> None:
+    expected = _expected_fixture_digest(expected_fixture_digest)
+    if fixture.fixture_digest != expected:
+        raise LckStopError(
+            "Review fixture identity does not match independently trusted digest"
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -257,7 +276,14 @@ class FrozenReviewFixture:
         )
 
     @classmethod
-    def from_manifest(cls, path: Path) -> FrozenReviewFixture:
+    def from_manifest(
+        cls,
+        path: Path,
+        *,
+        expected_fixture_digest: str | None = None,
+    ) -> FrozenReviewFixture:
+        """Load a manifest only when its identity has an external anchor."""
+        expected = _expected_fixture_digest(expected_fixture_digest)
         manifest = path
         if manifest.is_dir():
             manifest = manifest / FIXTURE_MANIFEST_NAME
@@ -268,10 +294,19 @@ class FrozenReviewFixture:
             value = read_json_file(manifest)
         except WorkflowToolError as exc:
             raise LckStopError("Review fixture manifest cannot be read") from exc
-        return cls.from_mapping(manifest.parent, value)
+        fixture = cls.from_mapping(manifest.parent, value)
+        _verify_expected_fixture_digest(fixture, expected)
+        return fixture.verify(expected_fixture_digest=expected)
 
-    def verify(self, runner: Any | None = None) -> FrozenReviewFixture:
+    def verify(
+        self,
+        runner: Any | None = None,
+        *,
+        expected_fixture_digest: str | None = None,
+    ) -> FrozenReviewFixture:
         """Verify the manifest and every protected artifact before Eval."""
+        if expected_fixture_digest is not None:
+            _verify_expected_fixture_digest(self, expected_fixture_digest)
         try:
             recorded = read_json_file(self.manifest_path)
         except WorkflowToolError as exc:
@@ -488,7 +523,10 @@ class ReviewFixtureBuilder:
                 "fixture_digest": fixture_digest,
             },
         )
-        return FrozenReviewFixture.from_manifest(destination).verify(self.runner)
+        return FrozenReviewFixture.from_manifest(
+            destination,
+            expected_fixture_digest=fixture_digest,
+        ).verify(self.runner, expected_fixture_digest=fixture_digest)
 
 
 def _canonical_artifact_text(value: Any) -> str:
@@ -502,9 +540,14 @@ def _canonical_artifact_text(value: Any) -> str:
     )
 
 
-def load_frozen_review_fixture(path: Path) -> FrozenReviewFixture:
-    """Load a fixture manifest without treating a branch/tag as authority."""
-    return FrozenReviewFixture.from_manifest(path)
+def load_frozen_review_fixture(
+    path: Path, *, expected_fixture_digest: str | None = None
+) -> FrozenReviewFixture:
+    """Load a fixture only against an independently retained identity digest."""
+    return FrozenReviewFixture.from_manifest(
+        path,
+        expected_fixture_digest=expected_fixture_digest,
+    )
 
 
 ReviewFixture = FrozenReviewFixture

--- a/tools/agent_workflow/lck_core/review_fixture.py
+++ b/tools/agent_workflow/lck_core/review_fixture.py
@@ -1,0 +1,524 @@
+"""Immutable Review Eval fixture packages and their verification boundary.
+
+The fixture is the authority for Eval.  A branch or tag may help a human find
+the package, but the manifest, its digests, and the self-contained Git bundle
+are the only inputs accepted by the materializer.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Final
+
+from workflow_common import (
+    CommandRunner,
+    WorkflowToolError,
+    atomic_write_json,
+    is_sha,
+    read_json_file,
+    sha256_bytes,
+    sha256_json,
+)
+
+from .models import LckStopError
+from .review_authority import FrozenReviewAuthority
+
+FIXTURE_SCHEMA_VERSION: Final = 1
+FIXTURE_MANIFEST_NAME: Final = "fixture-manifest.json"
+REPOSITORY_BUNDLE_NAME: Final = "repository.bundle"
+TASK_CONTRACT_NAME: Final = "task-contract.json"
+DETERMINISTIC_EVIDENCE_NAME: Final = "deterministic-evidence.json"
+_DIGEST_FIELDS: Final = (
+    "effective_diff_sha256",
+    "task_contract_sha256",
+    "deterministic_evidence_sha256",
+    "repository_artifact_sha256",
+)
+
+
+def _digest(value: bytes, *, field: str) -> str:
+    if not value:
+        raise LckStopError(f"Review fixture {field} is empty")
+    return sha256_bytes(value)
+
+
+def _digest_value(value: Any, *, field: str) -> str:
+    if isinstance(value, bytes):
+        return _digest(value, field=field)
+    if isinstance(value, str):
+        return _digest(value.encode("utf-8"), field=field)
+    return sha256_json(value)
+
+
+def _required_digest(value: Any, *, field: str) -> str:
+    if not isinstance(value, str) or len(value) != 64:
+        raise LckStopError(f"Review fixture {field} is unavailable")
+    try:
+        int(value, 16)
+    except ValueError as exc:
+        raise LckStopError(f"Review fixture {field} is not a SHA-256 digest") from exc
+    return value.lower()
+
+
+def _required_relative_path(value: Any, *, field: str) -> str:
+    if not isinstance(value, str) or not value or Path(value).is_absolute():
+        raise LckStopError(f"Review fixture {field} path is invalid")
+    path = Path(value)
+    if ".." in path.parts or path == Path("."):
+        raise LckStopError(f"Review fixture {field} path escapes the fixture")
+    return path.as_posix()
+
+
+def _safe_artifact(root: Path, relative: str, *, field: str) -> Path:
+    candidate = root / relative
+    if candidate.is_symlink():
+        raise LckStopError(f"Review fixture {field} artifact is unavailable")
+    path = candidate.resolve(strict=False)
+    try:
+        path.relative_to(root.resolve(strict=False))
+    except ValueError as exc:
+        raise LckStopError(f"Review fixture {field} escapes the fixture") from exc
+    if path.is_symlink() or not path.is_file():
+        raise LckStopError(f"Review fixture {field} artifact is unavailable")
+    return path
+
+
+def _manifest_payload(value: Mapping[str, Any]) -> dict[str, Any]:
+    """Remove self-referential digests before hashing the manifest."""
+    return {
+        str(key): item
+        for key, item in value.items()
+        if key not in {"fixture_manifest_sha256", "fixture_digest"}
+    }
+
+
+@dataclass(frozen=True, slots=True)
+class FrozenReviewFixture:
+    """A verified, self-contained authority package for one Review Eval."""
+
+    root: Path
+    fixture_id: str
+    fixture_schema_version: int
+    base_sha: str
+    head_sha: str
+    effective_diff_sha256: str
+    task_contract_sha256: str
+    deterministic_evidence_sha256: str
+    repository_artifact_sha256: str
+    fixture_manifest_sha256: str
+    fixture_digest: str
+    repository_bundle: str = REPOSITORY_BUNDLE_NAME
+    task_contract_artifact: str = TASK_CONTRACT_NAME
+    deterministic_evidence_artifact: str = DETERMINISTIC_EVIDENCE_NAME
+
+    def __post_init__(self) -> None:
+        root = self.root.resolve(strict=False)
+        object.__setattr__(self, "root", root)
+        if not root.is_dir():
+            raise LckStopError("Review fixture root is unavailable")
+        if not isinstance(self.fixture_id, str) or not self.fixture_id.strip():
+            raise LckStopError("Review fixture ID is unavailable")
+        if self.fixture_schema_version != FIXTURE_SCHEMA_VERSION:
+            raise LckStopError("Review fixture schema version is unsupported")
+        for field in ("base_sha", "head_sha"):
+            if not is_sha(getattr(self, field)):
+                raise LckStopError(f"Review fixture {field} is unavailable")
+        for field in (*_DIGEST_FIELDS, "fixture_manifest_sha256", "fixture_digest"):
+            _required_digest(getattr(self, field), field=field)
+        object.__setattr__(
+            self,
+            "repository_bundle",
+            _required_relative_path(self.repository_bundle, field="repository bundle"),
+        )
+        object.__setattr__(
+            self,
+            "task_contract_artifact",
+            _required_relative_path(self.task_contract_artifact, field="Task Contract"),
+        )
+        object.__setattr__(
+            self,
+            "deterministic_evidence_artifact",
+            _required_relative_path(
+                self.deterministic_evidence_artifact,
+                field="deterministic evidence",
+            ),
+        )
+
+    @property
+    def manifest_path(self) -> Path:
+        return self.root / FIXTURE_MANIFEST_NAME
+
+    @property
+    def repository_bundle_path(self) -> Path:
+        return _safe_artifact(
+            self.root, self.repository_bundle, field="repository bundle"
+        )
+
+    @property
+    def authority(self) -> FrozenReviewAuthority:
+        return FrozenReviewAuthority(
+            fixture_id=self.fixture_id,
+            base_sha=self.base_sha,
+            head_sha=self.head_sha,
+            effective_diff_sha256=self.effective_diff_sha256,
+            task_contract_sha256=self.task_contract_sha256,
+            deterministic_evidence_sha256=self.deterministic_evidence_sha256,
+            repository_artifact_sha256=self.repository_artifact_sha256,
+            fixture_schema_version=self.fixture_schema_version,
+            fixture_manifest_sha256=self.fixture_manifest_sha256,
+            fixture_digest=self.fixture_digest,
+        )
+
+    @property
+    def identity_digest(self) -> str:
+        return self.fixture_digest
+
+    def identity_payload(self) -> dict[str, Any]:
+        return {
+            "fixture_schema_version": self.fixture_schema_version,
+            "fixture_id": self.fixture_id,
+            "base_sha": self.base_sha,
+            "head_sha": self.head_sha,
+            "effective_diff_sha256": self.effective_diff_sha256,
+            "task_contract_sha256": self.task_contract_sha256,
+            "deterministic_evidence_sha256": self.deterministic_evidence_sha256,
+            "repository_artifact_sha256": self.repository_artifact_sha256,
+            "fixture_manifest_sha256": self.fixture_manifest_sha256,
+        }
+
+    def manifest_payload(self) -> dict[str, Any]:
+        return {
+            **self.identity_payload(),
+            "artifacts": {
+                "repository_bundle": {
+                    "path": self.repository_bundle,
+                    "sha256": self.repository_artifact_sha256,
+                },
+                "task_contract": {
+                    "path": self.task_contract_artifact,
+                    "sha256": self.task_contract_sha256,
+                },
+                "deterministic_evidence": {
+                    "path": self.deterministic_evidence_artifact,
+                    "sha256": self.deterministic_evidence_sha256,
+                },
+            },
+        }
+
+    def to_manifest(self) -> dict[str, Any]:
+        payload = self.manifest_payload()
+        return {
+            **payload,
+            "fixture_manifest_sha256": self.fixture_manifest_sha256,
+            "fixture_digest": self.fixture_digest,
+        }
+
+    @classmethod
+    def from_mapping(cls, root: Path, value: Mapping[str, Any]) -> FrozenReviewFixture:
+        if not isinstance(value, Mapping):
+            raise LckStopError("Review fixture manifest is not an object")
+        artifacts = value.get("artifacts")
+        if not isinstance(artifacts, Mapping):
+            raise LckStopError("Review fixture manifest artifacts are unavailable")
+
+        def artifact(name: str, default: str) -> tuple[str, str]:
+            item = artifacts.get(name)
+            if not isinstance(item, Mapping):
+                raise LckStopError(f"Review fixture artifact {name} is unavailable")
+            return (
+                _required_relative_path(item.get("path", default), field=name),
+                _required_digest(item.get("sha256"), field=f"{name} digest"),
+            )
+
+        repository_bundle, _ = artifact("repository_bundle", REPOSITORY_BUNDLE_NAME)
+        task_contract, _ = artifact("task_contract", TASK_CONTRACT_NAME)
+        evidence, _ = artifact("deterministic_evidence", DETERMINISTIC_EVIDENCE_NAME)
+        return cls(
+            root=root,
+            fixture_id=value.get("fixture_id", ""),
+            fixture_schema_version=value.get("fixture_schema_version", 0),
+            base_sha=value.get("base_sha", ""),
+            head_sha=value.get("head_sha", ""),
+            effective_diff_sha256=value.get("effective_diff_sha256", ""),
+            task_contract_sha256=value.get("task_contract_sha256", ""),
+            deterministic_evidence_sha256=value.get(
+                "deterministic_evidence_sha256", ""
+            ),
+            repository_artifact_sha256=value.get("repository_artifact_sha256", ""),
+            fixture_manifest_sha256=value.get("fixture_manifest_sha256", ""),
+            fixture_digest=value.get("fixture_digest", ""),
+            repository_bundle=repository_bundle,
+            task_contract_artifact=task_contract,
+            deterministic_evidence_artifact=evidence,
+        )
+
+    @classmethod
+    def from_manifest(cls, path: Path) -> FrozenReviewFixture:
+        manifest = path
+        if manifest.is_dir():
+            manifest = manifest / FIXTURE_MANIFEST_NAME
+        if manifest.is_symlink():
+            raise LckStopError("Review fixture manifest is unavailable")
+        manifest = manifest.resolve(strict=False)
+        try:
+            value = read_json_file(manifest)
+        except WorkflowToolError as exc:
+            raise LckStopError("Review fixture manifest cannot be read") from exc
+        return cls.from_mapping(manifest.parent, value)
+
+    def verify(self, runner: Any | None = None) -> FrozenReviewFixture:
+        """Verify the manifest and every protected artifact before Eval."""
+        try:
+            recorded = read_json_file(self.manifest_path)
+        except WorkflowToolError as exc:
+            raise LckStopError("Review fixture manifest cannot be read") from exc
+        if not isinstance(recorded, Mapping):
+            raise LckStopError("Review fixture manifest is not an object")
+        if self.manifest_path.is_symlink() or not self.manifest_path.is_file():
+            raise LckStopError("Review fixture manifest is unavailable")
+        current = type(self).from_mapping(self.root, recorded)
+        if current.to_manifest() != self.to_manifest():
+            raise LckStopError("Review fixture manifest identity does not match")
+        manifest_digest = sha256_json(_manifest_payload(recorded))
+        if manifest_digest != self.fixture_manifest_sha256:
+            raise LckStopError("Review fixture manifest digest mismatch")
+        computed_fixture_digest = sha256_json(self.identity_payload())
+        if computed_fixture_digest != self.fixture_digest:
+            raise LckStopError("Review fixture identity digest mismatch")
+
+        recorded_artifacts = recorded.get("artifacts")
+        if not isinstance(recorded_artifacts, Mapping):
+            raise LckStopError("Review fixture manifest artifacts are unavailable")
+        expected_artifacts = {
+            "repository_bundle": (
+                self.repository_bundle,
+                self.repository_artifact_sha256,
+            ),
+            "task_contract": (self.task_contract_artifact, self.task_contract_sha256),
+            "deterministic_evidence": (
+                self.deterministic_evidence_artifact,
+                self.deterministic_evidence_sha256,
+            ),
+        }
+        for name, (expected_path, expected_digest) in expected_artifacts.items():
+            item = recorded_artifacts.get(name)
+            if not isinstance(item, Mapping) or item.get("path") != expected_path:
+                raise LckStopError(f"Review fixture artifact {name} is inconsistent")
+            if item.get("sha256") != expected_digest:
+                raise LckStopError(f"Review fixture artifact {name} digest mismatch")
+
+        artifacts = (
+            (
+                self.repository_bundle,
+                self.repository_artifact_sha256,
+                "repository bundle",
+            ),
+            (
+                self.task_contract_artifact,
+                self.task_contract_sha256,
+                "Task Contract",
+            ),
+            (
+                self.deterministic_evidence_artifact,
+                self.deterministic_evidence_sha256,
+                "deterministic evidence",
+            ),
+        )
+        for relative, expected, field in artifacts:
+            path = _safe_artifact(self.root, relative, field=field)
+            if hashlib.sha256(path.read_bytes()).hexdigest() != expected:
+                raise LckStopError(f"Review fixture {field} digest mismatch")
+
+        if runner is not None:
+            verify_root = getattr(runner, "repo_root", None)
+            if isinstance(verify_root, Path) and (verify_root / ".git").exists():
+                result = runner.run(
+                    ["git", "bundle", "verify", str(self.repository_bundle_path)],
+                    command_id="review-fixture-bundle-verify",
+                    cwd=verify_root,
+                )
+                if result.returncode != 0:
+                    raise LckStopError("Review fixture Git bundle cannot be verified")
+        return self
+
+
+class ReviewFixtureBuilder:
+    """Create a fixture package whose contents can outlive the source clone."""
+
+    def __init__(self, repository: Path, *, runner: Any | None = None) -> None:
+        self.repository = repository.resolve()
+        if not self.repository.is_dir() or not (self.repository / ".git").exists():
+            raise LckStopError("Review fixture source repository is unavailable")
+        self.runner = runner or CommandRunner(self.repository)
+
+    def create(
+        self,
+        destination: Path,
+        *,
+        fixture_id: str,
+        base_sha: str,
+        head_sha: str,
+        task_contract: Any,
+        deterministic_evidence: Any,
+        effective_diff_sha256: str | None = None,
+    ) -> FrozenReviewFixture:
+        if not is_sha(base_sha) or not is_sha(head_sha):
+            raise LckStopError("Review fixture base/head identity is unavailable")
+        destination = destination.resolve(strict=False)
+        if destination.exists() and any(destination.iterdir()):
+            raise LckStopError("Review fixture destination must be empty")
+        destination.mkdir(parents=True, exist_ok=True)
+        bundle = destination / REPOSITORY_BUNDLE_NAME
+        current_head = self.runner.run(
+            ["git", "rev-parse", "HEAD"],
+            command_id="review-fixture-source-head",
+            cwd=self.repository,
+        )
+        bundle_revision = (
+            "HEAD"
+            if current_head.returncode == 0 and current_head.stdout.strip() == head_sha
+            else "--all"
+        )
+        result = self.runner.run(
+            # ``git bundle`` accepts symbolic refs more consistently than raw
+            # object IDs across supported Git versions.  The bundle may carry
+            # navigation refs, but verification and materialization below use
+            # only the explicit immutable base/head SHAs.
+            ["git", "bundle", "create", str(bundle), bundle_revision],
+            command_id="review-fixture-bundle-create",
+            cwd=self.repository,
+        )
+        if result.returncode != 0:
+            raise LckStopError(
+                "Review fixture Git bundle creation failed: "
+                + (result.stderr.strip() or f"exit {result.returncode}")
+            )
+        contract_path = destination / TASK_CONTRACT_NAME
+        evidence_path = destination / DETERMINISTIC_EVIDENCE_NAME
+        contract_path.write_text(
+            _canonical_artifact_text(task_contract), encoding="utf-8", newline="\n"
+        )
+        evidence_path.write_text(
+            _canonical_artifact_text(deterministic_evidence),
+            encoding="utf-8",
+            newline="\n",
+        )
+        if effective_diff_sha256 is None:
+            diff = self.runner.run(
+                [
+                    "git",
+                    "diff",
+                    "--binary",
+                    "--full-index",
+                    "--no-ext-diff",
+                    "--no-textconv",
+                    f"{base_sha}...{head_sha}",
+                ],
+                command_id="review-fixture-effective-diff",
+                cwd=self.repository,
+            )
+            if diff.returncode != 0:
+                raise LckStopError("Review fixture effective diff is unavailable")
+            effective_diff_sha256 = hashlib.sha256(
+                diff.stdout.encode("utf-8", errors="replace")
+            ).hexdigest()
+        effective_diff_sha256 = _required_digest(
+            effective_diff_sha256, field="effective diff"
+        )
+        manifest_payload = {
+            "fixture_schema_version": FIXTURE_SCHEMA_VERSION,
+            "fixture_id": fixture_id,
+            "base_sha": base_sha,
+            "head_sha": head_sha,
+            "effective_diff_sha256": effective_diff_sha256,
+            "task_contract_sha256": _digest(
+                contract_path.read_bytes(), field="Task Contract"
+            ),
+            "deterministic_evidence_sha256": _digest(
+                evidence_path.read_bytes(), field="deterministic evidence"
+            ),
+            "repository_artifact_sha256": _digest(
+                bundle.read_bytes(), field="repository bundle"
+            ),
+            "artifacts": {
+                "repository_bundle": {
+                    "path": REPOSITORY_BUNDLE_NAME,
+                    "sha256": _digest(bundle.read_bytes(), field="repository bundle"),
+                },
+                "task_contract": {
+                    "path": TASK_CONTRACT_NAME,
+                    "sha256": _digest(
+                        contract_path.read_bytes(), field="Task Contract"
+                    ),
+                },
+                "deterministic_evidence": {
+                    "path": DETERMINISTIC_EVIDENCE_NAME,
+                    "sha256": _digest(
+                        evidence_path.read_bytes(), field="deterministic evidence"
+                    ),
+                },
+            },
+        }
+        manifest_sha = sha256_json(manifest_payload)
+        identity = {
+            "fixture_schema_version": FIXTURE_SCHEMA_VERSION,
+            "fixture_id": fixture_id,
+            "base_sha": base_sha,
+            "head_sha": head_sha,
+            "effective_diff_sha256": effective_diff_sha256,
+            "task_contract_sha256": manifest_payload["task_contract_sha256"],
+            "deterministic_evidence_sha256": manifest_payload[
+                "deterministic_evidence_sha256"
+            ],
+            "repository_artifact_sha256": manifest_payload[
+                "repository_artifact_sha256"
+            ],
+            "fixture_manifest_sha256": manifest_sha,
+        }
+        fixture_digest = sha256_json(identity)
+        atomic_write_json(
+            destination / FIXTURE_MANIFEST_NAME,
+            {
+                **manifest_payload,
+                "fixture_manifest_sha256": manifest_sha,
+                "fixture_digest": fixture_digest,
+            },
+        )
+        return FrozenReviewFixture.from_manifest(destination).verify(self.runner)
+
+
+def _canonical_artifact_text(value: Any) -> str:
+    if isinstance(value, bytes):
+        return value.decode("utf-8")
+    if isinstance(value, str):
+        return value
+    return (
+        json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        + "\n"
+    )
+
+
+def load_frozen_review_fixture(path: Path) -> FrozenReviewFixture:
+    """Load a fixture manifest without treating a branch/tag as authority."""
+    return FrozenReviewFixture.from_manifest(path)
+
+
+ReviewFixture = FrozenReviewFixture
+ReviewEvalFixture = FrozenReviewFixture
+
+
+__all__ = [
+    "DETERMINISTIC_EVIDENCE_NAME",
+    "FIXTURE_MANIFEST_NAME",
+    "FIXTURE_SCHEMA_VERSION",
+    "FrozenReviewFixture",
+    "REPOSITORY_BUNDLE_NAME",
+    "ReviewEvalFixture",
+    "ReviewFixture",
+    "ReviewFixtureBuilder",
+    "load_frozen_review_fixture",
+]


### PR DESCRIPTION
Closes #252

## Summary
Add content-addressed frozen Review Eval fixture packages with self-contained Git bundle recovery, fail-closed identity verification, read-only detection Subjects, isolated remediation copies, and run receipts.

## Validation
- Critical Outcome: pass
- Formal Delivery validation: pass

## Risks / limitations
Review Eval fixture packages must be created with ReviewFixtureBuilder; legacy minimal FrozenReviewAuthority callers remain supported without strict artifact verification.
