### PR TITLE
[Bug] Research 依赖策略错误地将 continuation 视为 implementation admission

### DIFF
--- a/tests/tools/test_lck_research.py
+++ b/tests/tools/test_lck_research.py
@@ -519,7 +519,8 @@ def test_research_profile_binds_typed_outcome_to_reviewed_artifact(
                 "count": 1,
                 "truncated": False,
             },
-        }
+        },
+        downstream_profile=issue_profiles.TASK_PROFILE,
     )
     assert blocker_gate["status"] == "pass"
 
@@ -706,7 +707,12 @@ def test_research_blocker_uses_only_the_canonical_project_outcome() -> None:
 
     assert blocker["research_outcome"] == "DO NOT IMPLEMENT"
     assert blocker["research_outcome_is_canonical"] is True
-    assert _formal_blockers_gate(relationships)["status"] == "fail"
+    assert (
+        _formal_blockers_gate(
+            relationships, downstream_profile=issue_profiles.TASK_PROFILE
+        )["status"]
+        == "fail"
+    )
 
 
 def test_research_outcome_postcondition_paginates_past_first_page() -> None:
@@ -1302,7 +1308,8 @@ def test_closed_research_blocker_requires_an_implementation_outcome(
                 "count": 1,
                 "truncated": False,
             },
-        }
+        },
+        downstream_profile=issue_profiles.TASK_PROFILE,
     )
 
     assert result["status"] == expected
@@ -1329,6 +1336,7 @@ def test_closed_architecture_decision_requires_consistent_contract() -> None:
             downstream_contract={
                 "body": "### Decision Contract\n\nAdopt the repository-backed workflow contract and record the resulting ADR.\n",
             },
+            downstream_profile=issue_profiles.TASK_PROFILE,
         )["status"]
         == "pass"
     )

--- a/tests/tools/test_lck_typed_dependency_contracts.py
+++ b/tests/tools/test_lck_typed_dependency_contracts.py
@@ -19,8 +19,12 @@ if AGENT_WORKFLOW not in sys.path:
 from lck_core import eligibility, models, shared_facts  # type: ignore[import-not-found]  # noqa: E402
 from lck_core.issue_profiles import resolve_leaf_issue_profile  # type: ignore[import-not-found]  # noqa: E402
 from lck_core.profile_policies import validate_profile_contract  # type: ignore[import-not-found]  # noqa: E402
+from research_policy import decision_contract_snapshot, research_contract_snapshot  # type: ignore[import-not-found]  # noqa: E402
 from workflow_common import CommandResult, bounded_list, sha256_json  # type: ignore[import-not-found]  # noqa: E402
-from workflow_evidence import _relationship_snapshot as audit_relationship_snapshot  # type: ignore[import-not-found]  # noqa: E402
+from workflow_evidence import (  # type: ignore[import-not-found]  # noqa: E402
+    _formal_blockers_gate as audit_formal_blockers_gate,
+    _relationship_snapshot as audit_relationship_snapshot,
+)
 
 
 BUG_BODY = (
@@ -254,6 +258,169 @@ def test_lck_eligibility_accepts_long_research_architecture_dependency() -> None
         state, phase=models.Phase.REVIEW_PREPARE
     )
     assert reasons == ()
+
+
+def _research_dependency(outcome: str) -> dict[str, Any]:
+    dependency = _bounded_dependency(
+        _raw_dependency(number=191, label="type:research", body=RESEARCH_BODY)
+    )
+    dependency["research_outcome"] = outcome
+    dependency["decision_contract"] = decision_contract_snapshot(
+        RESEARCH_BODY, research=True
+    )
+    return dependency
+
+
+def _downstream_contract(label: str, *, matching_decision: bool) -> dict[str, Any]:
+    bodies = {
+        "type:task": "### Objective\n\nImplement the researched behavior.\n",
+        "type:bug": BUG_BODY,
+        "type:documentation": DOCUMENTATION_BODY,
+        "type:research": RESEARCH_BODY,
+    }
+    body = bodies[label]
+    if matching_decision:
+        body += (
+            "\n\n### Decision Contract\n\n"
+            "Adopt the repository-backed workflow contract.\n"
+        )
+    return {
+        "number": 300,
+        "body": body,
+        "body_sha256": sha256_json({"body": body}),
+    }
+
+
+@pytest.mark.parametrize(
+    ("downstream_label", "outcome", "matching_decision", "expected_code"),
+    [
+        ("type:research", "IMPLEMENT", False, None),
+        ("type:research", "DO NOT IMPLEMENT", False, None),
+        ("type:research", "NEEDS MORE EVIDENCE", False, None),
+        ("type:research", "ARCHITECTURE DECISION", False, None),
+        ("type:documentation", "IMPLEMENT", False, None),
+        ("type:documentation", "DO NOT IMPLEMENT", False, None),
+        ("type:documentation", "NEEDS MORE EVIDENCE", False, None),
+        ("type:documentation", "ARCHITECTURE DECISION", False, None),
+        ("type:task", "IMPLEMENT", False, None),
+        ("type:task", "DO NOT IMPLEMENT", False, "RESEARCH_OUTCOME_NOT_IMPLEMENTATION"),
+        (
+            "type:task",
+            "NEEDS MORE EVIDENCE",
+            False,
+            "RESEARCH_OUTCOME_NOT_IMPLEMENTATION",
+        ),
+        (
+            "type:task",
+            "ARCHITECTURE DECISION",
+            False,
+            "ARCHITECTURE_DECISION_UNMATCHED",
+        ),
+        ("type:task", "ARCHITECTURE DECISION", True, None),
+        ("type:bug", "IMPLEMENT", False, None),
+        ("type:bug", "DO NOT IMPLEMENT", False, "RESEARCH_OUTCOME_NOT_IMPLEMENTATION"),
+        (
+            "type:bug",
+            "NEEDS MORE EVIDENCE",
+            False,
+            "RESEARCH_OUTCOME_NOT_IMPLEMENTATION",
+        ),
+        ("type:bug", "ARCHITECTURE DECISION", False, "ARCHITECTURE_DECISION_UNMATCHED"),
+        ("type:bug", "ARCHITECTURE DECISION", True, None),
+    ],
+)
+def test_research_dependency_semantics_follow_downstream_profile(
+    downstream_label: str,
+    outcome: str,
+    matching_decision: bool,
+    expected_code: str | None,
+) -> None:
+    dependency = _research_dependency(outcome)
+    downstream = _downstream_contract(
+        downstream_label, matching_decision=matching_decision
+    )
+    issue = {
+        "number": 300,
+        "title": "Downstream leaf Issue",
+        "state": "OPEN",
+        "labels": [downstream_label],
+    }
+    resolution = resolve_leaf_issue_profile(issue)
+    assert resolution.resolved and resolution.profile is not None
+    relationships = {
+        "available": True,
+        "blocked_by": {"items": [dependency], "count": 1, "truncated": False},
+    }
+    state = models.LiveState(
+        issue_number=300,
+        repository="owner/repo",
+        issue=issue,
+        leaf_contract=downstream,
+        relationships=relationships,
+    )
+
+    reasons = eligibility.PhaseEligibilityResolver().blocker_reasons(
+        state, phase=models.Phase.REVIEW_PREPARE
+    )
+    audit_dependency = {
+        key: value for key, value in dependency.items() if key != "contract"
+    }
+    audit_dependency["research_contract"] = research_contract_snapshot(RESEARCH_BODY)
+    audit_result = audit_formal_blockers_gate(
+        {
+            **relationships,
+            "blocked_by": {
+                "items": [audit_dependency],
+                "count": 1,
+                "truncated": False,
+            },
+        },
+        downstream_contract=downstream,
+        downstream_profile=resolution.profile,
+    )
+
+    if expected_code is None:
+        assert reasons == ()
+        assert audit_result["status"] == "pass"
+    else:
+        assert any(f"[{expected_code}]" in reason for reason in reasons)
+        assert audit_result["status"] != "pass"
+
+
+def test_research_dependency_fails_closed_without_downstream_profile() -> None:
+    dependency = _research_dependency("IMPLEMENT")
+    state = models.LiveState(
+        issue_number=300,
+        repository="owner/repo",
+        issue={"number": 300, "state": "OPEN", "labels": ["type:unknown"]},
+        leaf_contract={"number": 300, "body": "Unknown profile"},
+        relationships={
+            "available": True,
+            "blocked_by": {"items": [dependency], "count": 1, "truncated": False},
+        },
+    )
+
+    reasons = eligibility.PhaseEligibilityResolver().blocker_reasons(
+        state, phase=models.Phase.REVIEW_PREPARE
+    )
+    assert any("[DOWNSTREAM_PROFILE_UNKNOWN]" in reason for reason in reasons)
+
+    audit_dependency = {
+        key: value for key, value in dependency.items() if key != "contract"
+    }
+    audit_dependency["research_contract"] = research_contract_snapshot(RESEARCH_BODY)
+    audit_result = audit_formal_blockers_gate(
+        {
+            "available": True,
+            "blocked_by": {
+                "items": [audit_dependency],
+                "count": 1,
+                "truncated": False,
+            },
+        }
+    )
+    assert audit_result["status"] == "unknown"
+    assert "downstream Issue profile is unavailable" in audit_result["detail"]
 
 
 @pytest.mark.parametrize(

--- a/tools/agent_workflow/lck_core/eligibility.py
+++ b/tools/agent_workflow/lck_core/eligibility.py
@@ -164,6 +164,7 @@ class PhaseEligibilityResolver:
                             relationships=state.relationships,
                             repository=state.repository,
                             downstream_contract=downstream_contract,
+                            downstream_profile=profile,
                         ),
                     )
                     reasons.extend(
@@ -227,6 +228,7 @@ class PhaseEligibilityResolver:
                             relationships=state.relationships,
                             repository=state.repository,
                             downstream_contract=downstream_contract,
+                            downstream_profile=profile,
                         ),
                     )
                 except ValueError as exc:

--- a/tools/agent_workflow/lck_core/profile_policies.py
+++ b/tools/agent_workflow/lck_core/profile_policies.py
@@ -394,6 +394,7 @@ class PolicyContext:
     relationships: Mapping[str, Any] | None = None
     repository: str | None = None
     downstream_contract: Mapping[str, Any] | None = None
+    downstream_profile: LeafIssueWorkflowProfile | None = None
     repo_root: Path | None = None
     runner: Any = None
     base_sha: str | None = None
@@ -1386,6 +1387,29 @@ class _ResearchPolicy(_BuiltinPolicy):
                     code="RESEARCH_OUTCOME_UNKNOWN",
                     kind="research-outcome",
                     detail=str(exc),
+                ),
+            )
+
+        downstream_profile = context.downstream_profile
+        if downstream_profile is None:
+            return (
+                PolicyBlocker(
+                    code="DOWNSTREAM_PROFILE_UNKNOWN",
+                    kind="downstream-profile",
+                    detail="The downstream Issue profile is unavailable",
+                ),
+            )
+        if downstream_profile.profile_id in {"research", "documentation"}:
+            return ()
+        if downstream_profile.profile_id not in {"task", "bug"}:
+            return (
+                PolicyBlocker(
+                    code="DOWNSTREAM_PROFILE_UNKNOWN",
+                    kind="downstream-profile",
+                    detail=(
+                        "The downstream Issue profile does not have defined "
+                        "Research dependency semantics"
+                    ),
                 ),
             )
 

--- a/tools/agent_workflow/workflow_evidence.py
+++ b/tools/agent_workflow/workflow_evidence.py
@@ -25,7 +25,7 @@ from documentation_policy import (
 )
 from lck_core import shared_facts
 from lck_core.eligibility import evaluate_shared_blockers
-from lck_core.issue_profiles import resolve_leaf_issue_profile
+from lck_core.issue_profiles import LeafIssueWorkflowProfile, resolve_leaf_issue_profile
 from lck_core.profile_policies import (
     DEFAULT_PROFILE_POLICY_REGISTRY,
     PolicyContext,
@@ -415,7 +415,13 @@ def _issue_gates(
         gates["issue_type"] = _gate(
             "pass" if matches_type else "unknown", expected_type_label
         )
-    gates["formal_blockers"] = _formal_blockers_gate(relationships)
+    downstream_resolution = resolve_leaf_issue_profile(issue)
+    gates["formal_blockers"] = _formal_blockers_gate(
+        relationships,
+        downstream_profile=(
+            downstream_resolution.profile if downstream_resolution.resolved else None
+        ),
+    )
     return gates
 
 
@@ -423,6 +429,7 @@ def _audit_formal_blockers_gate(
     relationships: Mapping[str, Any],
     *,
     downstream_contract: Mapping[str, Any] | None = None,
+    downstream_profile: LeafIssueWorkflowProfile | None = None,
 ) -> dict[str, Any]:
     """Audit adapter for the shared gate and registered profile capabilities."""
     shared_gate = evaluate_shared_blockers(relationships)
@@ -479,6 +486,7 @@ def _audit_formal_blockers_gate(
                     if isinstance(relationships.get("repository"), str)
                     else None,
                     downstream_contract=downstream_contract,
+                    downstream_profile=downstream_profile,
                 ),
             )
         except (TypeError, ValueError) as exc:
@@ -493,6 +501,7 @@ def _audit_formal_blockers_gate(
                         "CONTRACT_INVALID",
                         "RESEARCH_OUTCOME_UNKNOWN",
                         "ARCHITECTURE_DECISION_UNMATCHED",
+                        "DOWNSTREAM_PROFILE_UNKNOWN",
                     }
                     else "fail",
                     blocker.detail,


### PR DESCRIPTION
Closes #286

## Summary
Propagate the canonical downstream leaf profile into Research dependency policy evaluation; treat Research and Documentation as evidence consumers while preserving Task and Bug implementation admission, and keep the audit adapter aligned with regression-matrix coverage.

## Validation
- Formal Delivery validation: pass

## Risks / limitations
No known limitations; missing, unsupported, or ambiguous downstream profiles continue to fail closed.
