### PR TITLE
[Task] 抽取 Binance 公共历史 archive acquisition seam

### DIFF
--- a/src/tracequant/data/__init__.py
+++ b/src/tracequant/data/__init__.py
@@ -10,6 +10,13 @@ from tracequant.data.binance_contract_kline import (
     BinanceContractKlineStatus,
     plan_binance_contract_kline_archives,
 )
+from tracequant.data.binance_public_archive import (
+    BinanceArchiveAcquisitionOutcome,
+    BinanceArchiveAcquisitionStatus,
+    BinanceArchiveDatasetAdapter,
+    BinanceArchiveParseResult,
+    BinancePublicArchiveAcquisition,
+)
 from tracequant.data.public_history import (
     BinanceArchiveObjectBoundary,
     BinanceArchiveObjectGranularity,
@@ -44,8 +51,12 @@ from tracequant.data.raw_store import (
 
 __all__ = [
     "ArchiveHttpResponse",
+    "BinanceArchiveAcquisitionOutcome",
+    "BinanceArchiveAcquisitionStatus",
     "BinanceArchiveCoverageGapPlan",
+    "BinanceArchiveDatasetAdapter",
     "BinanceArchiveObjectPlan",
+    "BinanceArchiveParseResult",
     "BinanceArchiveObjectBoundary",
     "BinanceArchiveObjectGranularity",
     "BinanceContractKlineBackfill",
@@ -60,6 +71,7 @@ __all__ = [
     "BinancePublicHistorySourceIdentity",
     "BinancePublicHistorySourceKind",
     "BinancePublicHistorySubjectKind",
+    "BinancePublicArchiveAcquisition",
     "PublicHistoryContractError",
     "RawArtifact",
     "RawArtifactAmbiguousError",

--- a/src/tracequant/data/binance_contract_kline.py
+++ b/src/tracequant/data/binance_contract_kline.py
@@ -1,33 +1,32 @@
-"""Binance USDⓈ-M 1m contract-Kline archive backfill.
+"""Binance USDⓈ-M 1m contract-Kline archive backfill adapter.
 
-The adapter implements the archive-only supported path frozen by the public-
-history source contract.  It plans complete UTC months as monthly objects and
-the remaining intersecting UTC days as daily objects, verifies Binance's
-published checksum, parses the complete 12-column wire schema, and delegates
-all persistence and immutable-conflict decisions to :class:`RawStore`.
+The adapter owns contract-Kline planning, parsing, and coverage semantics.  It
+delegates official archive acquisition, evidence, and Raw publication to the
+typed shared Binance public-archive seam.
 """
 
 from __future__ import annotations
 
 import csv
-import hashlib
-import http.client
 import io
-import math
-import re
-import urllib.error
-import urllib.request
-import zipfile
-from collections.abc import Callable, Mapping
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, time, timedelta
-from decimal import Decimal, InvalidOperation
-from enum import StrEnum
 from pathlib import Path
-from typing import Final, Protocol
+from typing import Final
 
 import polars as pl
 
+from tracequant.data.binance_public_archive import (
+    ArchiveHttpGet,
+    ArchiveHttpResponse,
+    BinanceArchiveAcquisitionStatus,
+    BinanceArchiveObjectPlan,
+    BinanceArchiveParseResult,
+    BinancePublicArchiveAcquisition,
+    _coverage_gap,
+    _invalid_content,
+)
 from tracequant.data.public_history import (
     BinanceArchiveObjectBoundary,
     BinanceKlineInterval,
@@ -35,20 +34,7 @@ from tracequant.data.public_history import (
     BinancePublicHistoryRequest,
     BinancePublicHistorySourceKind,
 )
-from tracequant.data.raw_store import (
-    RawAcquisitionManifest,
-    RawAcquisitionResponse,
-    RawArtifact,
-    RawArtifactAmbiguousError,
-    RawArtifactConflictError,
-    RawArtifactIncompleteError,
-    RawArtifactNotFoundError,
-    RawArtifactValidationError,
-    RawObjectIdentity,
-    RawSourceObject,
-    RawSourceProvenance,
-    RawStore,
-)
+from tracequant.data.raw_store import RawStore
 from tracequant.domain import InstrumentId, TimeRange
 
 __all__ = [
@@ -64,25 +50,8 @@ __all__ = [
 
 _ARCHIVE_ROOT: Final = "https://data.binance.vision"
 _SCHEMA_IDENTIFIER: Final = "binance.um.contract-kline.csv.v1"
-_PRODUCER_VERSION: Final = "tracequant/0.1.0"
 _ONE_MINUTE_MS: Final = 60_000
 _MAX_SIGNED_INT64_TEXT: Final = str(2**63 - 1)
-_MAX_ARCHIVE_BYTES: Final = 512 * 1024 * 1024
-# Frozen per-instrument archive coverage from the approved Research contract.
-# These are observed object boundaries, not values to advance from wall time.
-_RESEARCH_ARCHIVE_COVERAGE: Final = {
-    "BTCUSDT": {
-        "monthly": (date(2020, 1, 1), date(2026, 7, 1)),
-        "daily": (date(2019, 12, 31), date(2026, 8, 29)),
-    },
-    "ETHUSDT": {
-        "monthly": (date(2020, 1, 1), date(2026, 7, 1)),
-        "daily": (date(2019, 12, 31), date(2026, 8, 29)),
-    },
-}
-_CHECKSUM_PATTERN: Final = re.compile(
-    r"\A([0-9A-Fa-f]{64})[ \t]+[*]?([^\r\n]+)[\r\n]*\Z"
-)
 _COLUMNS: Final = (
     "open_time",
     "open",
@@ -112,29 +81,20 @@ _DTYPES: Final = {
     "ignore": pl.String,
 }
 
+# Frozen per-instrument archive coverage from the approved Research contract.
+_RESEARCH_ARCHIVE_COVERAGE: Final = {
+    "BTCUSDT": {
+        "monthly": (date(2020, 1, 1), date(2026, 7, 1)),
+        "daily": (date(2019, 12, 31), date(2026, 8, 29)),
+    },
+    "ETHUSDT": {
+        "monthly": (date(2020, 1, 1), date(2026, 7, 1)),
+        "daily": (date(2019, 12, 31), date(2026, 8, 29)),
+    },
+}
 
-@dataclass(frozen=True, slots=True)
-class ArchiveHttpResponse:
-    """Bounded response returned by an injectable archive HTTP transport."""
 
-    status: int
-    body: bytes
-    headers: Mapping[str, str]
-
-
-class ArchiveHttpGet(Protocol):
-    def __call__(self, url: str, timeout: float) -> ArchiveHttpResponse: ...
-
-
-@dataclass(frozen=True, slots=True)
-class BinanceArchiveObjectPlan:
-    """One deterministic official archive object needed by a caller range."""
-
-    request: BinancePublicHistoryRequest
-    object_key: str
-    url: str
-    checksum_url: str
-    member_name: str
+BinanceContractKlineStatus = BinanceArchiveAcquisitionStatus
 
 
 @dataclass(frozen=True, slots=True)
@@ -162,18 +122,6 @@ class BinanceArchiveCoverageGapPlan:
 type BinanceContractKlinePlan = BinanceArchiveObjectPlan | BinanceArchiveCoverageGapPlan
 
 
-class BinanceContractKlineStatus(StrEnum):
-    PUBLISHED = "published"
-    EXISTING = "existing"
-    COVERAGE_GAP = "coverage_gap"
-    NOT_FOUND = "not_found"
-    CHECKSUM_NOT_FOUND = "checksum_not_found"
-    RETRYABLE_FAILURE = "retryable_failure"
-    INVALID_CONTENT = "invalid_content"
-    LOCAL_FAILURE = "local_failure"
-    CONFLICT = "conflict"
-
-
 @dataclass(frozen=True, slots=True)
 class BinanceContractKlineObjectResult:
     plan: BinanceContractKlinePlan
@@ -198,51 +146,6 @@ class BinanceContractKlineRunResult:
         return bool(self.objects) and all(
             item.status in successful for item in self.objects
         )
-
-
-class _InvalidContentError(ValueError):
-    def __init__(
-        self, message: str, *, response: ArchiveHttpResponse | None = None
-    ) -> None:
-        super().__init__(message)
-        self.response = response
-
-
-class _CoverageGapError(ValueError):
-    pass
-
-
-class _RetryableDownloadError(RuntimeError):
-    def __init__(
-        self,
-        message: str,
-        *,
-        resource: str,
-        response: ArchiveHttpResponse | None = None,
-    ) -> None:
-        super().__init__(message)
-        self.resource = resource
-        self.response = response
-
-
-@dataclass(frozen=True, slots=True)
-class _DownloadedResponse:
-    body: bytes
-    status: int
-    headers: Mapping[str, str]
-
-
-class _DownloadNotFoundError(FileNotFoundError):
-    def __init__(
-        self,
-        url: str,
-        *,
-        resource: str,
-        response: ArchiveHttpResponse | None = None,
-    ) -> None:
-        super().__init__(url)
-        self.resource = resource
-        self.response = response
 
 
 def _next_month(value: date) -> date:
@@ -345,104 +248,6 @@ def plan_binance_contract_kline_archives(
     return tuple(plans)
 
 
-def _default_http_get(url: str, timeout: float) -> ArchiveHttpResponse:
-    request = urllib.request.Request(url, headers={"User-Agent": "tracequant/0.1.0"})
-    try:
-        with urllib.request.urlopen(request, timeout=timeout) as response:
-            body = response.read(_MAX_ARCHIVE_BYTES + 1)
-            if len(body) > _MAX_ARCHIVE_BYTES:
-                raise _InvalidContentError("archive response exceeds the size limit")
-            return ArchiveHttpResponse(
-                status=response.status,
-                body=body,
-                headers=dict(response.headers.items()),
-            )
-    except urllib.error.HTTPError as error:
-        return ArchiveHttpResponse(
-            status=error.code,
-            body=error.read(4096),
-            headers=dict(error.headers.items()) if error.headers is not None else {},
-        )
-    except (TimeoutError, urllib.error.URLError):
-        raise
-
-
-def _download(
-    http_get: ArchiveHttpGet,
-    url: str,
-    timeout: float,
-    *,
-    resource: str,
-) -> _DownloadedResponse:
-    try:
-        response = http_get(url, timeout)
-    except _InvalidContentError:
-        raise
-    except (
-        TimeoutError,
-        ConnectionError,
-        OSError,
-        http.client.HTTPException,
-    ) as error:
-        detail = str(error).strip() or (
-            f"{type(error).__name__} while downloading {resource}"
-        )
-        raise _RetryableDownloadError(detail, resource=resource) from error
-    if response.status == 404:
-        raise _DownloadNotFoundError(url, resource=resource, response=response)
-    if response.status == 429 or 500 <= response.status <= 599:
-        raise _RetryableDownloadError(
-            f"HTTP {response.status} for {url}",
-            resource=resource,
-            response=response,
-        )
-    if response.status < 200 or response.status >= 300:
-        raise _InvalidContentError(
-            f"unexpected HTTP {response.status} for {url}", response=response
-        )
-    if not response.body:
-        raise _InvalidContentError(f"empty response for {url}", response=response)
-    return _DownloadedResponse(
-        body=response.body,
-        status=response.status,
-        headers=dict(response.headers),
-    )
-
-
-def _declared_checksum(payload: bytes, expected_filename: str) -> str:
-    try:
-        text = payload.decode("ascii")
-    except UnicodeDecodeError as error:
-        raise _InvalidContentError("checksum response is not ASCII") from error
-    match = _CHECKSUM_PATTERN.fullmatch(text)
-    if match is None or match.group(2) != expected_filename:
-        raise _InvalidContentError(
-            "checksum response has an unexpected format or filename"
-        )
-    return match.group(1).lower()
-
-
-def _parse_nonnegative_int(value: str, *, field: str) -> int:
-    if not value.isascii() or not value.isdigit():
-        raise _InvalidContentError(f"{field} must be a non-negative integer")
-    normalized = value.lstrip("0") or "0"
-    if len(normalized) > len(_MAX_SIGNED_INT64_TEXT) or (
-        len(normalized) == len(_MAX_SIGNED_INT64_TEXT)
-        and normalized > _MAX_SIGNED_INT64_TEXT
-    ):
-        raise _InvalidContentError(f"{field} exceeds signed 64-bit range")
-    return int(normalized)
-
-
-def _validate_decimal(value: str, *, field: str, nonnegative: bool = False) -> None:
-    try:
-        parsed = Decimal(value)
-    except InvalidOperation as error:
-        raise _InvalidContentError(f"{field} is not a decimal") from error
-    if not parsed.is_finite() or (nonnegative and parsed < 0):
-        raise _InvalidContentError(f"{field} has an invalid numeric value")
-
-
 def _archive_object_range(plan: BinanceArchiveObjectPlan) -> TimeRange:
     boundary = plan.request.archive_object_boundary
     assert boundary is not None
@@ -452,10 +257,7 @@ def _archive_object_range(plan: BinanceArchiveObjectPlan) -> TimeRange:
         if boundary.granularity.value == "month"
         else object_start + timedelta(days=1)
     )
-    return TimeRange(
-        start=object_start,
-        end=object_end,
-    )
+    return TimeRange(start=object_start, end=object_end)
 
 
 def _required_record_range(plan: BinanceArchiveObjectPlan) -> TimeRange:
@@ -469,9 +271,8 @@ def _required_record_range(plan: BinanceArchiveObjectPlan) -> TimeRange:
 def _validate_complete_object_coverage(
     plan: BinanceArchiveObjectPlan, actual_range: TimeRange
 ) -> None:
-    object_range = _archive_object_range(plan)
-    if actual_range != object_range:
-        raise _CoverageGapError(
+    if actual_range != _archive_object_range(plan):
+        raise _coverage_gap(
             "archive rows do not cover the complete source object boundary"
         )
 
@@ -484,41 +285,47 @@ def _validate_required_coverage(
         actual_range.start > required_range.start
         or actual_range.end < required_range.end
     ):
-        raise _CoverageGapError(
+        raise _coverage_gap(
             "archive rows do not cover the caller range within this source object"
         )
 
 
+def _parse_nonnegative_int(value: str, *, field: str) -> int:
+    if not value.isascii() or not value.isdigit():
+        raise _invalid_content(f"{field} must be a non-negative integer")
+    normalized = value.lstrip("0") or "0"
+    if len(normalized) > len(_MAX_SIGNED_INT64_TEXT) or (
+        len(normalized) == len(_MAX_SIGNED_INT64_TEXT)
+        and normalized > _MAX_SIGNED_INT64_TEXT
+    ):
+        raise _invalid_content(f"{field} exceeds signed 64-bit range")
+    return int(normalized)
+
+
+def _validate_decimal(value: str, *, field: str, nonnegative: bool = False) -> None:
+    from decimal import Decimal, InvalidOperation
+
+    try:
+        parsed = Decimal(value)
+    except InvalidOperation as error:
+        raise _invalid_content(f"{field} is not a decimal") from error
+    if not parsed.is_finite() or (nonnegative and parsed < 0):
+        raise _invalid_content(f"{field} has an invalid numeric value")
+
+
 def _parse_archive(
     plan: BinanceArchiveObjectPlan, payload: bytes
-) -> tuple[pl.DataFrame, TimeRange]:
+) -> BinanceArchiveParseResult:
     try:
-        with zipfile.ZipFile(io.BytesIO(payload)) as archive:
-            members = [item for item in archive.infolist() if not item.is_dir()]
-            if len(members) != 1 or members[0].filename != plan.member_name:
-                raise _InvalidContentError(
-                    "ZIP must contain exactly the expected CSV member"
-                )
-            member = members[0]
-            if member.flag_bits & 0x1:
-                raise _InvalidContentError("encrypted ZIP members are not supported")
-            if member.file_size > _MAX_ARCHIVE_BYTES:
-                raise _InvalidContentError("CSV member exceeds the size limit")
-            csv_payload = archive.read(member)
-            if len(csv_payload) > _MAX_ARCHIVE_BYTES:
-                raise _InvalidContentError("CSV member exceeds the size limit")
-    except (zipfile.BadZipFile, RuntimeError, OSError, NotImplementedError) as error:
-        raise _InvalidContentError("archive is not a readable ZIP") from error
-    try:
-        text = csv_payload.decode("utf-8-sig")
+        text = payload.decode("utf-8-sig")
     except UnicodeDecodeError as error:
-        raise _InvalidContentError("CSV member is not UTF-8") from error
+        raise _invalid_content("CSV member is not UTF-8") from error
 
     parsed_rows = list(csv.reader(io.StringIO(text, newline=""), strict=True))
     if parsed_rows and tuple(parsed_rows[0]) == _COLUMNS:
         parsed_rows = parsed_rows[1:]
     if not parsed_rows:
-        raise _InvalidContentError("CSV contains no data rows")
+        raise _invalid_content("CSV contains no data rows")
 
     columns: dict[str, list[str | int]] = {name: [] for name in _COLUMNS}
     previous_open: int | None = None
@@ -527,7 +334,7 @@ def _parse_archive(
     object_end_ms = int(object_range.end.timestamp() * 1000)
     for row_number, row in enumerate(parsed_rows, start=1):
         if len(row) != len(_COLUMNS):
-            raise _InvalidContentError(f"CSV row {row_number} does not have 12 columns")
+            raise _invalid_content(f"CSV row {row_number} does not have 12 columns")
         open_time = _parse_nonnegative_int(row[0], field="open_time")
         close_time = _parse_nonnegative_int(row[6], field="close_time")
         count = _parse_nonnegative_int(row[8], field="count")
@@ -535,25 +342,23 @@ def _parse_archive(
             datetime.fromtimestamp(open_time / 1000, tz=UTC)
             datetime.fromtimestamp(close_time / 1000, tz=UTC)
         except (OverflowError, OSError, ValueError) as error:
-            raise _InvalidContentError("row timestamp is not interpretable") from error
+            raise _invalid_content("row timestamp is not interpretable") from error
         if (
             open_time % _ONE_MINUTE_MS != 0
             or close_time != open_time + _ONE_MINUTE_MS - 1
         ):
-            raise _InvalidContentError(
-                "row does not have valid 1m timestamp boundaries"
-            )
+            raise _invalid_content("row does not have valid 1m timestamp boundaries")
         if not object_start_ms <= open_time < object_end_ms:
-            raise _InvalidContentError(
+            raise _invalid_content(
                 "row open_time is outside the archive object boundary"
             )
         if previous_open is not None:
             if open_time <= previous_open:
-                raise _InvalidContentError(
+                raise _invalid_content(
                     "row open_time values must be strictly increasing"
                 )
             if open_time != previous_open + _ONE_MINUTE_MS:
-                raise _CoverageGapError("archive rows contain a missing 1m timestamp")
+                raise _coverage_gap("archive rows contain a missing 1m timestamp")
         previous_open = open_time
         for index in (1, 2, 3, 4, 5, 7, 9, 10, 11):
             _validate_decimal(
@@ -587,11 +392,37 @@ def _parse_archive(
     )
     _validate_complete_object_coverage(plan, actual_range)
     _validate_required_coverage(plan, actual_range)
-    return frame, actual_range
+    return BinanceArchiveParseResult(
+        rows=frame,
+        actual_record_range=actual_range,
+        validation_evidence=("csv_schema_and_rows_verified",),
+    )
+
+
+class _ContractKlineArchiveAdapter:
+    raw_schema_identifier = _SCHEMA_IDENTIFIER
+
+    def parse_member(
+        self, plan: BinanceArchiveObjectPlan, payload: bytes
+    ) -> BinanceArchiveParseResult:
+        return _parse_archive(plan, payload)
+
+    def validate_complete_object_coverage(
+        self, plan: BinanceArchiveObjectPlan, actual_range: TimeRange
+    ) -> None:
+        _validate_complete_object_coverage(plan, actual_range)
+
+    def validate_required_coverage(
+        self, plan: BinanceArchiveObjectPlan, actual_range: TimeRange
+    ) -> None:
+        _validate_required_coverage(plan, actual_range)
+
+
+_CONTRACT_KLINE_ADAPTER = _ContractKlineArchiveAdapter()
 
 
 class BinanceContractKlineBackfill:
-    """Execute the official archive path without credentials or import-time I/O."""
+    """Execute the official contract-Kline archive path."""
 
     def __init__(
         self,
@@ -601,14 +432,12 @@ class BinanceContractKlineBackfill:
         timeout: float = 30.0,
         clock: Callable[[], datetime] | None = None,
     ) -> None:
-        if not isinstance(store, RawStore):
-            raise TypeError("store must be a RawStore")
-        if not math.isfinite(timeout) or timeout <= 0:
-            raise ValueError("timeout must be finite and greater than zero")
-        self._store = store
-        self._http_get = http_get or _default_http_get
-        self._timeout = timeout
-        self._clock = clock or (lambda: datetime.now(UTC))
+        self._acquisition = BinancePublicArchiveAcquisition(
+            store,
+            http_get=http_get,
+            timeout=timeout,
+            clock=clock,
+        )
 
     def run(
         self, instrument: InstrumentId, request_range: TimeRange
@@ -619,294 +448,20 @@ class BinanceContractKlineBackfill:
             request_range=request_range, objects=results
         )
 
-    @staticmethod
-    def _to_raw_response(
-        response: ArchiveHttpResponse | _DownloadedResponse | None,
-    ) -> RawAcquisitionResponse | None:
-        if response is None:
-            return None
-        return RawAcquisitionResponse(
-            status=response.status,
-            headers=response.headers,
-            body=response.body,
-        )
-
-    def _failure_result(
-        self,
-        plan: BinanceContractKlinePlan,
-        status: BinanceContractKlineStatus,
-        detail: str,
-        *,
-        artifact_path: Path | None = None,
-        source_response: RawAcquisitionResponse | None = None,
-        checksum_response: RawAcquisitionResponse | None = None,
-    ) -> BinanceContractKlineObjectResult:
-        request = plan.request
-        manifest = RawAcquisitionManifest(
-            manifest_schema_version=1,
-            completed=False,
-            object_identity=RawObjectIdentity.from_request(request),
-            caller_request_range=request.request_range,
-            status=status.value,
-            detail=detail,
-            recorded_at=self._clock(),
-            source_url=plan.url if isinstance(plan, BinanceArchiveObjectPlan) else None,
-            checksum_url=(
-                plan.checksum_url
-                if isinstance(plan, BinanceArchiveObjectPlan)
-                else None
-            ),
-            source_http_status=(
-                source_response.status if source_response is not None else None
-            ),
-            source_http_headers=(
-                source_response.headers if source_response is not None else {}
-            ),
-            source_body_sha256=(
-                source_response.body_sha256 if source_response is not None else None
-            ),
-            checksum_http_status=(
-                checksum_response.status if checksum_response is not None else None
-            ),
-            checksum_http_headers=(
-                checksum_response.headers if checksum_response is not None else {}
-            ),
-            checksum_response_sha256=(
-                checksum_response.body_sha256 if checksum_response is not None else None
-            ),
-        )
-        self._store.write_acquisition_manifest(
-            manifest,
-            source_response=source_response,
-            checksum_response=checksum_response,
-        )
-        return BinanceContractKlineObjectResult(
-            plan, status, artifact_path=artifact_path, detail=detail
-        )
-
     def _process(
         self, plan: BinanceContractKlinePlan
     ) -> BinanceContractKlineObjectResult:
         if isinstance(plan, BinanceArchiveCoverageGapPlan):
-            return self._failure_result(
-                plan, BinanceContractKlineStatus.COVERAGE_GAP, plan.detail
-            )
-
-        identity = RawObjectIdentity.from_request(plan.request)
-        existing: RawArtifact | None = None
-        try:
-            revisions = self._store.list_verified_revisions(identity)
-            if len(revisions) == 1:
-                existing = revisions[0]
-            elif not revisions:
-                existing = self._store.read_request(plan.request)
-            else:
-                for revision in revisions:
-                    try:
-                        _validate_complete_object_coverage(
-                            plan, revision.manifest.actual_record_range
-                        )
-                    except _CoverageGapError as error:
-                        return self._failure_result(
-                            plan,
-                            BinanceContractKlineStatus.COVERAGE_GAP,
-                            str(error),
-                            artifact_path=revision.path,
-                        )
-        except RawArtifactIncompleteError as error:
-            return self._failure_result(
-                plan, BinanceContractKlineStatus.LOCAL_FAILURE, str(error)
-            )
-        except RawArtifactNotFoundError:
-            pass
-        except (
-            RawArtifactAmbiguousError,
-            RawArtifactValidationError,
-            OSError,
-        ) as error:
-            return self._failure_result(
-                plan, BinanceContractKlineStatus.LOCAL_FAILURE, str(error)
+            outcome = self._acquisition.record_failure(
+                plan.request,
+                BinanceContractKlineStatus.COVERAGE_GAP,
+                plan.detail,
             )
         else:
-            if existing is not None:
-                try:
-                    _validate_complete_object_coverage(
-                        plan, existing.manifest.actual_record_range
-                    )
-                    _validate_required_coverage(
-                        plan, existing.manifest.actual_record_range
-                    )
-                except _CoverageGapError as error:
-                    return self._failure_result(
-                        plan,
-                        BinanceContractKlineStatus.COVERAGE_GAP,
-                        str(error),
-                        artifact_path=existing.path,
-                    )
-
-        checksum_payload: _DownloadedResponse | None = None
-        archive_payload: _DownloadedResponse | None = None
-        checksum_response: RawAcquisitionResponse | None = None
-        archive_response: RawAcquisitionResponse | None = None
-        resource = "checksum"
-        try:
-            checksum_payload = _download(
-                self._http_get,
-                plan.checksum_url,
-                self._timeout,
-                resource="checksum",
-            )
-            declared = _declared_checksum(
-                checksum_payload.body, plan.url.rsplit("/", 1)[-1]
-            )
-            resource = "archive"
-            archive_payload = _download(
-                self._http_get,
-                plan.url,
-                self._timeout,
-                resource="archive",
-            )
-            actual = hashlib.sha256(archive_payload.body).hexdigest()
-            if actual != declared:
-                raise _InvalidContentError(
-                    "archive SHA-256 does not match upstream checksum"
-                )
-            frame, actual_range = _parse_archive(plan, archive_payload.body)
-            source = RawSourceObject(
-                request=plan.request,
-                rows=frame,
-                actual_record_range=actual_range,
-                raw_schema_identifier=_SCHEMA_IDENTIFIER,
-                producer_version=_PRODUCER_VERSION,
-                upstream_checksum=f"sha256:{declared}",
-                upstream_revision=plan.url,
-                provenance=RawSourceProvenance(
-                    object_key=plan.object_key,
-                    source_url=plan.url,
-                    acquired_at=self._clock(),
-                    source_http_status=archive_payload.status,
-                    source_http_headers=archive_payload.headers,
-                    checksum_url=plan.checksum_url,
-                    checksum_http_status=checksum_payload.status,
-                    checksum_http_headers=checksum_payload.headers,
-                    checksum_response_sha256=hashlib.sha256(
-                        checksum_payload.body
-                    ).hexdigest(),
-                    archive_sha256=actual,
-                    csv_member=plan.member_name,
-                    validation_evidence=(
-                        "checksum_response_verified",
-                        "archive_sha256_matches_checksum",
-                        "zip_member_structure_verified",
-                        "csv_schema_and_rows_verified",
-                        "source_object_coverage_verified",
-                    ),
-                ),
-                archive_payload=archive_payload.body,
-                checksum_response_body=checksum_payload.body,
-            )
-            candidate_revision = source.revision_identity
-            matching_existing: RawArtifact | None = None
-            if candidate_revision is not None:
-                try:
-                    matching_existing = self._store.read_revision(
-                        identity, candidate_revision
-                    )
-                except RawArtifactNotFoundError:
-                    pass
-            else:
-                matching_existing = existing
-            artifact = self._store.write(source)
-        except _DownloadNotFoundError as error:
-            status = (
-                BinanceContractKlineStatus.CHECKSUM_NOT_FOUND
-                if error.resource == "checksum"
-                else BinanceContractKlineStatus.NOT_FOUND
-            )
-            if error.resource == "checksum":
-                checksum_response = self._to_raw_response(error.response)
-            else:
-                archive_response = self._to_raw_response(error.response)
-            return self._failure_result(
-                plan,
-                status,
-                str(error),
-                source_response=self._to_raw_response(archive_payload)
-                or archive_response,
-                checksum_response=self._to_raw_response(checksum_payload)
-                or checksum_response,
-            )
-        except _RetryableDownloadError as error:
-            if error.resource == "checksum":
-                checksum_response = self._to_raw_response(error.response)
-            else:
-                archive_response = self._to_raw_response(error.response)
-            return self._failure_result(
-                plan,
-                BinanceContractKlineStatus.RETRYABLE_FAILURE,
-                str(error),
-                source_response=self._to_raw_response(archive_payload)
-                or archive_response,
-                checksum_response=self._to_raw_response(checksum_payload)
-                or checksum_response,
-            )
-        except _CoverageGapError as error:
-            return self._failure_result(
-                plan,
-                BinanceContractKlineStatus.COVERAGE_GAP,
-                str(error),
-                source_response=self._to_raw_response(archive_payload),
-                checksum_response=self._to_raw_response(checksum_payload),
-            )
-        except (csv.Error, _InvalidContentError) as error:
-            response = (
-                error.response if isinstance(error, _InvalidContentError) else None
-            )
-            if response is not None:
-                if resource == "checksum" and checksum_payload is None:
-                    checksum_payload = _DownloadedResponse(
-                        body=response.body,
-                        status=response.status,
-                        headers=response.headers,
-                    )
-                elif resource == "archive" and archive_payload is None:
-                    archive_payload = _DownloadedResponse(
-                        body=response.body,
-                        status=response.status,
-                        headers=response.headers,
-                    )
-            return self._failure_result(
-                plan,
-                BinanceContractKlineStatus.INVALID_CONTENT,
-                str(error),
-                source_response=self._to_raw_response(archive_payload),
-                checksum_response=self._to_raw_response(checksum_payload),
-            )
-        except RawArtifactConflictError as error:
-            return self._failure_result(
-                plan,
-                BinanceContractKlineStatus.CONFLICT,
-                str(error),
-                source_response=self._to_raw_response(archive_payload),
-                checksum_response=self._to_raw_response(checksum_payload),
-            )
-        except (
-            RawArtifactNotFoundError,
-            RawArtifactValidationError,
-            OSError,
-        ) as error:
-            return self._failure_result(
-                plan,
-                BinanceContractKlineStatus.LOCAL_FAILURE,
-                str(error),
-                source_response=self._to_raw_response(archive_payload),
-                checksum_response=self._to_raw_response(checksum_payload),
-            )
-        status = (
-            BinanceContractKlineStatus.EXISTING
-            if matching_existing is not None
-            else BinanceContractKlineStatus.PUBLISHED
-        )
+            outcome = self._acquisition.acquire(plan, _CONTRACT_KLINE_ADAPTER)
         return BinanceContractKlineObjectResult(
-            plan, status, artifact_path=artifact.path
+            plan,
+            outcome.status,
+            artifact_path=outcome.artifact_path,
+            detail=outcome.detail,
         )

--- a/src/tracequant/data/binance_contract_kline.py
+++ b/src/tracequant/data/binance_contract_kline.py
@@ -418,9 +418,6 @@ class _ContractKlineArchiveAdapter:
         _validate_required_coverage(plan, actual_range)
 
 
-_CONTRACT_KLINE_ADAPTER = _ContractKlineArchiveAdapter()
-
-
 class BinanceContractKlineBackfill:
     """Execute the official contract-Kline archive path."""
 
@@ -458,7 +455,7 @@ class BinanceContractKlineBackfill:
                 plan.detail,
             )
         else:
-            outcome = self._acquisition.acquire(plan, _CONTRACT_KLINE_ADAPTER)
+            outcome = self._acquisition.acquire(plan, _ContractKlineArchiveAdapter())
         return BinanceContractKlineObjectResult(
             plan,
             outcome.status,

--- a/src/tracequant/data/binance_public_archive.py
+++ b/src/tracequant/data/binance_public_archive.py
@@ -1,0 +1,651 @@
+"""Shared, bounded acquisition mechanics for Binance official archives.
+
+This module owns the mechanical part of an official Binance archive read:
+checksum acquisition, bounded download, ZIP member framing, failure evidence,
+and revision-aware Raw publication.  Dataset adapters supply the typed object
+plan and parse the already-framed member bytes.
+"""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import http.client
+import io
+import math
+import re
+import urllib.error
+import urllib.request
+import zipfile
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+from pathlib import Path
+from typing import Final, Protocol
+
+import polars as pl
+
+from tracequant.data.public_history import (
+    BinancePublicHistoryRequest,
+    BinancePublicHistorySourceKind,
+)
+from tracequant.data.raw_store import (
+    RawAcquisitionManifest,
+    RawAcquisitionResponse,
+    RawArtifact,
+    RawArtifactAmbiguousError,
+    RawArtifactConflictError,
+    RawArtifactIncompleteError,
+    RawArtifactNotFoundError,
+    RawArtifactValidationError,
+    RawObjectIdentity,
+    RawSourceObject,
+    RawSourceProvenance,
+    RawStore,
+)
+from tracequant.domain import TimeRange
+
+__all__ = [
+    "ArchiveHttpGet",
+    "ArchiveHttpResponse",
+    "BinanceArchiveAcquisitionOutcome",
+    "BinanceArchiveAcquisitionStatus",
+    "BinanceArchiveDatasetAdapter",
+    "BinanceArchiveObjectPlan",
+    "BinanceArchiveParseResult",
+    "BinancePublicArchiveAcquisition",
+]
+
+_MAX_ARCHIVE_BYTES: Final = 512 * 1024 * 1024
+_CHECKSUM_PATTERN: Final = re.compile(
+    r"\A([0-9A-Fa-f]{64})[ \t]+[*]?([^\r\n]+)[\r\n]*\Z"
+)
+_PRODUCER_VERSION: Final = "tracequant/0.1.0"
+
+
+@dataclass(frozen=True, slots=True)
+class ArchiveHttpResponse:
+    """Bounded response returned by an injectable archive HTTP transport."""
+
+    status: int
+    body: bytes
+    headers: Mapping[str, str]
+
+
+class ArchiveHttpGet(Protocol):
+    def __call__(self, url: str, timeout: float) -> ArchiveHttpResponse: ...
+
+
+@dataclass(frozen=True, slots=True)
+class BinanceArchiveObjectPlan:
+    """Typed identity and framing contract for one official archive object."""
+
+    request: BinancePublicHistoryRequest
+    object_key: str
+    url: str
+    checksum_url: str
+    member_name: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.request, BinancePublicHistoryRequest):
+            raise TypeError("request must be a BinancePublicHistoryRequest")
+        if self.request.source_kind not in {
+            BinancePublicHistorySourceKind.ARCHIVE_DAILY,
+            BinancePublicHistorySourceKind.ARCHIVE_MONTHLY,
+        }:
+            raise ValueError("archive plan request must use an archive source")
+        for field_name in ("object_key", "url", "checksum_url", "member_name"):
+            value = getattr(self, field_name)
+            if not isinstance(value, str) or not value:
+                raise ValueError(f"{field_name} must be a non-empty string")
+
+
+@dataclass(frozen=True, slots=True)
+class BinanceArchiveParseResult:
+    """Dataset-specific rows and coverage evidence after member framing."""
+
+    rows: pl.DataFrame
+    actual_record_range: TimeRange
+    validation_evidence: tuple[str, ...]
+
+
+class BinanceArchiveDatasetAdapter(Protocol):
+    """The small typed boundary a dataset parser exposes to shared acquisition."""
+
+    raw_schema_identifier: str
+
+    def parse_member(
+        self, plan: BinanceArchiveObjectPlan, payload: bytes
+    ) -> BinanceArchiveParseResult: ...
+
+    def validate_complete_object_coverage(
+        self, plan: BinanceArchiveObjectPlan, actual_range: TimeRange
+    ) -> None: ...
+
+    def validate_required_coverage(
+        self, plan: BinanceArchiveObjectPlan, actual_range: TimeRange
+    ) -> None: ...
+
+
+class BinanceArchiveAcquisitionStatus(StrEnum):
+    """Stable mechanical outcomes shared by Binance archive adapters."""
+
+    PUBLISHED = "published"
+    EXISTING = "existing"
+    COVERAGE_GAP = "coverage_gap"
+    NOT_FOUND = "not_found"
+    CHECKSUM_NOT_FOUND = "checksum_not_found"
+    RETRYABLE_FAILURE = "retryable_failure"
+    INVALID_CONTENT = "invalid_content"
+    LOCAL_FAILURE = "local_failure"
+    CONFLICT = "conflict"
+
+
+@dataclass(frozen=True, slots=True)
+class BinanceArchiveAcquisitionOutcome:
+    """One shared acquisition outcome before an adapter adds its result type."""
+
+    status: BinanceArchiveAcquisitionStatus
+    artifact_path: Path | None = None
+    detail: str | None = None
+
+
+class _InvalidContentError(ValueError):
+    def __init__(
+        self, message: str, *, response: ArchiveHttpResponse | None = None
+    ) -> None:
+        super().__init__(message)
+        self.response = response
+
+
+class _CoverageGapError(ValueError):
+    pass
+
+
+class _RetryableDownloadError(RuntimeError):
+    def __init__(
+        self,
+        message: str,
+        *,
+        resource: str,
+        response: ArchiveHttpResponse | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.resource = resource
+        self.response = response
+
+
+@dataclass(frozen=True, slots=True)
+class _DownloadedResponse:
+    body: bytes
+    status: int
+    headers: Mapping[str, str]
+
+
+class _DownloadNotFoundError(FileNotFoundError):
+    def __init__(
+        self,
+        url: str,
+        *,
+        resource: str,
+        response: ArchiveHttpResponse | None = None,
+    ) -> None:
+        super().__init__(url)
+        self.resource = resource
+        self.response = response
+
+
+def _default_http_get(url: str, timeout: float) -> ArchiveHttpResponse:
+    request = urllib.request.Request(url, headers={"User-Agent": _PRODUCER_VERSION})
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            body = response.read(_MAX_ARCHIVE_BYTES + 1)
+            if len(body) > _MAX_ARCHIVE_BYTES:
+                raise _InvalidContentError("archive response exceeds the size limit")
+            return ArchiveHttpResponse(
+                status=response.status,
+                body=body,
+                headers=dict(response.headers.items()),
+            )
+    except urllib.error.HTTPError as error:
+        return ArchiveHttpResponse(
+            status=error.code,
+            body=error.read(4096),
+            headers=dict(error.headers.items()) if error.headers is not None else {},
+        )
+    except (TimeoutError, urllib.error.URLError):
+        raise
+
+
+def _download(
+    http_get: ArchiveHttpGet,
+    url: str,
+    timeout: float,
+    *,
+    resource: str,
+) -> _DownloadedResponse:
+    try:
+        response = http_get(url, timeout)
+    except _InvalidContentError:
+        raise
+    except (
+        TimeoutError,
+        ConnectionError,
+        OSError,
+        http.client.HTTPException,
+    ) as error:
+        detail = str(error).strip() or (
+            f"{type(error).__name__} while downloading {resource}"
+        )
+        raise _RetryableDownloadError(detail, resource=resource) from error
+    if response.status == 404:
+        raise _DownloadNotFoundError(url, resource=resource, response=response)
+    if response.status == 429 or 500 <= response.status <= 599:
+        raise _RetryableDownloadError(
+            f"HTTP {response.status} for {url}",
+            resource=resource,
+            response=response,
+        )
+    if response.status < 200 or response.status >= 300:
+        raise _InvalidContentError(
+            f"unexpected HTTP {response.status} for {url}", response=response
+        )
+    if not response.body:
+        raise _InvalidContentError(f"empty response for {url}", response=response)
+    return _DownloadedResponse(
+        body=response.body,
+        status=response.status,
+        headers=dict(response.headers),
+    )
+
+
+def _declared_checksum(payload: bytes, expected_filename: str) -> str:
+    try:
+        text = payload.decode("ascii")
+    except UnicodeDecodeError as error:
+        raise _InvalidContentError("checksum response is not ASCII") from error
+    match = _CHECKSUM_PATTERN.fullmatch(text)
+    if match is None or match.group(2) != expected_filename:
+        raise _InvalidContentError(
+            "checksum response has an unexpected format or filename"
+        )
+    return match.group(1).lower()
+
+
+def _extract_expected_member(plan: BinanceArchiveObjectPlan, payload: bytes) -> bytes:
+    try:
+        with zipfile.ZipFile(io.BytesIO(payload)) as archive:
+            members = [item for item in archive.infolist() if not item.is_dir()]
+            if len(members) != 1 or members[0].filename != plan.member_name:
+                raise _InvalidContentError(
+                    "ZIP must contain exactly the expected CSV member"
+                )
+            member = members[0]
+            if member.flag_bits & 0x1:
+                raise _InvalidContentError("encrypted ZIP members are not supported")
+            if member.file_size > _MAX_ARCHIVE_BYTES:
+                raise _InvalidContentError("CSV member exceeds the size limit")
+            csv_payload = archive.read(member)
+            if len(csv_payload) > _MAX_ARCHIVE_BYTES:
+                raise _InvalidContentError("CSV member exceeds the size limit")
+            return csv_payload
+    except (zipfile.BadZipFile, RuntimeError, OSError, NotImplementedError) as error:
+        raise _InvalidContentError("archive is not a readable ZIP") from error
+
+
+class BinancePublicArchiveAcquisition:
+    """Acquire one typed official archive object and publish it through RawStore."""
+
+    def __init__(
+        self,
+        store: RawStore,
+        *,
+        http_get: ArchiveHttpGet | None = None,
+        timeout: float = 30.0,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        if not isinstance(store, RawStore):
+            raise TypeError("store must be a RawStore")
+        if not math.isfinite(timeout) or timeout <= 0:
+            raise ValueError("timeout must be finite and greater than zero")
+        self._store = store
+        self._http_get = http_get or _default_http_get
+        self._timeout = timeout
+        self._clock = clock or (lambda: datetime.now(UTC))
+
+    @staticmethod
+    def _to_raw_response(
+        response: ArchiveHttpResponse | _DownloadedResponse | None,
+    ) -> RawAcquisitionResponse | None:
+        if response is None:
+            return None
+        return RawAcquisitionResponse(
+            status=response.status,
+            headers=response.headers,
+            body=response.body,
+        )
+
+    def record_failure(
+        self,
+        request: BinancePublicHistoryRequest,
+        status: BinanceArchiveAcquisitionStatus,
+        detail: str,
+        *,
+        source_url: str | None = None,
+        checksum_url: str | None = None,
+        artifact_path: Path | None = None,
+        source_response: RawAcquisitionResponse | None = None,
+        checksum_response: RawAcquisitionResponse | None = None,
+    ) -> BinanceArchiveAcquisitionOutcome:
+        manifest = RawAcquisitionManifest(
+            manifest_schema_version=1,
+            completed=False,
+            object_identity=RawObjectIdentity.from_request(request),
+            caller_request_range=request.request_range,
+            status=status.value,
+            detail=detail,
+            recorded_at=self._clock(),
+            source_url=source_url,
+            checksum_url=checksum_url,
+            source_http_status=(
+                source_response.status if source_response is not None else None
+            ),
+            source_http_headers=(
+                source_response.headers if source_response is not None else {}
+            ),
+            source_body_sha256=(
+                source_response.body_sha256 if source_response is not None else None
+            ),
+            checksum_http_status=(
+                checksum_response.status if checksum_response is not None else None
+            ),
+            checksum_http_headers=(
+                checksum_response.headers if checksum_response is not None else {}
+            ),
+            checksum_response_sha256=(
+                checksum_response.body_sha256 if checksum_response is not None else None
+            ),
+        )
+        self._store.write_acquisition_manifest(
+            manifest,
+            source_response=source_response,
+            checksum_response=checksum_response,
+        )
+        return BinanceArchiveAcquisitionOutcome(
+            status=status,
+            artifact_path=artifact_path,
+            detail=detail,
+        )
+
+    def _existing_artifact(
+        self,
+        plan: BinanceArchiveObjectPlan,
+        adapter: BinanceArchiveDatasetAdapter,
+    ) -> tuple[RawArtifact | None, BinanceArchiveAcquisitionOutcome | None]:
+        identity = RawObjectIdentity.from_request(plan.request)
+        try:
+            revisions = self._store.list_verified_revisions(identity)
+            if len(revisions) == 1:
+                existing = revisions[0]
+            elif not revisions:
+                existing = self._store.read_request(plan.request)
+            else:
+                for revision in revisions:
+                    try:
+                        adapter.validate_complete_object_coverage(
+                            plan, revision.manifest.actual_record_range
+                        )
+                    except _CoverageGapError as error:
+                        return None, self.record_failure(
+                            plan.request,
+                            BinanceArchiveAcquisitionStatus.COVERAGE_GAP,
+                            str(error),
+                            source_url=plan.url,
+                            checksum_url=plan.checksum_url,
+                            artifact_path=revision.path,
+                        )
+                existing = None
+        except RawArtifactIncompleteError as error:
+            return None, self.record_failure(
+                plan.request,
+                BinanceArchiveAcquisitionStatus.LOCAL_FAILURE,
+                str(error),
+                source_url=plan.url,
+                checksum_url=plan.checksum_url,
+            )
+        except RawArtifactNotFoundError:
+            return None, None
+        except (
+            RawArtifactAmbiguousError,
+            RawArtifactValidationError,
+            OSError,
+        ) as error:
+            return None, self.record_failure(
+                plan.request,
+                BinanceArchiveAcquisitionStatus.LOCAL_FAILURE,
+                str(error),
+                source_url=plan.url,
+                checksum_url=plan.checksum_url,
+            )
+        else:
+            if existing is not None:
+                try:
+                    adapter.validate_complete_object_coverage(
+                        plan, existing.manifest.actual_record_range
+                    )
+                    adapter.validate_required_coverage(
+                        plan, existing.manifest.actual_record_range
+                    )
+                except _CoverageGapError as error:
+                    return None, self.record_failure(
+                        plan.request,
+                        BinanceArchiveAcquisitionStatus.COVERAGE_GAP,
+                        str(error),
+                        source_url=plan.url,
+                        checksum_url=plan.checksum_url,
+                        artifact_path=existing.path,
+                    )
+        return existing, None
+
+    def acquire(
+        self,
+        plan: BinanceArchiveObjectPlan,
+        adapter: BinanceArchiveDatasetAdapter,
+    ) -> BinanceArchiveAcquisitionOutcome:
+        """Download, verify, parse, and revision-aware publish one object."""
+        if not isinstance(plan, BinanceArchiveObjectPlan):
+            raise TypeError("plan must be a BinanceArchiveObjectPlan")
+        existing, early = self._existing_artifact(plan, adapter)
+        if early is not None:
+            return early
+
+        checksum_payload: _DownloadedResponse | None = None
+        archive_payload: _DownloadedResponse | None = None
+        checksum_response: RawAcquisitionResponse | None = None
+        archive_response: RawAcquisitionResponse | None = None
+        resource = "checksum"
+        try:
+            checksum_payload = _download(
+                self._http_get,
+                plan.checksum_url,
+                self._timeout,
+                resource="checksum",
+            )
+            declared = _declared_checksum(
+                checksum_payload.body, plan.url.rsplit("/", 1)[-1]
+            )
+            resource = "archive"
+            archive_payload = _download(
+                self._http_get,
+                plan.url,
+                self._timeout,
+                resource="archive",
+            )
+            actual = hashlib.sha256(archive_payload.body).hexdigest()
+            if actual != declared:
+                raise _InvalidContentError(
+                    "archive SHA-256 does not match upstream checksum"
+                )
+            member_payload = _extract_expected_member(plan, archive_payload.body)
+            parsed = adapter.parse_member(plan, member_payload)
+            source = RawSourceObject(
+                request=plan.request,
+                rows=parsed.rows,
+                actual_record_range=parsed.actual_record_range,
+                raw_schema_identifier=adapter.raw_schema_identifier,
+                producer_version=_PRODUCER_VERSION,
+                upstream_checksum=f"sha256:{declared}",
+                upstream_revision=plan.url,
+                provenance=RawSourceProvenance(
+                    object_key=plan.object_key,
+                    source_url=plan.url,
+                    acquired_at=self._clock(),
+                    source_http_status=archive_payload.status,
+                    source_http_headers=archive_payload.headers,
+                    checksum_url=plan.checksum_url,
+                    checksum_http_status=checksum_payload.status,
+                    checksum_http_headers=checksum_payload.headers,
+                    checksum_response_sha256=hashlib.sha256(
+                        checksum_payload.body
+                    ).hexdigest(),
+                    archive_sha256=actual,
+                    csv_member=plan.member_name,
+                    validation_evidence=(
+                        "checksum_response_verified",
+                        "archive_sha256_matches_checksum",
+                        "zip_member_structure_verified",
+                        *parsed.validation_evidence,
+                        "source_object_coverage_verified",
+                    ),
+                ),
+                archive_payload=archive_payload.body,
+                checksum_response_body=checksum_payload.body,
+            )
+            identity = RawObjectIdentity.from_request(plan.request)
+            candidate_revision = source.revision_identity
+            matching_existing: RawArtifact | None = None
+            if candidate_revision is not None:
+                try:
+                    matching_existing = self._store.read_revision(
+                        identity, candidate_revision
+                    )
+                except RawArtifactNotFoundError:
+                    pass
+            else:
+                matching_existing = existing
+            artifact = self._store.write(source)
+        except _DownloadNotFoundError as error:
+            if error.resource == "checksum":
+                checksum_response = self._to_raw_response(error.response)
+            else:
+                archive_response = self._to_raw_response(error.response)
+            return self.record_failure(
+                plan.request,
+                (
+                    BinanceArchiveAcquisitionStatus.CHECKSUM_NOT_FOUND
+                    if error.resource == "checksum"
+                    else BinanceArchiveAcquisitionStatus.NOT_FOUND
+                ),
+                str(error),
+                source_url=plan.url,
+                checksum_url=plan.checksum_url,
+                source_response=self._to_raw_response(archive_payload)
+                or archive_response,
+                checksum_response=self._to_raw_response(checksum_payload)
+                or checksum_response,
+            )
+        except _RetryableDownloadError as error:
+            if error.resource == "checksum":
+                checksum_response = self._to_raw_response(error.response)
+            else:
+                archive_response = self._to_raw_response(error.response)
+            return self.record_failure(
+                plan.request,
+                BinanceArchiveAcquisitionStatus.RETRYABLE_FAILURE,
+                str(error),
+                source_url=plan.url,
+                checksum_url=plan.checksum_url,
+                source_response=self._to_raw_response(archive_payload)
+                or archive_response,
+                checksum_response=self._to_raw_response(checksum_payload)
+                or checksum_response,
+            )
+        except _CoverageGapError as error:
+            return self.record_failure(
+                plan.request,
+                BinanceArchiveAcquisitionStatus.COVERAGE_GAP,
+                str(error),
+                source_url=plan.url,
+                checksum_url=plan.checksum_url,
+                source_response=self._to_raw_response(archive_payload),
+                checksum_response=self._to_raw_response(checksum_payload),
+            )
+        except (csv.Error, _InvalidContentError) as error:
+            response = (
+                error.response if isinstance(error, _InvalidContentError) else None
+            )
+            if response is not None:
+                if resource == "checksum" and checksum_payload is None:
+                    checksum_payload = _DownloadedResponse(
+                        body=response.body,
+                        status=response.status,
+                        headers=response.headers,
+                    )
+                elif resource == "archive" and archive_payload is None:
+                    archive_payload = _DownloadedResponse(
+                        body=response.body,
+                        status=response.status,
+                        headers=response.headers,
+                    )
+            return self.record_failure(
+                plan.request,
+                BinanceArchiveAcquisitionStatus.INVALID_CONTENT,
+                str(error),
+                source_url=plan.url,
+                checksum_url=plan.checksum_url,
+                source_response=self._to_raw_response(archive_payload),
+                checksum_response=self._to_raw_response(checksum_payload),
+            )
+        except RawArtifactConflictError as error:
+            return self.record_failure(
+                plan.request,
+                BinanceArchiveAcquisitionStatus.CONFLICT,
+                str(error),
+                source_url=plan.url,
+                checksum_url=plan.checksum_url,
+                source_response=self._to_raw_response(archive_payload),
+                checksum_response=self._to_raw_response(checksum_payload),
+            )
+        except (
+            RawArtifactNotFoundError,
+            RawArtifactValidationError,
+            OSError,
+        ) as error:
+            return self.record_failure(
+                plan.request,
+                BinanceArchiveAcquisitionStatus.LOCAL_FAILURE,
+                str(error),
+                source_url=plan.url,
+                checksum_url=plan.checksum_url,
+                source_response=self._to_raw_response(archive_payload),
+                checksum_response=self._to_raw_response(checksum_payload),
+            )
+        return BinanceArchiveAcquisitionOutcome(
+            status=(
+                BinanceArchiveAcquisitionStatus.EXISTING
+                if matching_existing is not None
+                else BinanceArchiveAcquisitionStatus.PUBLISHED
+            ),
+            artifact_path=artifact.path,
+        )
+
+
+def _coverage_gap(message: str) -> _CoverageGapError:
+    """Create the shared coverage exception for dataset adapters."""
+    return _CoverageGapError(message)
+
+
+def _invalid_content(message: str) -> _InvalidContentError:
+    """Create the shared invalid-content exception for dataset adapters."""
+    return _InvalidContentError(message)

--- a/tests/data/test_binance_public_archive.py
+++ b/tests/data/test_binance_public_archive.py
@@ -10,6 +10,7 @@ import pytest
 from tracequant.data import (
     ArchiveHttpResponse,
     BinanceArchiveAcquisitionOutcome,
+    BinanceArchiveAcquisitionStatus,
     BinanceArchiveDatasetAdapter,
     BinanceArchiveObjectPlan,
     BinanceContractKlineBackfill,
@@ -96,3 +97,50 @@ def test_contract_kline_uses_shared_archive_acquisition_pipeline(
     assert artifact.frame.height == 24 * 60
     assert artifact.manifest.provenance is not None
     assert artifact.manifest.provenance.csv_member == plan.member_name
+
+
+def test_contract_kline_creates_an_isolated_adapter_per_archive_object(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    request_range = TimeRange(
+        start=datetime(2024, 2, 29, tzinfo=UTC),
+        end=datetime(2024, 3, 2, tzinfo=UTC),
+    )
+    assert (
+        len(
+            plan_binance_contract_kline_archives(InstrumentId("BTCUSDT"), request_range)
+        )
+        == 2
+    )
+    adapters: list[BinanceArchiveDatasetAdapter] = []
+    adapter_ids: list[int] = []
+    schema_identifiers: list[str] = []
+
+    def acquire(
+        self: BinancePublicArchiveAcquisition,
+        shared_plan: BinanceArchiveObjectPlan,
+        adapter: BinanceArchiveDatasetAdapter,
+    ) -> BinanceArchiveAcquisitionOutcome:
+        del self, shared_plan
+        adapters.append(adapter)
+        adapter_ids.append(id(adapter))
+        schema_identifiers.append(adapter.raw_schema_identifier)
+        if len(adapter_ids) == 1:
+            adapter.raw_schema_identifier = "mutated-by-fixture"
+        return BinanceArchiveAcquisitionOutcome(
+            status=BinanceArchiveAcquisitionStatus.PUBLISHED
+        )
+
+    monkeypatch.setattr(BinancePublicArchiveAcquisition, "acquire", acquire)
+
+    result = BinanceContractKlineBackfill(RawStore(tmp_path)).run(
+        InstrumentId("BTCUSDT"), request_range
+    )
+
+    assert result.completed
+    assert len(adapter_ids) == 2
+    assert adapters[0] is not adapters[1]
+    assert schema_identifiers == [
+        "binance.um.contract-kline.csv.v1",
+        "binance.um.contract-kline.csv.v1",
+    ]

--- a/tests/data/test_binance_public_archive.py
+++ b/tests/data/test_binance_public_archive.py
@@ -1,0 +1,98 @@
+import hashlib
+import io
+import zipfile
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from tracequant.data import (
+    ArchiveHttpResponse,
+    BinanceArchiveAcquisitionOutcome,
+    BinanceArchiveDatasetAdapter,
+    BinanceArchiveObjectPlan,
+    BinanceContractKlineBackfill,
+    BinancePublicArchiveAcquisition,
+    RawStore,
+    plan_binance_contract_kline_archives,
+)
+from tracequant.domain import InstrumentId, TimeRange
+
+
+def _archive(member_name: str, start_open_time: int) -> bytes:
+    header = (
+        "open_time,open,high,low,close,volume,close_time,quote_volume,count,"
+        "taker_buy_volume,taker_buy_quote_volume,ignore\n"
+    )
+    rows = "".join(
+        f"{start_open_time + offset * 60_000},61000.0,61020.0,60990.0,"
+        f"61010.0,12.5,{start_open_time + offset * 60_000 + 59_999},"
+        "762500.0,42,6.0,366000.0,0\n"
+        for offset in range(24 * 60)
+    )
+    output = io.BytesIO()
+    with zipfile.ZipFile(output, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr(member_name, (header + rows).encode())
+    return output.getvalue()
+
+
+def test_contract_kline_uses_shared_archive_acquisition_pipeline(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    request_range = TimeRange(
+        start=datetime(2024, 2, 29, tzinfo=UTC),
+        end=datetime(2024, 2, 29, 0, 1, tzinfo=UTC),
+    )
+    plan = cast(
+        BinanceArchiveObjectPlan,
+        plan_binance_contract_kline_archives(InstrumentId("BTCUSDT"), request_range)[0],
+    )
+    archive = _archive(plan.member_name, 1_709_164_800_000)
+    checksum_name = plan.url.rsplit("/", 1)[-1]
+    responses = {
+        plan.url: ArchiveHttpResponse(
+            200, archive, {"Content-Type": "application/zip"}
+        ),
+        plan.checksum_url: ArchiveHttpResponse(
+            200,
+            f"{hashlib.sha256(archive).hexdigest()}  {checksum_name}\n".encode(),
+            {"Content-Type": "text/plain"},
+        ),
+    }
+    calls = 0
+    original_acquire = BinancePublicArchiveAcquisition.acquire
+
+    def acquire(
+        self: BinancePublicArchiveAcquisition,
+        shared_plan: BinanceArchiveObjectPlan,
+        adapter: BinanceArchiveDatasetAdapter,
+    ) -> BinanceArchiveAcquisitionOutcome:
+        nonlocal calls
+        calls += 1
+        return original_acquire(self, shared_plan, adapter)
+
+    monkeypatch.setattr(BinancePublicArchiveAcquisition, "acquire", acquire)
+
+    class FixtureTransport:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        def __call__(self, url: str, timeout: float) -> ArchiveHttpResponse:
+            del timeout
+            self.calls.append(url)
+            return responses.get(url, ArchiveHttpResponse(404, b"missing", {}))
+
+    transport = FixtureTransport()
+    store = RawStore(tmp_path)
+    result = BinanceContractKlineBackfill(store, http_get=transport).run(
+        InstrumentId("BTCUSDT"), request_range
+    )
+
+    assert calls == 1
+    assert result.completed
+    assert transport.calls == [plan.checksum_url, plan.url]
+    artifact = store.read_request(plan.request)
+    assert artifact.frame.height == 24 * 60
+    assert artifact.manifest.provenance is not None
+    assert artifact.manifest.provenance.csv_member == plan.member_name


### PR DESCRIPTION
Closes #270

## Summary
Extract shared typed Binance archive acquisition mechanics and migrate contract-Kline backfill onto the seam while preserving checksum, coverage, failure evidence, and revision-aware Raw behavior.

## Validation
- Critical Outcome: pass
- Formal Delivery validation: pass

## Risks / limitations
No mark/index/funding adapter is added; shared adapter contract is currently exercised by contract-Kline only.
