### PR TITLE
[Task] 实现 Binance USDⓈ-M 已结算资金费率官方月度历史文件回填

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,17 +154,19 @@ The currently implemented public package is `tracequant` under `src/`:
 - `tracequant.data`: typed Binance USDⓈ-M public-history contracts, an
   immutable local Raw Parquet/manifest store, and explicit archive-backfill
   adapters for BTCUSDT and ETHUSDT 1m contract, mark-price, and index-price
-  Klines. Backfill calls perform bounded public HTTP downloads, checksum and
-  ZIP/CSV validation, and Raw persistence; importing the module performs no I/O.
+  Klines plus settled funding-rate monthly objects. Backfill calls perform
+  bounded public HTTP downloads, checksum and ZIP/CSV validation, and Raw
+  persistence; importing the module performs no I/O.
 
 The `apps/`, `packages/`, and `deploy/` directories currently establish future
 boundaries through small README files. They are not implemented product
 packages. The implemented ingestion path is limited to Binance's public USDⓈ-M
-1m contract-Kline, mark-price-Kline, and index-price-Kline archives; there is no
-private or trading exchange client, REST recent synchronization, general data
-pipeline, canonical quality or repair layer, database, feature or label
-pipeline, backtester, strategy, machine-learning model, order or account
-service, risk engine, live runtime, or multi-exchange implementation.
+1m contract-Kline, mark-price-Kline, and index-price-Kline archives and settled
+funding-rate monthly archives; there is no private or trading exchange client,
+REST recent synchronization, general data pipeline, canonical quality or repair
+layer, database, feature or label pipeline, backtester, strategy,
+machine-learning model, order or account service, risk engine, live runtime, or
+multi-exchange implementation.
 
 ### Binance index-price archive backfill
 
@@ -211,6 +213,58 @@ non-trading `placeholder_*` fields. It has no REST/USDC fallback, tradability
 decision, retry scheduler, canonical repair, or aggregation behavior. Inspect
 every object status and `result.completed`; partial success or any gap/failure
 keeps the batch incomplete.
+
+### Binance settled funding-rate archive backfill
+
+`BinanceFundingRateBackfill.run(instrument, request_range)` accepts only
+BTCUSDT or ETHUSDT `InstrumentId` values. Every UTC month intersecting the
+half-open request maps to at most one complete official monthly object, even
+for a narrow point request. Frozen object evidence covers `2020-01` through
+`2026-07`; other months are explicit coverage gaps and do not trigger guessed
+monthly, daily, or REST URLs.
+
+```python
+from datetime import UTC, datetime
+
+from tracequant.data import BinanceFundingRateBackfill, RawObjectIdentity, RawStore
+from tracequant.domain import InstrumentId, TimeRange
+
+store = RawStore("raw")
+result = BinanceFundingRateBackfill(store).run(
+    InstrumentId("BTCUSDT"),
+    TimeRange(
+        start=datetime(2026, 7, 15, tzinfo=UTC),
+        end=datetime(2026, 7, 16, tzinfo=UTC),
+    ),
+)
+for object_result in result.objects:
+    if object_result.artifact_path is None:
+        continue
+    identity = RawObjectIdentity.from_request(object_result.plan.request)
+    for artifact in store.list_verified_revisions(identity):
+        revision = artifact.revision_identity
+        assert revision is not None
+        exact_artifact = store.read_exact_revision(identity, revision)
+```
+
+The Raw schema `binance.um.funding-rate.csv.v1` preserves the archive's exact
+three-field meaning: integer `calc_time`, positive integer
+`funding_interval_hours`, and the original finite `last_funding_rate` string.
+It does not invent REST-only symbol, mark-price, or rate-type fields. Funding
+rows are events, so `actual_record_range` is the observed point span
+`[first_calc_time,last_calc_time+1ms)`, not continuous month coverage. Object
+coverage is checked separately: a fixed declared interval must account for
+the first, every intermediate, and the tail event through the month boundary.
+Missing events, interval changes, or insufficient tail evidence remain an
+explicit coverage gap and are never exposed as completed Raw data.
+Each object result exposes its request range, actual event range (when parsed),
+coverage status, Raw artifact path, acquisition status, and detail.
+
+The backfill has no daily archive, REST/current-month fallback, prediction,
+fee/PnL derivation, generic retry loop, or CLI behavior. Inspect each monthly
+status and `result.completed`; successful months remain immutable and exactly
+revision-readable when another month fails or Binance later replaces an
+object.
 
 “Research MVP” therefore means a reliable foundation for later research work,
 not a claim that research, backtesting, Demo, or Live trading is available.
@@ -292,6 +346,7 @@ src/tracequant/                 implemented bootstrap package
   data/public_history.py        Binance public-history contracts
   data/raw_store.py             immutable Raw Parquet/manifest persistence
   data/binance_contract_kline.py  explicit Binance archive backfill adapter
+  data/binance_funding_rate.py  settled funding monthly archive adapter
   data/binance_index_price_kline.py  explicit index-price pair archive adapter
   data/binance_mark_price_kline.py  explicit mark-price archive adapter
 tests/                          package and workflow tests

--- a/docs/architecture/technical-baseline.md
+++ b/docs/architecture/technical-baseline.md
@@ -45,10 +45,10 @@ The public foundation consists of:
    acquisition outcomes in separate manifests with optional quarantined
    response bodies;
 7. explicit Binance USDⓈ-M public-archive backfill adapters for BTCUSDT and
-   ETHUSDT 1m contract, mark-price, and index-price Klines, including bounded
-   HTTP, upstream checksum verification, ZIP/CSV validation, complete 12-field
-   Raw parsing, typed price-index-pair identity, and dataset-specific
-   placeholder field names;
+   ETHUSDT 1m contract, mark-price, and index-price Klines plus settled funding
+   monthly objects, including bounded HTTP, upstream checksum verification,
+   ZIP/CSV validation, typed price-index-pair identity, dataset-specific
+   placeholder field names, and event-specific funding coverage evidence;
 8. deterministic test-only factories for the domain models.
 
 Polars is the sole runtime third-party dependency in `pyproject.toml` and is
@@ -69,7 +69,7 @@ The full current tree and import rules are in
 - domain models depend on UTC utilities but not on network, exchange, UI,
   deployment, logging setup, or test fixtures;
 - data contracts remain separate from transport and persistence concerns;
-  `BinanceContractKlineBackfill` and `RawStore` perform network and filesystem
+  public-history backfill adapters and `RawStore` perform network and filesystem
   work only when explicitly called, and module imports remain side-effect free;
 - tests may use `tests/fixtures`, but fixtures are not production runtime
   dependencies;

--- a/src/tracequant/data/__init__.py
+++ b/src/tracequant/data/__init__.py
@@ -10,6 +10,15 @@ from tracequant.data.binance_contract_kline import (
     BinanceContractKlineStatus,
     plan_binance_contract_kline_archives,
 )
+from tracequant.data.binance_funding_rate import (
+    BinanceFundingRateBackfill,
+    BinanceFundingRateCoverageGapPlan,
+    BinanceFundingRateCoverageStatus,
+    BinanceFundingRateObjectResult,
+    BinanceFundingRateRunResult,
+    BinanceFundingRateStatus,
+    plan_binance_funding_rate_archives,
+)
 from tracequant.data.binance_index_price_kline import (
     BinanceIndexPriceKlineBackfill,
     BinanceIndexPriceKlineCoverageGapPlan,
@@ -88,6 +97,12 @@ __all__ = [
     "BinanceContractKlineObjectResult",
     "BinanceContractKlineRunResult",
     "BinanceContractKlineStatus",
+    "BinanceFundingRateBackfill",
+    "BinanceFundingRateCoverageGapPlan",
+    "BinanceFundingRateCoverageStatus",
+    "BinanceFundingRateObjectResult",
+    "BinanceFundingRateRunResult",
+    "BinanceFundingRateStatus",
     "BinanceKlineInterval",
     "BinanceIndexPriceKlineBackfill",
     "BinanceIndexPriceKlineCoverageGapPlan",
@@ -130,6 +145,7 @@ __all__ = [
     "RawStore",
     "RawStoreError",
     "plan_binance_contract_kline_archives",
+    "plan_binance_funding_rate_archives",
     "plan_binance_index_price_kline_archives",
     "plan_binance_mark_price_kline_archives",
     "next_binance_funding_cursor",

--- a/src/tracequant/data/binance_funding_rate.py
+++ b/src/tracequant/data/binance_funding_rate.py
@@ -1,0 +1,465 @@
+"""Binance USDⓈ-M settled-funding monthly archive backfill adapter.
+
+Funding rows are events rather than candles.  The adapter therefore records
+the observed event-point range separately from its fail-closed object coverage
+decision.  Official archive acquisition, evidence, and immutable Raw
+publication remain delegated to the shared Binance public-archive seam.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, date, datetime, time, timedelta
+from decimal import Decimal, InvalidOperation
+from enum import StrEnum
+from pathlib import Path
+from typing import Final
+
+import polars as pl
+
+from tracequant.data.binance_public_archive import (
+    ArchiveHttpGet,
+    ArchiveHttpResponse,
+    BinanceArchiveAcquisitionStatus,
+    BinanceArchiveObjectPlan,
+    BinanceArchiveParseResult,
+    BinancePublicArchiveAcquisition,
+    _coverage_gap,
+    _invalid_content,
+)
+from tracequant.data.public_history import (
+    BinanceArchiveObjectBoundary,
+    BinancePublicHistoryDataType,
+    BinancePublicHistoryRequest,
+    BinancePublicHistorySourceKind,
+)
+from tracequant.data.raw_store import RawStore
+from tracequant.domain import InstrumentId, TimeRange
+
+__all__ = [
+    "ArchiveHttpResponse",
+    "BinanceArchiveObjectPlan",
+    "BinanceFundingRateBackfill",
+    "BinanceFundingRateCoverageGapPlan",
+    "BinanceFundingRateCoverageStatus",
+    "BinanceFundingRateObjectResult",
+    "BinanceFundingRateRunResult",
+    "BinanceFundingRateStatus",
+    "plan_binance_funding_rate_archives",
+]
+
+_ARCHIVE_ROOT: Final = "https://data.binance.vision"
+_SCHEMA_IDENTIFIER: Final = "binance.um.funding-rate.csv.v1"
+_MICROSECOND: Final = timedelta(microseconds=1)
+_MILLISECONDS_PER_HOUR: Final = 60 * 60 * 1000
+_MAX_SIGNED_INT64_TEXT: Final = str(2**63 - 1)
+_COLUMNS: Final = (
+    "calc_time",
+    "funding_interval_hours",
+    "last_funding_rate",
+)
+_DTYPES: Final = {
+    "calc_time": pl.Int64,
+    "funding_interval_hours": pl.Int64,
+    "last_funding_rate": pl.String,
+}
+_DECIMAL_PATTERN: Final = re.compile(
+    r"\A[+-]?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)(?:[eE][+-]?[0-9]+)?\Z"
+)
+
+# Frozen object-existence evidence from the approved Research contract.  This
+# is an inclusive monthly range, not a promise about current or future objects.
+_RESEARCH_MONTHLY_COVERAGE: Final = {
+    "BTCUSDT": (date(2020, 1, 1), date(2026, 7, 1)),
+    "ETHUSDT": (date(2020, 1, 1), date(2026, 7, 1)),
+}
+
+
+BinanceFundingRateStatus = BinanceArchiveAcquisitionStatus
+
+
+class BinanceFundingRateCoverageStatus(StrEnum):
+    """Independent event-coverage judgment for one planned monthly object."""
+
+    COMPLETE = "complete"
+    GAP = "gap"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True, slots=True)
+class BinanceFundingRateCoverageGapPlan:
+    """One month for which Research did not prove a funding archive object."""
+
+    instrument: InstrumentId
+    request_range: TimeRange
+    boundary: BinanceArchiveObjectBoundary
+    detail: str
+
+    @property
+    def request(self) -> BinancePublicHistoryRequest:
+        """Return the monthly funding source identity represented by this gap."""
+        return BinancePublicHistoryRequest(
+            instrument=self.instrument,
+            data_type=BinancePublicHistoryDataType.SETTLED_FUNDING_RATE,
+            request_range=self.request_range,
+            source_kind=BinancePublicHistorySourceKind.ARCHIVE_MONTHLY,
+            interval=None,
+            archive_object_boundary=self.boundary,
+        )
+
+
+type BinanceFundingRatePlan = (
+    BinanceArchiveObjectPlan | BinanceFundingRateCoverageGapPlan
+)
+
+
+@dataclass(frozen=True, slots=True)
+class BinanceFundingRateObjectResult:
+    plan: BinanceFundingRatePlan
+    status: BinanceFundingRateStatus
+    artifact_path: Path | None = None
+    detail: str | None = None
+    actual_record_range: TimeRange | None = None
+
+    @property
+    def request_range(self) -> TimeRange:
+        return self.plan.request.request_range
+
+    @property
+    def coverage_status(self) -> BinanceFundingRateCoverageStatus:
+        if self.status in {
+            BinanceFundingRateStatus.PUBLISHED,
+            BinanceFundingRateStatus.EXISTING,
+        }:
+            return BinanceFundingRateCoverageStatus.COMPLETE
+        if self.status is BinanceFundingRateStatus.COVERAGE_GAP and self.detail:
+            if "unknown" not in self.detail and "does not prove" not in self.detail:
+                return BinanceFundingRateCoverageStatus.GAP
+        return BinanceFundingRateCoverageStatus.UNKNOWN
+
+
+@dataclass(frozen=True, slots=True)
+class BinanceFundingRateRunResult:
+    """Per-month outcomes for one request; completion is deliberately all-or-none."""
+
+    request_range: TimeRange
+    objects: tuple[BinanceFundingRateObjectResult, ...]
+
+    @property
+    def completed(self) -> bool:
+        successful = {
+            BinanceFundingRateStatus.PUBLISHED,
+            BinanceFundingRateStatus.EXISTING,
+        }
+        return bool(self.objects) and all(
+            item.status in successful for item in self.objects
+        )
+
+
+def _next_month(value: date) -> date:
+    if value.month == 12:
+        return date(value.year + 1, 1, 1)
+    return date(value.year, value.month + 1, 1)
+
+
+def _utc_midnight(value: date) -> datetime:
+    return datetime.combine(value, time.min, tzinfo=UTC)
+
+
+def _month_start(value: datetime) -> date:
+    return date(value.year, value.month, 1)
+
+
+def _archive_object_range(plan: BinanceArchiveObjectPlan) -> TimeRange:
+    boundary = plan.request.archive_object_boundary
+    assert boundary is not None
+    return TimeRange(
+        start=_utc_midnight(boundary.period_start),
+        end=_utc_midnight(_next_month(boundary.period_start)),
+    )
+
+
+def _build_plan(
+    instrument: InstrumentId,
+    request_range: TimeRange,
+    boundary: BinanceArchiveObjectBoundary,
+) -> BinanceArchiveObjectPlan:
+    suffix = boundary.period_start.strftime("%Y-%m")
+    filename = f"{instrument}-fundingRate-{suffix}.zip"
+    object_key = f"data/futures/um/monthly/fundingRate/{instrument}/{filename}"
+    request = BinancePublicHistoryRequest(
+        instrument=instrument,
+        data_type=BinancePublicHistoryDataType.SETTLED_FUNDING_RATE,
+        request_range=request_range,
+        source_kind=BinancePublicHistorySourceKind.ARCHIVE_MONTHLY,
+        interval=None,
+        archive_object_boundary=boundary,
+    )
+    return BinanceArchiveObjectPlan(
+        request=request,
+        object_key=object_key,
+        url=f"{_ARCHIVE_ROOT}/{object_key}",
+        checksum_url=f"{_ARCHIVE_ROOT}/{object_key}.CHECKSUM",
+        member_name=f"{instrument}-fundingRate-{suffix}.csv",
+    )
+
+
+def plan_binance_funding_rate_archives(
+    instrument: InstrumentId,
+    request_range: TimeRange,
+) -> tuple[BinanceFundingRatePlan, ...]:
+    """Map every request-intersecting month to one full object or explicit gap."""
+    if not isinstance(instrument, InstrumentId):
+        raise TypeError("instrument must be an InstrumentId")
+    if not isinstance(request_range, TimeRange):
+        raise TypeError("request_range must be a TimeRange")
+
+    coverage = _RESEARCH_MONTHLY_COVERAGE.get(str(instrument))
+    if coverage is None:
+        raise ValueError(
+            f"instrument {instrument!s} has no frozen funding-rate archive coverage"
+        )
+
+    first_month, last_month = coverage
+    cursor = _month_start(request_range.start)
+    final_month = _month_start(request_range.end - _MICROSECOND)
+    plans: list[BinanceFundingRatePlan] = []
+    while cursor <= final_month:
+        boundary = BinanceArchiveObjectBoundary.month(cursor.year, cursor.month)
+        if first_month <= cursor <= last_month:
+            plans.append(_build_plan(instrument, request_range, boundary))
+        else:
+            plans.append(
+                BinanceFundingRateCoverageGapPlan(
+                    instrument=instrument,
+                    request_range=request_range,
+                    boundary=boundary,
+                    detail=(
+                        "Research did not prove a settled-funding monthly archive "
+                        f"object for {instrument!s} in {cursor:%Y-%m}"
+                    ),
+                )
+            )
+        cursor = _next_month(cursor)
+    return tuple(plans)
+
+
+def _parse_nonnegative_int(value: str, *, field: str) -> int:
+    if not value.isascii() or not value.isdigit():
+        raise _invalid_content(f"{field} must be a non-negative integer")
+    normalized = value.lstrip("0") or "0"
+    if len(normalized) > len(_MAX_SIGNED_INT64_TEXT) or (
+        len(normalized) == len(_MAX_SIGNED_INT64_TEXT)
+        and normalized > _MAX_SIGNED_INT64_TEXT
+    ):
+        raise _invalid_content(f"{field} exceeds signed 64-bit range")
+    return int(normalized)
+
+
+def _parse_positive_int(value: str, *, field: str) -> int:
+    parsed = _parse_nonnegative_int(value, field=field)
+    if parsed == 0:
+        raise _invalid_content(f"{field} must be a positive integer")
+    return parsed
+
+
+def _validate_rate(value: str) -> None:
+    if _DECIMAL_PATTERN.fullmatch(value) is None:
+        raise _invalid_content("last_funding_rate must be a finite numeric string")
+    try:
+        parsed = Decimal(value)
+    except InvalidOperation as error:
+        raise _invalid_content(
+            "last_funding_rate must be a finite numeric string"
+        ) from error
+    if not parsed.is_finite():
+        raise _invalid_content("last_funding_rate must be a finite numeric string")
+
+
+def _validate_event_coverage(
+    plan: BinanceArchiveObjectPlan,
+    calc_times: list[int],
+    intervals: list[int],
+    actual_range: TimeRange,
+) -> None:
+    object_range = _archive_object_range(plan)
+    object_start_ms = int(object_range.start.timestamp() * 1000)
+    object_end_ms = int(object_range.end.timestamp() * 1000)
+    declared_intervals = set(intervals)
+    if len(declared_intervals) != 1:
+        raise _coverage_gap(
+            "funding interval changes make source-object coverage unknown",
+            actual_record_range=actual_range,
+        )
+    interval_ms = intervals[0] * _MILLISECONDS_PER_HOUR
+    if calc_times[0] != object_start_ms:
+        raise _coverage_gap(
+            "funding archive is missing the first monthly event",
+            actual_record_range=actual_range,
+        )
+    for previous, current in zip(calc_times, calc_times[1:], strict=False):
+        if current - previous != interval_ms:
+            raise _coverage_gap(
+                "funding archive contains a missing event for its declared interval",
+                actual_record_range=actual_range,
+            )
+    if calc_times[-1] + interval_ms != object_end_ms:
+        raise _coverage_gap(
+            "funding archive tail does not prove complete monthly event coverage",
+            actual_record_range=actual_range,
+        )
+
+
+def _parse_archive(
+    plan: BinanceArchiveObjectPlan, payload: bytes
+) -> BinanceArchiveParseResult:
+    try:
+        text = payload.decode("utf-8-sig")
+    except UnicodeDecodeError as error:
+        raise _invalid_content("CSV member is not UTF-8") from error
+
+    parsed_rows = list(csv.reader(io.StringIO(text, newline=""), strict=True))
+    if not parsed_rows or tuple(parsed_rows[0]) != _COLUMNS:
+        raise _invalid_content("CSV header must exactly match the funding schema")
+    parsed_rows = parsed_rows[1:]
+    if not parsed_rows:
+        raise _invalid_content("CSV contains no data rows")
+
+    calc_times: list[int] = []
+    intervals: list[int] = []
+    rates: list[str] = []
+    previous_calc_time: int | None = None
+    object_range = _archive_object_range(plan)
+    object_start_ms = int(object_range.start.timestamp() * 1000)
+    object_end_ms = int(object_range.end.timestamp() * 1000)
+    for row_number, row in enumerate(parsed_rows, start=1):
+        if len(row) != len(_COLUMNS):
+            raise _invalid_content(f"CSV row {row_number} does not have 3 columns")
+        calc_time = _parse_nonnegative_int(row[0], field="calc_time")
+        interval = _parse_positive_int(row[1], field="funding_interval_hours")
+        _validate_rate(row[2])
+        try:
+            datetime.fromtimestamp(calc_time / 1000, tz=UTC)
+        except (OverflowError, OSError, ValueError) as error:
+            raise _invalid_content("calc_time is not interpretable as UTC") from error
+        if not object_start_ms <= calc_time < object_end_ms:
+            raise _invalid_content(
+                "calc_time is outside the funding archive object month"
+            )
+        if previous_calc_time is not None and calc_time <= previous_calc_time:
+            raise _invalid_content("calc_time values must be strictly increasing")
+        previous_calc_time = calc_time
+        calc_times.append(calc_time)
+        intervals.append(interval)
+        rates.append(row[2])
+
+    actual_range = TimeRange(
+        start=datetime.fromtimestamp(calc_times[0] / 1000, tz=UTC),
+        end=datetime.fromtimestamp((calc_times[-1] + 1) / 1000, tz=UTC),
+    )
+    _validate_event_coverage(plan, calc_times, intervals, actual_range)
+    frame = pl.DataFrame(
+        {
+            "calc_time": calc_times,
+            "funding_interval_hours": intervals,
+            "last_funding_rate": rates,
+        },
+        schema=_DTYPES,
+    )
+    return BinanceArchiveParseResult(
+        rows=frame,
+        actual_record_range=actual_range,
+        validation_evidence=(
+            "funding_csv_schema_and_rows_verified",
+            "funding_event_time_range_recorded",
+            "funding_fixed_interval_object_coverage_verified",
+        ),
+    )
+
+
+def _validate_existing_complete_object_coverage(
+    plan: BinanceArchiveObjectPlan, actual_range: TimeRange
+) -> None:
+    """Validate the point-range shape of a previously verified funding object."""
+    object_range = _archive_object_range(plan)
+    if (
+        actual_range.start != object_range.start
+        or actual_range.end <= actual_range.start
+        or actual_range.end > object_range.end
+    ):
+        raise _coverage_gap(
+            "existing funding event range is incompatible with its source month",
+            actual_record_range=actual_range,
+        )
+
+
+class _FundingRateArchiveAdapter:
+    raw_schema_identifier = _SCHEMA_IDENTIFIER
+
+    def parse_member(
+        self, plan: BinanceArchiveObjectPlan, payload: bytes
+    ) -> BinanceArchiveParseResult:
+        return _parse_archive(plan, payload)
+
+    def validate_complete_object_coverage(
+        self, plan: BinanceArchiveObjectPlan, actual_range: TimeRange
+    ) -> None:
+        _validate_existing_complete_object_coverage(plan, actual_range)
+
+    def validate_required_coverage(
+        self, plan: BinanceArchiveObjectPlan, actual_range: TimeRange
+    ) -> None:
+        # Event coverage was proven independently while parsing the complete
+        # monthly source object.  The point range must not be compared with an
+        # arbitrary continuous caller range.
+        _validate_existing_complete_object_coverage(plan, actual_range)
+
+
+class BinanceFundingRateBackfill:
+    """Execute the official settled-funding monthly archive path."""
+
+    def __init__(
+        self,
+        store: RawStore,
+        *,
+        http_get: ArchiveHttpGet | None = None,
+        timeout: float = 30.0,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._acquisition = BinancePublicArchiveAcquisition(
+            store,
+            http_get=http_get,
+            timeout=timeout,
+            clock=clock,
+        )
+
+    def run(
+        self, instrument: InstrumentId, request_range: TimeRange
+    ) -> BinanceFundingRateRunResult:
+        plans = plan_binance_funding_rate_archives(instrument, request_range)
+        results = tuple(self._process(plan) for plan in plans)
+        return BinanceFundingRateRunResult(
+            request_range=request_range,
+            objects=results,
+        )
+
+    def _process(self, plan: BinanceFundingRatePlan) -> BinanceFundingRateObjectResult:
+        if isinstance(plan, BinanceFundingRateCoverageGapPlan):
+            outcome = self._acquisition.record_failure(
+                plan.request,
+                BinanceFundingRateStatus.COVERAGE_GAP,
+                plan.detail,
+            )
+        else:
+            outcome = self._acquisition.acquire(plan, _FundingRateArchiveAdapter())
+        return BinanceFundingRateObjectResult(
+            plan=plan,
+            status=outcome.status,
+            artifact_path=outcome.artifact_path,
+            detail=outcome.detail,
+            actual_record_range=outcome.actual_record_range,
+        )

--- a/src/tracequant/data/binance_public_archive.py
+++ b/src/tracequant/data/binance_public_archive.py
@@ -149,6 +149,7 @@ class BinanceArchiveAcquisitionOutcome:
     status: BinanceArchiveAcquisitionStatus
     artifact_path: Path | None = None
     detail: str | None = None
+    actual_record_range: TimeRange | None = None
 
 
 class _InvalidContentError(ValueError):
@@ -160,7 +161,14 @@ class _InvalidContentError(ValueError):
 
 
 class _CoverageGapError(ValueError):
-    pass
+    def __init__(
+        self,
+        message: str,
+        *,
+        actual_record_range: TimeRange | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.actual_record_range = actual_record_range
 
 
 class _RetryableDownloadError(RuntimeError):
@@ -337,6 +345,7 @@ class BinancePublicArchiveAcquisition:
         artifact_path: Path | None = None,
         source_response: RawAcquisitionResponse | None = None,
         checksum_response: RawAcquisitionResponse | None = None,
+        actual_record_range: TimeRange | None = None,
     ) -> BinanceArchiveAcquisitionOutcome:
         manifest = RawAcquisitionManifest(
             manifest_schema_version=1,
@@ -376,6 +385,7 @@ class BinancePublicArchiveAcquisition:
             status=status,
             artifact_path=artifact_path,
             detail=detail,
+            actual_record_range=actual_record_range,
         )
 
     def _existing_artifact(
@@ -404,6 +414,7 @@ class BinancePublicArchiveAcquisition:
                             source_url=plan.url,
                             checksum_url=plan.checksum_url,
                             artifact_path=revision.path,
+                            actual_record_range=error.actual_record_range,
                         )
                 existing = None
         except RawArtifactIncompleteError as error:
@@ -445,6 +456,7 @@ class BinancePublicArchiveAcquisition:
                         source_url=plan.url,
                         checksum_url=plan.checksum_url,
                         artifact_path=existing.path,
+                        actual_record_range=error.actual_record_range,
                     )
         return existing, None
 
@@ -580,6 +592,7 @@ class BinancePublicArchiveAcquisition:
                 checksum_url=plan.checksum_url,
                 source_response=self._to_raw_response(archive_payload),
                 checksum_response=self._to_raw_response(checksum_payload),
+                actual_record_range=error.actual_record_range,
             )
         except (csv.Error, _InvalidContentError) as error:
             response = (
@@ -638,12 +651,20 @@ class BinancePublicArchiveAcquisition:
                 else BinanceArchiveAcquisitionStatus.PUBLISHED
             ),
             artifact_path=artifact.path,
+            actual_record_range=artifact.manifest.actual_record_range,
         )
 
 
-def _coverage_gap(message: str) -> _CoverageGapError:
+def _coverage_gap(
+    message: str,
+    *,
+    actual_record_range: TimeRange | None = None,
+) -> _CoverageGapError:
     """Create the shared coverage exception for dataset adapters."""
-    return _CoverageGapError(message)
+    return _CoverageGapError(
+        message,
+        actual_record_range=actual_record_range,
+    )
 
 
 def _invalid_content(message: str) -> _InvalidContentError:

--- a/tests/data/test_binance_funding_rate_backfill.py
+++ b/tests/data/test_binance_funding_rate_backfill.py
@@ -1,0 +1,445 @@
+import hashlib
+import io
+import zipfile
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from tracequant.data import (
+    ArchiveHttpResponse,
+    BinanceArchiveObjectPlan,
+    BinanceFundingRateBackfill,
+    BinanceFundingRateCoverageGapPlan,
+    BinanceFundingRateCoverageStatus,
+    BinanceFundingRateStatus,
+    BinancePriceIndexId,
+    BinancePublicHistoryDataType,
+    RawArtifactNotFoundError,
+    RawObjectIdentity,
+    RawStore,
+    plan_binance_funding_rate_archives,
+)
+from tracequant.domain import InstrumentId, TimeRange
+
+HEADER = "calc_time,funding_interval_hours,last_funding_rate\n"
+EIGHT_HOURS_MS = 8 * 60 * 60 * 1000
+
+
+class FixtureHttp:
+    def __init__(self, responses: dict[str, ArchiveHttpResponse]) -> None:
+        self.responses = responses
+        self.calls: list[tuple[str, float]] = []
+
+    def __call__(self, url: str, timeout: float) -> ArchiveHttpResponse:
+        self.calls.append((url, timeout))
+        return self.responses.get(url, ArchiveHttpResponse(404, b"missing", {}))
+
+
+def _range(start: str, end: str) -> TimeRange:
+    return TimeRange(
+        start=datetime.fromisoformat(start).replace(tzinfo=UTC),
+        end=datetime.fromisoformat(end).replace(tzinfo=UTC),
+    )
+
+
+def _plan(
+    instrument: InstrumentId, request_range: TimeRange
+) -> BinanceArchiveObjectPlan:
+    plans = plan_binance_funding_rate_archives(instrument, request_range)
+    assert len(plans) == 1
+    assert isinstance(plans[0], BinanceArchiveObjectPlan)
+    return plans[0]
+
+
+def _zip(member_name: str, payload: str) -> bytes:
+    output = io.BytesIO()
+    with zipfile.ZipFile(output, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr(member_name, payload.encode())
+    return output.getvalue()
+
+
+def _archive(plan: BinanceArchiveObjectPlan, rows: list[str]) -> bytes:
+    return _zip(plan.member_name, HEADER + "".join(rows))
+
+
+def _monthly_rows(
+    start: datetime,
+    end: datetime,
+    *,
+    interval_hours: int = 8,
+) -> list[str]:
+    rows: list[str] = []
+    cursor = start
+    rates = ("-0.00010000", "0", "0.00020000")
+    while cursor < end:
+        rows.append(
+            f"{int(cursor.timestamp() * 1000)},{interval_hours},"
+            f"{rates[len(rows) % len(rates)]}\n"
+        )
+        cursor += timedelta(hours=interval_hours)
+    return rows
+
+
+def _july_rows() -> list[str]:
+    return _monthly_rows(
+        datetime(2026, 7, 1, tzinfo=UTC),
+        datetime(2026, 8, 1, tzinfo=UTC),
+    )
+
+
+def _responses(
+    plan: BinanceArchiveObjectPlan, archive: bytes
+) -> dict[str, ArchiveHttpResponse]:
+    digest = hashlib.sha256(archive).hexdigest()
+    return {
+        plan.url: ArchiveHttpResponse(
+            200,
+            archive,
+            {"Content-Type": "application/zip", "ETag": "not-an-identity"},
+        ),
+        plan.checksum_url: ArchiveHttpResponse(
+            200,
+            f"{digest}  {plan.url.rsplit('/', 1)[-1]}\n".encode(),
+            {"Content-Type": "text/plain"},
+        ),
+    }
+
+
+def test_funding_planner_uses_each_intersecting_full_month_once() -> None:
+    request_range = _range("2024-01-31T23:59:59", "2024-03-01T00:00:01")
+    plans = plan_binance_funding_rate_archives(InstrumentId("BTCUSDT"), request_range)
+
+    assert len(plans) == 3
+    assert all(isinstance(plan, BinanceArchiveObjectPlan) for plan in plans)
+    object_plans = [
+        plan for plan in plans if isinstance(plan, BinanceArchiveObjectPlan)
+    ]
+    assert [
+        plan.request.archive_object_boundary.period_start.isoformat()
+        for plan in object_plans
+        if plan.request.archive_object_boundary is not None
+    ] == ["2024-01-01", "2024-02-01", "2024-03-01"]
+    assert all(
+        plan.request.data_type is BinancePublicHistoryDataType.SETTLED_FUNDING_RATE
+        for plan in object_plans
+    )
+    assert all(plan.request.interval is None for plan in object_plans)
+    assert object_plans[1].object_key == (
+        "data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2024-02.zip"
+    )
+
+    tiny = plan_binance_funding_rate_archives(
+        InstrumentId("BTCUSDT"),
+        TimeRange(
+            start=datetime(2024, 2, 1, tzinfo=UTC),
+            end=datetime(2024, 2, 1, tzinfo=UTC) + timedelta(microseconds=1),
+        ),
+    )
+    assert len(tiny) == 1
+    assert isinstance(tiny[0], BinanceArchiveObjectPlan)
+
+
+def test_unknown_month_is_gap_without_speculative_download(tmp_path: Path) -> None:
+    transport = FixtureHttp({})
+    store = RawStore(tmp_path)
+
+    result = BinanceFundingRateBackfill(store, http_get=transport).run(
+        InstrumentId("ETHUSDT"),
+        _range("2026-07-31T23:00:00", "2026-08-01T01:00:00"),
+    )
+
+    assert result.completed is False
+    assert [item.status for item in result.objects] == [
+        BinanceFundingRateStatus.CHECKSUM_NOT_FOUND,
+        BinanceFundingRateStatus.COVERAGE_GAP,
+    ]
+    assert isinstance(result.objects[1].plan, BinanceFundingRateCoverageGapPlan)
+    assert result.objects[1].coverage_status is BinanceFundingRateCoverageStatus.GAP
+    assert result.objects[1].actual_record_range is None
+    first_plan = result.objects[0].plan
+    assert isinstance(first_plan, BinanceArchiveObjectPlan)
+    assert [url for url, _ in transport.calls] == [first_plan.checksum_url]
+    gap_identity = RawObjectIdentity.from_request(result.objects[1].plan.request)
+    assert store.list_acquisition_manifests(gap_identity)[0].status == "coverage_gap"
+
+
+@pytest.mark.parametrize("symbol", ["BTCUSDC", "ETHUSDC", "BNBUSDT"])
+def test_unsupported_instrument_is_rejected_before_fetch(
+    tmp_path: Path, symbol: str
+) -> None:
+    transport = FixtureHttp({})
+    backfill = BinanceFundingRateBackfill(RawStore(tmp_path), http_get=transport)
+
+    with pytest.raises(
+        ValueError,
+        match=rf"^instrument {symbol} has no frozen funding-rate archive coverage$",
+    ):
+        backfill.run(
+            InstrumentId(symbol),
+            _range("2026-07-01T00:00:00", "2026-08-01T00:00:00"),
+        )
+
+    assert transport.calls == []
+
+
+def test_price_index_pair_is_rejected_before_fetch(tmp_path: Path) -> None:
+    transport = FixtureHttp({})
+    backfill = BinanceFundingRateBackfill(RawStore(tmp_path), http_get=transport)
+
+    with pytest.raises(TypeError, match="^instrument must be an InstrumentId$"):
+        backfill.run(
+            cast(InstrumentId, BinancePriceIndexId("BTCUSDT")),
+            _range("2026-07-01T00:00:00", "2026-08-01T00:00:00"),
+        )
+
+    assert transport.calls == []
+
+
+def test_funding_backfill_publishes_verified_raw_from_supported_entry(
+    tmp_path: Path,
+) -> None:
+    cases = (
+        (
+            "BTCUSDT",
+            _range("2026-07-01T00:00:00", "2026-08-01T00:00:00"),
+        ),
+        (
+            "ETHUSDT",
+            _range("2026-07-15T12:00:00", "2026-07-15T12:00:01"),
+        ),
+    )
+    rows = _july_rows()
+    assert len(rows) == 93
+
+    for symbol, request_range in cases:
+        instrument = InstrumentId(symbol)
+        plan = _plan(instrument, request_range)
+        archive = _archive(plan, rows)
+        responses = _responses(plan, archive)
+        transport = FixtureHttp(responses)
+        store = RawStore(tmp_path / symbol)
+
+        result = BinanceFundingRateBackfill(
+            store,
+            http_get=transport,
+            timeout=2.5,
+            clock=lambda: datetime(2026, 8, 2, tzinfo=UTC),
+        ).run(instrument, request_range)
+
+        assert result.request_range == request_range
+        assert result.completed is True
+        assert result.objects[0].status is BinanceFundingRateStatus.PUBLISHED
+        assert (
+            result.objects[0].coverage_status
+            is BinanceFundingRateCoverageStatus.COMPLETE
+        )
+        assert result.objects[0].request_range == request_range
+        assert result.objects[0].actual_record_range == _range(
+            "2026-07-01T00:00:00", "2026-07-31T16:00:00.001000"
+        )
+        artifact = store.read_request(plan.request)
+        assert artifact.frame.columns == [
+            "calc_time",
+            "funding_interval_hours",
+            "last_funding_rate",
+        ]
+        assert artifact.frame.height == 93
+        assert artifact.frame["calc_time"].head(1).item() == 1_782_864_000_000
+        assert artifact.frame["calc_time"].tail(1).item() == 1_785_513_600_000
+        assert set(artifact.frame["funding_interval_hours"].to_list()) == {8}
+        assert set(artifact.frame["last_funding_rate"].head(3).to_list()) == {
+            "-0.00010000",
+            "0",
+            "0.00020000",
+        }
+        assert artifact.manifest.caller_request_range == request_range
+        assert artifact.manifest.actual_record_range == _range(
+            "2026-07-01T00:00:00", "2026-07-31T16:00:00.001000"
+        )
+        assert artifact.manifest.raw_schema_identifier == (
+            "binance.um.funding-rate.csv.v1"
+        )
+        assert artifact.manifest.upstream_checksum == (
+            f"sha256:{hashlib.sha256(archive).hexdigest()}"
+        )
+        assert artifact.manifest.provenance is not None
+        assert artifact.manifest.provenance.object_key == plan.object_key
+        assert artifact.manifest.provenance.csv_member == plan.member_name
+        assert (
+            artifact.manifest.provenance.archive_sha256
+            == hashlib.sha256(archive).hexdigest()
+        )
+        assert artifact.manifest.provenance.validation_evidence == (
+            "checksum_response_verified",
+            "archive_sha256_matches_checksum",
+            "zip_member_structure_verified",
+            "funding_csv_schema_and_rows_verified",
+            "funding_event_time_range_recorded",
+            "funding_fixed_interval_object_coverage_verified",
+            "source_object_coverage_verified",
+        )
+        assert artifact.archive_path.read_bytes() == archive
+        assert (
+            artifact.checksum_response_path.read_bytes()
+            == responses[plan.checksum_url].body
+        )
+        revision = artifact.revision_identity
+        assert revision is not None
+        assert store.read_exact_revision(
+            RawObjectIdentity.from_request(plan.request), revision
+        ).frame.equals(artifact.frame)
+        assert [url for url, _ in transport.calls] == [
+            plan.checksum_url,
+            plan.url,
+        ]
+        assert all(timeout == 2.5 for _, timeout in transport.calls)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "1782864000000,8,0.0001\n",
+        "calc_time,funding_interval_hours,last_funding_rate,extra\n"
+        "1782864000000,8,0.0001,x\n",
+        "calc_time,last_funding_rate\n1782864000000,0.0001\n",
+    ],
+)
+def test_unknown_missing_or_headerless_schema_is_rejected(
+    tmp_path: Path, payload: str
+) -> None:
+    request_range = _range("2026-07-01T00:00:00", "2026-08-01T00:00:00")
+    plan = _plan(InstrumentId("BTCUSDT"), request_range)
+    archive = _zip(plan.member_name, payload)
+
+    result = BinanceFundingRateBackfill(
+        RawStore(tmp_path), http_get=FixtureHttp(_responses(plan, archive))
+    ).run(InstrumentId("BTCUSDT"), request_range)
+
+    assert result.objects[0].status is BinanceFundingRateStatus.INVALID_CONTENT
+    assert result.objects[0].detail == (
+        "CSV header must exactly match the funding schema"
+    )
+
+
+@pytest.mark.parametrize(
+    ("row_index", "replacement", "expected_status", "message"),
+    [
+        (0, "1782864000000,0,0.1\n", "invalid_content", "positive integer"),
+        (0, "1782864000000,8,NaN\n", "invalid_content", "finite numeric"),
+        (0, "1782864000000,8, 0.1\n", "invalid_content", "finite numeric"),
+        (1, "1782864000000,8,0.1\n", "invalid_content", "strictly increasing"),
+        (0, "1780185600000,8,0.1\n", "invalid_content", "outside"),
+        (1, "1782907200000,8,0.1\n", "coverage_gap", "missing event"),
+        (0, "1782864000000,4,0.1\n", "coverage_gap", "interval changes"),
+    ],
+)
+def test_invalid_rows_and_unproven_coverage_fail_closed(
+    tmp_path: Path,
+    row_index: int,
+    replacement: str,
+    expected_status: str,
+    message: str,
+) -> None:
+    request_range = _range("2026-07-01T00:00:00", "2026-08-01T00:00:00")
+    plan = _plan(InstrumentId("BTCUSDT"), request_range)
+    rows = _july_rows()
+    rows[row_index] = replacement
+    archive = _archive(plan, rows)
+    store = RawStore(tmp_path)
+
+    result = BinanceFundingRateBackfill(
+        store, http_get=FixtureHttp(_responses(plan, archive))
+    ).run(InstrumentId("BTCUSDT"), request_range)
+
+    assert result.completed is False
+    assert result.objects[0].status.value == expected_status
+    assert message in (result.objects[0].detail or "")
+    if expected_status == "coverage_gap":
+        assert result.objects[0].actual_record_range is not None
+    with pytest.raises(RawArtifactNotFoundError):
+        store.read_request(plan.request)
+
+
+@pytest.mark.parametrize("missing", ["first", "middle", "last"])
+def test_missing_edge_or_middle_event_is_a_coverage_gap(
+    tmp_path: Path, missing: str
+) -> None:
+    request_range = _range("2026-07-10T00:00:00", "2026-07-10T00:00:01")
+    plan = _plan(InstrumentId("ETHUSDT"), request_range)
+    rows = _july_rows()
+    del rows[{"first": 0, "middle": 40, "last": 92}[missing]]
+    archive = _archive(plan, rows)
+
+    result = BinanceFundingRateBackfill(
+        RawStore(tmp_path), http_get=FixtureHttp(_responses(plan, archive))
+    ).run(InstrumentId("ETHUSDT"), request_range)
+
+    assert result.objects[0].status is BinanceFundingRateStatus.COVERAGE_GAP
+    assert result.completed is False
+
+
+def test_idempotency_and_upstream_replacement_preserve_exact_revisions(
+    tmp_path: Path,
+) -> None:
+    request_range = _range("2026-07-15T00:00:00", "2026-07-15T00:00:01")
+    instrument = InstrumentId("BTCUSDT")
+    plan = _plan(instrument, request_range)
+    original = _archive(plan, _july_rows())
+    revised_rows = _july_rows()
+    revised_rows[1] = revised_rows[1].replace(",0\n", ",0.00000001\n")
+    revised = _archive(plan, revised_rows)
+    store = RawStore(tmp_path)
+
+    first = BinanceFundingRateBackfill(
+        store, http_get=FixtureHttp(_responses(plan, original))
+    ).run(instrument, request_range)
+    repeated = BinanceFundingRateBackfill(
+        store, http_get=FixtureHttp(_responses(plan, original))
+    ).run(instrument, request_range)
+    replacement = BinanceFundingRateBackfill(
+        store, http_get=FixtureHttp(_responses(plan, revised))
+    ).run(instrument, request_range)
+
+    assert first.objects[0].status is BinanceFundingRateStatus.PUBLISHED
+    assert repeated.objects[0].status is BinanceFundingRateStatus.EXISTING
+    assert replacement.objects[0].status is BinanceFundingRateStatus.PUBLISHED
+    identity = RawObjectIdentity.from_request(plan.request)
+    revisions = store.list_verified_revisions(identity)
+    assert len(revisions) == 2
+    assert {
+        item.frame["last_funding_rate"].head(2).to_list()[1] for item in revisions
+    } == {"0", "0.00000001"}
+
+
+def test_cross_month_partial_failure_does_not_hide_published_month(
+    tmp_path: Path,
+) -> None:
+    request_range = _range("2026-06-30T23:00:00", "2026-07-01T01:00:00")
+    plans = plan_binance_funding_rate_archives(InstrumentId("BTCUSDT"), request_range)
+    assert all(isinstance(plan, BinanceArchiveObjectPlan) for plan in plans)
+    june, july = plans
+    assert isinstance(june, BinanceArchiveObjectPlan)
+    assert isinstance(july, BinanceArchiveObjectPlan)
+    june_archive = _archive(
+        june,
+        _monthly_rows(
+            datetime(2026, 6, 1, tzinfo=UTC),
+            datetime(2026, 7, 1, tzinfo=UTC),
+        ),
+    )
+    store = RawStore(tmp_path)
+
+    result = BinanceFundingRateBackfill(
+        store, http_get=FixtureHttp(_responses(june, june_archive))
+    ).run(InstrumentId("BTCUSDT"), request_range)
+
+    assert [item.status for item in result.objects] == [
+        BinanceFundingRateStatus.PUBLISHED,
+        BinanceFundingRateStatus.CHECKSUM_NOT_FOUND,
+    ]
+    assert result.completed is False
+    assert store.read_request(june.request).frame.height == 90
+    with pytest.raises(RawArtifactNotFoundError):
+        store.read_request(july.request)


### PR DESCRIPTION
Closes #281

## Summary
Add BTCUSDT/ETHUSDT monthly settled-funding planning, strict three-column event parsing, interval-aware fail-closed coverage, immutable Raw provenance/revision integration, public exports, tests, and documentation.

## Validation
- Critical Outcome: pass
- Formal Delivery validation: pass

## Risks / limitations
Coverage is intentionally frozen to 2020-01 through 2026-07; interval-changing or tail-ambiguous months fail closed, and daily/REST/current-month fallback remains out of scope.
