### PR TITLE
[Task] 实现 Binance USDⓈ-M 1m Mark Price Kline 官方历史文件回填

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,19 +152,19 @@ The currently implemented public package is `tracequant` under `src/`:
 - `tracequant.domain`: the initial immutable `InstrumentId`, `TimeRange`, and
   `OHLCVBar` models with validation and JSON-compatible serialization.
 - `tracequant.data`: typed Binance USDⓈ-M public-history contracts, an
-  immutable local Raw Parquet/manifest store, and an explicit archive-backfill
-  adapter for BTCUSDT and ETHUSDT 1m contract Klines. Backfill calls perform
-  bounded public HTTP downloads, checksum and ZIP/CSV validation, and Raw
-  persistence; importing the module performs no I/O.
+  immutable local Raw Parquet/manifest store, and explicit archive-backfill
+  adapters for BTCUSDT and ETHUSDT 1m contract and mark-price Klines. Backfill
+  calls perform bounded public HTTP downloads, checksum and ZIP/CSV validation,
+  and Raw persistence; importing the module performs no I/O.
 
 The `apps/`, `packages/`, and `deploy/` directories currently establish future
 boundaries through small README files. They are not implemented product
-packages. The implemented ingestion path is limited to Binance's public
-USDⓈ-M 1m contract-Kline archives; there is no private or trading exchange
-client, REST recent synchronization, general data pipeline, canonical quality
-or repair layer, database, feature or label pipeline, backtester, strategy,
-machine-learning model, order or account service, risk engine, live runtime,
-or multi-exchange implementation.
+packages. The implemented ingestion path is limited to Binance's public USDⓈ-M
+1m contract-Kline and mark-price-Kline archives; there is no private or trading
+exchange client, REST recent synchronization, general data pipeline, canonical
+quality or repair layer, database, feature or label pipeline, backtester,
+strategy, machine-learning model, order or account service, risk engine, live
+runtime, or multi-exchange implementation.
 
 “Research MVP” therefore means a reliable foundation for later research work,
 not a claim that research, backtesting, Demo, or Live trading is available.
@@ -246,6 +246,7 @@ src/tracequant/                 implemented bootstrap package
   data/public_history.py        Binance public-history contracts
   data/raw_store.py             immutable Raw Parquet/manifest persistence
   data/binance_contract_kline.py  explicit Binance archive backfill adapter
+  data/binance_mark_price_kline.py  explicit mark-price archive adapter
 tests/                          package and workflow tests
   fixtures/domain.py            deterministic domain factories, test-only
 apps/                           future research/runtime/console boundaries

--- a/docs/architecture/technical-baseline.md
+++ b/docs/architecture/technical-baseline.md
@@ -44,9 +44,10 @@ The public foundation consists of:
    plus a provenance/checksum manifest, and durably records non-completed
    acquisition outcomes in separate manifests with optional quarantined
    response bodies;
-7. an explicit Binance USDⓈ-M public-archive backfill adapter for BTCUSDT and
-   ETHUSDT 1m contract Klines, including bounded HTTP, upstream checksum
-   verification, ZIP/CSV validation, and complete 12-field Raw parsing;
+7. explicit Binance USDⓈ-M public-archive backfill adapters for BTCUSDT and
+   ETHUSDT 1m contract and mark-price Klines, including bounded HTTP, upstream
+   checksum verification, ZIP/CSV validation, complete 12-field Raw parsing,
+   and mark-price-specific placeholder field names;
 8. deterministic test-only factories for the domain models.
 
 Polars is the sole runtime third-party dependency in `pyproject.toml` and is
@@ -170,12 +171,15 @@ public exchange data
 ```
 
 Only the first, narrow part of this flow currently exists: callers can retrieve
-approved Binance USDⓈ-M BTCUSDT/ETHUSDT 1m contract-Kline archives and publish
-immutable Raw Parquet objects with manifests. There is no general Binance or
-private API client, REST recent/gap synchronization, canonical schema,
-missing/duplicate/out-of-order policy, feature pipeline, label pipeline, or
-future-data-leakage check. The preserved Binance 12-field wire schema is Raw
-source data and must not be treated as a canonical schema.
+approved Binance USDⓈ-M BTCUSDT/ETHUSDT 1m contract-Kline or mark-price-Kline
+archives and publish immutable Raw Parquet objects with manifests. There is no
+general Binance or private API client, REST recent/gap synchronization,
+canonical schema, data repair, feature pipeline, label pipeline, or
+future-data-leakage check. Each adapter validates missing, duplicate, and
+out-of-order minutes before publication. The preserved 12-field wire values are
+Raw source data and must not be treated as a canonical schema; mark-price
+volume, quote, count, taker, and ignore fields have explicit `placeholder_*`
+names and no contract-trade meaning.
 
 Archive planning is bounded by the per-instrument daily and monthly coverage
 frozen in the approved Research contract. Dates outside those observed bounds
@@ -215,11 +219,12 @@ boundaries until such an Issue is implemented and reviewed.
 ## 8. Research and trading scope limits
 
 The current public-data capability is limited to explicitly requested Binance
-USDⓈ-M BTCUSDT/ETHUSDT 1m contract-Kline archives and local immutable Raw
-artifacts. None of the following is currently available: private Binance API
-access, REST recent/gap synchronization, multi-timeframe aggregation, factors,
-models, backtests, Demo orders, Live orders, private API credentials, database
-state, or multi-exchange production execution.
+USDⓈ-M BTCUSDT/ETHUSDT 1m contract-Kline and mark-price-Kline archives and local
+immutable Raw artifacts. None of the following is currently available: private
+Binance API access, REST recent/gap synchronization, index-price or funding
+ingestion, multi-timeframe aggregation, factors, models, backtests, Demo orders,
+Live orders, private API credentials, database state, or multi-exchange
+production execution.
 
 Historical research, planning documents, and workflow documentation must retain
 their stated roles. Workflow controls such as LCK and the Validation Runner

--- a/src/tracequant/data/__init__.py
+++ b/src/tracequant/data/__init__.py
@@ -10,6 +10,14 @@ from tracequant.data.binance_contract_kline import (
     BinanceContractKlineStatus,
     plan_binance_contract_kline_archives,
 )
+from tracequant.data.binance_mark_price_kline import (
+    BinanceMarkPriceKlineBackfill,
+    BinanceMarkPriceKlineCoverageGapPlan,
+    BinanceMarkPriceKlineObjectResult,
+    BinanceMarkPriceKlineRunResult,
+    BinanceMarkPriceKlineStatus,
+    plan_binance_mark_price_kline_archives,
+)
 from tracequant.data.binance_public_archive import (
     BinanceArchiveAcquisitionOutcome,
     BinanceArchiveAcquisitionStatus,
@@ -64,6 +72,11 @@ __all__ = [
     "BinanceContractKlineRunResult",
     "BinanceContractKlineStatus",
     "BinanceKlineInterval",
+    "BinanceMarkPriceKlineBackfill",
+    "BinanceMarkPriceKlineCoverageGapPlan",
+    "BinanceMarkPriceKlineObjectResult",
+    "BinanceMarkPriceKlineRunResult",
+    "BinanceMarkPriceKlineStatus",
     "BinanceMarket",
     "BinancePriceIndexId",
     "BinancePublicHistoryDataType",
@@ -90,4 +103,5 @@ __all__ = [
     "RawStore",
     "RawStoreError",
     "plan_binance_contract_kline_archives",
+    "plan_binance_mark_price_kline_archives",
 ]

--- a/src/tracequant/data/binance_mark_price_kline.py
+++ b/src/tracequant/data/binance_mark_price_kline.py
@@ -1,0 +1,490 @@
+"""Binance USDⓈ-M 1m mark-price-Kline archive backfill adapter.
+
+The adapter owns mark-price planning, parsing, and coverage semantics.  It
+delegates official archive acquisition, evidence, and immutable Raw publication
+to the shared Binance public-archive seam.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, date, datetime, time, timedelta
+from pathlib import Path
+from typing import Final
+
+import polars as pl
+
+from tracequant.data.binance_public_archive import (
+    ArchiveHttpGet,
+    ArchiveHttpResponse,
+    BinanceArchiveAcquisitionStatus,
+    BinanceArchiveObjectPlan,
+    BinanceArchiveParseResult,
+    BinancePublicArchiveAcquisition,
+    _coverage_gap,
+    _invalid_content,
+)
+from tracequant.data.public_history import (
+    BinanceArchiveObjectBoundary,
+    BinanceKlineInterval,
+    BinancePublicHistoryDataType,
+    BinancePublicHistoryRequest,
+    BinancePublicHistorySourceKind,
+)
+from tracequant.data.raw_store import RawStore
+from tracequant.domain import InstrumentId, TimeRange
+
+__all__ = [
+    "ArchiveHttpResponse",
+    "BinanceArchiveObjectPlan",
+    "BinanceMarkPriceKlineBackfill",
+    "BinanceMarkPriceKlineCoverageGapPlan",
+    "BinanceMarkPriceKlineObjectResult",
+    "BinanceMarkPriceKlineRunResult",
+    "BinanceMarkPriceKlineStatus",
+    "plan_binance_mark_price_kline_archives",
+]
+
+_ARCHIVE_ROOT: Final = "https://data.binance.vision"
+_SCHEMA_IDENTIFIER: Final = "binance.um.mark-price-kline.csv.v1"
+_ONE_MINUTE_MS: Final = 60_000
+_MAX_SIGNED_INT64_TEXT: Final = str(2**63 - 1)
+
+# These are the physical names in Binance's CSV header.  They do not describe
+# the semantics of mark-price placeholder fields and are never published as the
+# Raw frame's column names.
+_UPSTREAM_COLUMNS: Final = (
+    "open_time",
+    "open",
+    "high",
+    "low",
+    "close",
+    "volume",
+    "close_time",
+    "quote_volume",
+    "count",
+    "taker_buy_volume",
+    "taker_buy_quote_volume",
+    "ignore",
+)
+
+# Mark-price archives use the contract-Kline physical row shape, but fields 5,
+# 7, 8, and 9..11 are non-semantic placeholders.  Explicit Raw names prevent
+# them from being mistaken for trade volume or trade count downstream.
+_RAW_COLUMNS: Final = (
+    "open_time",
+    "mark_open",
+    "mark_high",
+    "mark_low",
+    "mark_close",
+    "placeholder_volume",
+    "close_time",
+    "placeholder_quote_volume",
+    "placeholder_count",
+    "placeholder_taker_buy_volume",
+    "placeholder_taker_buy_quote_volume",
+    "placeholder_ignore",
+)
+_DTYPES: Final = {
+    "open_time": pl.Int64,
+    "mark_open": pl.String,
+    "mark_high": pl.String,
+    "mark_low": pl.String,
+    "mark_close": pl.String,
+    "placeholder_volume": pl.String,
+    "close_time": pl.Int64,
+    "placeholder_quote_volume": pl.String,
+    "placeholder_count": pl.String,
+    "placeholder_taker_buy_volume": pl.String,
+    "placeholder_taker_buy_quote_volume": pl.String,
+    "placeholder_ignore": pl.String,
+}
+
+# Frozen per-instrument archive coverage from the approved source contract.
+# The first daily object is intentionally included even though it is partial;
+# object-coverage validation classifies that object as a gap instead of
+# publishing an incomplete artifact.
+_RESEARCH_ARCHIVE_COVERAGE: Final = {
+    "BTCUSDT": {
+        "monthly": (date(2020, 1, 1), date(2026, 7, 1)),
+        "daily": (date(2019, 12, 23), date(2026, 8, 29)),
+    },
+    "ETHUSDT": {
+        "monthly": (date(2020, 1, 1), date(2026, 7, 1)),
+        "daily": (date(2019, 12, 23), date(2026, 8, 29)),
+    },
+}
+
+
+BinanceMarkPriceKlineStatus = BinanceArchiveAcquisitionStatus
+
+
+@dataclass(frozen=True, slots=True)
+class BinanceMarkPriceKlineCoverageGapPlan:
+    """One UTC day for which Research did not prove a usable archive object."""
+
+    instrument: InstrumentId
+    request_range: TimeRange
+    boundary: BinanceArchiveObjectBoundary
+    detail: str
+
+    @property
+    def request(self) -> BinancePublicHistoryRequest:
+        """Return the mark-price source request identity represented by this gap."""
+        return BinancePublicHistoryRequest(
+            instrument=self.instrument,
+            data_type=BinancePublicHistoryDataType.MARK_PRICE_KLINE,
+            request_range=self.request_range,
+            source_kind=BinancePublicHistorySourceKind.ARCHIVE_DAILY,
+            interval=BinanceKlineInterval.ONE_MINUTE,
+            archive_object_boundary=self.boundary,
+        )
+
+
+type BinanceMarkPriceKlinePlan = (
+    BinanceArchiveObjectPlan | BinanceMarkPriceKlineCoverageGapPlan
+)
+
+
+@dataclass(frozen=True, slots=True)
+class BinanceMarkPriceKlineObjectResult:
+    plan: BinanceMarkPriceKlinePlan
+    status: BinanceMarkPriceKlineStatus
+    artifact_path: Path | None = None
+    detail: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class BinanceMarkPriceKlineRunResult:
+    """All object outcomes for one request; success is deliberately all-or-none."""
+
+    request_range: TimeRange
+    objects: tuple[BinanceMarkPriceKlineObjectResult, ...]
+
+    @property
+    def completed(self) -> bool:
+        successful = {
+            BinanceMarkPriceKlineStatus.PUBLISHED,
+            BinanceMarkPriceKlineStatus.EXISTING,
+        }
+        return bool(self.objects) and all(
+            item.status in successful for item in self.objects
+        )
+
+
+def _next_month(value: date) -> date:
+    if value.month == 12:
+        return date(value.year + 1, 1, 1)
+    return date(value.year, value.month + 1, 1)
+
+
+def _utc_midnight(value: date) -> datetime:
+    return datetime.combine(value, time.min, tzinfo=UTC)
+
+
+def _build_plan(
+    instrument: InstrumentId,
+    request_range: TimeRange,
+    boundary: BinanceArchiveObjectBoundary,
+) -> BinanceArchiveObjectPlan:
+    monthly = boundary.granularity.value == "month"
+    cadence = "monthly" if monthly else "daily"
+    suffix = (
+        boundary.period_start.strftime("%Y-%m")
+        if monthly
+        else boundary.period_start.isoformat()
+    )
+    filename = f"{instrument}-1m-{suffix}.zip"
+    object_key = f"data/futures/um/{cadence}/markPriceKlines/{instrument}/1m/{filename}"
+    request = BinancePublicHistoryRequest(
+        instrument=instrument,
+        data_type=BinancePublicHistoryDataType.MARK_PRICE_KLINE,
+        request_range=request_range,
+        source_kind=(
+            BinancePublicHistorySourceKind.ARCHIVE_MONTHLY
+            if monthly
+            else BinancePublicHistorySourceKind.ARCHIVE_DAILY
+        ),
+        interval=BinanceKlineInterval.ONE_MINUTE,
+        archive_object_boundary=boundary,
+    )
+    return BinanceArchiveObjectPlan(
+        request=request,
+        object_key=object_key,
+        url=f"{_ARCHIVE_ROOT}/{object_key}",
+        checksum_url=f"{_ARCHIVE_ROOT}/{object_key}.CHECKSUM",
+        member_name=f"{instrument}-1m-{suffix}.csv",
+    )
+
+
+def plan_binance_mark_price_kline_archives(
+    instrument: InstrumentId,
+    request_range: TimeRange,
+) -> tuple[BinanceMarkPriceKlinePlan, ...]:
+    """Map a UTC ``[start, end)`` range to proven objects or explicit gaps."""
+    if not isinstance(instrument, InstrumentId):
+        raise TypeError("instrument must be an InstrumentId")
+    if not isinstance(request_range, TimeRange):
+        raise TypeError("request_range must be a TimeRange")
+
+    coverage = _RESEARCH_ARCHIVE_COVERAGE.get(str(instrument))
+    if coverage is None:
+        raise ValueError(
+            f"instrument {instrument!s} has no frozen mark-price-Kline archive coverage"
+        )
+
+    monthly_first, monthly_last = coverage["monthly"]
+    daily_first, daily_last = coverage["daily"]
+    cursor = request_range.start.date()
+    final_day = (request_range.end - timedelta(microseconds=1)).date()
+    plans: list[BinanceMarkPriceKlinePlan] = []
+    while cursor <= final_day:
+        following_month = _next_month(cursor)
+        can_use_month = (
+            cursor.day == 1
+            and monthly_first <= cursor <= monthly_last
+            and request_range.start <= _utc_midnight(cursor)
+            and request_range.end >= _utc_midnight(following_month)
+        )
+        if can_use_month:
+            boundary = BinanceArchiveObjectBoundary.month(cursor.year, cursor.month)
+            cursor = following_month
+        else:
+            boundary = BinanceArchiveObjectBoundary.day(cursor)
+            cursor += timedelta(days=1)
+        if (
+            boundary.granularity.value == "month"
+            or daily_first <= boundary.period_start <= daily_last
+        ):
+            plans.append(_build_plan(instrument, request_range, boundary))
+        else:
+            plans.append(
+                BinanceMarkPriceKlineCoverageGapPlan(
+                    instrument=instrument,
+                    request_range=request_range,
+                    boundary=boundary,
+                    detail=(
+                        "Research did not prove a mark-price-Kline archive object "
+                        f"for {instrument!s} on {boundary.period_start.isoformat()}"
+                    ),
+                )
+            )
+    return tuple(plans)
+
+
+def _archive_object_range(plan: BinanceArchiveObjectPlan) -> TimeRange:
+    boundary = plan.request.archive_object_boundary
+    assert boundary is not None
+    object_start = _utc_midnight(boundary.period_start)
+    object_end = (
+        _utc_midnight(_next_month(boundary.period_start))
+        if boundary.granularity.value == "month"
+        else object_start + timedelta(days=1)
+    )
+    return TimeRange(start=object_start, end=object_end)
+
+
+def _required_record_range(plan: BinanceArchiveObjectPlan) -> TimeRange:
+    object_range = _archive_object_range(plan)
+    return TimeRange(
+        start=max(plan.request.request_range.start, object_range.start),
+        end=min(plan.request.request_range.end, object_range.end),
+    )
+
+
+def _validate_complete_object_coverage(
+    plan: BinanceArchiveObjectPlan, actual_range: TimeRange
+) -> None:
+    if actual_range != _archive_object_range(plan):
+        raise _coverage_gap(
+            "archive rows do not cover the complete source object boundary"
+        )
+
+
+def _validate_required_coverage(
+    plan: BinanceArchiveObjectPlan, actual_range: TimeRange
+) -> None:
+    required_range = _required_record_range(plan)
+    if (
+        actual_range.start > required_range.start
+        or actual_range.end < required_range.end
+    ):
+        raise _coverage_gap(
+            "archive rows do not cover the caller range within this source object"
+        )
+
+
+def _parse_nonnegative_int(value: str, *, field: str) -> int:
+    if not value.isascii() or not value.isdigit():
+        raise _invalid_content(f"{field} must be a non-negative integer")
+    normalized = value.lstrip("0") or "0"
+    if len(normalized) > len(_MAX_SIGNED_INT64_TEXT) or (
+        len(normalized) == len(_MAX_SIGNED_INT64_TEXT)
+        and normalized > _MAX_SIGNED_INT64_TEXT
+    ):
+        raise _invalid_content(f"{field} exceeds signed 64-bit range")
+    return int(normalized)
+
+
+def _validate_decimal(value: str, *, field: str) -> None:
+    from decimal import Decimal, InvalidOperation
+
+    try:
+        parsed = Decimal(value)
+    except InvalidOperation as error:
+        raise _invalid_content(f"{field} is not a decimal") from error
+    if not parsed.is_finite() or parsed < 0:
+        raise _invalid_content(f"{field} has an invalid numeric value")
+
+
+def _parse_archive(
+    plan: BinanceArchiveObjectPlan, payload: bytes
+) -> BinanceArchiveParseResult:
+    try:
+        text = payload.decode("utf-8-sig")
+    except UnicodeDecodeError as error:
+        raise _invalid_content("CSV member is not UTF-8") from error
+
+    parsed_rows = list(csv.reader(io.StringIO(text, newline=""), strict=True))
+    if parsed_rows and tuple(parsed_rows[0]) == _UPSTREAM_COLUMNS:
+        parsed_rows = parsed_rows[1:]
+    if not parsed_rows:
+        raise _invalid_content("CSV contains no data rows")
+
+    columns: dict[str, list[str | int]] = {name: [] for name in _RAW_COLUMNS}
+    previous_open: int | None = None
+    object_range = _archive_object_range(plan)
+    object_start_ms = int(object_range.start.timestamp() * 1000)
+    object_end_ms = int(object_range.end.timestamp() * 1000)
+    for row_number, row in enumerate(parsed_rows, start=1):
+        if len(row) != len(_UPSTREAM_COLUMNS):
+            raise _invalid_content(f"CSV row {row_number} does not have 12 columns")
+        open_time = _parse_nonnegative_int(row[0], field="open_time")
+        close_time = _parse_nonnegative_int(row[6], field="close_time")
+        _parse_nonnegative_int(row[8], field="placeholder_count")
+        try:
+            datetime.fromtimestamp(open_time / 1000, tz=UTC)
+            datetime.fromtimestamp(close_time / 1000, tz=UTC)
+        except (OverflowError, OSError, ValueError) as error:
+            raise _invalid_content("row timestamp is not interpretable") from error
+        if (
+            open_time % _ONE_MINUTE_MS != 0
+            or close_time != open_time + _ONE_MINUTE_MS - 1
+        ):
+            raise _invalid_content("row does not have valid 1m timestamp boundaries")
+        if not object_start_ms <= open_time < object_end_ms:
+            raise _invalid_content(
+                "row open_time is outside the archive object boundary"
+            )
+        if previous_open is not None:
+            if open_time <= previous_open:
+                raise _invalid_content(
+                    "row open_time values must be strictly increasing"
+                )
+            if open_time != previous_open + _ONE_MINUTE_MS:
+                raise _coverage_gap("archive rows contain a missing 1m timestamp")
+        previous_open = open_time
+        for index in (1, 2, 3, 4, 5, 7, 9, 10, 11):
+            _validate_decimal(row[index], field=_RAW_COLUMNS[index])
+        typed: tuple[str | int, ...] = (
+            open_time,
+            row[1],
+            row[2],
+            row[3],
+            row[4],
+            row[5],
+            close_time,
+            row[7],
+            row[8],
+            row[9],
+            row[10],
+            row[11],
+        )
+        for name, value in zip(_RAW_COLUMNS, typed, strict=True):
+            columns[name].append(value)
+
+    frame = pl.DataFrame(columns, schema=_DTYPES)
+    first_open = int(frame.item(0, "open_time"))
+    last_open = int(frame.item(frame.height - 1, "open_time"))
+    actual_range = TimeRange(
+        start=datetime.fromtimestamp(first_open / 1000, tz=UTC),
+        end=datetime.fromtimestamp((last_open + _ONE_MINUTE_MS) / 1000, tz=UTC),
+    )
+    _validate_complete_object_coverage(plan, actual_range)
+    _validate_required_coverage(plan, actual_range)
+    return BinanceArchiveParseResult(
+        rows=frame,
+        actual_record_range=actual_range,
+        validation_evidence=(
+            "mark_price_csv_schema_and_rows_verified",
+            "mark_price_placeholders_preserved",
+        ),
+    )
+
+
+class _MarkPriceKlineArchiveAdapter:
+    raw_schema_identifier = _SCHEMA_IDENTIFIER
+
+    def parse_member(
+        self, plan: BinanceArchiveObjectPlan, payload: bytes
+    ) -> BinanceArchiveParseResult:
+        return _parse_archive(plan, payload)
+
+    def validate_complete_object_coverage(
+        self, plan: BinanceArchiveObjectPlan, actual_range: TimeRange
+    ) -> None:
+        _validate_complete_object_coverage(plan, actual_range)
+
+    def validate_required_coverage(
+        self, plan: BinanceArchiveObjectPlan, actual_range: TimeRange
+    ) -> None:
+        _validate_required_coverage(plan, actual_range)
+
+
+class BinanceMarkPriceKlineBackfill:
+    """Execute the official mark-price-Kline archive path."""
+
+    def __init__(
+        self,
+        store: RawStore,
+        *,
+        http_get: ArchiveHttpGet | None = None,
+        timeout: float = 30.0,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._acquisition = BinancePublicArchiveAcquisition(
+            store,
+            http_get=http_get,
+            timeout=timeout,
+            clock=clock,
+        )
+
+    def run(
+        self, instrument: InstrumentId, request_range: TimeRange
+    ) -> BinanceMarkPriceKlineRunResult:
+        plans = plan_binance_mark_price_kline_archives(instrument, request_range)
+        results = tuple(self._process(plan) for plan in plans)
+        return BinanceMarkPriceKlineRunResult(
+            request_range=request_range, objects=results
+        )
+
+    def _process(
+        self, plan: BinanceMarkPriceKlinePlan
+    ) -> BinanceMarkPriceKlineObjectResult:
+        if isinstance(plan, BinanceMarkPriceKlineCoverageGapPlan):
+            outcome = self._acquisition.record_failure(
+                plan.request,
+                BinanceMarkPriceKlineStatus.COVERAGE_GAP,
+                plan.detail,
+            )
+        else:
+            outcome = self._acquisition.acquire(plan, _MarkPriceKlineArchiveAdapter())
+        return BinanceMarkPriceKlineObjectResult(
+            plan,
+            outcome.status,
+            artifact_path=outcome.artifact_path,
+            detail=outcome.detail,
+        )

--- a/tests/data/test_binance_mark_price_kline_backfill.py
+++ b/tests/data/test_binance_mark_price_kline_backfill.py
@@ -1,0 +1,460 @@
+import hashlib
+import io
+import zipfile
+from collections.abc import Callable
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from tracequant.data import (
+    ArchiveHttpResponse,
+    BinanceArchiveObjectPlan,
+    BinanceMarkPriceKlineBackfill,
+    BinanceMarkPriceKlineStatus,
+    BinancePublicHistoryDataType,
+    RawObjectIdentity,
+    RawStore,
+    plan_binance_mark_price_kline_archives,
+)
+from tracequant.domain import InstrumentId, TimeRange
+
+HEADER = (
+    "open_time,open,high,low,close,volume,close_time,quote_volume,count,"
+    "taker_buy_volume,taker_buy_quote_volume,ignore\n"
+)
+ONE_MINUTE_MS = 60_000
+
+
+class FixtureHttp:
+    def __init__(self, responses: dict[str, ArchiveHttpResponse]) -> None:
+        self.responses = responses
+        self.calls: list[tuple[str, float]] = []
+
+    def __call__(self, url: str, timeout: float) -> ArchiveHttpResponse:
+        self.calls.append((url, timeout))
+        return self.responses.get(url, ArchiveHttpResponse(404, b"missing", {}))
+
+
+def _range(start: str, end: str) -> TimeRange:
+    return TimeRange(
+        start=datetime.fromisoformat(start).replace(tzinfo=UTC),
+        end=datetime.fromisoformat(end).replace(tzinfo=UTC),
+    )
+
+
+def _plan(
+    instrument: InstrumentId, request_range: TimeRange
+) -> BinanceArchiveObjectPlan:
+    plans = plan_binance_mark_price_kline_archives(instrument, request_range)
+    assert len(plans) == 1
+    assert isinstance(plans[0], BinanceArchiveObjectPlan)
+    return plans[0]
+
+
+def _row(
+    open_time: int,
+    *,
+    mark_close: str = "61010.00000000",
+    placeholder_count: str = "60",
+) -> str:
+    return (
+        f"{open_time},61000.10000000,61020.20000000,60990.30000000,"
+        f"{mark_close},0.00000000,{open_time + 59_999},0,"
+        f"{placeholder_count},0.000,0.00,0\n"
+    )
+
+
+def _zip(member: str, payload: bytes) -> bytes:
+    output = io.BytesIO()
+    with zipfile.ZipFile(output, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr(member, payload)
+    return output.getvalue()
+
+
+def _archive(
+    plan: BinanceArchiveObjectPlan,
+    rows: list[str],
+    *,
+    header: bool = True,
+    member: str | None = None,
+) -> bytes:
+    payload = ((HEADER if header else "") + "".join(rows)).encode()
+    return _zip(member or plan.member_name, payload)
+
+
+def _full_daily_archive(
+    plan: BinanceArchiveObjectPlan,
+    start_open_time: int,
+    *,
+    first_close: str = "61010.00000000",
+    first_count: str = "60",
+) -> bytes:
+    rows = [_row(start_open_time + offset * ONE_MINUTE_MS) for offset in range(24 * 60)]
+    rows[0] = _row(
+        start_open_time,
+        mark_close=first_close,
+        placeholder_count=first_count,
+    )
+    return _archive(plan, rows)
+
+
+def _responses(
+    plan: BinanceArchiveObjectPlan, archive: bytes
+) -> dict[str, ArchiveHttpResponse]:
+    checksum = hashlib.sha256(archive).hexdigest()
+    return {
+        plan.url: ArchiveHttpResponse(
+            200, archive, {"Content-Type": "application/zip"}
+        ),
+        plan.checksum_url: ArchiveHttpResponse(
+            200,
+            f"{checksum}  {plan.url.rsplit('/', 1)[-1]}\n".encode(),
+            {"Content-Type": "text/plain"},
+        ),
+    }
+
+
+@pytest.mark.parametrize("symbol", ["BTCUSDT", "ETHUSDT"])
+def test_planner_uses_mark_price_identity_and_daily_monthly_archives(
+    symbol: str,
+) -> None:
+    plans = plan_binance_mark_price_kline_archives(
+        InstrumentId(symbol),
+        _range("2024-01-31T23:30:00", "2024-03-01T00:30:00"),
+    )
+
+    assert all(isinstance(plan, BinanceArchiveObjectPlan) for plan in plans)
+    object_plans = [
+        plan for plan in plans if isinstance(plan, BinanceArchiveObjectPlan)
+    ]
+    assert [plan.request.source_kind.value for plan in object_plans] == [
+        "archive_daily",
+        "archive_monthly",
+        "archive_daily",
+    ]
+    assert all(
+        plan.request.data_type is BinancePublicHistoryDataType.MARK_PRICE_KLINE
+        for plan in object_plans
+    )
+    assert object_plans[1].object_key == (
+        f"data/futures/um/monthly/markPriceKlines/{symbol}/1m/{symbol}-1m-2024-02.zip"
+    )
+
+
+@pytest.mark.parametrize("symbol", ["BTCUSDC", "ETHUSDC"])
+def test_planner_does_not_silently_support_usdc_instruments(symbol: str) -> None:
+    with pytest.raises(
+        ValueError,
+        match=rf"^instrument {symbol} has no frozen mark-price-Kline archive coverage$",
+    ):
+        plan_binance_mark_price_kline_archives(
+            InstrumentId(symbol),
+            _range("2024-02-29T00:00:00", "2024-03-01T00:00:00"),
+        )
+
+
+def test_backfill_mark_price_klines_publishes_verified_raw_artifact(
+    tmp_path: Path,
+) -> None:
+    request_range = _range("2024-02-29T00:00:00", "2024-02-29T00:02:00")
+    plan = _plan(InstrumentId("BTCUSDT"), request_range)
+    archive = _full_daily_archive(
+        plan,
+        1_709_164_800_000,
+        first_close="61010.12340000",
+        first_count="060",
+    )
+    responses = _responses(plan, archive)
+    transport = FixtureHttp(responses)
+    store = RawStore(tmp_path)
+
+    result = BinanceMarkPriceKlineBackfill(store, http_get=transport, timeout=2.5).run(
+        InstrumentId("BTCUSDT"), request_range
+    )
+
+    assert result.completed is True
+    assert result.objects[0].status is BinanceMarkPriceKlineStatus.PUBLISHED
+    artifact = store.read_request(plan.request)
+    assert artifact.manifest.raw_schema_identifier == (
+        "binance.um.mark-price-kline.csv.v1"
+    )
+    assert artifact.frame.columns == [
+        "open_time",
+        "mark_open",
+        "mark_high",
+        "mark_low",
+        "mark_close",
+        "placeholder_volume",
+        "close_time",
+        "placeholder_quote_volume",
+        "placeholder_count",
+        "placeholder_taker_buy_volume",
+        "placeholder_taker_buy_quote_volume",
+        "placeholder_ignore",
+    ]
+    assert artifact.frame.row(0, named=True) == {
+        "open_time": 1_709_164_800_000,
+        "mark_open": "61000.10000000",
+        "mark_high": "61020.20000000",
+        "mark_low": "60990.30000000",
+        "mark_close": "61010.12340000",
+        "placeholder_volume": "0.00000000",
+        "close_time": 1_709_164_859_999,
+        "placeholder_quote_volume": "0",
+        "placeholder_count": "060",
+        "placeholder_taker_buy_volume": "0.000",
+        "placeholder_taker_buy_quote_volume": "0.00",
+        "placeholder_ignore": "0",
+    }
+    assert "volume" not in artifact.frame.columns
+    assert "count" not in artifact.frame.columns
+    assert artifact.manifest.upstream_checksum == (
+        f"sha256:{hashlib.sha256(archive).hexdigest()}"
+    )
+    assert artifact.manifest.provenance is not None
+    assert artifact.manifest.provenance.validation_evidence == (
+        "checksum_response_verified",
+        "archive_sha256_matches_checksum",
+        "zip_member_structure_verified",
+        "mark_price_csv_schema_and_rows_verified",
+        "mark_price_placeholders_preserved",
+        "source_object_coverage_verified",
+    )
+    assert artifact.archive_path.read_bytes() == archive
+    assert (
+        artifact.checksum_response_path.read_bytes()
+        == responses[plan.checksum_url].body
+    )
+    assert [url for url, _ in transport.calls] == [plan.checksum_url, plan.url]
+    assert all(timeout == 2.5 for _, timeout in transport.calls)
+
+
+@pytest.mark.parametrize(
+    ("mutate", "expected_status"),
+    [
+        (
+            lambda plan, archive, responses: responses.pop(plan.checksum_url),
+            BinanceMarkPriceKlineStatus.CHECKSUM_NOT_FOUND,
+        ),
+        (
+            lambda plan, archive, responses: responses.pop(plan.url),
+            BinanceMarkPriceKlineStatus.NOT_FOUND,
+        ),
+        (
+            lambda plan, archive, responses: responses.__setitem__(
+                plan.checksum_url,
+                ArchiveHttpResponse(
+                    200,
+                    f"{'0' * 64}  {plan.url.rsplit('/', 1)[-1]}\n".encode(),
+                    {},
+                ),
+            ),
+            BinanceMarkPriceKlineStatus.INVALID_CONTENT,
+        ),
+    ],
+)
+def test_acquisition_failures_do_not_publish_completed_artifacts(
+    tmp_path: Path,
+    mutate: Callable[
+        [BinanceArchiveObjectPlan, bytes, dict[str, ArchiveHttpResponse]], object
+    ],
+    expected_status: BinanceMarkPriceKlineStatus,
+) -> None:
+    request_range = _range("2024-02-29T00:00:00", "2024-03-01T00:00:00")
+    plan = _plan(InstrumentId("BTCUSDT"), request_range)
+    archive = _full_daily_archive(plan, 1_709_164_800_000)
+    responses = _responses(plan, archive)
+    mutate(plan, archive, responses)
+    store = RawStore(tmp_path)
+
+    result = BinanceMarkPriceKlineBackfill(store, http_get=FixtureHttp(responses)).run(
+        InstrumentId("BTCUSDT"), request_range
+    )
+
+    assert result.completed is False
+    assert result.objects[0].status is expected_status
+    assert not store.path_for(RawObjectIdentity.from_request(plan.request)).exists()
+
+
+@pytest.mark.parametrize(
+    ("build_archive", "expected_status"),
+    [
+        (
+            lambda plan: b"not a ZIP",
+            BinanceMarkPriceKlineStatus.INVALID_CONTENT,
+        ),
+        (
+            lambda plan: _archive(
+                plan,
+                [_row(1_709_164_800_000)],
+                member="unexpected.csv",
+            ),
+            BinanceMarkPriceKlineStatus.INVALID_CONTENT,
+        ),
+        (
+            lambda plan: _archive(plan, ["1,2,3\n"]),
+            BinanceMarkPriceKlineStatus.INVALID_CONTENT,
+        ),
+        (
+            lambda plan: _zip(plan.member_name, b"\xff\xfe"),
+            BinanceMarkPriceKlineStatus.INVALID_CONTENT,
+        ),
+        (
+            lambda plan: _archive(plan, []),
+            BinanceMarkPriceKlineStatus.INVALID_CONTENT,
+        ),
+        (
+            lambda plan: _archive(
+                plan,
+                [
+                    _row(1_709_164_800_000),
+                    _row(1_709_164_920_000),
+                ],
+            ),
+            BinanceMarkPriceKlineStatus.COVERAGE_GAP,
+        ),
+        (
+            lambda plan: _archive(
+                plan,
+                [
+                    _row(1_709_164_800_000),
+                    _row(1_709_164_800_000),
+                ],
+            ),
+            BinanceMarkPriceKlineStatus.INVALID_CONTENT,
+        ),
+        (
+            lambda plan: _archive(
+                plan,
+                [_row(1_709_164_800_001)],
+            ),
+            BinanceMarkPriceKlineStatus.INVALID_CONTENT,
+        ),
+        (
+            lambda plan: _archive(
+                plan,
+                [_row(1_709_164_800_000).replace("61020.20000000", "not-a-number")],
+            ),
+            BinanceMarkPriceKlineStatus.INVALID_CONTENT,
+        ),
+        (
+            lambda plan: _archive(
+                plan,
+                [_row(1_709_078_400_000)],
+            ),
+            BinanceMarkPriceKlineStatus.INVALID_CONTENT,
+        ),
+    ],
+)
+def test_parser_rejects_invalid_or_incomplete_objects(
+    tmp_path: Path,
+    build_archive: Callable[[BinanceArchiveObjectPlan], bytes],
+    expected_status: BinanceMarkPriceKlineStatus,
+) -> None:
+    request_range = _range("2024-02-29T00:00:00", "2024-03-01T00:00:00")
+    plan = _plan(InstrumentId("ETHUSDT"), request_range)
+    archive = build_archive(plan)
+    store = RawStore(tmp_path)
+
+    result = BinanceMarkPriceKlineBackfill(
+        store, http_get=FixtureHttp(_responses(plan, archive))
+    ).run(InstrumentId("ETHUSDT"), request_range)
+
+    assert result.completed is False
+    assert result.objects[0].status is expected_status
+    assert not store.path_for(RawObjectIdentity.from_request(plan.request)).exists()
+
+
+@pytest.mark.parametrize("failure", [429, 503, TimeoutError()])
+def test_retryable_failures_are_classified_without_publication(
+    tmp_path: Path, failure: int | TimeoutError
+) -> None:
+    request_range = _range("2024-02-29T00:00:00", "2024-03-01T00:00:00")
+    plan = _plan(InstrumentId("BTCUSDT"), request_range)
+
+    def transport(url: str, timeout: float) -> ArchiveHttpResponse:
+        del url, timeout
+        if isinstance(failure, TimeoutError):
+            raise failure
+        return ArchiveHttpResponse(failure, b"retry later", {})
+
+    store = RawStore(tmp_path)
+    result = BinanceMarkPriceKlineBackfill(store, http_get=transport).run(
+        InstrumentId("BTCUSDT"), request_range
+    )
+
+    assert result.completed is False
+    assert result.objects[0].status is BinanceMarkPriceKlineStatus.RETRYABLE_FAILURE
+    assert not store.path_for(RawObjectIdentity.from_request(plan.request)).exists()
+
+
+def test_partial_first_archive_is_not_published_as_a_completed_object(
+    tmp_path: Path,
+) -> None:
+    request_range = _range("2019-12-23T11:58:00", "2019-12-24T00:00:00")
+    plan = _plan(InstrumentId("BTCUSDT"), request_range)
+    rows = [_row(1_577_102_280_000 + offset * ONE_MINUTE_MS) for offset in range(722)]
+    archive = _archive(plan, rows)
+    store = RawStore(tmp_path)
+
+    result = BinanceMarkPriceKlineBackfill(
+        store, http_get=FixtureHttp(_responses(plan, archive))
+    ).run(InstrumentId("BTCUSDT"), request_range)
+
+    assert result.completed is False
+    assert result.objects[0].status is BinanceMarkPriceKlineStatus.COVERAGE_GAP
+    assert result.objects[0].detail == (
+        "archive rows do not cover the complete source object boundary"
+    )
+    assert not store.path_for(RawObjectIdentity.from_request(plan.request)).exists()
+
+
+def test_upstream_replacement_creates_a_new_immutable_raw_revision(
+    tmp_path: Path,
+) -> None:
+    request_range = _range("2024-02-29T00:00:00", "2024-02-29T00:01:00")
+    plan = _plan(InstrumentId("BTCUSDT"), request_range)
+    original = _full_daily_archive(plan, 1_709_164_800_000)
+    replacement = _full_daily_archive(
+        plan, 1_709_164_800_000, first_close="62000.00000000"
+    )
+    store = RawStore(tmp_path)
+
+    first = BinanceMarkPriceKlineBackfill(
+        store, http_get=FixtureHttp(_responses(plan, original))
+    ).run(InstrumentId("BTCUSDT"), request_range)
+    second = BinanceMarkPriceKlineBackfill(
+        store, http_get=FixtureHttp(_responses(plan, replacement))
+    ).run(InstrumentId("BTCUSDT"), request_range)
+
+    assert first.completed is True
+    assert second.completed is True
+    assert second.objects[0].status is BinanceMarkPriceKlineStatus.PUBLISHED
+    revisions = store.list_verified_revisions(
+        RawObjectIdentity.from_request(plan.request)
+    )
+    assert len(revisions) == 2
+    assert {item.frame.item(0, "mark_close") for item in revisions} == {
+        "61010.00000000",
+        "62000.00000000",
+    }
+
+
+def test_incomplete_local_artifact_is_reported_as_local_failure(
+    tmp_path: Path,
+) -> None:
+    request_range = _range("2024-02-29T00:00:00", "2024-02-29T00:01:00")
+    plan = _plan(InstrumentId("ETHUSDT"), request_range)
+    store = RawStore(tmp_path)
+    incomplete_path = store.path_for(RawObjectIdentity.from_request(plan.request))
+    incomplete_path.mkdir(parents=True)
+    (incomplete_path / "interrupted-write").write_text("preserve", encoding="utf-8")
+
+    result = BinanceMarkPriceKlineBackfill(store, http_get=FixtureHttp({})).run(
+        InstrumentId("ETHUSDT"), request_range
+    )
+
+    assert result.completed is False
+    assert result.objects[0].status is BinanceMarkPriceKlineStatus.LOCAL_FAILURE
+    assert {path.name for path in incomplete_path.iterdir()} == {"interrupted-write"}


### PR DESCRIPTION
Closes #271

## Summary
Add BTCUSDT and ETHUSDT Binance USDⓈ-M 1m mark-price daily/monthly archive planning and parsing through the shared acquisition seam, preserving 12 raw values with explicit placeholder semantics and immutable revision publication; export the adapter, document the supported boundary, and cover success, validation, failure, and replacement behavior.

## Validation
- Critical Outcome: pass
- Formal Delivery validation: pass

## Risks / limitations
Coverage is frozen to observed monthly 2020-01 through 2026-07 and daily 2019-12-23 through 2026-08-29; the partial 2019-12-23 object remains a coverage gap. REST recent, USDC, index/funding, canonical projection, aggregation, gap repair, and data repair remain out of scope.
