### PR TITLE
[Bug] LCK Delivery Prepare 跳过 In Progress 状态

### DIFF
--- a/.agents/skills/task-delivery-runner/SKILL.md
+++ b/.agents/skills/task-delivery-runner/SKILL.md
@@ -163,8 +163,12 @@ uv run --frozen python tools/agent_workflow/lck.py delivery prepare <TASK>
 
 Proceed only when LCK returns a resolved Delivery context. LCK reacquires live
 Git/GitHub facts, resolves the canonical leaf profile, verifies readiness and
-blockers, and creates, selects, or restores the one correct profile-owned
-workspace.
+blockers, creates, selects, or restores the one correct profile-owned workspace,
+verifies its postcondition, then performs and verifies the kernel-owned Project
+Status transition from `Ready` to `In Progress`. An already-`In Progress` safe
+recovery is idempotent and does not repeat the status write. LCK must not return
+`READY_FOR_DELIVERY` after an admission, workspace, status-write, or status-
+postcondition failure.
 
 Do not pass branch, expected SHA, base SHA, PR number, remote, or refspec.
 
@@ -242,6 +246,7 @@ Within one bounded invocation, LCK performs the deterministic sequence:
 ```text
 reacquire live Task/Git/GitHub facts and the canonical leaf profile
 → validate Delivery Complete eligibility
+→ require Project Status `In Progress` (or operation-owned partial `Review` recovery)
 → parse the Task Critical Outcome only when the selected profile requires it
 → stage current candidate tree
 → run the selected profile's delivery gates

--- a/.claude/skills/task-delivery-runner/SKILL.md
+++ b/.claude/skills/task-delivery-runner/SKILL.md
@@ -145,8 +145,12 @@ uv run --frozen python tools/agent_workflow/lck.py delivery prepare <TASK>
 
 Proceed only when LCK returns a resolved Delivery context. LCK reacquires live
 Git/GitHub facts, resolves the canonical leaf profile, verifies readiness and
-blockers, and creates, selects, or restores the one correct profile-owned
-workspace.
+blockers, creates, selects, or restores the one correct profile-owned workspace,
+verifies its postcondition, then performs and verifies the kernel-owned Project
+Status transition from `Ready` to `In Progress`. An already-`In Progress` safe
+recovery is idempotent and does not repeat the status write. LCK must not return
+`READY_FOR_DELIVERY` after an admission, workspace, status-write, or status-
+postcondition failure.
 
 Do not pass branch, expected SHA, base SHA, PR number, remote, or refspec.
 
@@ -224,6 +228,7 @@ Within one bounded invocation, LCK performs the deterministic sequence:
 ```text
 reacquire live Task/Git/GitHub facts and the canonical leaf profile
 → validate Delivery Complete eligibility
+→ require Project Status `In Progress` (or operation-owned partial `Review` recovery)
 → parse the Task Critical Outcome only when the selected profile requires it
 → stage current candidate tree
 → run the selected profile's delivery gates

--- a/docs/development/issue-workflow.md
+++ b/docs/development/issue-workflow.md
@@ -20,7 +20,8 @@ Codex 与 Claude Code 的 workflow Skills 引用本文件作为生命周期语�
 ```text
 Issue (Specifying)
   → Ready（codex:ready + Project Ready + 无 blocker）
-  → Delivery（branch → implementation/tests → commit/push → PR）
+  → Delivery Prepare（workspace postcondition → Project In Progress）
+  → Delivery（implementation/tests → commit/push → PR → Project Review）
   → Independent Review（fresh session，read-only；可与 CI 并行）
   → maintainer manual Squash Merge
   → Closeout（merge identity / state convergence / branch cleanup）
@@ -154,6 +155,11 @@ subprocesses continue to receive the same path through `build_workflow_env()`.
 - Initial Delivery 的 lifecycle mechanics（workspace prepare、commit validated tree、
   remote synchronization、OPEN PR resolve/create、Project Status → Review）由 LCK
   deterministic control 执行；Agent/Skill 不提供 branch/SHA/PR/refspec authority。
+- Delivery Prepare 只有在 workspace 创建、选择或恢复及其 postcondition 成功后，
+  才通过 kernel-owned bounded effect 执行 Project Status `Ready → In Progress`，
+  并在返回 `READY_FOR_DELIVERY` 前验证 live status。already-`In Progress` 的安全
+  恢复路径幂等成功且不重复写入；admission、workspace、status write 或 status
+  postcondition 失败均不得声称 Prepare 成功。
 - Documentation 使用独立的 `documentation/<Issue>-<slug>` branch namespace；Task 的
   `task/`、历史 Task aliases 与其匹配规则保持不变。
 - Bug 使用独立的 `bug/<Issue>-<slug>` branch namespace；不会创建 wrapper Task，且与
@@ -165,10 +171,14 @@ subprocesses continue to receive the same path through `build_workflow_env()`.
 - Research Review PASS 必须携带四个精确值之一：`IMPLEMENT`、`DO NOT IMPLEMENT`、
   `NEEDS MORE EVIDENCE`、`ARCHITECTURE DECISION`。后两者是成功的 Research 结果，不能
   被误报为 lifecycle failure；Closeout 在合并后写入并确认 Project 的 `Research Outcome`。
-- 一次 Initial Delivery 覆盖：LCK Delivery Prepare → semantic implementation / targeted
+- 一次 Initial Delivery 覆盖：LCK Delivery Prepare → Project Status `In Progress` →
+  semantic implementation / targeted
   development validation → LCK Delivery Complete → Critical Outcome → formal validation →
   commit validated tree → ensure remote branch → ensure OPEN PR → observe current CI checks
   （non-blocking）→ Project Status `Review` → final live verification → `READY_FOR_REVIEW`。
+- 正常 Delivery Complete 只接受 `In Progress`；若 live status 仍为 `Ready`，必须
+  fail closed 并要求重新执行 Delivery Prepare。仅保留 operation-owned partial
+  `Review` 的 completion recovery 语义。
 - 一个 Task 通常产生一个 PR（base = `main`）。
 - Initial Task branch bootstrap is LCK-owned. An existing branch is reusable only when
   Task identity, ownership, base, and the required worktree state are mechanically proven.

--- a/tests/tools/test_agent_neutral_workflow.py
+++ b/tests/tools/test_agent_neutral_workflow.py
@@ -88,6 +88,17 @@ def test_source_of_truth_is_dual_layer_not_linear_precedence() -> None:
     assert "不得覆盖 current Issue requirement" in text
 
 
+def test_initial_delivery_lifecycle_requires_in_progress_between_ready_and_review() -> (
+    None
+):
+    text = ISSUE_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "Project In Progress" in text
+    assert "`Ready → In Progress`" in text
+    assert "正常 Delivery Complete 只接受 `In Progress`" in text
+    assert "重新执行 Delivery Prepare" in text
+
+
 def test_failure_and_ambiguity_handling_has_review_stop_and_local_stale_results() -> (
     None
 ):

--- a/tests/tools/test_lck_delivery.py
+++ b/tests/tools/test_lck_delivery.py
@@ -2188,3 +2188,29 @@ def test_set_review_status_accepts_nonblocking_checks_observation(
     )
 
     assert receipt.action == "already-review"
+
+
+def test_set_review_status_rejects_ready_without_mutation(tmp_path: Path) -> None:
+    head = "b" * 40
+    state = _live_state(
+        head=head,
+        clean=True,
+        project_status="Ready",
+        open_pr=None,
+        remote_oid=head,
+    )
+    runner = CompletionRunner()
+    resolver = SequenceResolver(tmp_path, runner, [state])
+    identity = {"number": 10, "head_sha": head, "base_sha": SHA}
+
+    with pytest.raises(
+        lck_models.LckStopError,
+        match="requires In Progress before Review",
+    ):
+        lck_effects.SetReviewStatusEffect(cast(Any, resolver)).execute(
+            state,
+            expected_pr=identity,
+            checks_result={"status": "observed", "pr": identity},
+        )
+
+    assert not any(command[:2] == ("gh", "project") for command in runner.commands)

--- a/tests/tools/test_lck_prepare.py
+++ b/tests/tools/test_lck_prepare.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 from typing import (
@@ -17,11 +18,16 @@ if AGENT_WORKFLOW not in sys.path:
 
 from lck_core import (  # type: ignore[import-not-found]  # noqa: E402
     delivery as lck_delivery,
+    effects as lck_effects,
     eligibility as lck_eligibility,
     models as lck_models,
     state as lck_state,
 )
 from pr_resolve import resolve_open_pr  # type: ignore[import-not-found]  # noqa: E402
+from workflow_common import (  # type: ignore[import-not-found]  # noqa: E402
+    CommandResult,
+    WorkflowToolError,
+)
 from lck_test_support import (  # noqa: E402
     FakeRunner,
     SHA,
@@ -32,6 +38,65 @@ from lck_test_support import (  # noqa: E402
     _relationships,
     _resolver,
 )
+
+
+class ProjectStatusRunner(FakeRunner):
+    def __init__(self, *, project_status: str = "Ready", **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.project_status = project_status
+
+    def run(
+        self,
+        argv: list[str] | tuple[str, ...],
+        *,
+        command_id: str,
+        **kwargs: Any,
+    ) -> CommandResult:
+        command = tuple(str(item) for item in argv)
+        if command[:3] == ("gh", "issue", "view") and command[-1] == "projectItems":
+            self.commands.append(command)
+            return CommandResult(
+                command_id=command_id,
+                argv=command,
+                returncode=0,
+                stdout=json.dumps(
+                    {"projectItems": [{"status": {"name": self.project_status}}]}
+                ),
+                stderr="",
+            )
+        return super().run(argv, command_id=command_id, **kwargs)
+
+
+def _install_project_status_write(
+    monkeypatch: pytest.MonkeyPatch,
+    fake: ProjectStatusRunner,
+    issue: dict[str, Any],
+    *,
+    update_status: bool = True,
+    fail: bool = False,
+) -> list[str]:
+    writes: list[str] = []
+
+    def write(
+        runner: Any,
+        repository: str,
+        task: int,
+        *,
+        value: str,
+        **_kwargs: Any,
+    ) -> None:
+        assert runner is fake
+        assert repository == "owner/repo"
+        assert task == 159
+        writes.append(value)
+        if fail:
+            raise WorkflowToolError("simulated status write failure")
+        if update_status:
+            fake.project_status = value
+            issue["project_status"] = value
+
+    monkeypatch.setattr(lck_effects, "set_project_status_with_runner", write)
+    return writes
 
 
 def test_lck_live_snapshot_overrides_legacy_read_only_environment(
@@ -180,8 +245,10 @@ def test_multiple_task_branches_stop_fail_closed(
 def test_delivery_prepare_creates_then_reuses_workspace(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    fake = FakeRunner(branch="main")
-    _install_facts(monkeypatch, fake)
+    fake = ProjectStatusRunner(branch="main")
+    issue = _issue()
+    writes = _install_project_status_write(monkeypatch, fake, issue)
+    _install_facts(monkeypatch, fake, issue=issue)
     preparer = lck_delivery.DeliveryPreparer(_resolver(fake))
 
     created = preparer.prepare(159)
@@ -190,6 +257,17 @@ def test_delivery_prepare_creates_then_reuses_workspace(
     assert created.action == "created-from-main"
     assert reused.action == "already-prepared"
     assert created.to_dict()["task_contract"]["body"] == "Task Contract"
+    assert created.effects[0].to_dict() == {
+        "effect": "set_in_progress_status",
+        "action": "updated",
+        "details": {
+            "previous_status": "Ready",
+            "status": "In Progress",
+            "postcondition": "verified",
+        },
+    }
+    assert reused.effects[0].action == "already-in-progress"
+    assert writes == ["In Progress"]
     assert fake.branch == "task/159-lck-core-live-state-resolution"
     assert sum(command[:2] == ("git", "switch") for command in fake.commands) == 1
     assert not any(
@@ -222,14 +300,103 @@ def test_delivery_prepare_restores_remote_workspace(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     branch = "task/159-lck-core-live-state-resolution"
-    fake = FakeRunner(branch="main", remote_branches={branch: SHA})
-    _install_facts(monkeypatch, fake)
+    fake = ProjectStatusRunner(branch="main", remote_branches={branch: SHA})
+    issue = _issue()
+    writes = _install_project_status_write(monkeypatch, fake, issue)
+    _install_facts(monkeypatch, fake, issue=issue)
 
     context = lck_delivery.DeliveryPreparer(_resolver(fake)).prepare(159)
 
     assert context.action == "restored-from-remote"
+    assert context.effects[0].action == "updated"
+    assert writes == ["In Progress"]
     assert fake.branch == branch
     assert branch in fake.local_branches
+
+
+def test_delivery_prepare_stops_before_status_write_when_workspace_postcondition_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = ProjectStatusRunner(branch="main")
+    issue = _issue()
+    writes = _install_project_status_write(monkeypatch, fake, issue)
+    _install_facts(monkeypatch, fake, issue=issue)
+    preparer = lck_delivery.DeliveryPreparer(_resolver(fake))
+
+    def fail_postcondition(_branch: str, _expected_head: str | None) -> None:
+        raise lck_models.LckStopError("simulated workspace postcondition failure")
+
+    monkeypatch.setattr(preparer, "_verify_workspace", fail_postcondition)
+
+    with pytest.raises(
+        lck_models.LckStopError, match="workspace postcondition failure"
+    ):
+        preparer.prepare(159)
+
+    assert writes == []
+    assert not any(command[:3] == ("gh", "issue", "view") for command in fake.commands)
+
+
+def test_delivery_prepare_status_write_failure_stops_after_reusable_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = ProjectStatusRunner(branch="main")
+    issue = _issue()
+    writes = _install_project_status_write(monkeypatch, fake, issue, fail=True)
+    _install_facts(monkeypatch, fake, issue=issue)
+
+    with pytest.raises(lck_models.LckStopError, match="status write failure"):
+        lck_delivery.DeliveryPreparer(_resolver(fake)).prepare(159)
+
+    assert writes == ["In Progress"]
+    assert fake.branch == "task/159-lck-core-live-state-resolution"
+    assert fake.project_status == "Ready"
+
+
+def test_delivery_prepare_status_postcondition_failure_stops_and_reuses_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = ProjectStatusRunner(branch="main")
+    issue = _issue()
+    writes = _install_project_status_write(
+        monkeypatch, fake, issue, update_status=False
+    )
+    _install_facts(monkeypatch, fake, issue=issue)
+
+    with pytest.raises(lck_models.LckStopError, match="postcondition failed"):
+        lck_delivery.DeliveryPreparer(_resolver(fake)).prepare(159)
+
+    branch = "task/159-lck-core-live-state-resolution"
+    assert writes == ["In Progress"]
+    assert fake.branch == branch
+    assert branch in fake.local_branches
+
+    fake.project_status = "In Progress"
+    issue["project_status"] = "In Progress"
+    recovered = lck_delivery.DeliveryPreparer(_resolver(fake)).prepare(159)
+
+    assert recovered.action == "already-prepared"
+    assert recovered.effects[0].action == "already-in-progress"
+    assert writes == ["In Progress"]
+
+
+def test_delivery_complete_ready_requires_delivery_prepare(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = FakeRunner()
+    _install_facts(monkeypatch, fake)
+    state = _resolver(fake).resolve(159)
+
+    decision = lck_eligibility.PhaseEligibilityResolver().resolve(
+        state, lck_models.Phase.DELIVERY_COMPLETE
+    )
+
+    assert decision.eligible is False
+    assert (
+        "Delivery Complete requires Project Status In Progress; "
+        "run Delivery Prepare first"
+    ) in decision.reasons
+    assert "Project Status is unavailable or unknown" not in decision.reasons
 
 
 def test_dirty_unrelated_worktree_is_not_switched(

--- a/tests/tools/test_lck_receipts.py
+++ b/tests/tools/test_lck_receipts.py
@@ -354,6 +354,63 @@ def test_lifecycle_agent_views_include_the_selected_issue_profile(
         assert value.to_dict()["issue_profile"] == profile
 
 
+def test_delivery_prepare_receipt_preserves_status_effect_and_postcondition(
+    tmp_path: Path,
+) -> None:
+    state = _review_state()
+    state = replace(
+        state,
+        issue={**(state.issue or {}), "project_status": "Ready"},
+    )
+    snapshot = lck_models.OperationSnapshot(
+        operation=lck_models.Phase.DELIVERY_PREPARE.value,
+        state=state,
+    )
+    effect = lck_models.EffectReceipt(
+        effect="set_in_progress_status",
+        action="updated",
+        details={"status": "In Progress", "postcondition": "verified"},
+    )
+    context = lck_delivery.DeliveryContext(
+        task_number=159,
+        repository="owner/repo",
+        branch=state.target_branch,
+        base_sha=SHA,
+        action="created-from-main",
+        operation_snapshot=snapshot,
+        eligibility=lck_eligibility.PhaseDecision(
+            phase=lck_models.Phase.DELIVERY_PREPARE,
+            eligible=True,
+        ),
+        effects=(effect,),
+    )
+    store = lck_receipts.AuditReceiptStore(tmp_path)
+
+    payload = lck_receipts._write_success_receipt(
+        context,
+        operation="delivery-prepare",
+        task_number=159,
+        operation_id="f" * 32,
+        store=store,
+    )
+    receipt = store.read(payload["receipt_reference"])
+
+    assert payload["effects"] == [
+        {
+            "effect": "set_in_progress_status",
+            "action": "updated",
+            "postcondition": {
+                "status": "verified",
+                "project_status": "In Progress",
+            },
+        }
+    ]
+    assert receipt["audit"]["effects"] == [effect.to_dict()]
+    assert receipt["operation_snapshot"]["state"]["issue"]["project_status"] == (
+        "Ready"
+    )
+
+
 def test_review_prepare_failure_receipt_preserves_validation_payload(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/tools/test_workflow_skills.py
+++ b/tests/tools/test_workflow_skills.py
@@ -203,6 +203,8 @@ def test_delivery_runner_uses_lck_for_initial_delivery_and_explicit_remediation(
     assert "Agent / Skill MUST NOT directly" in text
     assert "branch/SHA/base/PR identity as workflow authority" in text
     assert "no alternate write route" in text
+    assert "Project\nStatus transition from `Ready` to `In Progress`" in text
+    assert "require Project Status `In Progress`" in text
 
     assert "## Review remediation" in text
     assert "tools/agent_workflow/lck.py remediation prepare" in text

--- a/tools/agent_workflow/lck_core/delivery.py
+++ b/tools/agent_workflow/lck_core/delivery.py
@@ -11,6 +11,7 @@ from .effects import (
     EnsureOpenPrEffect,
     EnsureRemoteBranchEffect,
     ReuseExistingOpenPrEffect,
+    SetInProgressStatusEffect,
     SetReviewStatusEffect,
 )
 from .eligibility import PhaseDecision, PhaseEligibilityResolver
@@ -57,6 +58,7 @@ class DeliveryContext:
     action: str
     operation_snapshot: OperationSnapshot
     eligibility: PhaseDecision
+    effects: tuple[EffectReceipt, ...] = ()
 
     @property
     def state(self) -> LiveState:
@@ -75,6 +77,7 @@ class DeliveryContext:
             "task_contract": _jsonable(_leaf_contract_from_state(self.state)),
             "operation_snapshot": self.operation_snapshot.to_dict(),
             "eligibility": self.eligibility.to_dict(),
+            "effects": [item.to_dict() for item in self.effects],
         }
 
 
@@ -87,6 +90,7 @@ class DeliveryPreparer:
         *,
         eligibility: PhaseEligibilityResolver | None = None,
         profile_resolver: ProfileResolver | None = None,
+        status_effect: SetInProgressStatusEffect | None = None,
     ) -> None:
         self.resolver = resolver
         self.snapshots = OperationSnapshotBuilder(resolver)
@@ -98,7 +102,9 @@ class DeliveryPreparer:
         self.eligibility = eligibility or PhaseEligibilityResolver(
             profile_resolver=self.profile_resolver
         )
+        self.status_effect = status_effect or SetInProgressStatusEffect(resolver)
         self.last_snapshot: OperationSnapshot | None = None
+        self.last_effects: list[EffectReceipt] = []
 
     def _run_git(self, args: Sequence[str], command_id: str) -> None:
         result = self.resolver.runner.run(
@@ -133,6 +139,7 @@ class DeliveryPreparer:
             )
 
     def prepare(self, task_number: int) -> DeliveryContext:
+        self.last_effects = []
         snapshot = self.snapshots.acquire(
             task_number,
             operation=Phase.DELIVERY_PREPARE.value,
@@ -194,6 +201,8 @@ class DeliveryPreparer:
             else base_sha
         )
         self._verify_workspace(branch, expected_head)
+        status_receipt = self.status_effect.execute(state)
+        self.last_effects.append(status_receipt)
         return DeliveryContext(
             task_number=task_number,
             repository=state.repository,
@@ -202,6 +211,7 @@ class DeliveryPreparer:
             action=action,
             operation_snapshot=snapshot,
             eligibility=decision,
+            effects=tuple(self.last_effects),
         )
 
 

--- a/tools/agent_workflow/lck_core/effects.py
+++ b/tools/agent_workflow/lck_core/effects.py
@@ -876,6 +876,95 @@ class ReuseExistingOpenPrEffect:
         )
 
 
+def _query_issue_project_status(
+    resolver: LiveStateResolver,
+    repository: str,
+    task_number: int,
+    *,
+    command_id: str,
+) -> str | None:
+    result = resolver.runner.run(
+        [
+            "gh",
+            "issue",
+            "view",
+            str(task_number),
+            "--repo",
+            repository,
+            "--json",
+            "projectItems",
+        ],
+        command_id=command_id,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+    value = read_json_text(result.stdout, field=command_id)
+    if not isinstance(value, Mapping):
+        return None
+    return _find_project_status(value.get("projectItems"))
+
+
+class SetInProgressStatusEffect:
+    """Move Delivery Prepare to In Progress after workspace verification."""
+
+    def __init__(self, resolver: LiveStateResolver) -> None:
+        self.resolver = resolver
+
+    def execute(self, state: LiveState) -> EffectReceipt:
+        if state.repository is None:
+            raise LckStopError(
+                "cannot set In Progress status without repository identity"
+            )
+        observed = _query_issue_project_status(
+            self.resolver,
+            state.repository,
+            state.issue_number,
+            command_id="lck-in-progress-status-precondition",
+        )
+        if observed == "In Progress":
+            return EffectReceipt(
+                effect="set_in_progress_status",
+                action="already-in-progress",
+                details={"status": "In Progress", "postcondition": "verified"},
+            )
+        if observed != "Ready":
+            raise LckStopError(
+                "Project Status precondition failed: Delivery Prepare requires "
+                "live Ready or In Progress"
+            )
+        try:
+            set_project_status_with_runner(
+                self.resolver.runner,
+                state.repository,
+                state.issue_number,
+                value="In Progress",
+            )
+        except WorkflowToolError as exc:
+            raise LckStopError(
+                f"Project Status In Progress write failed: {exc}"
+            ) from exc
+        observed = _query_issue_project_status(
+            self.resolver,
+            state.repository,
+            state.issue_number,
+            command_id="lck-in-progress-status-postcondition",
+        )
+        if observed != "In Progress":
+            raise LckStopError(
+                "Project Status In Progress postcondition failed: live status "
+                "was not In Progress"
+            )
+        return EffectReceipt(
+            effect="set_in_progress_status",
+            action="updated",
+            details={
+                "previous_status": "Ready",
+                "status": "In Progress",
+                "postcondition": "verified",
+            },
+        )
+
+
 class SetReviewStatusEffect:
     """Move the Task to Review and verify only that metadata effect."""
 
@@ -883,25 +972,12 @@ class SetReviewStatusEffect:
         self.resolver = resolver
 
     def _query_project_status(self, repository: str, task_number: int) -> str | None:
-        result = self.resolver.runner.run(
-            [
-                "gh",
-                "issue",
-                "view",
-                str(task_number),
-                "--repo",
-                repository,
-                "--json",
-                "projectItems",
-            ],
+        return _query_issue_project_status(
+            self.resolver,
+            repository,
+            task_number,
             command_id="lck-review-status-postcondition",
         )
-        if result.returncode != 0 or not result.stdout.strip():
-            return None
-        value = read_json_text(result.stdout, field="lck-review-status-postcondition")
-        if not isinstance(value, Mapping):
-            return None
-        return _find_project_status(value.get("projectItems"))
 
     def execute(
         self,
@@ -943,9 +1019,10 @@ class SetReviewStatusEffect:
                 effect="set_review_status", action="already-review", details={}
             )
         previous_status = state.project_status
-        if previous_status not in {"Ready", "In Progress"}:
+        if previous_status != "In Progress":
             raise LckStopError(
-                "Project Status precondition failed: prior status cannot be restored"
+                "Project Status precondition failed: Delivery Complete requires "
+                "In Progress before Review"
             )
         set_project_status_with_runner(
             self.resolver.runner,

--- a/tools/agent_workflow/lck_core/eligibility.py
+++ b/tools/agent_workflow/lck_core/eligibility.py
@@ -292,7 +292,7 @@ class PhaseEligibilityResolver:
                 # a later final verification stopped.  Allow the same LCK
                 # Delivery Complete path to reacquire and safely finish that
                 # partial invocation.
-                Phase.DELIVERY_COMPLETE: {"Ready", "In Progress", "Review"},
+                Phase.DELIVERY_COMPLETE: {"In Progress", "Review"},
                 Phase.REVIEW_PREPARE: {"Review", "In Progress"},
                 Phase.REVIEW_COMPLETE: {"Review", "In Progress"},
                 Phase.REMEDIATION_PREPARE: {"Review"},
@@ -308,7 +308,12 @@ class PhaseEligibilityResolver:
                     "Done",
                 },
             }[phase]
-            if project not in allowed_projects:
+            if phase is Phase.DELIVERY_COMPLETE and project == "Ready":
+                reasons.append(
+                    "Delivery Complete requires Project Status In Progress; "
+                    "run Delivery Prepare first"
+                )
+            elif project not in allowed_projects:
                 reasons.append("Project Status is unavailable or unknown")
 
         reasons.extend(self.blocker_reasons(state, phase=phase))

--- a/tools/agent_workflow/lck_core/receipts.py
+++ b/tools/agent_workflow/lck_core/receipts.py
@@ -182,6 +182,28 @@ def _effect_agent_view(value: Any) -> list[dict[str, Any]]:
     return result
 
 
+def _delivery_prepare_effect_agent_view(value: Any) -> list[dict[str, Any]]:
+    result = _effect_agent_view(value)
+    if not isinstance(value, (list, tuple)):
+        return result
+    for compact, item in zip(result, value, strict=False):
+        details = (
+            item.details
+            if isinstance(item, EffectReceipt)
+            else item.get("details")
+            if isinstance(item, Mapping)
+            else None
+        )
+        if compact.get("effect") == "set_in_progress_status" and isinstance(
+            details, Mapping
+        ):
+            compact["postcondition"] = {
+                "status": details.get("postcondition"),
+                "project_status": details.get("status"),
+            }
+    return result
+
+
 def _delivery_pr_agent_view(effects: Any) -> dict[str, Any] | None:
     if not isinstance(effects, (list, tuple)):
         return None
@@ -242,6 +264,7 @@ def _agent_view_for_result(value: Any) -> dict[str, Any]:
                 "eligible": value.eligibility.eligible,
                 "reasons": list(value.eligibility.reasons),
             },
+            "effects": _delivery_prepare_effect_agent_view(value.effects),
             "human_boundary": "implement the Task before LCK Delivery Complete",
             "next_action": "implement the Task and run LCK Delivery Complete",
         }


### PR DESCRIPTION
Closes #288

## Summary
Add an audited, fail-closed Ready-to-In-Progress effect after Delivery Prepare workspace verification; require In Progress before Delivery Complete; cover transition, idempotency, failure, receipt, and documentation behavior.

## Validation
- Formal Delivery validation: pass

## Risks / limitations
No known functional limitations. Live Project Status reads and writes fail closed when the provider response is unavailable or inconsistent.
