### PR TITLE
[Task] 将 Structured Review v2 接入正式 Independent Review

### DIFF
--- a/.agents/skills/task-pr-review-runner/SKILL.md
+++ b/.agents/skills/task-pr-review-runner/SKILL.md
@@ -69,6 +69,9 @@ uv run --frozen python tools/agent_workflow/lck.py review prepare <TASK>
 
 Proceed only on `READY_FOR_SEMANTIC_REVIEW`. Use the returned `review_id`, current
 Task Contract, current review target, validation/check state, and `review_root`.
+The returned `structured_review_instructions` is the canonical Structured Review
+v2 semantic handoff. Use it to organize the review; do not replace it with an
+ad-hoc prompt or a Task-specific checklist.
 Before sealing, Review Prepare has already run and persisted the authoritative
 formal Review validation for the exact reviewed head. Consume that returned
 validation/check evidence; do not independently reproduce it. The `review_root`
@@ -92,6 +95,14 @@ Reason
 Judge
 Report
 ```
+
+Complete all applicable obligations named by `structured_review_instructions`
+before the existing final verdict. A High or Medium blocker does not end the
+semantic review; continue the remaining applicable surfaces and perform the
+adversarial residual sweep before reporting. Use the existing canonical finding
+and report semantics, including concrete evidence and falsification reasoning
+when applicable. This handoff is semantic guidance only; it adds no receipt,
+completion gate, or new verdict.
 
 Read the complete effective diff and necessary related code. Build an independent AC
 coverage/evidence matrix. The current Task Contract, effective diff, and necessary related

--- a/.claude/skills/task-pr-review-runner/SKILL.md
+++ b/.claude/skills/task-pr-review-runner/SKILL.md
@@ -55,6 +55,9 @@ uv run --frozen python tools/agent_workflow/lck.py review prepare <TASK>
 
 Proceed only on `READY_FOR_SEMANTIC_REVIEW`. Use the returned `review_id`, current
 Task Contract, current review target, validation/check state, and `review_root`.
+The returned `structured_review_instructions` is the canonical Structured Review
+v2 semantic handoff. Use it to organize the review; do not replace it with an
+ad-hoc prompt or a Task-specific checklist.
 Before sealing, Review Prepare has already run and persisted the authoritative
 formal Review validation for the exact reviewed head. Consume that returned
 validation/check evidence; do not independently reproduce it. The `review_root`
@@ -78,6 +81,14 @@ Reason
 Judge
 Report
 ```
+
+Complete all applicable obligations named by `structured_review_instructions`
+before the existing final verdict. A High or Medium blocker does not end the
+semantic review; continue the remaining applicable surfaces and perform the
+adversarial residual sweep before reporting. Use the existing canonical finding
+and report semantics, including concrete evidence and falsification reasoning
+when applicable. This handoff is semantic guidance only; it adds no receipt,
+completion gate, or new verdict.
 
 Read the complete effective diff and necessary related code. Build an independent AC
 coverage/evidence matrix. The current Task Contract, effective diff, and necessary related

--- a/docs/development/pr-review.md
+++ b/docs/development/pr-review.md
@@ -109,6 +109,19 @@ Review Prepare 不等待 CI checks 进入终态；semantic Review 可以与 CI �
 success 只在 Review Complete 与后续 Merge Preflight 的 fresh gate 中决定是否可进入
 人工合并边界。
 
+## 4.1 Structured Review v2 semantic instructions
+
+Structured Review v2 的唯一 reviewer-facing owner 是
+`tools/agent_workflow/lck_core/structured_review_instructions.py`。Review Prepare
+通过 `structured_review_instructions` 将该 owner 返回的 instruction data 放入
+standard semantic handoff；因此正常 `task-pr-review-runner` invocation 不需要
+maintainer 追加实验性提示词。该 handoff 要求 Reviewer 完成其列出的全部适用
+semantic surfaces，在 blocker 后继续审查，并在现有 verdict 前执行 residual sweep。
+
+这是 semantic guidance，不是新的 completion state、receipt gate 或 verdict
+authority。Review Complete、现有 finding/report semantics、Merge Preflight、freshness
+与 maintainer manual merge boundary 保持不变。
+
 ## 5. Review Complete：fresh applicability snapshot
 
 语义审查结束后，调用 `review complete`。它是一个**新的 LCK operation**，不是

--- a/tests/tools/test_lck_profile_architecture.py
+++ b/tests/tools/test_lck_profile_architecture.py
@@ -903,6 +903,7 @@ def test_generic_kernel_models_have_no_synthetic_fixed_slots() -> None:
             "review_root",
             "issue_profile",
             "profile_evidence",
+            "structured_review_instructions",
         },
         lck_delivery.DeliveryCompletionResult: {
             "task_number",

--- a/tests/tools/test_lck_review.py
+++ b/tests/tools/test_lck_review.py
@@ -23,9 +23,11 @@ if AGENT_WORKFLOW not in sys.path:
 from lck_core import (  # type: ignore[import-not-found]  # noqa: E402
     eligibility as lck_eligibility,
     models as lck_models,
+    receipts as lck_receipts,
     review as lck_review,
     review_workspace as lck_review_workspace,
     state as lck_state,
+    structured_review_instructions as lck_structured_review_instructions,
     validation as lck_validation,
 )
 from workflow_common import (  # type: ignore[import-not-found]  # noqa: E402
@@ -143,6 +145,59 @@ def test_review_prepare_builds_context_only_from_live_resolution(
     assert inflight["state"] == "handed-off"
     assert inflight["review_id"] == context.review_id
     assert checks.calls == 1
+
+
+def test_standard_review_path_provides_canonical_structured_review_instructions(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The normal Review Prepare handoff carries owner-provided guidance only."""
+    state = _review_state()
+    resolver = cast(Any, StaticResolver(tmp_path, state))
+    identity = _review_identity_value()
+    monkeypatch.setattr(
+        lck_review, "_review_identity", lambda *_args, **_kwargs: identity
+    )
+    calls = 0
+    owner = lck_structured_review_instructions
+    original_provider = owner.canonical_structured_review_instructions
+    expected = original_provider()
+
+    def provide_instructions() -> dict[str, Any]:
+        nonlocal calls
+        calls += 1
+        return cast(dict[str, Any], original_provider())
+
+    monkeypatch.setattr(
+        owner, "canonical_structured_review_instructions", provide_instructions
+    )
+    context = lck_review.ReviewPreparer(
+        resolver,
+        validation=cast(Any, FakeReviewValidation()),
+        checks_gate=cast(Any, FakeReviewChecks()),
+        workspace=cast(Any, FakeReviewWorkspace(tmp_path / "review-root")),
+        store=lck_review_workspace.ReviewInvocationStore(tmp_path),
+    ).prepare(159)
+
+    value = context.to_dict()
+    handoff = value["structured_review_instructions"]
+    assert calls == 1
+    assert handoff == expected
+    assert [item["obligation_id"] for item in handoff["obligations"]] == [
+        "contract-critical-outcome",
+        "functional-invariants",
+        "boundary-conversion-error",
+        "state-persistence-compatibility",
+        "tests-vs-claims",
+        "adversarial-residual-sweep",
+    ]
+    assert any("blocker" in item for item in handoff["review_sequence"])
+    assert any("residual sweep" in item for item in handoff["review_sequence"])
+
+    agent_view = lck_receipts._agent_view_for_result(context)
+    assert agent_view["structured_review_instructions"] == expected
+    assert agent_view["workspace_mode"] == "implementation-read-only"
+    assert agent_view["mechanical_authority"].startswith("live Git/GitHub")
 
 
 def test_review_prepare_allows_pending_checks_for_parallel_semantic_review(

--- a/tools/agent_workflow/lck_core/receipts.py
+++ b/tools/agent_workflow/lck_core/receipts.py
@@ -257,6 +257,9 @@ def _agent_view_for_result(value: Any) -> dict[str, Any]:
             "task_contract": _jsonable(value.task_contract),
             "review_target": value.identity.to_dict(),
             "profile_evidence": _profile_evidence(value.profile_evidence),
+            "structured_review_instructions": _jsonable(
+                value.structured_review_instructions
+            ),
             "checks": _checks_agent_view(value.checks),
             "validation": _validation_agent_view(value.validation),
             "review_root": str(value.review_root),

--- a/tools/agent_workflow/lck_core/review.py
+++ b/tools/agent_workflow/lck_core/review.py
@@ -9,6 +9,7 @@ from typing import Any, cast
 
 from workflow_common import ProgressReporter, is_sha, safe_text
 
+from . import structured_review_instructions as structured_review_instruction_owner
 from .eligibility import PhaseEligibilityResolver
 from .issue_profiles import resolve_leaf_issue_profile
 from .models import (
@@ -66,6 +67,7 @@ class ReviewContext:
     review_root: Path
     issue_profile: Mapping[str, Any] | None = None
     profile_evidence: ProfileEvidenceEnvelope | None = None
+    structured_review_instructions: Mapping[str, Any] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -80,6 +82,13 @@ class ReviewContext:
             "validation": _jsonable(self.validation),
             "profile_evidence": (
                 self.profile_evidence.to_dict() if self.profile_evidence else None
+            ),
+            "structured_review_instructions": (
+                _jsonable(self.structured_review_instructions)
+                if self.structured_review_instructions is not None
+                else _jsonable(
+                    structured_review_instruction_owner.canonical_structured_review_instructions()
+                )
             ),
             "review_root": str(self.review_root),
             "workspace_mode": "implementation-read-only",
@@ -256,6 +265,7 @@ class ReviewPreparer:
                 policy_registry=self.policy_registry,
                 profile_resolver=self.profile_resolver,
             )
+            structured_instructions = structured_review_instruction_owner.canonical_structured_review_instructions()
             profile, _policy = resolve_issue_policy(
                 _policy_issue_from_state(state),
                 registry=self.policy_registry,
@@ -317,6 +327,7 @@ class ReviewPreparer:
                     if review_stage.profile_evidence
                     else None
                 ),
+                "structured_review_instructions": structured_instructions,
                 "snapshot": snapshot.to_dict(),
                 "authority": (
                     "sealed Review Prepare target; historical identity for Review Complete "
@@ -340,6 +351,7 @@ class ReviewPreparer:
                 review_root=review_root,
                 issue_profile=state.issue_profile,
                 profile_evidence=review_stage.profile_evidence,
+                structured_review_instructions=structured_instructions,
             )
             invocation.release_lock()
         except BaseException as exc:

--- a/tools/agent_workflow/lck_core/structured_review_instructions.py
+++ b/tools/agent_workflow/lck_core/structured_review_instructions.py
@@ -1,0 +1,111 @@
+"""Canonical semantic instructions for production Independent Review.
+
+This module owns the reviewer-facing Structured Review v2 guidance.  It is
+instruction data only: it does not create a completion gate, receipt protocol,
+new verdict, or lifecycle state.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final
+
+from tracequant.contracts import ReviewSurface
+
+STRUCTURED_REVIEW_INSTRUCTION_OWNER: Final[str] = (
+    "tools/agent_workflow/lck_core/structured_review_instructions.py"
+)
+STRUCTURED_REVIEW_INSTRUCTION_VERSION: Final[str] = "v2"
+
+
+_OBLIGATIONS: Final[tuple[dict[str, Any], ...]] = (
+    {
+        "obligation_id": "contract-critical-outcome",
+        "instruction": (
+            "Map the Objective, Requirements, Acceptance Criteria, Critical "
+            "Outcome, constraints, and non-goals to the implementation and "
+            "available evidence."
+        ),
+        "review_surfaces": (ReviewSurface.CONTRACT_CONFORMANCE.value,),
+    },
+    {
+        "obligation_id": "functional-invariants",
+        "instruction": (
+            "Identify the relevant functional invariants and caller/callee "
+            "assumptions, then construct applicable counterexamples."
+        ),
+        "review_surfaces": (ReviewSurface.FUNCTIONAL_CORRECTNESS.value,),
+    },
+    {
+        "obligation_id": "boundary-conversion-error",
+        "instruction": (
+            "Enumerate applicable boundary, parsing, conversion, external-input, "
+            "transport, exception, timeout, retry, malformed, missing, partial, "
+            "and result-mapping outcomes."
+        ),
+        "review_surfaces": (ReviewSurface.ERROR_FAILURE_PATHS.value,),
+    },
+    {
+        "obligation_id": "state-persistence-compatibility",
+        "instruction": (
+            "When applicable, inspect state transitions, persistence behavior, "
+            "recovery and conflict paths, and Base-to-Head compatibility."
+        ),
+        "review_surfaces": (
+            ReviewSurface.STATE_TRANSITIONS.value,
+            ReviewSurface.PERSISTENCE_ATOMICITY.value,
+            ReviewSurface.COMPATIBILITY_MIGRATION.value,
+        ),
+    },
+    {
+        "obligation_id": "tests-vs-claims",
+        "instruction": (
+            "Distinguish what tests and deterministic evidence actually prove "
+            "from happy-path-only claims and remaining failure, boundary, state, "
+            "compatibility, and invariant gaps."
+        ),
+        "review_surfaces": (ReviewSurface.TESTS_VS_CLAIMS.value,),
+    },
+    {
+        "obligation_id": "adversarial-residual-sweep",
+        "instruction": (
+            "Before the final verdict, assume supported findings are fixed and "
+            "search for independent root causes and residual risks across the "
+            "applicable review surfaces."
+        ),
+        "review_surfaces": (ReviewSurface.FUNCTIONAL_CORRECTNESS.value,),
+    },
+)
+
+
+def canonical_structured_review_instructions() -> dict[str, Any]:
+    """Return the fresh reviewer handoff owned by this module."""
+    return {
+        "owner": STRUCTURED_REVIEW_INSTRUCTION_OWNER,
+        "version": STRUCTURED_REVIEW_INSTRUCTION_VERSION,
+        "obligations": [
+            {
+                **obligation,
+                "review_surfaces": list(obligation["review_surfaces"]),
+            }
+            for obligation in _OBLIGATIONS
+        ],
+        "review_sequence": [
+            "Complete every applicable obligation before the final verdict.",
+            "A High or Medium blocker does not end semantic review; continue all "
+            "remaining applicable surfaces.",
+            "Perform the adversarial residual sweep before the existing final verdict.",
+        ],
+        "finding_guidance": [
+            "Use the existing canonical finding/report semantics.",
+            "When applicable, include affected location, violated contract or "
+            "invariant, concrete failure scenario, supporting evidence, why "
+            "current tests/evidence do not exclude it, and falsification reasoning.",
+        ],
+    }
+
+
+__all__ = [
+    "STRUCTURED_REVIEW_INSTRUCTION_OWNER",
+    "STRUCTURED_REVIEW_INSTRUCTION_VERSION",
+    "canonical_structured_review_instructions",
+]


### PR DESCRIPTION
Closes #256

## Summary
Provide canonical Structured Review v2 semantic instructions through the standard Independent Review handoff while preserving existing Review and merge authority.

## Validation
- Critical Outcome: pass
- Formal Delivery validation: pass

## Risks / limitations
Semantic guidance is reviewer-facing only; model coverage remains a semantic review responsibility and is not mechanically receipt-gated.
