### PR TITLE
[Bug] LCK Research Closeout 误要求预设 Outcome 且遗漏 ProjectV2 自定义字段

### DIFF
--- a/docs/architecture/typed-leaf-workflows.md
+++ b/docs/architecture/typed-leaf-workflows.md
@@ -55,6 +55,11 @@ the generic shared blocker gate and registered policy blockers; it must not
 contain a special case for a profile or blocker. A profile cannot use an
 arbitrary callable or hidden side effect to bypass the registry, policy
 validation, bounded effect executor, postcondition, or receipt authority.
+For Closeout, the generic policy context distinguishes the target being
+completed from a closed dependency: a target completion postcondition is not
+an admission prerequisite. Research derives its Project outcome only from the
+exact reviewed artifact binding and asks the bounded effect executor to set and
+verify it; maintainers do not pre-populate that field.
 
 The generic registry injection seam is independently testable: an isolated
 registry may register an additional policy and resolve it through the same

--- a/docs/development/issue-workflow.md
+++ b/docs/development/issue-workflow.md
@@ -315,7 +315,10 @@ Closeout 仅在 maintainer 已人工 Squash Merge 后执行：
 2. 将 Business Delivery 与 Cleanup 分离：merged PR 可立即得到
    Business Delivery = COMPLETE，cleanup 失败只产生 Cleanup = PENDING。Research 的
    `Research Outcome` 写入与 postcondition 也必须完成；DO NOT IMPLEMENT 与
-   NEEDS MORE EVIDENCE 仍然是 Business Delivery 的成功结果；
+   NEEDS MORE EVIDENCE 仍然是 Business Delivery 的成功结果。该值由 LCK 在验证
+   current Task contract、merged PR/base/head 与最新 Review PASS 的 exact artifact
+   binding 后，通过受约束 completion effect 自动写入 canonical Project；人工预设
+   不是正常步骤，也不是 fallback；
 3. 收敛 Issue / Project lifecycle（state、Status、labels）并同步 canonical
    `main`；
 4. 仅在 head/tree/worktree proof 完整时删除已验证的 Task branch，识别

--- a/tests/tools/test_lck_bug.py
+++ b/tests/tools/test_lck_bug.py
@@ -86,20 +86,52 @@ def test_live_issue_view_carries_the_bug_form_contract() -> None:
         repo_root = ROOT
 
         def run(self, argv: Any, *, command_id: str, **_: Any) -> CommandResult:
+            value: dict[str, Any]
+            if command_id == "gh-issue-project-items-159":
+                value = {
+                    "data": {
+                        "repository": {
+                            "issue": {
+                                "number": 159,
+                                "projectItems": {
+                                    "nodes": [
+                                        {
+                                            "project": {
+                                                "number": 1,
+                                                "title": "Quant System Development",
+                                                "owner": {"login": "owner"},
+                                            },
+                                            "content": {
+                                                "number": 159,
+                                                "repository": {
+                                                    "nameWithOwner": "owner/repo"
+                                                },
+                                            },
+                                            "fieldValues": {
+                                                "nodes": [],
+                                                "pageInfo": {"hasNextPage": False},
+                                            },
+                                        }
+                                    ],
+                                    "pageInfo": {"hasNextPage": False},
+                                },
+                            }
+                        }
+                    }
+                }
+            else:
+                value = {
+                    "number": 159,
+                    "title": "[Bug] enable implementation-bearing Bug workflow",
+                    "state": "OPEN",
+                    "labels": [{"name": "type:bug"}],
+                    "body": BUG_BODY,
+                }
             return CommandResult(
                 command_id,
                 tuple(str(item) for item in argv),
                 0,
-                json.dumps(
-                    {
-                        "number": 159,
-                        "title": "[Bug] enable implementation-bearing Bug workflow",
-                        "state": "OPEN",
-                        "labels": [{"name": "type:bug"}],
-                        "body": BUG_BODY,
-                        "projectItems": [],
-                    }
-                ),
+                json.dumps(value),
                 "",
             )
 

--- a/tests/tools/test_lck_delivery.py
+++ b/tests/tools/test_lck_delivery.py
@@ -878,6 +878,36 @@ Verification test: tests/tools/test_lck_delivery.py::test_task_160_critical_outc
                     "pageInfo": {"hasPreviousPage": False},
                 },
             }
+        elif "projectItems(first:20)" in query and "blockedBy" not in query:
+            issue = {
+                "number": 160,
+                "projectItems": {
+                    "nodes": [
+                        {
+                            "project": {
+                                "number": 1,
+                                "title": "Quant System Development",
+                                "owner": {"login": "owner"},
+                            },
+                            "content": {
+                                "number": 160,
+                                "repository": {"nameWithOwner": "owner/repo"},
+                            },
+                            "fieldValues": {
+                                "nodes": [
+                                    {
+                                        "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                        "name": self.project_status,
+                                        "field": {"name": "Status"},
+                                    }
+                                ],
+                                "pageInfo": {"hasNextPage": False},
+                            },
+                        }
+                    ],
+                    "pageInfo": {"hasNextPage": False},
+                },
+            }
         else:
             issue = {
                 "issueType": {"name": "Task"},

--- a/tests/tools/test_lck_receipts.py
+++ b/tests/tools/test_lck_receipts.py
@@ -80,7 +80,7 @@ def test_closeout_failure_receipt_preserves_completed_effects(
         metadata_effect=cast(Any, FailingMetadata()),
     )
     handler._validate_merged_identity = lambda _state: (SHA, "b" * 40)
-    handler._validate_reviewed_identity = lambda _state, _pr: None
+    handler._validate_reviewed_identity = lambda _state, _pr: {}
 
     with pytest.raises(lck_models.LckStopError, match="metadata convergence failed"):
         handler.complete(159)

--- a/tests/tools/test_lck_research.py
+++ b/tests/tools/test_lck_research.py
@@ -27,6 +27,7 @@ from lck_core import (  # type: ignore[import-not-found]  # noqa: E402
     models as lck_models,
     review as lck_review,
     review_workspace as lck_review_workspace,
+    shared_facts as lck_shared_facts,
 )
 from lck_test_support import FakeReviewWorkspace  # noqa: E402
 from research_policy import (  # type: ignore[import-not-found]  # noqa: E402
@@ -89,20 +90,68 @@ def test_live_research_issue_contract_uses_research_form() -> None:
         repo_root = ROOT
 
         def run(self, argv: Any, *, command_id: str, **_: Any) -> CommandResult:
+            value: dict[str, Any]
+            if command_id == "gh-issue-project-items-199":
+                value = {
+                    "data": {
+                        "repository": {
+                            "issue": {
+                                "number": 199,
+                                "projectItems": {
+                                    "nodes": [
+                                        {
+                                            "project": {
+                                                "number": 1,
+                                                "title": "Quant System Development",
+                                                "owner": {"login": "owner"},
+                                            },
+                                            "content": {
+                                                "number": 199,
+                                                "repository": {
+                                                    "nameWithOwner": "owner/repo"
+                                                },
+                                            },
+                                            "fieldValues": {
+                                                "nodes": [
+                                                    {
+                                                        "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                                        "name": "Review",
+                                                        "field": {"name": "Status"},
+                                                    },
+                                                    {
+                                                        "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                                        "name": "NEEDS MORE EVIDENCE",
+                                                        "field": {
+                                                            "name": "Research Outcome"
+                                                        },
+                                                    },
+                                                ],
+                                                "pageInfo": {"hasNextPage": False},
+                                            },
+                                        }
+                                    ],
+                                    "pageInfo": {"hasNextPage": False},
+                                },
+                            }
+                        }
+                    }
+                }
+            else:
+                value = {
+                    "number": 199,
+                    "title": "[Research] supported workflow",
+                    "state": "OPEN",
+                    "labels": [{"name": "type:research"}],
+                    "body": RESEARCH_BODY,
+                    # The CLI projection is intentionally incomplete and
+                    # conflicts with the authoritative GraphQL status.
+                    "projectItems": [{"status": {"name": "Ready"}}],
+                }
             return CommandResult(
                 command_id,
                 tuple(str(item) for item in argv),
                 0,
-                json.dumps(
-                    {
-                        "number": 199,
-                        "title": "[Research] supported workflow",
-                        "state": "OPEN",
-                        "labels": [{"name": "type:research"}],
-                        "body": RESEARCH_BODY,
-                        "projectItems": [],
-                    }
-                ),
+                json.dumps(value),
                 "",
             )
 
@@ -124,6 +173,98 @@ def test_live_research_issue_contract_uses_research_form() -> None:
     assert research_contract["template_path"] == ".github/ISSUE_TEMPLATE/research.yml"
     assert is_valid_research_contract(research_contract)
     assert contract["research_contract"] == research_contract
+    assert issue["project_status"] == "Review"
+    assert issue["research_outcome"] == "NEEDS MORE EVIDENCE"
+
+
+@pytest.mark.parametrize(
+    "defect",
+    (
+        "project-pagination",
+        "field-pagination",
+        "duplicate-canonical-project",
+        "wrong-owner",
+        "wrong-project-title",
+        "wrong-content-number",
+        "wrong-content-repository",
+        "malformed-single-select",
+    ),
+)
+def test_canonical_projectv2_facts_fail_closed(defect: str) -> None:
+    project_item: dict[str, Any] = {
+        "project": {
+            "number": 1,
+            "title": "Quant System Development",
+            "owner": {"login": "owner"},
+        },
+        "content": {
+            "number": 199,
+            "repository": {"nameWithOwner": "owner/repo"},
+        },
+        "fieldValues": {
+            "nodes": [
+                {
+                    "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                    "name": "Review",
+                    "field": {"name": "Status"},
+                }
+            ],
+            "pageInfo": {"hasNextPage": False},
+        },
+    }
+    raw: dict[str, Any] = {
+        "nodes": [project_item],
+        "pageInfo": {"hasNextPage": False},
+    }
+    if defect == "project-pagination":
+        raw["pageInfo"]["hasNextPage"] = True
+    elif defect == "field-pagination":
+        project_item["fieldValues"]["pageInfo"]["hasNextPage"] = True
+    elif defect == "duplicate-canonical-project":
+        raw["nodes"].append(json.loads(json.dumps(project_item)))
+    elif defect == "wrong-owner":
+        project_item["project"]["owner"]["login"] = "someone-else"
+    elif defect == "wrong-project-title":
+        project_item["project"]["title"] = "Different Project"
+    elif defect == "wrong-content-number":
+        project_item["content"]["number"] = 200
+    elif defect == "wrong-content-repository":
+        project_item["content"]["repository"]["nameWithOwner"] = "owner/other"
+    elif defect == "malformed-single-select":
+        project_item["fieldValues"]["nodes"][0].pop("__typename")
+
+    normalized = lck_shared_facts._normalize_project_items(raw)
+
+    assert (
+        lck_shared_facts.canonical_project_field(
+            normalized,
+            repository="owner/repo",
+            issue_number=199,
+            field_name="Status",
+        )
+        is None
+    )
+
+
+def test_root_projectv2_graphql_error_is_incomplete() -> None:
+    class Runner:
+        def run(self, argv: Any, *, command_id: str, **_: Any) -> CommandResult:
+            return CommandResult(
+                command_id,
+                tuple(str(item) for item in argv),
+                0,
+                json.dumps({"errors": [{"message": "query failed"}]}),
+                "",
+            )
+
+    warnings: list[dict[str, Any]] = []
+    project_items = lck_shared_facts._issue_project_items_snapshot(
+        Runner(), "owner/repo", 199, warnings
+    )
+
+    assert project_items["complete"] is False
+    assert project_items["truncated"] is True
+    assert warnings
 
 
 def test_research_profile_binds_typed_outcome_to_reviewed_artifact(
@@ -166,7 +307,8 @@ def test_research_profile_binds_typed_outcome_to_reviewed_artifact(
     # closed-PR Closeout path, Project Research Outcome, and blocker admission.
     report = tmp_path / "docs" / "research" / "lifecycle.md"
     report.write_text(
-        "# Research report\n\nResearch Outcome: IMPLEMENT\n", encoding="utf-8"
+        "# Research report\n\nResearch Outcome: NEEDS MORE EVIDENCE\n",
+        encoding="utf-8",
     )
     review_root = tmp_path / "review-root"
     review_report = review_root / "docs" / "research" / "lifecycle.md"
@@ -243,9 +385,9 @@ def test_research_profile_binds_typed_outcome_to_reviewed_artifact(
                                                     },
                                                     "fieldValueByName": {
                                                         "name": (
-                                                            "IMPLEMENT"
+                                                            "NEEDS MORE EVIDENCE"
                                                             if self.project_writes
-                                                            else "DO NOT IMPLEMENT"
+                                                            else None
                                                         )
                                                     },
                                                 }
@@ -267,16 +409,54 @@ def test_research_profile_binds_typed_outcome_to_reviewed_artifact(
             raise AssertionError(f"unsupported lifecycle command: {command}")
 
     runner = Runner()
+    root_project_items = lck_shared_facts._normalize_project_items(
+        {
+            "nodes": [
+                {
+                    "project": {
+                        "number": 1,
+                        "title": "Quant System Development",
+                        "owner": {"login": "owner"},
+                    },
+                    "content": {
+                        "number": 199,
+                        "repository": {"nameWithOwner": "owner/repo"},
+                    },
+                    "fieldValues": {
+                        "nodes": [
+                            {
+                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                "name": "Review",
+                                "field": {"name": "Status"},
+                            }
+                        ],
+                        "pageInfo": {"hasNextPage": False},
+                    },
+                }
+            ],
+            "pageInfo": {"hasNextPage": False},
+        }
+    )
     issue = {
         "number": 199,
         "title": "[Research] supported workflow",
         "state": "OPEN",
         "labels": {"items": ["type:research", "codex:ready"]},
         "project_status": "Review",
+        "project_items": root_project_items,
         "body": RESEARCH_BODY,
         "body_sha256": body_sha,
         "research_contract": research_contract_snapshot(RESEARCH_BODY),
     }
+    assert (
+        lck_shared_facts.canonical_project_field(
+            root_project_items,
+            repository="owner/repo",
+            issue_number=199,
+            field_name="Research Outcome",
+        )
+        is None
+    )
     pr = {
         "number": 299,
         "state": "OPEN",
@@ -445,7 +625,7 @@ def test_research_profile_binds_typed_outcome_to_reviewed_artifact(
     ).complete(199, review_id, verdict="PASS")
     assert review_result.status == "READY_FOR_MERGE_PREFLIGHT"
     review_record = review_store.read_record(199, review_id)
-    assert review_record["research_outcome"] == "IMPLEMENT"
+    assert review_record["research_outcome"] == "NEEDS MORE EVIDENCE"
 
     merge_result = lck_review.MergePreflight(
         resolver,
@@ -487,7 +667,6 @@ def test_research_profile_binds_typed_outcome_to_reviewed_artifact(
 
     closeout = lck_closeout.CloseoutCompleter(
         resolver,
-        eligibility=cast(Any, Eligible()),
         main_effect=cast(Any, FixedEffect("synchronize_main", "synchronized")),
         metadata_effect=cast(
             Any, FixedEffect("converge_task_metadata", "already-converged")
@@ -499,7 +678,7 @@ def test_research_profile_binds_typed_outcome_to_reviewed_artifact(
     closeout._validate_reviewed_identity = lambda _state, _pr: review_record
     closeout_result = closeout.complete(199)
     assert closeout_result.business_delivery == "COMPLETE"
-    assert closeout_result.research_outcome == "IMPLEMENT"
+    assert closeout_result.research_outcome == "NEEDS MORE EVIDENCE"
     assert runner.project_writes == 1
 
     blocker_gate = _formal_blockers_gate(
@@ -525,13 +704,14 @@ def test_research_profile_binds_typed_outcome_to_reviewed_artifact(
     assert blocker_gate["status"] == "pass"
 
 
-def test_research_completion_rejects_artifact_divergence_from_review_identity(
-    tmp_path: Path,
+@pytest.mark.parametrize("outcome", ("IMPLEMENT", "DO NOT IMPLEMENT"))
+def test_research_completion_accepts_typed_outcomes_and_rejects_artifact_divergence(
+    tmp_path: Path, outcome: str
 ) -> None:
     artifact_path = tmp_path / "docs" / "research" / "report.md"
     artifact_path.parent.mkdir(parents=True)
     artifact_path.write_text(
-        "# Research report\n\nResearch Outcome: IMPLEMENT\n",
+        f"# Research report\n\nResearch Outcome: {outcome}\n",
         encoding="utf-8",
     )
     body_sha = sha256_json({"body": RESEARCH_BODY})
@@ -583,6 +763,7 @@ def test_research_completion_rejects_artifact_divergence_from_review_identity(
         completion_input,
     )
     assert result.effect is not None
+    assert result.effect.parameters["value"] == outcome
 
     tampered = dict(binding)
     tampered["artifact_sha256"] = "f" * 64
@@ -602,6 +783,85 @@ def test_research_completion_rejects_artifact_divergence_from_review_identity(
             issue,
             tampered_input,
         )
+
+
+def test_closeout_rejects_missing_review_artifact_before_any_effect(
+    tmp_path: Path,
+) -> None:
+    body_sha = sha256_json({"body": RESEARCH_BODY})
+    issue = {
+        "number": 199,
+        "title": "[Research] supported workflow",
+        "state": "CLOSED",
+        "labels": {"items": ["type:research", "codex:ready"]},
+        "project_status": "Review",
+        "body_sha256": body_sha,
+        "research_contract": research_contract_snapshot(RESEARCH_BODY),
+    }
+    state = lck_models.LiveState(
+        issue_number=199,
+        repository="owner/repo",
+        issue=issue,
+        leaf_contract={
+            "number": 199,
+            "title": issue["title"],
+            "body": RESEARCH_BODY,
+            "body_sha256": body_sha,
+            "research_contract": issue["research_contract"],
+        },
+        relationships={
+            "available": True,
+            "blocked_by": {"items": [], "count": 0, "truncated": False},
+        },
+        merged_pr={"number": 299},
+    )
+    resolver = cast(
+        Any,
+        type(
+            "Resolver",
+            (),
+            {
+                "repo_root": tmp_path,
+                "resolve": lambda _self, _task_number: state,
+            },
+        )(),
+    )
+
+    class Eligible:
+        def resolve(
+            self,
+            _state: lck_models.LiveState,
+            phase: lck_models.Phase,
+        ) -> lck_eligibility.PhaseDecision:
+            return lck_eligibility.PhaseDecision(phase=phase, eligible=True)
+
+    class ForbiddenEffect:
+        def execute(self, *_args: Any, **_kwargs: Any) -> lck_models.EffectReceipt:
+            raise AssertionError("Closeout effect ran before completion validation")
+
+    handler = lck_closeout.CloseoutCompleter(
+        resolver,
+        eligibility=cast(Any, Eligible()),
+        main_effect=cast(Any, ForbiddenEffect()),
+    )
+    handler._validate_merged_identity = lambda _state: ("2" * 40, "3" * 40)
+    handler._validate_reviewed_identity = lambda _state, _pr: {
+        "identity": {
+            "task_number": 199,
+            "pr_number": 299,
+            "base_sha": "1" * 40,
+            "head_sha": "2" * 40,
+            "task_body_sha256": body_sha,
+        }
+    }
+
+    with pytest.raises(
+        lck_models.LckStopError,
+        match="reviewed artifact binding",
+    ):
+        handler.complete(199)
+
+    assert handler.last_effects == []
 
 
 def test_research_blocker_uses_only_the_canonical_project_outcome() -> None:
@@ -638,13 +898,21 @@ def test_research_blocker_uses_only_the_canonical_project_outcome() -> None:
                                                         {
                                                             "project": {
                                                                 "number": 17,
+                                                                "title": "Other",
                                                                 "owner": {
                                                                     "login": "owner"
+                                                                },
+                                                            },
+                                                            "content": {
+                                                                "number": 198,
+                                                                "repository": {
+                                                                    "nameWithOwner": "owner/repo"
                                                                 },
                                                             },
                                                             "fieldValues": {
                                                                 "nodes": [
                                                                     {
+                                                                        "__typename": "ProjectV2ItemFieldSingleSelectValue",
                                                                         "name": "IMPLEMENT",
                                                                         "field": {
                                                                             "name": "Research Outcome"
@@ -659,13 +927,21 @@ def test_research_blocker_uses_only_the_canonical_project_outcome() -> None:
                                                         {
                                                             "project": {
                                                                 "number": 1,
+                                                                "title": "Quant System Development",
                                                                 "owner": {
                                                                     "login": "owner"
+                                                                },
+                                                            },
+                                                            "content": {
+                                                                "number": 198,
+                                                                "repository": {
+                                                                    "nameWithOwner": "owner/repo"
                                                                 },
                                                             },
                                                             "fieldValues": {
                                                                 "nodes": [
                                                                     {
+                                                                        "__typename": "ProjectV2ItemFieldSingleSelectValue",
                                                                         "name": "DO NOT IMPLEMENT",
                                                                         "field": {
                                                                             "name": "Research Outcome"

--- a/tests/tools/test_lck_typed_dependency_contracts.py
+++ b/tests/tools/test_lck_typed_dependency_contracts.py
@@ -97,10 +97,19 @@ Adopt the repository-backed workflow contract.
 DEPENDENCY_PROJECT = {
     "nodes": [
         {
-            "project": {"number": 1, "owner": {"login": "owner"}},
+            "project": {
+                "number": 1,
+                "title": "Quant System Development",
+                "owner": {"login": "owner"},
+            },
+            "content": {
+                "number": 191,
+                "repository": {"nameWithOwner": "owner/repo"},
+            },
             "fieldValues": {
                 "nodes": [
                     {
+                        "__typename": "ProjectV2ItemFieldSingleSelectValue",
                         "name": "ARCHITECTURE DECISION",
                         "field": {"name": "Research Outcome"},
                     }

--- a/tests/tools/test_workflow_evidence.py
+++ b/tests/tools/test_workflow_evidence.py
@@ -110,6 +110,20 @@ elif args[:2] == ['api','graphql']:
                 number_value=arg.split('=',1)[1]
         issue=state.get('issues',{{}}).get(number_value)
         dump({{'data':{{'repository':{{'issue':issue}}}}}})
+    elif 'projectItems(first:20)' in query and 'blockedBy' not in query:
+        number_value=None
+        for arg in args:
+            if arg.startswith('number='):
+                number_value=arg.split('=',1)[1]
+        issue=state.get('issues',{{}}).get(number_value)
+        status=None
+        if issue is not None:
+            items=issue.get('projectItems',[])
+            if items:
+                status=items[0].get('status',{{}}).get('name')
+        fields=[] if status is None else [{{'__typename':'ProjectV2ItemFieldSingleSelectValue','name':status,'field':{{'name':'Status'}}}}]
+        project_items={{'nodes':[{{'project':{{'number':1,'title':'Quant System Development','owner':{{'login':'owner'}}}},'content':{{'number':int(number_value),'repository':{{'nameWithOwner':'owner/repo'}}}},'fieldValues':{{'nodes':fields,'pageInfo':{{'hasNextPage':False}}}}}}],'pageInfo':{{'hasNextPage':False}}}}
+        dump({{'data':{{'repository':{{'issue':{{'number':int(number_value),'projectItems':project_items}}}}}}}})
     else:
         number_value=None
         for arg in args:

--- a/tools/agent_workflow/lck_core/closeout.py
+++ b/tools/agent_workflow/lck_core/closeout.py
@@ -639,12 +639,6 @@ class CloseoutCompleter:
         if not isinstance(state.merged_pr, Mapping):
             raise LckStopError("Closeout STOP: merged PR identity is unavailable")
         review_record = self._validate_reviewed_identity(state, state.merged_pr)
-        main = self.main_effect.execute(state, merge_sha=merge_sha)
-        effects.append(main)
-
-        metadata = self.metadata_effect.execute(state)
-        effects.append(metadata)
-
         try:
             profile, _policy = resolve_issue_policy(
                 _policy_issue_from_state(state),
@@ -682,6 +676,15 @@ class CloseoutCompleter:
             ) from exc
 
         self.last_profile_evidence = completion.profile_evidence
+        # Validate the exact Review/artifact binding and bounded completion
+        # descriptor before any Closeout effect. Execution still follows the
+        # established main -> metadata -> profile completion -> cleanup order.
+        main = self.main_effect.execute(state, merge_sha=merge_sha)
+        effects.append(main)
+
+        metadata = self.metadata_effect.execute(state)
+        effects.append(metadata)
+
         completion_effect: EffectReceipt | None = None
         if completion.effect is not None:
             if main.action in {"synchronized", "already-synced"}:

--- a/tools/agent_workflow/lck_core/eligibility.py
+++ b/tools/agent_workflow/lck_core/eligibility.py
@@ -165,6 +165,7 @@ class PhaseEligibilityResolver:
                             repository=state.repository,
                             downstream_contract=downstream_contract,
                             downstream_profile=profile,
+                            blocker_subject="target",
                         ),
                     )
                     reasons.extend(
@@ -229,6 +230,7 @@ class PhaseEligibilityResolver:
                             repository=state.repository,
                             downstream_contract=downstream_contract,
                             downstream_profile=profile,
+                            blocker_subject="dependency",
                         ),
                     )
                 except ValueError as exc:

--- a/tools/agent_workflow/lck_core/profile_policies.py
+++ b/tools/agent_workflow/lck_core/profile_policies.py
@@ -395,6 +395,7 @@ class PolicyContext:
     repository: str | None = None
     downstream_contract: Mapping[str, Any] | None = None
     downstream_profile: LeafIssueWorkflowProfile | None = None
+    blocker_subject: str | None = None
     repo_root: Path | None = None
     runner: Any = None
     base_sha: str | None = None
@@ -1371,12 +1372,18 @@ class _ResearchPolicy(_BuiltinPolicy):
         )
         if str(leaf_contract.get("state", "")).upper() != "CLOSED":
             return ()
+        if context.phase == "Closeout" and context.blocker_subject == "target":
+            # The target's completion postcondition is produced only after
+            # the exact reviewed artifact has been validated. It is not a
+            # prerequisite for entering that same completion path.
+            return ()
 
         outcome = leaf_contract.get("research_outcome")
         if outcome is None:
             outcome = canonical_project_field(
                 leaf_contract.get("project_items"),
                 repository=context.repository,
+                issue_number=leaf_contract.get("number"),
                 field_name=RESEARCH_OUTCOME_FIELD,
             )
         try:

--- a/tools/agent_workflow/lck_core/shared_facts.py
+++ b/tools/agent_workflow/lck_core/shared_facts.py
@@ -28,6 +28,43 @@ SCHEMA_VERSION: Final = 1
 MAX_CHILDREN: Final = 50
 MAX_FILES: Final = 100
 CANONICAL_PROJECT_NUMBER: Final = 1
+CANONICAL_PROJECT_TITLE: Final = "Quant System Development"
+
+ISSUE_PROJECT_ITEMS_QUERY: Final = r"""
+query($owner:String!, $name:String!, $number:Int!) {
+  repository(owner:$owner, name:$name) {
+    issue(number:$number) {
+      number
+      projectItems(first:20) {
+        nodes {
+          project {
+            number
+            title
+            owner {
+              ... on User { login }
+              ... on Organization { login }
+            }
+          }
+          content {
+            ... on Issue { number repository { nameWithOwner } }
+          }
+          fieldValues(first:100) {
+            nodes {
+              __typename
+              ... on ProjectV2ItemFieldSingleSelectValue {
+                name
+                field { ... on ProjectV2SingleSelectField { name } }
+              }
+            }
+            pageInfo { hasNextPage }
+          }
+        }
+        pageInfo { hasNextPage }
+      }
+    }
+  }
+}
+"""
 
 RELATIONSHIPS_QUERY: Final = r"""
 query($owner:String!, $name:String!, $number:Int!) {
@@ -61,13 +98,18 @@ query($owner:String!, $name:String!, $number:Int!) {
             nodes {
               project {
                 number
+                title
                 owner {
                   ... on User { login }
                   ... on Organization { login }
                 }
               }
-              fieldValues(first:20) {
+              content {
+                ... on Issue { number repository { nameWithOwner } }
+              }
+              fieldValues(first:100) {
                 nodes {
+                  __typename
                   ... on ProjectV2ItemFieldSingleSelectValue {
                     name
                     field { ... on ProjectV2SingleSelectField { name } }
@@ -92,13 +134,18 @@ query($owner:String!, $name:String!, $number:Int!) {
             nodes {
               project {
                 number
+                title
                 owner {
                   ... on User { login }
                   ... on Organization { login }
                 }
               }
-              fieldValues(first:20) {
+              content {
+                ... on Issue { number repository { nameWithOwner } }
+              }
+              fieldValues(first:100) {
                 nodes {
+                  __typename
                   ... on ProjectV2ItemFieldSingleSelectValue {
                     name
                     field { ... on ProjectV2SingleSelectField { name } }
@@ -459,39 +506,54 @@ def _graphql(
 
 
 def _normalize_project_items(value: Any) -> dict[str, Any]:
-    """Normalize Project metadata without interpreting any field name."""
+    """Normalize complete ProjectV2 single-select facts without policy meaning."""
     if isinstance(value, Mapping):
         nodes = value.get("nodes")
         page = value.get("pageInfo")
-    elif isinstance(value, list):
-        nodes = value
-        page = {"hasNextPage": False}
     else:
-        return {"items": [], "count": 0, "truncated": True}
+        return {"items": [], "count": 0, "truncated": True, "complete": False}
     if not isinstance(nodes, list) or not isinstance(page, Mapping):
-        return {"items": [], "count": 0, "truncated": True}
+        return {"items": [], "count": 0, "truncated": True, "complete": False}
+    page_complete = page.get("hasNextPage") is False
     normalized: list[dict[str, Any]] = []
+    all_items_complete = True
     for item in nodes:
         if not isinstance(item, Mapping):
+            all_items_complete = False
             continue
         project = item.get("project")
         if not isinstance(project, Mapping):
-            # Some GitHub/compatibility callers expose already-flattened
-            # Project fields (for example ``{"status": {"name": "Ready"}}``)
-            # rather than ProjectV2 item metadata. Preserve those normalized
-            # fields for generic status lookup, but never treat them as a
-            # canonical Project identity.
-            normalized.append(
-                {
-                    "number": None,
-                    "owner": None,
-                    "fields": dict(item),
-                    "fields_complete": True,
-                }
-            )
+            all_items_complete = False
             continue
         owner = project.get("owner")
         owner_login = owner.get("login") if isinstance(owner, Mapping) else None
+        project_number = project.get("number")
+        project_title = project.get("title")
+        content = item.get("content")
+        content_number = content.get("number") if isinstance(content, Mapping) else None
+        content_repository = (
+            content.get("repository") if isinstance(content, Mapping) else None
+        )
+        content_repository_name = (
+            content_repository.get("nameWithOwner")
+            if isinstance(content_repository, Mapping)
+            else None
+        )
+        item_identity_complete = (
+            isinstance(project_number, int)
+            and not isinstance(project_number, bool)
+            and project_number > 0
+            and isinstance(project_title, str)
+            and bool(project_title.strip())
+            and isinstance(owner_login, str)
+            and bool(owner_login.strip())
+            and isinstance(content, Mapping)
+            and isinstance(content_number, int)
+            and not isinstance(content_number, bool)
+            and content_number > 0
+            and isinstance(content_repository_name, str)
+            and bool(content_repository_name.strip())
+        )
         fields_value = item.get("fieldValues")
         fields: dict[str, str] = {}
         fields_complete = False
@@ -499,33 +561,103 @@ def _normalize_project_items(value: Any) -> dict[str, Any]:
             raw_fields = fields_value.get("nodes")
             field_page = fields_value.get("pageInfo")
             if isinstance(raw_fields, list):
+                fields_complete = (
+                    isinstance(field_page, Mapping)
+                    and field_page.get("hasNextPage") is False
+                )
                 for field_value in raw_fields:
                     if not isinstance(field_value, Mapping):
+                        fields_complete = False
+                        continue
+                    field_type = field_value.get("__typename")
+                    if field_type != "ProjectV2ItemFieldSingleSelectValue":
+                        if isinstance(field_type, str) and field_type:
+                            continue
+                        fields_complete = False
                         continue
                     field = field_value.get("field")
                     field_name = (
                         field.get("name") if isinstance(field, Mapping) else None
                     )
                     field_value_name = field_value.get("name")
-                    if isinstance(field_name, str) and isinstance(
-                        field_value_name, str
+                    if (
+                        isinstance(field_name, str)
+                        and isinstance(field_value_name, str)
+                        and field_name.strip()
+                        and field_value_name.strip()
                     ):
-                        fields[safe_text(field_name)] = safe_text(field_value_name)
-                fields_complete = (
-                    isinstance(field_page, Mapping)
-                    and field_page.get("hasNextPage") is False
-                )
+                        normalized_name = safe_text(field_name)
+                        normalized_value = safe_text(field_value_name)
+                        if normalized_name is None or normalized_value is None:
+                            fields_complete = False
+                        elif normalized_name in fields:
+                            fields_complete = False
+                        else:
+                            fields[normalized_name] = normalized_value
+                    else:
+                        fields_complete = False
+        item_complete = item_identity_complete and fields_complete
+        all_items_complete = all_items_complete and item_complete
         normalized.append(
             {
-                "number": project.get("number"),
+                "number": project_number,
+                "title": safe_text(project_title),
                 "owner": safe_text(owner_login),
+                "content_number": content_number,
+                "content_repository": safe_text(content_repository_name),
                 "fields": fields,
                 "fields_complete": fields_complete,
+                "identity_complete": item_identity_complete,
             }
         )
     bounded = bounded_list(normalized)
-    bounded["truncated"] = bounded["truncated"] or page.get("hasNextPage") is True
+    bounded["truncated"] = bounded["truncated"] or not page_complete
+    bounded["complete"] = (
+        page_complete and not bounded["truncated"] and all_items_complete
+    )
     return bounded
+
+
+def _issue_project_items_snapshot(
+    runner: CommandRunner,
+    repository: str,
+    number: int,
+    warnings: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Acquire one root Issue's canonical ProjectV2 facts."""
+    command_id = f"gh-issue-project-items-{number}"
+    value = _graphql(
+        runner,
+        repository,
+        number,
+        ISSUE_PROJECT_ITEMS_QUERY,
+        command_id=command_id,
+        warnings=warnings,
+    )
+    issue = None
+    if isinstance(value, Mapping):
+        data = value.get("data")
+        repo = data.get("repository") if isinstance(data, Mapping) else None
+        issue = repo.get("issue") if isinstance(repo, Mapping) else None
+    if not isinstance(issue, Mapping) or issue.get("number") != number:
+        warnings.append(
+            {
+                "command_id": command_id,
+                "exit_code": 0,
+                "error": "ProjectV2 Issue response is missing or has the wrong identity",
+            }
+        )
+        return {"items": [], "count": 0, "truncated": True, "complete": False}
+    project_items = _normalize_project_items(issue.get("projectItems"))
+    if project_items.get("complete") is not True:
+        warnings.append(
+            {
+                "command_id": command_id,
+                "exit_code": 0,
+                "error": "ProjectV2 item or single-select field facts are incomplete",
+            }
+        )
+    return project_items
 
 
 def _find_project_field(value: Any, field_name: str) -> str | None:
@@ -570,6 +702,7 @@ def canonical_project_field(
     value: Any,
     *,
     repository: str | None,
+    issue_number: int | None,
     field_name: str,
 ) -> str | None:
     """Return a field from the repository owner's canonical Project item.
@@ -577,7 +710,11 @@ def canonical_project_field(
     Project identity and field normalization are mechanical facts.  The caller
     chooses which normalized field has business meaning.
     """
-    if not isinstance(value, Mapping) or repository is None:
+    if (
+        not isinstance(value, Mapping)
+        or repository is None
+        or value.get("complete") is not True
+    ):
         return None
     owner, separator, _name = repository.partition("/")
     if not separator or not owner:
@@ -590,8 +727,13 @@ def canonical_project_field(
         for item in items
         if isinstance(item, Mapping)
         and item.get("number") == CANONICAL_PROJECT_NUMBER
+        and item.get("title") == CANONICAL_PROJECT_TITLE
         and isinstance(item.get("owner"), str)
         and item.get("owner", "").casefold() == owner.casefold()
+        and isinstance(item.get("content_repository"), str)
+        and item.get("content_repository", "").casefold() == repository.casefold()
+        and item.get("content_number") == issue_number
+        and item.get("identity_complete") is True
         and item.get("fields_complete") is True
     ]
     if len(canonical) != 1:
@@ -752,7 +894,7 @@ def _issue_view_with_contract(
     include_contract: bool = True,
 ) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
     """Read and normalize one Issue without profile interpretation."""
-    fields = ["number", "title", "state", "labels", "projectItems", "url"]
+    fields = ["number", "title", "state", "labels", "url"]
     if include_contract:
         fields.append("body")
     if include_comments:
@@ -789,7 +931,6 @@ def _issue_view_with_contract(
                     if field
                     not in {
                         "comments",
-                        "projectItems",
                         "closedByPullRequestsReferences",
                     }
                 ),
@@ -838,7 +979,7 @@ def _issue_view_with_contract(
                 }
             )
     body = value.get("body") if isinstance(value.get("body"), str) else None
-    project_items = _normalize_project_items(value.get("projectItems"))
+    project_items = _issue_project_items_snapshot(runner, repository, number, warnings)
     pull_refs: list[dict[str, Any]] = []
     raw_pull_refs = value.get("closedByPullRequestsReferences", [])
     if isinstance(raw_pull_refs, list):
@@ -859,7 +1000,12 @@ def _issue_view_with_contract(
         "state": safe_text(value.get("state")),
         "labels": bounded_list(sorted(normalized_labels)),
         "project_items": project_items,
-        "project_status": _find_project_status(project_items),
+        "project_status": canonical_project_field(
+            project_items,
+            repository=repository,
+            issue_number=number,
+            field_name="Status",
+        ),
         "url": safe_text(value.get("url")),
         "closed_at": safe_text(value.get("closedAt")),
         "closing_pull_requests": bounded_list(pull_refs),

--- a/tools/agent_workflow/workflow_evidence.py
+++ b/tools/agent_workflow/workflow_evidence.py
@@ -233,6 +233,7 @@ def _audit_issue_view_with_contract(
         shared_facts.canonical_project_field(
             result.get("project_items"),
             repository=repository,
+            issue_number=result.get("number"),
             field_name=RESEARCH_OUTCOME_FIELD,
         )
         if is_research
@@ -302,6 +303,7 @@ def _audit_relationship_snapshot(
                 shared_facts.canonical_project_field(
                     item.get("project_items"),
                     repository=repository,
+                    issue_number=item.get("number"),
                     field_name=RESEARCH_OUTCOME_FIELD,
                 )
                 if is_research
@@ -487,6 +489,7 @@ def _audit_formal_blockers_gate(
                     else None,
                     downstream_contract=downstream_contract,
                     downstream_profile=downstream_profile,
+                    blocker_subject="dependency",
                 ),
             )
         except (TypeError, ValueError) as exc:


### PR DESCRIPTION
Closes #291

## Summary
Acquire complete canonical ProjectV2 facts for root and relationship Issues, distinguish Closeout targets from dependencies, validate reviewed Research completion intent before effects, and add regression coverage and documentation.

## Validation
- Formal Delivery validation: pass

## Risks / limitations
ProjectV2 facts now fail closed on incomplete pagination, malformed fields, or canonical identity mismatch. Issue #279 Closeout remains explicitly out of scope and was not run.
