### PR TITLE
[Task] 实现 Binance USDⓈ-M 1m Index Price Kline 官方历史文件回填

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,18 +153,64 @@ The currently implemented public package is `tracequant` under `src/`:
   `OHLCVBar` models with validation and JSON-compatible serialization.
 - `tracequant.data`: typed Binance USDⓈ-M public-history contracts, an
   immutable local Raw Parquet/manifest store, and explicit archive-backfill
-  adapters for BTCUSDT and ETHUSDT 1m contract and mark-price Klines. Backfill
-  calls perform bounded public HTTP downloads, checksum and ZIP/CSV validation,
-  and Raw persistence; importing the module performs no I/O.
+  adapters for BTCUSDT and ETHUSDT 1m contract, mark-price, and index-price
+  Klines. Backfill calls perform bounded public HTTP downloads, checksum and
+  ZIP/CSV validation, and Raw persistence; importing the module performs no I/O.
 
 The `apps/`, `packages/`, and `deploy/` directories currently establish future
 boundaries through small README files. They are not implemented product
 packages. The implemented ingestion path is limited to Binance's public USDⓈ-M
-1m contract-Kline and mark-price-Kline archives; there is no private or trading
-exchange client, REST recent synchronization, general data pipeline, canonical
-quality or repair layer, database, feature or label pipeline, backtester,
-strategy, machine-learning model, order or account service, risk engine, live
-runtime, or multi-exchange implementation.
+1m contract-Kline, mark-price-Kline, and index-price-Kline archives; there is no
+private or trading exchange client, REST recent synchronization, general data
+pipeline, canonical quality or repair layer, database, feature or label
+pipeline, backtester, strategy, machine-learning model, order or account
+service, risk engine, live runtime, or multi-exchange implementation.
+
+### Binance index-price archive backfill
+
+`BinanceIndexPriceKlineBackfill` accepts a semantic price-index pair, not an
+orderable `InstrumentId`, and a UTC half-open `TimeRange`:
+
+```python
+from datetime import UTC, datetime
+from pathlib import Path
+
+from tracequant.data import (
+    BinanceIndexPriceKlineBackfill,
+    BinancePriceIndexId,
+    RawObjectIdentity,
+    RawStore,
+)
+from tracequant.domain import TimeRange
+
+store = RawStore(Path("raw"))
+request_range = TimeRange(
+    start=datetime(2024, 2, 29, tzinfo=UTC),
+    end=datetime(2024, 3, 1, tzinfo=UTC),
+)
+result = BinanceIndexPriceKlineBackfill(store).run(
+    BinancePriceIndexId("BTCUSDT"), request_range
+)
+
+plan = result.objects[0].plan
+identity = RawObjectIdentity.from_request(plan.request)
+for artifact in store.list_verified_revisions(identity):
+    revision = artifact.revision_identity
+    assert revision is not None
+    exact_artifact = store.read_revision(identity, revision)
+```
+
+The frozen archive coverage is monthly `2020-01` through `2026-07` and daily
+`2019-12-23` through `2026-08-29` for BTCUSDT and ETHUSDT. Complete covered
+months use monthly objects; UTC edge dates use daily objects. The first daily
+object is partial from 11:58 UTC and is reported as a coverage gap, not
+published as complete. Dates outside the frozen coverage are explicit gaps and
+do not trigger speculative URLs. The adapter preserves ZIP, checksum response,
+manifest digests, original millisecond timestamps, decimal strings, and
+non-trading `placeholder_*` fields. It has no REST/USDC fallback, tradability
+decision, retry scheduler, canonical repair, or aggregation behavior. Inspect
+every object status and `result.completed`; partial success or any gap/failure
+keeps the batch incomplete.
 
 “Research MVP” therefore means a reliable foundation for later research work,
 not a claim that research, backtesting, Demo, or Live trading is available.
@@ -246,6 +292,7 @@ src/tracequant/                 implemented bootstrap package
   data/public_history.py        Binance public-history contracts
   data/raw_store.py             immutable Raw Parquet/manifest persistence
   data/binance_contract_kline.py  explicit Binance archive backfill adapter
+  data/binance_index_price_kline.py  explicit index-price pair archive adapter
   data/binance_mark_price_kline.py  explicit mark-price archive adapter
 tests/                          package and workflow tests
   fixtures/domain.py            deterministic domain factories, test-only

--- a/docs/architecture/technical-baseline.md
+++ b/docs/architecture/technical-baseline.md
@@ -45,9 +45,10 @@ The public foundation consists of:
    acquisition outcomes in separate manifests with optional quarantined
    response bodies;
 7. explicit Binance USDⓈ-M public-archive backfill adapters for BTCUSDT and
-   ETHUSDT 1m contract and mark-price Klines, including bounded HTTP, upstream
-   checksum verification, ZIP/CSV validation, complete 12-field Raw parsing,
-   and mark-price-specific placeholder field names;
+   ETHUSDT 1m contract, mark-price, and index-price Klines, including bounded
+   HTTP, upstream checksum verification, ZIP/CSV validation, complete 12-field
+   Raw parsing, typed price-index-pair identity, and dataset-specific
+   placeholder field names;
 8. deterministic test-only factories for the domain models.
 
 Polars is the sole runtime third-party dependency in `pyproject.toml` and is
@@ -171,15 +172,16 @@ public exchange data
 ```
 
 Only the first, narrow part of this flow currently exists: callers can retrieve
-approved Binance USDⓈ-M BTCUSDT/ETHUSDT 1m contract-Kline or mark-price-Kline
-archives and publish immutable Raw Parquet objects with manifests. There is no
-general Binance or private API client, REST recent/gap synchronization,
-canonical schema, data repair, feature pipeline, label pipeline, or
-future-data-leakage check. Each adapter validates missing, duplicate, and
-out-of-order minutes before publication. The preserved 12-field wire values are
-Raw source data and must not be treated as a canonical schema; mark-price
-volume, quote, count, taker, and ignore fields have explicit `placeholder_*`
-names and no contract-trade meaning.
+approved Binance USDⓈ-M BTCUSDT/ETHUSDT 1m contract-Kline, mark-price-Kline, or
+index-price-Kline archives and publish immutable Raw Parquet objects with
+manifests. There is no general Binance or private API client, REST recent/gap
+synchronization, canonical schema, data repair, feature pipeline, label
+pipeline, or future-data-leakage check. Each adapter validates missing,
+duplicate, and out-of-order minutes before publication. The preserved 12-field
+wire values are Raw source data and must not be treated as a canonical schema;
+mark/index volume, quote, count, taker, and ignore fields have explicit
+`placeholder_*` names and no contract-trade meaning. Index history is keyed by
+typed price-index pair and does not establish instrument tradability.
 
 Archive planning is bounded by the per-instrument daily and monthly coverage
 frozen in the approved Research contract. Dates outside those observed bounds
@@ -219,12 +221,12 @@ boundaries until such an Issue is implemented and reviewed.
 ## 8. Research and trading scope limits
 
 The current public-data capability is limited to explicitly requested Binance
-USDⓈ-M BTCUSDT/ETHUSDT 1m contract-Kline and mark-price-Kline archives and local
-immutable Raw artifacts. None of the following is currently available: private
-Binance API access, REST recent/gap synchronization, index-price or funding
-ingestion, multi-timeframe aggregation, factors, models, backtests, Demo orders,
-Live orders, private API credentials, database state, or multi-exchange
-production execution.
+USDⓈ-M BTCUSDT/ETHUSDT 1m contract-Kline, mark-price-Kline, and index-price-Kline
+archives and local immutable Raw artifacts. None of the following is currently
+available: private Binance API access, REST recent/gap synchronization, funding
+ingestion, USDC archive acquisition, multi-timeframe aggregation, factors,
+models, backtests, Demo orders, Live orders, private API credentials, database
+state, or multi-exchange production execution.
 
 Historical research, planning documents, and workflow documentation must retain
 their stated roles. Workflow controls such as LCK and the Validation Runner

--- a/src/tracequant/data/__init__.py
+++ b/src/tracequant/data/__init__.py
@@ -10,6 +10,14 @@ from tracequant.data.binance_contract_kline import (
     BinanceContractKlineStatus,
     plan_binance_contract_kline_archives,
 )
+from tracequant.data.binance_index_price_kline import (
+    BinanceIndexPriceKlineBackfill,
+    BinanceIndexPriceKlineCoverageGapPlan,
+    BinanceIndexPriceKlineObjectResult,
+    BinanceIndexPriceKlineRunResult,
+    BinanceIndexPriceKlineStatus,
+    plan_binance_index_price_kline_archives,
+)
 from tracequant.data.binance_mark_price_kline import (
     BinanceMarkPriceKlineBackfill,
     BinanceMarkPriceKlineCoverageGapPlan,
@@ -81,6 +89,11 @@ __all__ = [
     "BinanceContractKlineRunResult",
     "BinanceContractKlineStatus",
     "BinanceKlineInterval",
+    "BinanceIndexPriceKlineBackfill",
+    "BinanceIndexPriceKlineCoverageGapPlan",
+    "BinanceIndexPriceKlineObjectResult",
+    "BinanceIndexPriceKlineRunResult",
+    "BinanceIndexPriceKlineStatus",
     "BinanceMarkPriceKlineBackfill",
     "BinanceMarkPriceKlineCoverageGapPlan",
     "BinanceMarkPriceKlineObjectResult",
@@ -117,6 +130,7 @@ __all__ = [
     "RawStore",
     "RawStoreError",
     "plan_binance_contract_kline_archives",
+    "plan_binance_index_price_kline_archives",
     "plan_binance_mark_price_kline_archives",
     "next_binance_funding_cursor",
     "next_binance_kline_cursor",

--- a/src/tracequant/data/binance_index_price_kline.py
+++ b/src/tracequant/data/binance_index_price_kline.py
@@ -1,0 +1,486 @@
+"""Binance USDⓈ-M 1m index-price-Kline archive backfill adapter.
+
+The adapter owns price-index-pair planning, parsing, and coverage semantics.
+It delegates official archive acquisition, evidence, and immutable Raw
+publication to the shared Binance public-archive seam.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, date, datetime, time, timedelta
+from pathlib import Path
+from typing import Final
+
+import polars as pl
+
+from tracequant.data.binance_public_archive import (
+    ArchiveHttpGet,
+    ArchiveHttpResponse,
+    BinanceArchiveAcquisitionStatus,
+    BinanceArchiveObjectPlan,
+    BinanceArchiveParseResult,
+    BinancePublicArchiveAcquisition,
+    _coverage_gap,
+    _invalid_content,
+)
+from tracequant.data.public_history import (
+    BinanceArchiveObjectBoundary,
+    BinanceKlineInterval,
+    BinancePriceIndexId,
+    BinancePublicHistoryDataType,
+    BinancePublicHistoryRequest,
+    BinancePublicHistorySourceKind,
+)
+from tracequant.data.raw_store import RawStore
+from tracequant.domain import TimeRange
+
+__all__ = [
+    "ArchiveHttpResponse",
+    "BinanceArchiveObjectPlan",
+    "BinanceIndexPriceKlineBackfill",
+    "BinanceIndexPriceKlineCoverageGapPlan",
+    "BinanceIndexPriceKlineObjectResult",
+    "BinanceIndexPriceKlineRunResult",
+    "BinanceIndexPriceKlineStatus",
+    "plan_binance_index_price_kline_archives",
+]
+
+_ARCHIVE_ROOT: Final = "https://data.binance.vision"
+_SCHEMA_IDENTIFIER: Final = "binance.um.index-price-kline.csv.v1"
+_ONE_MINUTE_MS: Final = 60_000
+_MAX_SIGNED_INT64_TEXT: Final = str(2**63 - 1)
+
+# Binance uses the contract-Kline physical header for index-price archives.
+# These names are recognized only at the wire boundary; placeholder fields are
+# published with names that prevent them being interpreted as traded values.
+_UPSTREAM_COLUMNS: Final = (
+    "open_time",
+    "open",
+    "high",
+    "low",
+    "close",
+    "volume",
+    "close_time",
+    "quote_volume",
+    "count",
+    "taker_buy_volume",
+    "taker_buy_quote_volume",
+    "ignore",
+)
+_RAW_COLUMNS: Final = (
+    "open_time",
+    "index_open",
+    "index_high",
+    "index_low",
+    "index_close",
+    "placeholder_volume",
+    "close_time",
+    "placeholder_quote_volume",
+    "placeholder_count",
+    "placeholder_taker_buy_volume",
+    "placeholder_taker_buy_quote_volume",
+    "placeholder_ignore",
+)
+_DTYPES: Final = {
+    "open_time": pl.Int64,
+    "index_open": pl.String,
+    "index_high": pl.String,
+    "index_low": pl.String,
+    "index_close": pl.String,
+    "placeholder_volume": pl.String,
+    "close_time": pl.Int64,
+    "placeholder_quote_volume": pl.String,
+    "placeholder_count": pl.String,
+    "placeholder_taker_buy_volume": pl.String,
+    "placeholder_taker_buy_quote_volume": pl.String,
+    "placeholder_ignore": pl.String,
+}
+
+# Frozen pair coverage from the approved Research source contract. The first
+# daily object is intentionally planned; parsing classifies its partial rows as
+# a coverage gap rather than publishing it as a complete source object.
+_RESEARCH_ARCHIVE_COVERAGE: Final = {
+    "BTCUSDT": {
+        "monthly": (date(2020, 1, 1), date(2026, 7, 1)),
+        "daily": (date(2019, 12, 23), date(2026, 8, 29)),
+    },
+    "ETHUSDT": {
+        "monthly": (date(2020, 1, 1), date(2026, 7, 1)),
+        "daily": (date(2019, 12, 23), date(2026, 8, 29)),
+    },
+}
+
+
+BinanceIndexPriceKlineStatus = BinanceArchiveAcquisitionStatus
+
+
+@dataclass(frozen=True, slots=True)
+class BinanceIndexPriceKlineCoverageGapPlan:
+    """One UTC day without a Research-proven index-price archive object."""
+
+    pair: BinancePriceIndexId
+    request_range: TimeRange
+    boundary: BinanceArchiveObjectBoundary
+    detail: str
+
+    @property
+    def request(self) -> BinancePublicHistoryRequest:
+        """Return the typed index-price source request represented by this gap."""
+        return BinancePublicHistoryRequest(
+            price_index_pair=self.pair,
+            data_type=BinancePublicHistoryDataType.INDEX_PRICE_KLINE,
+            request_range=self.request_range,
+            source_kind=BinancePublicHistorySourceKind.ARCHIVE_DAILY,
+            interval=BinanceKlineInterval.ONE_MINUTE,
+            archive_object_boundary=self.boundary,
+        )
+
+
+type BinanceIndexPriceKlinePlan = (
+    BinanceArchiveObjectPlan | BinanceIndexPriceKlineCoverageGapPlan
+)
+
+
+@dataclass(frozen=True, slots=True)
+class BinanceIndexPriceKlineObjectResult:
+    plan: BinanceIndexPriceKlinePlan
+    status: BinanceIndexPriceKlineStatus
+    artifact_path: Path | None = None
+    detail: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class BinanceIndexPriceKlineRunResult:
+    """All object outcomes for one request; success is deliberately all-or-none."""
+
+    request_range: TimeRange
+    objects: tuple[BinanceIndexPriceKlineObjectResult, ...]
+
+    @property
+    def completed(self) -> bool:
+        successful = {
+            BinanceIndexPriceKlineStatus.PUBLISHED,
+            BinanceIndexPriceKlineStatus.EXISTING,
+        }
+        return bool(self.objects) and all(
+            item.status in successful for item in self.objects
+        )
+
+
+def _next_month(value: date) -> date:
+    if value.month == 12:
+        return date(value.year + 1, 1, 1)
+    return date(value.year, value.month + 1, 1)
+
+
+def _utc_midnight(value: date) -> datetime:
+    return datetime.combine(value, time.min, tzinfo=UTC)
+
+
+def _build_plan(
+    pair: BinancePriceIndexId,
+    request_range: TimeRange,
+    boundary: BinanceArchiveObjectBoundary,
+) -> BinanceArchiveObjectPlan:
+    monthly = boundary.granularity.value == "month"
+    cadence = "monthly" if monthly else "daily"
+    suffix = (
+        boundary.period_start.strftime("%Y-%m")
+        if monthly
+        else boundary.period_start.isoformat()
+    )
+    filename = f"{pair}-1m-{suffix}.zip"
+    object_key = f"data/futures/um/{cadence}/indexPriceKlines/{pair}/1m/{filename}"
+    request = BinancePublicHistoryRequest(
+        price_index_pair=pair,
+        data_type=BinancePublicHistoryDataType.INDEX_PRICE_KLINE,
+        request_range=request_range,
+        source_kind=(
+            BinancePublicHistorySourceKind.ARCHIVE_MONTHLY
+            if monthly
+            else BinancePublicHistorySourceKind.ARCHIVE_DAILY
+        ),
+        interval=BinanceKlineInterval.ONE_MINUTE,
+        archive_object_boundary=boundary,
+    )
+    return BinanceArchiveObjectPlan(
+        request=request,
+        object_key=object_key,
+        url=f"{_ARCHIVE_ROOT}/{object_key}",
+        checksum_url=f"{_ARCHIVE_ROOT}/{object_key}.CHECKSUM",
+        member_name=f"{pair}-1m-{suffix}.csv",
+    )
+
+
+def plan_binance_index_price_kline_archives(
+    pair: BinancePriceIndexId,
+    request_range: TimeRange,
+) -> tuple[BinanceIndexPriceKlinePlan, ...]:
+    """Map a UTC ``[start, end)`` range to proven objects or explicit gaps."""
+    if not isinstance(pair, BinancePriceIndexId):
+        raise TypeError("pair must be a BinancePriceIndexId")
+    if not isinstance(request_range, TimeRange):
+        raise TypeError("request_range must be a TimeRange")
+
+    coverage = _RESEARCH_ARCHIVE_COVERAGE.get(str(pair))
+    if coverage is None:
+        raise ValueError(
+            f"price-index pair {pair!s} has no frozen index-price-Kline archive coverage"
+        )
+
+    monthly_first, monthly_last = coverage["monthly"]
+    daily_first, daily_last = coverage["daily"]
+    cursor = request_range.start.date()
+    final_day = (request_range.end - timedelta(microseconds=1)).date()
+    plans: list[BinanceIndexPriceKlinePlan] = []
+    while cursor <= final_day:
+        following_month = _next_month(cursor)
+        can_use_month = (
+            cursor.day == 1
+            and monthly_first <= cursor <= monthly_last
+            and request_range.start <= _utc_midnight(cursor)
+            and request_range.end >= _utc_midnight(following_month)
+        )
+        if can_use_month:
+            boundary = BinanceArchiveObjectBoundary.month(cursor.year, cursor.month)
+            cursor = following_month
+        else:
+            boundary = BinanceArchiveObjectBoundary.day(cursor)
+            cursor += timedelta(days=1)
+        if (
+            boundary.granularity.value == "month"
+            or daily_first <= boundary.period_start <= daily_last
+        ):
+            plans.append(_build_plan(pair, request_range, boundary))
+        else:
+            plans.append(
+                BinanceIndexPriceKlineCoverageGapPlan(
+                    pair=pair,
+                    request_range=request_range,
+                    boundary=boundary,
+                    detail=(
+                        "Research did not prove an index-price-Kline archive object "
+                        f"for pair {pair!s} on {boundary.period_start.isoformat()}"
+                    ),
+                )
+            )
+    return tuple(plans)
+
+
+def _archive_object_range(plan: BinanceArchiveObjectPlan) -> TimeRange:
+    boundary = plan.request.archive_object_boundary
+    assert boundary is not None
+    object_start = _utc_midnight(boundary.period_start)
+    object_end = (
+        _utc_midnight(_next_month(boundary.period_start))
+        if boundary.granularity.value == "month"
+        else object_start + timedelta(days=1)
+    )
+    return TimeRange(start=object_start, end=object_end)
+
+
+def _required_record_range(plan: BinanceArchiveObjectPlan) -> TimeRange:
+    object_range = _archive_object_range(plan)
+    return TimeRange(
+        start=max(plan.request.request_range.start, object_range.start),
+        end=min(plan.request.request_range.end, object_range.end),
+    )
+
+
+def _validate_complete_object_coverage(
+    plan: BinanceArchiveObjectPlan, actual_range: TimeRange
+) -> None:
+    if actual_range != _archive_object_range(plan):
+        raise _coverage_gap(
+            "archive rows do not cover the complete source object boundary"
+        )
+
+
+def _validate_required_coverage(
+    plan: BinanceArchiveObjectPlan, actual_range: TimeRange
+) -> None:
+    required_range = _required_record_range(plan)
+    if (
+        actual_range.start > required_range.start
+        or actual_range.end < required_range.end
+    ):
+        raise _coverage_gap(
+            "archive rows do not cover the caller range within this source object"
+        )
+
+
+def _parse_nonnegative_int(value: str, *, field: str) -> int:
+    if not value.isascii() or not value.isdigit():
+        raise _invalid_content(f"{field} must be a non-negative integer")
+    normalized = value.lstrip("0") or "0"
+    if len(normalized) > len(_MAX_SIGNED_INT64_TEXT) or (
+        len(normalized) == len(_MAX_SIGNED_INT64_TEXT)
+        and normalized > _MAX_SIGNED_INT64_TEXT
+    ):
+        raise _invalid_content(f"{field} exceeds signed 64-bit range")
+    return int(normalized)
+
+
+def _validate_decimal(value: str, *, field: str) -> None:
+    from decimal import Decimal, InvalidOperation
+
+    try:
+        parsed = Decimal(value)
+    except InvalidOperation as error:
+        raise _invalid_content(f"{field} is not a decimal") from error
+    if not parsed.is_finite() or parsed < 0:
+        raise _invalid_content(f"{field} has an invalid numeric value")
+
+
+def _parse_archive(
+    plan: BinanceArchiveObjectPlan, payload: bytes
+) -> BinanceArchiveParseResult:
+    try:
+        text = payload.decode("utf-8-sig")
+    except UnicodeDecodeError as error:
+        raise _invalid_content("CSV member is not UTF-8") from error
+
+    parsed_rows = list(csv.reader(io.StringIO(text, newline=""), strict=True))
+    if parsed_rows and tuple(parsed_rows[0]) == _UPSTREAM_COLUMNS:
+        parsed_rows = parsed_rows[1:]
+    if not parsed_rows:
+        raise _invalid_content("CSV contains no data rows")
+
+    columns: dict[str, list[str | int]] = {name: [] for name in _RAW_COLUMNS}
+    previous_open: int | None = None
+    object_range = _archive_object_range(plan)
+    object_start_ms = int(object_range.start.timestamp() * 1000)
+    object_end_ms = int(object_range.end.timestamp() * 1000)
+    for row_number, row in enumerate(parsed_rows, start=1):
+        if len(row) != len(_UPSTREAM_COLUMNS):
+            raise _invalid_content(f"CSV row {row_number} does not have 12 columns")
+        open_time = _parse_nonnegative_int(row[0], field="open_time")
+        close_time = _parse_nonnegative_int(row[6], field="close_time")
+        _parse_nonnegative_int(row[8], field="placeholder_count")
+        try:
+            datetime.fromtimestamp(open_time / 1000, tz=UTC)
+            datetime.fromtimestamp(close_time / 1000, tz=UTC)
+        except (OverflowError, OSError, ValueError) as error:
+            raise _invalid_content("row timestamp is not interpretable") from error
+        if (
+            open_time % _ONE_MINUTE_MS != 0
+            or close_time != open_time + _ONE_MINUTE_MS - 1
+        ):
+            raise _invalid_content("row does not have valid 1m timestamp boundaries")
+        if not object_start_ms <= open_time < object_end_ms:
+            raise _invalid_content(
+                "row open_time is outside the archive object boundary"
+            )
+        if previous_open is not None:
+            if open_time <= previous_open:
+                raise _invalid_content(
+                    "row open_time values must be strictly increasing"
+                )
+            if open_time != previous_open + _ONE_MINUTE_MS:
+                raise _coverage_gap("archive rows contain a missing 1m timestamp")
+        previous_open = open_time
+        for index in (1, 2, 3, 4, 5, 7, 9, 10, 11):
+            _validate_decimal(row[index], field=_RAW_COLUMNS[index])
+        typed: tuple[str | int, ...] = (
+            open_time,
+            row[1],
+            row[2],
+            row[3],
+            row[4],
+            row[5],
+            close_time,
+            row[7],
+            row[8],
+            row[9],
+            row[10],
+            row[11],
+        )
+        for name, value in zip(_RAW_COLUMNS, typed, strict=True):
+            columns[name].append(value)
+
+    frame = pl.DataFrame(columns, schema=_DTYPES)
+    first_open = int(frame.item(0, "open_time"))
+    last_open = int(frame.item(frame.height - 1, "open_time"))
+    actual_range = TimeRange(
+        start=datetime.fromtimestamp(first_open / 1000, tz=UTC),
+        end=datetime.fromtimestamp((last_open + _ONE_MINUTE_MS) / 1000, tz=UTC),
+    )
+    _validate_complete_object_coverage(plan, actual_range)
+    _validate_required_coverage(plan, actual_range)
+    return BinanceArchiveParseResult(
+        rows=frame,
+        actual_record_range=actual_range,
+        validation_evidence=(
+            "index_price_csv_schema_and_rows_verified",
+            "index_price_placeholders_preserved",
+        ),
+    )
+
+
+class _IndexPriceKlineArchiveAdapter:
+    raw_schema_identifier = _SCHEMA_IDENTIFIER
+
+    def parse_member(
+        self, plan: BinanceArchiveObjectPlan, payload: bytes
+    ) -> BinanceArchiveParseResult:
+        return _parse_archive(plan, payload)
+
+    def validate_complete_object_coverage(
+        self, plan: BinanceArchiveObjectPlan, actual_range: TimeRange
+    ) -> None:
+        _validate_complete_object_coverage(plan, actual_range)
+
+    def validate_required_coverage(
+        self, plan: BinanceArchiveObjectPlan, actual_range: TimeRange
+    ) -> None:
+        _validate_required_coverage(plan, actual_range)
+
+
+class BinanceIndexPriceKlineBackfill:
+    """Execute the official index-price-Kline archive path for typed pairs."""
+
+    def __init__(
+        self,
+        store: RawStore,
+        *,
+        http_get: ArchiveHttpGet | None = None,
+        timeout: float = 30.0,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._acquisition = BinancePublicArchiveAcquisition(
+            store,
+            http_get=http_get,
+            timeout=timeout,
+            clock=clock,
+        )
+
+    def run(
+        self, pair: BinancePriceIndexId, request_range: TimeRange
+    ) -> BinanceIndexPriceKlineRunResult:
+        plans = plan_binance_index_price_kline_archives(pair, request_range)
+        results = tuple(self._process(plan) for plan in plans)
+        return BinanceIndexPriceKlineRunResult(
+            request_range=request_range, objects=results
+        )
+
+    def _process(
+        self, plan: BinanceIndexPriceKlinePlan
+    ) -> BinanceIndexPriceKlineObjectResult:
+        if isinstance(plan, BinanceIndexPriceKlineCoverageGapPlan):
+            outcome = self._acquisition.record_failure(
+                plan.request,
+                BinanceIndexPriceKlineStatus.COVERAGE_GAP,
+                plan.detail,
+            )
+        else:
+            outcome = self._acquisition.acquire(plan, _IndexPriceKlineArchiveAdapter())
+        return BinanceIndexPriceKlineObjectResult(
+            plan,
+            outcome.status,
+            artifact_path=outcome.artifact_path,
+            detail=outcome.detail,
+        )

--- a/tests/data/test_binance_index_price_kline_backfill.py
+++ b/tests/data/test_binance_index_price_kline_backfill.py
@@ -1,0 +1,577 @@
+import hashlib
+import io
+import zipfile
+from collections.abc import Callable
+from datetime import UTC, date, datetime, timedelta
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from tracequant.data import (
+    ArchiveHttpResponse,
+    BinanceArchiveObjectPlan,
+    BinanceIndexPriceKlineBackfill,
+    BinanceIndexPriceKlineCoverageGapPlan,
+    BinanceIndexPriceKlineStatus,
+    BinancePriceIndexId,
+    BinancePublicHistoryDataType,
+    RawArtifactConflictError,
+    RawObjectIdentity,
+    RawStore,
+    plan_binance_index_price_kline_archives,
+)
+from tracequant.domain import InstrumentId, TimeRange
+
+HEADER = (
+    "open_time,open,high,low,close,volume,close_time,quote_volume,count,"
+    "taker_buy_volume,taker_buy_quote_volume,ignore\n"
+)
+ONE_MINUTE_MS = 60_000
+
+
+class FixtureHttp:
+    def __init__(self, responses: dict[str, ArchiveHttpResponse]) -> None:
+        self.responses = responses
+        self.calls: list[tuple[str, float]] = []
+
+    def __call__(self, url: str, timeout: float) -> ArchiveHttpResponse:
+        self.calls.append((url, timeout))
+        return self.responses.get(url, ArchiveHttpResponse(404, b"missing", {}))
+
+
+def _range(start: str, end: str) -> TimeRange:
+    return TimeRange(
+        start=datetime.fromisoformat(start).replace(tzinfo=UTC),
+        end=datetime.fromisoformat(end).replace(tzinfo=UTC),
+    )
+
+
+def _plans(
+    pair: BinancePriceIndexId, request_range: TimeRange
+) -> tuple[BinanceArchiveObjectPlan, ...]:
+    plans = plan_binance_index_price_kline_archives(pair, request_range)
+    assert all(isinstance(plan, BinanceArchiveObjectPlan) for plan in plans)
+    return tuple(plan for plan in plans if isinstance(plan, BinanceArchiveObjectPlan))
+
+
+def _row(
+    open_time: int,
+    *,
+    index_close: str = "61010.00000000",
+    placeholder_count: str = "60",
+) -> str:
+    return (
+        f"{open_time},61000.10000000,61020.20000000,60990.30000000,"
+        f"{index_close},0.00000000,{open_time + 59_999},0,"
+        f"{placeholder_count},0.000,0.00,0\n"
+    )
+
+
+def _zip(member: str, payload: bytes) -> bytes:
+    output = io.BytesIO()
+    with zipfile.ZipFile(output, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr(member, payload)
+    return output.getvalue()
+
+
+def _archive(
+    plan: BinanceArchiveObjectPlan,
+    rows: list[str],
+    *,
+    header: str | None = HEADER,
+    member: str | None = None,
+) -> bytes:
+    payload = ((header or "") + "".join(rows)).encode()
+    return _zip(member or plan.member_name, payload)
+
+
+def _complete_archive(
+    plan: BinanceArchiveObjectPlan,
+    *,
+    first_close: str = "61010.00000000",
+    first_count: str = "60",
+    header: str | None = HEADER,
+) -> bytes:
+    boundary = plan.request.archive_object_boundary
+    assert boundary is not None
+    start = datetime.combine(boundary.period_start, datetime.min.time(), tzinfo=UTC)
+    if boundary.granularity.value == "month":
+        if boundary.period_start.month == 12:
+            next_date = date(boundary.period_start.year + 1, 1, 1)
+        else:
+            next_date = date(
+                boundary.period_start.year, boundary.period_start.month + 1, 1
+            )
+        end = datetime.combine(next_date, datetime.min.time(), tzinfo=UTC)
+    else:
+        end = start + timedelta(days=1)
+    start_ms = int(start.timestamp() * 1000)
+    row_count = int((end - start).total_seconds() // 60)
+    rows = [_row(start_ms + offset * ONE_MINUTE_MS) for offset in range(row_count)]
+    rows[0] = _row(
+        start_ms,
+        index_close=first_close,
+        placeholder_count=first_count,
+    )
+    return _archive(plan, rows, header=header)
+
+
+def _responses(
+    plan: BinanceArchiveObjectPlan, archive: bytes
+) -> dict[str, ArchiveHttpResponse]:
+    checksum = hashlib.sha256(archive).hexdigest()
+    return {
+        plan.url: ArchiveHttpResponse(
+            200, archive, {"Content-Type": "application/zip"}
+        ),
+        plan.checksum_url: ArchiveHttpResponse(
+            200,
+            f"{checksum}  {plan.url.rsplit('/', 1)[-1]}\n".encode(),
+            {"Content-Type": "text/plain"},
+        ),
+    }
+
+
+def test_index_backfill_publishes_verified_raw_from_supported_entry(
+    tmp_path: Path,
+) -> None:
+    scenarios = (
+        ("BTCUSDT", _range("2024-02-29T00:00:00", "2024-03-01T00:00:00")),
+        ("BTCUSDT", _range("2024-02-01T00:00:00", "2024-03-01T00:00:00")),
+        ("ETHUSDT", _range("2024-02-29T00:00:00", "2024-03-01T00:00:00")),
+        ("ETHUSDT", _range("2024-02-01T00:00:00", "2024-03-01T00:00:00")),
+    )
+    store = RawStore(tmp_path)
+
+    for index, (value, request_range) in enumerate(scenarios):
+        pair = BinancePriceIndexId(value)
+        plan = _plans(pair, request_range)[0]
+        archive = _complete_archive(
+            plan,
+            first_close=f"61010.1234000{index}",
+            first_count="060",
+            header=None if index % 2 else HEADER,
+        )
+        responses = _responses(plan, archive)
+        transport = FixtureHttp(responses)
+
+        result = BinanceIndexPriceKlineBackfill(
+            store, http_get=transport, timeout=2.5
+        ).run(pair, request_range)
+
+        assert result.request_range == request_range
+        assert result.completed is True
+        assert result.objects[0].status is BinanceIndexPriceKlineStatus.PUBLISHED
+        artifact = store.read_request(plan.request)
+        assert artifact.manifest.object_identity.source.price_index_pair == pair
+        assert artifact.manifest.object_identity.source.data_type is (
+            BinancePublicHistoryDataType.INDEX_PRICE_KLINE
+        )
+        assert artifact.manifest.raw_schema_identifier == (
+            "binance.um.index-price-kline.csv.v1"
+        )
+        assert artifact.frame.columns == [
+            "open_time",
+            "index_open",
+            "index_high",
+            "index_low",
+            "index_close",
+            "placeholder_volume",
+            "close_time",
+            "placeholder_quote_volume",
+            "placeholder_count",
+            "placeholder_taker_buy_volume",
+            "placeholder_taker_buy_quote_volume",
+            "placeholder_ignore",
+        ]
+        assert artifact.frame.item(0, "index_close") == f"61010.1234000{index}"
+        assert artifact.frame.item(0, "placeholder_count") == "060"
+        assert "volume" not in artifact.frame.columns
+        assert "count" not in artifact.frame.columns
+        assert artifact.archive_path.read_bytes() == archive
+        assert artifact.checksum_response_path.read_bytes() == (
+            responses[plan.checksum_url].body
+        )
+        assert artifact.manifest.provenance is not None
+        assert artifact.manifest.provenance.validation_evidence == (
+            "checksum_response_verified",
+            "archive_sha256_matches_checksum",
+            "zip_member_structure_verified",
+            "index_price_csv_schema_and_rows_verified",
+            "index_price_placeholders_preserved",
+            "source_object_coverage_verified",
+        )
+        assert [url for url, _ in transport.calls] == [plan.checksum_url, plan.url]
+        assert all(timeout == 2.5 for _, timeout in transport.calls)
+
+
+def test_planner_preserves_pair_identity_and_uses_monthly_between_daily_edges() -> None:
+    pair = BinancePriceIndexId("ethusdt")
+    plans = _plans(
+        pair,
+        _range("2024-01-31T23:30:00", "2024-03-01T00:30:00"),
+    )
+
+    assert [plan.request.source_kind.value for plan in plans] == [
+        "archive_daily",
+        "archive_monthly",
+        "archive_daily",
+    ]
+    assert all(plan.request.price_index_pair == pair for plan in plans)
+    assert all(
+        plan.request.request_range == plans[0].request.request_range for plan in plans
+    )
+    assert plans[1].object_key == (
+        "data/futures/um/monthly/indexPriceKlines/ETHUSDT/1m/ETHUSDT-1m-2024-02.zip"
+    )
+    assert plans[1].member_name == "ETHUSDT-1m-2024-02.csv"
+
+
+def test_planner_marks_frozen_coverage_bounds_without_speculative_io(
+    tmp_path: Path,
+) -> None:
+    pair = BinancePriceIndexId("BTCUSDT")
+    plans = plan_binance_index_price_kline_archives(
+        pair,
+        _range("2026-08-29T00:00:00", "2026-08-31T00:00:00"),
+    )
+    assert isinstance(plans[0], BinanceArchiveObjectPlan)
+    assert isinstance(plans[1], BinanceIndexPriceKlineCoverageGapPlan)
+
+    transport = FixtureHttp({})
+    result = BinanceIndexPriceKlineBackfill(RawStore(tmp_path), http_get=transport).run(
+        pair,
+        _range("2026-08-30T00:00:00", "2026-08-31T00:00:00"),
+    )
+    assert result.completed is False
+    assert result.objects[0].status is BinanceIndexPriceKlineStatus.COVERAGE_GAP
+    assert transport.calls == []
+
+
+@pytest.mark.parametrize(
+    "invalid_pair",
+    [InstrumentId("BTCUSDT"), BinancePriceIndexId("BTCUSDC")],
+)
+def test_invalid_or_unsupported_subject_is_rejected_before_io(
+    tmp_path: Path, invalid_pair: object
+) -> None:
+    transport = FixtureHttp({})
+    backfill = BinanceIndexPriceKlineBackfill(RawStore(tmp_path), http_get=transport)
+
+    with pytest.raises((TypeError, ValueError)):
+        backfill.run(
+            cast(BinancePriceIndexId, invalid_pair),
+            _range("2024-02-29T00:00:00", "2024-03-01T00:00:00"),
+        )
+
+    assert transport.calls == []
+
+
+@pytest.mark.parametrize(
+    ("build_archive", "expected_status"),
+    [
+        (lambda plan: b"not a ZIP", BinanceIndexPriceKlineStatus.INVALID_CONTENT),
+        (
+            lambda plan: _archive(plan, [_row(1_709_164_800_000)], member="wrong.csv"),
+            BinanceIndexPriceKlineStatus.INVALID_CONTENT,
+        ),
+        (
+            lambda plan: _archive(
+                plan, [_row(1_709_164_800_000)], header="bad,header\n"
+            ),
+            BinanceIndexPriceKlineStatus.INVALID_CONTENT,
+        ),
+        (
+            lambda plan: _archive(plan, ["1,2,3\n"]),
+            BinanceIndexPriceKlineStatus.INVALID_CONTENT,
+        ),
+        (
+            lambda plan: _archive(
+                plan,
+                [_row(1_709_164_800_000), _row(1_709_164_920_000)],
+            ),
+            BinanceIndexPriceKlineStatus.COVERAGE_GAP,
+        ),
+        (
+            lambda plan: _archive(
+                plan,
+                [_row(1_709_164_800_000), _row(1_709_164_800_000)],
+            ),
+            BinanceIndexPriceKlineStatus.INVALID_CONTENT,
+        ),
+        (
+            lambda plan: _archive(
+                plan,
+                [_row(1_709_164_860_000), _row(1_709_164_800_000)],
+            ),
+            BinanceIndexPriceKlineStatus.INVALID_CONTENT,
+        ),
+        (
+            lambda plan: _archive(plan, [_row(1_709_164_800_001)]),
+            BinanceIndexPriceKlineStatus.INVALID_CONTENT,
+        ),
+        (
+            lambda plan: _archive(
+                plan,
+                [_row(1_709_164_800_000).replace("61020.20000000", "NaN")],
+            ),
+            BinanceIndexPriceKlineStatus.INVALID_CONTENT,
+        ),
+    ],
+)
+def test_invalid_schema_values_and_time_coverage_fail_closed(
+    tmp_path: Path,
+    build_archive: Callable[[BinanceArchiveObjectPlan], bytes],
+    expected_status: BinanceIndexPriceKlineStatus,
+) -> None:
+    pair = BinancePriceIndexId("ETHUSDT")
+    request_range = _range("2024-02-29T00:00:00", "2024-03-01T00:00:00")
+    plan = _plans(pair, request_range)[0]
+    archive = build_archive(plan)
+    store = RawStore(tmp_path)
+
+    result = BinanceIndexPriceKlineBackfill(
+        store, http_get=FixtureHttp(_responses(plan, archive))
+    ).run(pair, request_range)
+
+    assert result.completed is False
+    assert result.objects[0].status is expected_status
+    assert not store.path_for(RawObjectIdentity.from_request(plan.request)).exists()
+
+
+def test_partial_first_daily_object_is_a_coverage_gap(tmp_path: Path) -> None:
+    pair = BinancePriceIndexId("BTCUSDT")
+    request_range = _range("2019-12-23T11:58:00", "2019-12-24T00:00:00")
+    plan = _plans(pair, request_range)[0]
+    rows = [_row(1_577_102_280_000 + offset * ONE_MINUTE_MS) for offset in range(722)]
+    archive = _archive(plan, rows)
+
+    result = BinanceIndexPriceKlineBackfill(
+        RawStore(tmp_path), http_get=FixtureHttp(_responses(plan, archive))
+    ).run(pair, request_range)
+
+    assert result.completed is False
+    assert result.objects[0].status is BinanceIndexPriceKlineStatus.COVERAGE_GAP
+    assert result.objects[0].detail == (
+        "archive rows do not cover the complete source object boundary"
+    )
+
+
+@pytest.mark.parametrize(
+    ("mutate", "expected_status"),
+    [
+        (
+            lambda plan, responses: responses.pop(plan.checksum_url),
+            BinanceIndexPriceKlineStatus.CHECKSUM_NOT_FOUND,
+        ),
+        (
+            lambda plan, responses: responses.pop(plan.url),
+            BinanceIndexPriceKlineStatus.NOT_FOUND,
+        ),
+        (
+            lambda plan, responses: responses.__setitem__(
+                plan.checksum_url,
+                ArchiveHttpResponse(
+                    200,
+                    f"{'0' * 64}  {plan.url.rsplit('/', 1)[-1]}\n".encode(),
+                    {},
+                ),
+            ),
+            BinanceIndexPriceKlineStatus.INVALID_CONTENT,
+        ),
+        (
+            lambda plan, responses: responses.__setitem__(
+                plan.checksum_url, ArchiveHttpResponse(503, b"retry", {})
+            ),
+            BinanceIndexPriceKlineStatus.RETRYABLE_FAILURE,
+        ),
+    ],
+)
+def test_acquisition_failures_keep_distinct_status_and_evidence(
+    tmp_path: Path,
+    mutate: Callable[
+        [BinanceArchiveObjectPlan, dict[str, ArchiveHttpResponse]], object
+    ],
+    expected_status: BinanceIndexPriceKlineStatus,
+) -> None:
+    pair = BinancePriceIndexId("BTCUSDT")
+    request_range = _range("2024-02-29T00:00:00", "2024-03-01T00:00:00")
+    plan = _plans(pair, request_range)[0]
+    archive = _complete_archive(plan)
+    responses = _responses(plan, archive)
+    mutate(plan, responses)
+    store = RawStore(tmp_path)
+
+    result = BinanceIndexPriceKlineBackfill(store, http_get=FixtureHttp(responses)).run(
+        pair, request_range
+    )
+
+    assert result.completed is False
+    assert result.objects[0].status is expected_status
+    identity = RawObjectIdentity.from_request(plan.request)
+    assert not store.path_for(identity).exists()
+    assert store.list_acquisition_manifests(identity)[0].status == expected_status.value
+
+
+def test_network_failure_is_retryable_and_preserves_failure_evidence(
+    tmp_path: Path,
+) -> None:
+    pair = BinancePriceIndexId("BTCUSDT")
+    request_range = _range("2024-02-29T00:00:00", "2024-03-01T00:00:00")
+    plan = _plans(pair, request_range)[0]
+    store = RawStore(tmp_path)
+
+    def timeout(url: str, timeout: float) -> ArchiveHttpResponse:
+        del url, timeout
+        raise TimeoutError("upstream timeout")
+
+    result = BinanceIndexPriceKlineBackfill(store, http_get=timeout).run(
+        pair, request_range
+    )
+
+    assert result.completed is False
+    assert result.objects[0].status is BinanceIndexPriceKlineStatus.RETRYABLE_FAILURE
+    identity = RawObjectIdentity.from_request(plan.request)
+    assert store.list_acquisition_manifests(identity)[0].detail == "upstream timeout"
+
+
+def test_cross_object_failure_preserves_success_but_not_batch_completion(
+    tmp_path: Path,
+) -> None:
+    pair = BinancePriceIndexId("BTCUSDT")
+    request_range = _range("2024-02-29T23:59:00", "2024-03-01T00:01:00")
+    plans = _plans(pair, request_range)
+    first_archive = _complete_archive(plans[0])
+    store = RawStore(tmp_path)
+
+    result = BinanceIndexPriceKlineBackfill(
+        store, http_get=FixtureHttp(_responses(plans[0], first_archive))
+    ).run(pair, request_range)
+
+    assert result.completed is False
+    assert [item.status for item in result.objects] == [
+        BinanceIndexPriceKlineStatus.PUBLISHED,
+        BinanceIndexPriceKlineStatus.CHECKSUM_NOT_FOUND,
+    ]
+    assert store.read_request(plans[0].request).frame.height == 24 * 60
+
+
+def test_repeat_and_upstream_replacement_keep_exact_immutable_revisions(
+    tmp_path: Path,
+) -> None:
+    pair = BinancePriceIndexId("ETHUSDT")
+    request_range = _range("2024-02-29T00:00:00", "2024-02-29T00:01:00")
+    plan = _plans(pair, request_range)[0]
+    original = _complete_archive(plan)
+    replacement = _complete_archive(plan, first_close="62000.00000000")
+    store = RawStore(tmp_path)
+
+    first = BinanceIndexPriceKlineBackfill(
+        store, http_get=FixtureHttp(_responses(plan, original))
+    ).run(pair, request_range)
+    repeated = BinanceIndexPriceKlineBackfill(
+        store, http_get=FixtureHttp(_responses(plan, original))
+    ).run(pair, request_range)
+    revised = BinanceIndexPriceKlineBackfill(
+        store, http_get=FixtureHttp(_responses(plan, replacement))
+    ).run(pair, request_range)
+
+    assert first.objects[0].status is BinanceIndexPriceKlineStatus.PUBLISHED
+    assert repeated.objects[0].status is BinanceIndexPriceKlineStatus.EXISTING
+    assert revised.objects[0].status is BinanceIndexPriceKlineStatus.PUBLISHED
+    revisions = store.list_verified_revisions(
+        RawObjectIdentity.from_request(plan.request)
+    )
+    assert len(revisions) == 2
+    assert {item.frame.item(0, "index_close") for item in revisions} == {
+        "61010.00000000",
+        "62000.00000000",
+    }
+    for item in revisions:
+        revision = item.revision_identity
+        assert revision is not None
+        assert (
+            store.read_revision(item.manifest.object_identity, revision).path
+            == item.path
+        )
+
+
+def test_local_corruption_and_write_conflict_fail_without_overwrite(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pair = BinancePriceIndexId("BTCUSDT")
+    request_range = _range("2024-02-29T00:00:00", "2024-02-29T00:01:00")
+    plan = _plans(pair, request_range)[0]
+    archive = _complete_archive(plan)
+    store = RawStore(tmp_path)
+    incomplete_path = store.path_for(RawObjectIdentity.from_request(plan.request))
+    incomplete_path.mkdir(parents=True)
+    sentinel = incomplete_path / "interrupted-write"
+    sentinel.write_text("preserve", encoding="utf-8")
+
+    damaged = BinanceIndexPriceKlineBackfill(store, http_get=FixtureHttp({})).run(
+        pair, request_range
+    )
+    assert damaged.objects[0].status is BinanceIndexPriceKlineStatus.LOCAL_FAILURE
+    assert sentinel.read_text(encoding="utf-8") == "preserve"
+
+    clean_store = RawStore(tmp_path / "clean")
+
+    def conflict(self: RawStore, source: object) -> None:
+        del self, source
+        raise RawArtifactConflictError("same verified revision differs locally")
+
+    monkeypatch.setattr(RawStore, "write", conflict)
+    conflicted = BinanceIndexPriceKlineBackfill(
+        clean_store, http_get=FixtureHttp(_responses(plan, archive))
+    ).run(pair, request_range)
+    assert conflicted.objects[0].status is BinanceIndexPriceKlineStatus.CONFLICT
+
+
+def test_existing_corrupt_revision_is_local_failure_without_network(
+    tmp_path: Path,
+) -> None:
+    pair = BinancePriceIndexId("BTCUSDT")
+    request_range = _range("2024-02-29T00:00:00", "2024-02-29T00:01:00")
+    plan = _plans(pair, request_range)[0]
+    archive = _complete_archive(plan)
+    store = RawStore(tmp_path)
+    first = BinanceIndexPriceKlineBackfill(
+        store, http_get=FixtureHttp(_responses(plan, archive))
+    ).run(pair, request_range)
+    assert first.completed is True
+    artifact = store.read_request(plan.request)
+    artifact.data_path.write_bytes(artifact.data_path.read_bytes() + b"corrupt")
+    transport = FixtureHttp({})
+
+    second = BinanceIndexPriceKlineBackfill(store, http_get=transport).run(
+        pair, request_range
+    )
+
+    assert second.completed is False
+    assert second.objects[0].status is BinanceIndexPriceKlineStatus.LOCAL_FAILURE
+    assert transport.calls == []
+
+
+def test_disk_write_failure_is_local_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pair = BinancePriceIndexId("BTCUSDT")
+    request_range = _range("2024-02-29T00:00:00", "2024-02-29T00:01:00")
+    plan = _plans(pair, request_range)[0]
+    archive = _complete_archive(plan)
+    store = RawStore(tmp_path)
+
+    def disk_failure(self: RawStore, source: object) -> None:
+        del self, source
+        raise OSError("disk full")
+
+    monkeypatch.setattr(RawStore, "write", disk_failure)
+    result = BinanceIndexPriceKlineBackfill(
+        store, http_get=FixtureHttp(_responses(plan, archive))
+    ).run(pair, request_range)
+
+    assert result.completed is False
+    assert result.objects[0].status is BinanceIndexPriceKlineStatus.LOCAL_FAILURE
+    assert result.objects[0].detail == "disk full"


### PR DESCRIPTION
Closes #280

## Summary
Add the typed BTCUSDT/ETHUSDT 1m index-price archive planner and public backfill entry, validate complete daily/monthly CSV objects with index-specific Raw schema and placeholder semantics, publish through shared immutable revision-aware acquisition, expose object-level outcomes, and document usage and frozen limits with focused coverage.

## Validation
- Critical Outcome: pass
- Formal Delivery validation: pass

## Risks / limitations
Archive coverage is intentionally frozen to monthly 2020-01..2026-07 and daily 2019-12-23..2026-08-29; the first daily object remains a coverage gap. REST, USDC acquisition, tradability, retry scheduling, canonical repair, and aggregation remain out of scope.
