### PR TITLE
[Research] 补证 Binance USDⓈ-M REST recent/gap 有限验收窗口

### DIFF
--- a/docs/research/binance-usdm-feature11-rest-window-follow-up-probes.json
+++ b/docs/research/binance-usdm-feature11-rest-window-follow-up-probes.json
@@ -1,0 +1,2642 @@
+{
+  "manifest_version": 1,
+  "issue": {
+    "number": 295,
+    "title": "[Research] 补证 Binance USDⓈ-M REST recent/gap 有限验收窗口",
+    "url": "https://github.com/PhoenixSss/tracequant/issues/295"
+  },
+  "research_outcome": "IMPLEMENT",
+  "artifact_binding": {
+    "observation_set_id": "issue-295-probe-run-2026-09-09T18:33:30.868474Z",
+    "manifest_path": "docs/research/binance-usdm-feature11-rest-window-follow-up-probes.json",
+    "report_path": "docs/research/binance-usdm-feature11-rest-window-follow-up.md",
+    "binding_rule": "report and manifest share this observation_set_id; response_sha256 binds every complete actual response"
+  },
+  "probe_run": {
+    "request_list_frozen_at": "2026-09-09T18:33:30.868474Z",
+    "started_at": "2026-09-09T18:33:30.868907Z",
+    "finished_at": "2026-09-09T18:33:40.919630Z",
+    "elapsed_seconds": 10.050724,
+    "elapsed_time_basis": "monotonic_clock",
+    "policy": {
+      "request_limit": 34,
+      "total_response_bytes_limit": 33554432,
+      "response_bytes_limit": 16777216,
+      "elapsed_seconds_limit": 300,
+      "timeout_seconds": 10,
+      "attempts_per_non_server_semantic_request_limit": 2,
+      "server_time_total_attempt_limit": 2,
+      "redirect_policy": "do_not_follow",
+      "retry_policy": "non-server requests retry only transport failures and 5xx; 429 and other 4xx stop the path",
+      "network_policy": {
+        "proxy_source": "HTTPS_PROXY",
+        "explicit_proxy_required": true,
+        "curl_config_disabled": true,
+        "no_proxy_bypass_disabled": true,
+        "direct_fallback": "disabled",
+        "proxy_credentials_or_url_recorded": false
+      }
+    },
+    "allocation_before_first_request": {
+      "primary_requests": 17,
+      "server_time": 1,
+      "rest_recent": 8,
+      "rest_gap_maximum": 8,
+      "retry_reserve": 17,
+      "frozen_request_list": [
+        {
+          "semantic_id": "server_time",
+          "endpoint": "/fapi/v1/time",
+          "params": {},
+          "derivation": "fixed before first request; at most two total attempts until first valid T0"
+        },
+        {
+          "semantic_id": "rest:contract_kline:BTCUSDT:recent",
+          "endpoint": "/fapi/v1/klines",
+          "subject_kind": "symbol",
+          "subject": "BTCUSDT",
+          "params_derivation": "frozen Issue #295 recent-window formula applied to first valid T0"
+        },
+        {
+          "semantic_id": "rest:contract_kline:BTCUSDT:gap",
+          "endpoint": "/fapi/v1/klines",
+          "subject_kind": "symbol",
+          "subject": "BTCUSDT",
+          "params_derivation": "frozen Issue #295 gap-window formula; funding requires first recent settled fundingTime"
+        },
+        {
+          "semantic_id": "rest:contract_kline:ETHUSDT:recent",
+          "endpoint": "/fapi/v1/klines",
+          "subject_kind": "symbol",
+          "subject": "ETHUSDT",
+          "params_derivation": "frozen Issue #295 recent-window formula applied to first valid T0"
+        },
+        {
+          "semantic_id": "rest:contract_kline:ETHUSDT:gap",
+          "endpoint": "/fapi/v1/klines",
+          "subject_kind": "symbol",
+          "subject": "ETHUSDT",
+          "params_derivation": "frozen Issue #295 gap-window formula; funding requires first recent settled fundingTime"
+        },
+        {
+          "semantic_id": "rest:mark_price_kline:BTCUSDT:recent",
+          "endpoint": "/fapi/v1/markPriceKlines",
+          "subject_kind": "symbol",
+          "subject": "BTCUSDT",
+          "params_derivation": "frozen Issue #295 recent-window formula applied to first valid T0"
+        },
+        {
+          "semantic_id": "rest:mark_price_kline:BTCUSDT:gap",
+          "endpoint": "/fapi/v1/markPriceKlines",
+          "subject_kind": "symbol",
+          "subject": "BTCUSDT",
+          "params_derivation": "frozen Issue #295 gap-window formula; funding requires first recent settled fundingTime"
+        },
+        {
+          "semantic_id": "rest:mark_price_kline:ETHUSDT:recent",
+          "endpoint": "/fapi/v1/markPriceKlines",
+          "subject_kind": "symbol",
+          "subject": "ETHUSDT",
+          "params_derivation": "frozen Issue #295 recent-window formula applied to first valid T0"
+        },
+        {
+          "semantic_id": "rest:mark_price_kline:ETHUSDT:gap",
+          "endpoint": "/fapi/v1/markPriceKlines",
+          "subject_kind": "symbol",
+          "subject": "ETHUSDT",
+          "params_derivation": "frozen Issue #295 gap-window formula; funding requires first recent settled fundingTime"
+        },
+        {
+          "semantic_id": "rest:index_price_kline:BTCUSDT:recent",
+          "endpoint": "/fapi/v1/indexPriceKlines",
+          "subject_kind": "pair",
+          "subject": "BTCUSDT",
+          "params_derivation": "frozen Issue #295 recent-window formula applied to first valid T0"
+        },
+        {
+          "semantic_id": "rest:index_price_kline:BTCUSDT:gap",
+          "endpoint": "/fapi/v1/indexPriceKlines",
+          "subject_kind": "pair",
+          "subject": "BTCUSDT",
+          "params_derivation": "frozen Issue #295 gap-window formula; funding requires first recent settled fundingTime"
+        },
+        {
+          "semantic_id": "rest:index_price_kline:ETHUSDT:recent",
+          "endpoint": "/fapi/v1/indexPriceKlines",
+          "subject_kind": "pair",
+          "subject": "ETHUSDT",
+          "params_derivation": "frozen Issue #295 recent-window formula applied to first valid T0"
+        },
+        {
+          "semantic_id": "rest:index_price_kline:ETHUSDT:gap",
+          "endpoint": "/fapi/v1/indexPriceKlines",
+          "subject_kind": "pair",
+          "subject": "ETHUSDT",
+          "params_derivation": "frozen Issue #295 gap-window formula; funding requires first recent settled fundingTime"
+        },
+        {
+          "semantic_id": "rest:settled_funding_rate:BTCUSDT:recent",
+          "endpoint": "/fapi/v1/fundingRate",
+          "subject_kind": "symbol",
+          "subject": "BTCUSDT",
+          "params_derivation": "frozen Issue #295 recent-window formula applied to first valid T0"
+        },
+        {
+          "semantic_id": "rest:settled_funding_rate:BTCUSDT:gap",
+          "endpoint": "/fapi/v1/fundingRate",
+          "subject_kind": "symbol",
+          "subject": "BTCUSDT",
+          "params_derivation": "frozen Issue #295 gap-window formula; funding requires first recent settled fundingTime"
+        },
+        {
+          "semantic_id": "rest:settled_funding_rate:ETHUSDT:recent",
+          "endpoint": "/fapi/v1/fundingRate",
+          "subject_kind": "symbol",
+          "subject": "ETHUSDT",
+          "params_derivation": "frozen Issue #295 recent-window formula applied to first valid T0"
+        },
+        {
+          "semantic_id": "rest:settled_funding_rate:ETHUSDT:gap",
+          "endpoint": "/fapi/v1/fundingRate",
+          "subject_kind": "symbol",
+          "subject": "ETHUSDT",
+          "params_derivation": "frozen Issue #295 gap-window formula; funding requires first recent settled fundingTime"
+        }
+      ]
+    },
+    "consumed": {
+      "http_requests": 17,
+      "response_bytes": 53577,
+      "retries": 0,
+      "redirects_followed": 0,
+      "stop_reason": null
+    }
+  },
+  "t0": {
+    "status": "supported",
+    "server_time_ms": 1788978812658,
+    "server_time_utc": "2026-09-09T18:33:32.658Z",
+    "minute_floor_ms": 1788978780000,
+    "minute_floor_utc": "2026-09-09T18:33:00.000Z",
+    "attempt_ids": [
+      "server_time:attempt:1"
+    ],
+    "validation_errors": [],
+    "prohibited_substitutions_used": []
+  },
+  "attempts": [
+    {
+      "semantic_id": "server_time",
+      "attempt": 1,
+      "method": "GET",
+      "endpoint": "/fapi/v1/time",
+      "url": "https://fapi.binance.com/fapi/v1/time",
+      "normalized_params": {},
+      "family": null,
+      "subject_kind": null,
+      "subject": null,
+      "window_kind": null,
+      "observed_at": "2026-09-09T18:33:30.868953Z",
+      "http_status": 200,
+      "response_complete": true,
+      "response_bytes": 28,
+      "response_sha256": "851a5d31443821735ad0bec300b011143e432f1ffd24d22c3d08fb4e73d2420d",
+      "headers": {
+        "date": "Wed, 09 Sep 2026 18:33:32 GMT",
+        "content-type": "application/json",
+        "content-length": "28",
+        "x-mbx-used-weight-1m": "1"
+      },
+      "transport_failure": null,
+      "redirects_followed": 0,
+      "proxy_enforcement": {
+        "source": "HTTPS_PROXY",
+        "curl_config_disabled": true,
+        "no_proxy_bypass_disabled": true,
+        "direct_fallback": "disabled",
+        "proxy_value_recorded": false
+      },
+      "local_full_response_file": "server_time-attempt-1.body",
+      "budget_after": {
+        "http_requests": 1,
+        "total_response_bytes": 28,
+        "elapsed_seconds": 0.49968
+      },
+      "classification": "valid_server_time",
+      "bounded_sample": {
+        "serverTime": 1788978812658
+      }
+    },
+    {
+      "semantic_id": "rest:contract_kline:BTCUSDT:recent",
+      "attempt": 1,
+      "method": "GET",
+      "endpoint": "/fapi/v1/klines",
+      "url": "https://fapi.binance.com/fapi/v1/klines?symbol=BTCUSDT&interval=1m&startTime=1788975180000&endTime=1788978779999&limit=60",
+      "normalized_params": {
+        "symbol": "BTCUSDT",
+        "interval": "1m",
+        "startTime": 1788975180000,
+        "endTime": 1788978779999,
+        "limit": 60
+      },
+      "family": "contract_kline",
+      "subject_kind": "symbol",
+      "subject": "BTCUSDT",
+      "window_kind": "recent",
+      "observed_at": "2026-09-09T18:33:31.368694Z",
+      "http_status": 200,
+      "response_complete": true,
+      "response_bytes": 7935,
+      "response_sha256": "a253a934a1badc71edda32c22ab9204e8aee257109f7dc9473662b1c55a0c976",
+      "headers": {
+        "date": "Wed, 09 Sep 2026 18:33:33 GMT",
+        "content-type": "application/json",
+        "content-length": "7935",
+        "x-mbx-used-weight-1m": "2"
+      },
+      "transport_failure": null,
+      "redirects_followed": 0,
+      "proxy_enforcement": {
+        "source": "HTTPS_PROXY",
+        "curl_config_disabled": true,
+        "no_proxy_bypass_disabled": true,
+        "direct_fallback": "disabled",
+        "proxy_value_recorded": false
+      },
+      "local_full_response_file": "rest-contract_kline-BTCUSDT-recent-attempt-1.body",
+      "budget_after": {
+        "http_requests": 2,
+        "total_response_bytes": 7963,
+        "elapsed_seconds": 0.807772
+      },
+      "classification": "supported",
+      "bounded_sample": {
+        "first": [
+          1788975180000,
+          "78745.80",
+          "78768.90",
+          "78736.40",
+          "78768.90",
+          "34.600",
+          1788975239999,
+          "2724821.57470",
+          1324,
+          "15.361",
+          "1209770.02020",
+          "0"
+        ],
+        "last": [
+          1788978720000,
+          "78590.70",
+          "78590.70",
+          "78544.00",
+          "78567.30",
+          "38.825",
+          1788978779999,
+          "3050120.02140",
+          1587,
+          "19.473",
+          "1529665.58520",
+          "0"
+        ]
+      },
+      "row_count": 60,
+      "first_time_ms": 1788975180000,
+      "last_time_ms": 1788978720000
+    },
+    {
+      "semantic_id": "rest:contract_kline:ETHUSDT:recent",
+      "attempt": 1,
+      "method": "GET",
+      "endpoint": "/fapi/v1/klines",
+      "url": "https://fapi.binance.com/fapi/v1/klines?symbol=ETHUSDT&interval=1m&startTime=1788975180000&endTime=1788978779999&limit=60",
+      "normalized_params": {
+        "symbol": "ETHUSDT",
+        "interval": "1m",
+        "startTime": 1788975180000,
+        "endTime": 1788978779999,
+        "limit": 60
+      },
+      "family": "contract_kline",
+      "subject_kind": "symbol",
+      "subject": "ETHUSDT",
+      "window_kind": "recent",
+      "observed_at": "2026-09-09T18:33:31.676945Z",
+      "http_status": 200,
+      "response_complete": true,
+      "response_bytes": 7816,
+      "response_sha256": "82d2a49a6751df1137c1293e969dfc2f991e0b20c296edda0e52b69d9aef7cd7",
+      "headers": {
+        "date": "Wed, 09 Sep 2026 18:33:33 GMT",
+        "content-type": "application/json",
+        "content-length": "7816",
+        "x-mbx-used-weight-1m": "3"
+      },
+      "transport_failure": null,
+      "redirects_followed": 0,
+      "proxy_enforcement": {
+        "source": "HTTPS_PROXY",
+        "curl_config_disabled": true,
+        "no_proxy_bypass_disabled": true,
+        "direct_fallback": "disabled",
+        "proxy_value_recorded": false
+      },
+      "local_full_response_file": "rest-contract_kline-ETHUSDT-recent-attempt-1.body",
+      "budget_after": {
+        "http_requests": 3,
+        "total_response_bytes": 15779,
+        "elapsed_seconds": 1.33801
+      },
+      "classification": "supported",
+      "bounded_sample": {
+        "first": [
+          1788975180000,
+          "2493.02",
+          "2493.49",
+          "2492.24",
+          "2493.37",
+          "796.590",
+          1788975239999,
+          "1985766.94105",
+          2103,
+          "406.690",
+          "1013800.28556",
+          "0"
+        ],
+        "last": [
+          1788978720000,
+          "2489.88",
+          "2489.88",
+          "2488.52",
+          "2489.35",
+          "791.453",
+          1788978779999,
+          "1969990.08557",
+          1649,
+          "550.703",
+          "1370690.39963",
+          "0"
+        ]
+      },
+      "row_count": 60,
+      "first_time_ms": 1788975180000,
+      "last_time_ms": 1788978720000
+    },
+    {
+      "semantic_id": "rest:mark_price_kline:BTCUSDT:recent",
+      "attempt": 1,
+      "method": "GET",
+      "endpoint": "/fapi/v1/markPriceKlines",
+      "url": "https://fapi.binance.com/fapi/v1/markPriceKlines?symbol=BTCUSDT&interval=1m&startTime=1788975180000&endTime=1788978779999&limit=60",
+      "normalized_params": {
+        "symbol": "BTCUSDT",
+        "interval": "1m",
+        "startTime": 1788975180000,
+        "endTime": 1788978779999,
+        "limit": 60
+      },
+      "family": "mark_price_kline",
+      "subject_kind": "symbol",
+      "subject": "BTCUSDT",
+      "window_kind": "recent",
+      "observed_at": "2026-09-09T18:33:32.207139Z",
+      "http_status": 200,
+      "response_complete": true,
+      "response_bytes": 7261,
+      "response_sha256": "32c27367498032aa538e19bb06d90812c2a15a3766c935f2ceb9d61858f6957c",
+      "headers": {
+        "date": "Wed, 09 Sep 2026 18:33:33 GMT",
+        "content-type": "application/json",
+        "content-length": "7261",
+        "x-mbx-used-weight-1m": "4"
+      },
+      "transport_failure": null,
+      "redirects_followed": 0,
+      "proxy_enforcement": {
+        "source": "HTTPS_PROXY",
+        "curl_config_disabled": true,
+        "no_proxy_bypass_disabled": true,
+        "direct_fallback": "disabled",
+        "proxy_value_recorded": false
+      },
+      "local_full_response_file": "rest-mark_price_kline-BTCUSDT-recent-attempt-1.body",
+      "budget_after": {
+        "http_requests": 4,
+        "total_response_bytes": 23040,
+        "elapsed_seconds": 1.571579
+      },
+      "classification": "supported",
+      "bounded_sample": {
+        "first": [
+          1788975180000,
+          "78745.80000000",
+          "78767.70000000",
+          "78736.40000000",
+          "78767.10000000",
+          "0",
+          1788975239999,
+          "0",
+          60,
+          "0",
+          "0",
+          "0"
+        ],
+        "last": [
+          1788978720000,
+          "78590.80000000",
+          "78590.80000000",
+          "78547.10000000",
+          "78567.20000000",
+          "0",
+          1788978779999,
+          "0",
+          60,
+          "0",
+          "0",
+          "0"
+        ]
+      },
+      "row_count": 60,
+      "first_time_ms": 1788975180000,
+      "last_time_ms": 1788978720000
+    },
+    {
+      "semantic_id": "rest:mark_price_kline:ETHUSDT:recent",
+      "attempt": 1,
+      "method": "GET",
+      "endpoint": "/fapi/v1/markPriceKlines",
+      "url": "https://fapi.binance.com/fapi/v1/markPriceKlines?symbol=ETHUSDT&interval=1m&startTime=1788975180000&endTime=1788978779999&limit=60",
+      "normalized_params": {
+        "symbol": "ETHUSDT",
+        "interval": "1m",
+        "startTime": 1788975180000,
+        "endTime": 1788978779999,
+        "limit": 60
+      },
+      "family": "mark_price_kline",
+      "subject_kind": "symbol",
+      "subject": "ETHUSDT",
+      "window_kind": "recent",
+      "observed_at": "2026-09-09T18:33:32.440732Z",
+      "http_status": 200,
+      "response_complete": true,
+      "response_bytes": 7021,
+      "response_sha256": "c7163b4f125e983fb4ede8d707a70ff8e80a39462714732a020503a1f7e15ea6",
+      "headers": {
+        "date": "Wed, 09 Sep 2026 18:33:34 GMT",
+        "content-type": "application/json",
+        "content-length": "7021",
+        "x-mbx-used-weight-1m": "5"
+      },
+      "transport_failure": null,
+      "redirects_followed": 0,
+      "proxy_enforcement": {
+        "source": "HTTPS_PROXY",
+        "curl_config_disabled": true,
+        "no_proxy_bypass_disabled": true,
+        "direct_fallback": "disabled",
+        "proxy_value_recorded": false
+      },
+      "local_full_response_file": "rest-mark_price_kline-ETHUSDT-recent-attempt-1.body",
+      "budget_after": {
+        "http_requests": 5,
+        "total_response_bytes": 30061,
+        "elapsed_seconds": 1.936072
+      },
+      "classification": "supported",
+      "bounded_sample": {
+        "first": [
+          1788975180000,
+          "2493.16840310",
+          "2493.49000000",
+          "2492.61921812",
+          "2493.37000000",
+          "0",
+          1788975239999,
+          "0",
+          60,
+          "0",
+          "0",
+          "0"
+        ],
+        "last": [
+          1788978720000,
+          "2489.88000000",
+          "2489.88000000",
+          "2488.68638733",
+          "2489.35000000",
+          "0",
+          1788978779999,
+          "0",
+          60,
+          "0",
+          "0",
+          "0"
+        ]
+      },
+      "row_count": 60,
+      "first_time_ms": 1788975180000,
+      "last_time_ms": 1788978720000
+    },
+    {
+      "semantic_id": "rest:index_price_kline:BTCUSDT:recent",
+      "attempt": 1,
+      "method": "GET",
+      "endpoint": "/fapi/v1/indexPriceKlines",
+      "url": "https://fapi.binance.com/fapi/v1/indexPriceKlines?pair=BTCUSDT&interval=1m&startTime=1788975180000&endTime=1788978779999&limit=60",
+      "normalized_params": {
+        "pair": "BTCUSDT",
+        "interval": "1m",
+        "startTime": 1788975180000,
+        "endTime": 1788978779999,
+        "limit": 60
+      },
+      "family": "index_price_kline",
+      "subject_kind": "pair",
+      "subject": "BTCUSDT",
+      "window_kind": "recent",
+      "observed_at": "2026-09-09T18:33:32.805179Z",
+      "http_status": 200,
+      "response_complete": true,
+      "response_bytes": 7261,
+      "response_sha256": "e66727e9d38c6959847fe5efb1dd602d4aa31262c95df041a09117e7ff5a1515",
+      "headers": {
+        "date": "Wed, 09 Sep 2026 18:33:34 GMT",
+        "content-type": "application/json",
+        "content-length": "7261",
+        "x-mbx-used-weight-1m": "6"
+      },
+      "transport_failure": null,
+      "redirects_followed": 0,
+      "proxy_enforcement": {
+        "source": "HTTPS_PROXY",
+        "curl_config_disabled": true,
+        "no_proxy_bypass_disabled": true,
+        "direct_fallback": "disabled",
+        "proxy_value_recorded": false
+      },
+      "local_full_response_file": "rest-index_price_kline-BTCUSDT-recent-attempt-1.body",
+      "budget_after": {
+        "http_requests": 6,
+        "total_response_bytes": 37322,
+        "elapsed_seconds": 2.739779
+      },
+      "classification": "supported",
+      "bounded_sample": {
+        "first": [
+          1788975180000,
+          "78787.69869565",
+          "78800.12195652",
+          "78779.04456522",
+          "78798.99369565",
+          "0",
+          1788975239999,
+          "0",
+          60,
+          "0",
+          "0",
+          "0"
+        ],
+        "last": [
+          1788978720000,
+          "78619.46891304",
+          "78619.46891304",
+          "78587.34086957",
+          "78598.87239130",
+          "0",
+          1788978779999,
+          "0",
+          60,
+          "0",
+          "0",
+          "0"
+        ]
+      },
+      "row_count": 60,
+      "first_time_ms": 1788975180000,
+      "last_time_ms": 1788978720000
+    },
+    {
+      "semantic_id": "rest:index_price_kline:ETHUSDT:recent",
+      "attempt": 1,
+      "method": "GET",
+      "endpoint": "/fapi/v1/indexPriceKlines",
+      "url": "https://fapi.binance.com/fapi/v1/indexPriceKlines?pair=ETHUSDT&interval=1m&startTime=1788975180000&endTime=1788978779999&limit=60",
+      "normalized_params": {
+        "pair": "ETHUSDT",
+        "interval": "1m",
+        "startTime": 1788975180000,
+        "endTime": 1788978779999,
+        "limit": 60
+      },
+      "family": "index_price_kline",
+      "subject_kind": "pair",
+      "subject": "ETHUSDT",
+      "window_kind": "recent",
+      "observed_at": "2026-09-09T18:33:33.608919Z",
+      "http_status": 200,
+      "response_complete": true,
+      "response_bytes": 7021,
+      "response_sha256": "e87aad187eae9bf664b39f7acb468114962dc25d7daad35509d8b67e07004531",
+      "headers": {
+        "date": "Wed, 09 Sep 2026 18:33:35 GMT",
+        "content-type": "application/json",
+        "content-length": "7021",
+        "x-mbx-used-weight-1m": "7"
+      },
+      "transport_failure": null,
+      "redirects_followed": 0,
+      "proxy_enforcement": {
+        "source": "HTTPS_PROXY",
+        "curl_config_disabled": true,
+        "no_proxy_bypass_disabled": true,
+        "direct_fallback": "disabled",
+        "proxy_value_recorded": false
+      },
+      "local_full_response_file": "rest-index_price_kline-ETHUSDT-recent-attempt-1.body",
+      "budget_after": {
+        "http_requests": 7,
+        "total_response_bytes": 44343,
+        "elapsed_seconds": 3.095
+      },
+      "classification": "supported",
+      "bounded_sample": {
+        "first": [
+          1788975180000,
+          "2494.25023256",
+          "2494.36348837",
+          "2493.51627907",
+          "2494.18906977",
+          "0",
+          1788975239999,
+          "0",
+          60,
+          "0",
+          "0",
+          "0"
+        ],
+        "last": [
+          1788978720000,
+          "2490.86139535",
+          "2490.86139535",
+          "2489.86465116",
+          "2490.47255814",
+          "0",
+          1788978779999,
+          "0",
+          60,
+          "0",
+          "0",
+          "0"
+        ]
+      },
+      "row_count": 60,
+      "first_time_ms": 1788975180000,
+      "last_time_ms": 1788978720000
+    },
+    {
+      "semantic_id": "rest:settled_funding_rate:BTCUSDT:recent",
+      "attempt": 1,
+      "method": "GET",
+      "endpoint": "/fapi/v1/fundingRate",
+      "url": "https://fapi.binance.com/fapi/v1/fundingRate?symbol=BTCUSDT&startTime=1788374012658&endTime=1788978812657&limit=1000",
+      "normalized_params": {
+        "symbol": "BTCUSDT",
+        "startTime": 1788374012658,
+        "endTime": 1788978812657,
+        "limit": 1000
+      },
+      "family": "settled_funding_rate",
+      "subject_kind": "symbol",
+      "subject": "BTCUSDT",
+      "window_kind": "recent",
+      "observed_at": "2026-09-09T18:33:33.964227Z",
+      "http_status": 200,
+      "response_complete": true,
+      "response_bytes": 2648,
+      "response_sha256": "2bd472efeb5b2d6336fda340914d77770151589cb3a14ff419e1ed149ef41f71",
+      "headers": {
+        "date": "Wed, 09 Sep 2026 18:33:36 GMT",
+        "content-type": "application/json;charset=UTF-8",
+        "content-length": "2648"
+      },
+      "transport_failure": null,
+      "redirects_followed": 0,
+      "proxy_enforcement": {
+        "source": "HTTPS_PROXY",
+        "curl_config_disabled": true,
+        "no_proxy_bypass_disabled": true,
+        "direct_fallback": "disabled",
+        "proxy_value_recorded": false
+      },
+      "local_full_response_file": "rest-settled_funding_rate-BTCUSDT-recent-attempt-1.body",
+      "budget_after": {
+        "http_requests": 8,
+        "total_response_bytes": 46991,
+        "elapsed_seconds": 4.240328
+      },
+      "classification": "supported",
+      "bounded_sample": {
+        "first": {
+          "symbol": "BTCUSDT",
+          "fundingTime": 1788393600000,
+          "fundingRate": "0.00007287",
+          "markPrice": "77301.45594203",
+          "rateType": "Regular"
+        },
+        "last": {
+          "symbol": "BTCUSDT",
+          "fundingTime": 1788969600002,
+          "fundingRate": "0.00004815",
+          "markPrice": "78569.90000000",
+          "rateType": "Regular"
+        }
+      },
+      "row_count": 21,
+      "first_time_ms": 1788393600000,
+      "last_time_ms": 1788969600002
+    },
+    {
+      "semantic_id": "rest:settled_funding_rate:ETHUSDT:recent",
+      "attempt": 1,
+      "method": "GET",
+      "endpoint": "/fapi/v1/fundingRate",
+      "url": "https://fapi.binance.com/fapi/v1/fundingRate?symbol=ETHUSDT&startTime=1788374012658&endTime=1788978812657&limit=1000",
+      "normalized_params": {
+        "symbol": "ETHUSDT",
+        "startTime": 1788374012658,
+        "endTime": 1788978812657,
+        "limit": 1000
+      },
+      "family": "settled_funding_rate",
+      "subject_kind": "symbol",
+      "subject": "ETHUSDT",
+      "window_kind": "recent",
+      "observed_at": "2026-09-09T18:33:35.109386Z",
+      "http_status": 200,
+      "response_complete": true,
+      "response_bytes": 2627,
+      "response_sha256": "368852dd6686fce1fac1d940f7153dc5099acc8125c7ae8bac4d4b0ece24cace",
+      "headers": {
+        "date": "Wed, 09 Sep 2026 18:33:38 GMT",
+        "content-type": "application/json;charset=UTF-8",
+        "content-length": "2627"
+      },
+      "transport_failure": null,
+      "redirects_followed": 0,
+      "proxy_enforcement": {
+        "source": "HTTPS_PROXY",
+        "curl_config_disabled": true,
+        "no_proxy_bypass_disabled": true,
+        "direct_fallback": "disabled",
+        "proxy_value_recorded": false
+      },
+      "local_full_response_file": "rest-settled_funding_rate-ETHUSDT-recent-attempt-1.body",
+      "budget_after": {
+        "http_requests": 9,
+        "total_response_bytes": 49618,
+        "elapsed_seconds": 5.421564
+      },
+      "classification": "supported",
+      "bounded_sample": {
+        "first": {
+          "symbol": "ETHUSDT",
+          "fundingTime": 1788393600000,
+          "fundingRate": "0.00008972",
+          "markPrice": "2390.91482171",
+          "rateType": "Regular"
+        },
+        "last": {
+          "symbol": "ETHUSDT",
+          "fundingTime": 1788969600002,
+          "fundingRate": "0.00003070",
+          "markPrice": "2488.97000000",
+          "rateType": "Regular"
+        }
+      },
+      "row_count": 21,
+      "first_time_ms": 1788393600000,
+      "last_time_ms": 1788969600002
+    },
+    {
+      "semantic_id": "rest:contract_kline:BTCUSDT:gap",
+      "attempt": 1,
+      "method": "GET",
+      "endpoint": "/fapi/v1/klines",
+      "url": "https://fapi.binance.com/fapi/v1/klines?symbol=BTCUSDT&interval=1m&startTime=1788975180000&endTime=1788975479999&limit=5",
+      "normalized_params": {
+        "symbol": "BTCUSDT",
+        "interval": "1m",
+        "startTime": 1788975180000,
+        "endTime": 1788975479999,
+        "limit": 5
+      },
+      "family": "contract_kline",
+      "subject_kind": "symbol",
+      "subject": "BTCUSDT",
+      "window_kind": "gap",
+      "observed_at": "2026-09-09T18:33:36.290610Z",
+      "http_status": 200,
+      "response_complete": true,
+      "response_bytes": 664,
+      "response_sha256": "1087f26b529e5b0fc4f8a690533186333396ddfdeee6df3d4f6a223deba27b23",
+      "headers": {
+        "date": "Wed, 09 Sep 2026 18:33:38 GMT",
+        "content-type": "application/json",
+        "content-length": "664",
+        "x-mbx-used-weight-1m": "8"
+      },
+      "transport_failure": null,
+      "redirects_followed": 0,
+      "proxy_enforcement": {
+        "source": "HTTPS_PROXY",
+        "curl_config_disabled": true,
+        "no_proxy_bypass_disabled": true,
+        "direct_fallback": "disabled",
+        "proxy_value_recorded": false
+      },
+      "local_full_response_file": "rest-contract_kline-BTCUSDT-gap-attempt-1.body",
+      "budget_after": {
+        "http_requests": 10,
+        "total_response_bytes": 50282,
+        "elapsed_seconds": 5.675249
+      },
+      "classification": "supported",
+      "bounded_sample": {
+        "first": [
+          1788975180000,
+          "78745.80",
+          "78768.90",
+          "78736.40",
+          "78768.90",
+          "34.600",
+          1788975239999,
+          "2724821.57470",
+          1324,
+          "15.361",
+          "1209770.02020",
+          "0"
+        ],
+        "last": [
+          1788975420000,
+          "78795.60",
+          "78795.60",
+          "78764.30",
+          "78770.30",
+          "34.370",
+          1788975479999,
+          "2707636.89380",
+          1372,
+          "15.490",
+          "1220175.22490",
+          "0"
+        ]
+      },
+      "row_count": 5,
+      "first_time_ms": 1788975180000,
+      "last_time_ms": 1788975420000
+    },
+    {
+      "semantic_id": "rest:contract_kline:ETHUSDT:gap",
+      "attempt": 1,
+      "method": "GET",
+      "endpoint": "/fapi/v1/klines",
+      "url": "https://fapi.binance.com/fapi/v1/klines?symbol=ETHUSDT&interval=1m&startTime=1788975180000&endTime=1788975479999&limit=5",
+      "normalized_params": {
+        "symbol": "ETHUSDT",
+        "interval": "1m",
+        "startTime": 1788975180000,
+        "endTime": 1788975479999,
+        "limit": 5
+      },
+      "family": "contract_kline",
+      "subject_kind": "symbol",
+      "subject": "ETHUSDT",
+      "window_kind": "gap",
+      "observed_at": "2026-09-09T18:33:36.544279Z",
+      "http_status": 200,
+      "response_complete": true,
+      "response_bytes": 658,
+      "response_sha256": "2f73448e36f9fca77f89cd4485ce6bccafab40dc6edcafcbb349b7ba6694e12d",
+      "headers": {
+        "date": "Wed, 09 Sep 2026 18:33:39 GMT",
+        "content-type": "application/json",
+        "content-length": "658",
+        "x-mbx-used-weight-1m": "9"
+      },
+      "transport_failure": null,
+      "redirects_followed": 0,
+      "proxy_enforcement": {
+        "source": "HTTPS_PROXY",
+        "curl_config_disabled": true,
+        "no_proxy_bypass_disabled": true,
+        "direct_fallback": "disabled",
+        "proxy_value_recorded": false
+      },
+      "local_full_response_file": "rest-contract_kline-ETHUSDT-gap-attempt-1.body",
+      "budget_after": {
+        "http_requests": 11,
+        "total_response_bytes": 50940,
+        "elapsed_seconds": 6.990918
+      },
+      "classification": "supported",
+      "bounded_sample": {
+        "first": [
+          1788975180000,
+          "2493.02",
+          "2493.49",
+          "2492.24",
+          "2493.37",
+          "796.590",
+          1788975239999,
+          "1985766.94105",
+          2103,
+          "406.690",
+          "1013800.28556",
+          "0"
+        ],
+        "last": [
+          1788975420000,
+          "2494.21",
+          "2494.57",
+          "2492.97",
+          "2493.31",
+          "2100.186",
+          1788975479999,
+          "5236928.09795",
+          2689,
+          "156.360",
+          "389938.30821",
+          "0"
+        ]
+      },
+      "row_count": 5,
+      "first_time_ms": 1788975180000,
+      "last_time_ms": 1788975420000
+    },
+    {
+      "semantic_id": "rest:mark_price_kline:BTCUSDT:gap",
+      "attempt": 1,
+      "method": "GET",
+      "endpoint": "/fapi/v1/markPriceKlines",
+      "url": "https://fapi.binance.com/fapi/v1/markPriceKlines?symbol=BTCUSDT&interval=1m&startTime=1788975180000&endTime=1788975479999&limit=5",
+      "normalized_params": {
+        "symbol": "BTCUSDT",
+        "interval": "1m",
+        "startTime": 1788975180000,
+        "endTime": 1788975479999,
+        "limit": 5
+      },
+      "family": "mark_price_kline",
+      "subject_kind": "symbol",
+      "subject": "BTCUSDT",
+      "window_kind": "gap",
+      "observed_at": "2026-09-09T18:33:37.859947Z",
+      "http_status": 200,
+      "response_complete": true,
+      "response_bytes": 606,
+      "response_sha256": "f82e8808b2d7551789fc000d667b44c4ba1b5f1957b3db1fbe45b0ce52b72769",
+      "headers": {
+        "date": "Wed, 09 Sep 2026 18:33:40 GMT",
+        "content-type": "application/json",
+        "content-length": "606",
+        "x-mbx-used-weight-1m": "10"
+      },
+      "transport_failure": null,
+      "redirects_followed": 0,
+      "proxy_enforcement": {
+        "source": "HTTPS_PROXY",
+        "curl_config_disabled": true,
+        "no_proxy_bypass_disabled": true,
+        "direct_fallback": "disabled",
+        "proxy_value_recorded": false
+      },
+      "local_full_response_file": "rest-mark_price_kline-BTCUSDT-gap-attempt-1.body",
+      "budget_after": {
+        "http_requests": 12,
+        "total_response_bytes": 51546,
+        "elapsed_seconds": 7.546179
+      },
+      "classification": "supported",
+      "bounded_sample": {
+        "first": [
+          1788975180000,
+          "78745.80000000",
+          "78767.70000000",
+          "78736.40000000",
+          "78767.10000000",
+          "0",
+          1788975239999,
+          "0",
+          60,
+          "0",
+          "0",
+          "0"
+        ],
+        "last": [
+          1788975420000,
+          "78806.25352174",
+          "78806.25352174",
+          "78769.68550725",
+          "78773.92715142",
+          "0",
+          1788975479999,
+          "0",
+          60,
+          "0",
+          "0",
+          "0"
+        ]
+      },
+      "row_count": 5,
+      "first_time_ms": 1788975180000,
+      "last_time_ms": 1788975420000
+    },
+    {
+      "semantic_id": "rest:mark_price_kline:ETHUSDT:gap",
+      "attempt": 1,
+      "method": "GET",
+      "endpoint": "/fapi/v1/markPriceKlines",
+      "url": "https://fapi.binance.com/fapi/v1/markPriceKlines?symbol=ETHUSDT&interval=1m&startTime=1788975180000&endTime=1788975479999&limit=5",
+      "normalized_params": {
+        "symbol": "ETHUSDT",
+        "interval": "1m",
+        "startTime": 1788975180000,
+        "endTime": 1788975479999,
+        "limit": 5
+      },
+      "family": "mark_price_kline",
+      "subject_kind": "symbol",
+      "subject": "ETHUSDT",
+      "window_kind": "gap",
+      "observed_at": "2026-09-09T18:33:38.415210Z",
+      "http_status": 200,
+      "response_complete": true,
+      "response_bytes": 586,
+      "response_sha256": "24de765be36ea51df0c2f989e6167959b7196fcc871f8626f2335ee39e617c75",
+      "headers": {
+        "date": "Wed, 09 Sep 2026 18:33:41 GMT",
+        "content-type": "application/json",
+        "content-length": "586",
+        "x-mbx-used-weight-1m": "11"
+      },
+      "transport_failure": null,
+      "redirects_followed": 0,
+      "proxy_enforcement": {
+        "source": "HTTPS_PROXY",
+        "curl_config_disabled": true,
+        "no_proxy_bypass_disabled": true,
+        "direct_fallback": "disabled",
+        "proxy_value_recorded": false
+      },
+      "local_full_response_file": "rest-mark_price_kline-ETHUSDT-gap-attempt-1.body",
+      "budget_after": {
+        "http_requests": 13,
+        "total_response_bytes": 52132,
+        "elapsed_seconds": 8.476296
+      },
+      "classification": "supported",
+      "bounded_sample": {
+        "first": [
+          1788975180000,
+          "2493.16840310",
+          "2493.49000000",
+          "2492.61921812",
+          "2493.37000000",
+          "0",
+          1788975239999,
+          "0",
+          60,
+          "0",
+          "0",
+          "0"
+        ],
+        "last": [
+          1788975420000,
+          "2494.61040310",
+          "2494.61040310",
+          "2493.50888132",
+          "2493.50888132",
+          "0",
+          1788975479999,
+          "0",
+          60,
+          "0",
+          "0",
+          "0"
+        ]
+      },
+      "row_count": 5,
+      "first_time_ms": 1788975180000,
+      "last_time_ms": 1788975420000
+    },
+    {
+      "semantic_id": "rest:index_price_kline:BTCUSDT:gap",
+      "attempt": 1,
+      "method": "GET",
+      "endpoint": "/fapi/v1/indexPriceKlines",
+      "url": "https://fapi.binance.com/fapi/v1/indexPriceKlines?pair=BTCUSDT&interval=1m&startTime=1788975180000&endTime=1788975479999&limit=5",
+      "normalized_params": {
+        "pair": "BTCUSDT",
+        "interval": "1m",
+        "startTime": 1788975180000,
+        "endTime": 1788975479999,
+        "limit": 5
+      },
+      "family": "index_price_kline",
+      "subject_kind": "pair",
+      "subject": "BTCUSDT",
+      "window_kind": "gap",
+      "observed_at": "2026-09-09T18:33:39.345326Z",
+      "http_status": 200,
+      "response_complete": true,
+      "response_bytes": 606,
+      "response_sha256": "8e28c4123a103faf9c14bb329edabe2420839be7d42858e4bf4b41df8a9ce455",
+      "headers": {
+        "date": "Wed, 09 Sep 2026 18:33:41 GMT",
+        "content-type": "application/json",
+        "content-length": "606",
+        "x-mbx-used-weight-1m": "12"
+      },
+      "transport_failure": null,
+      "redirects_followed": 0,
+      "proxy_enforcement": {
+        "source": "HTTPS_PROXY",
+        "curl_config_disabled": true,
+        "no_proxy_bypass_disabled": true,
+        "direct_fallback": "disabled",
+        "proxy_value_recorded": false
+      },
+      "local_full_response_file": "rest-index_price_kline-BTCUSDT-gap-attempt-1.body",
+      "budget_after": {
+        "http_requests": 14,
+        "total_response_bytes": 52738,
+        "elapsed_seconds": 8.812912
+      },
+      "classification": "supported",
+      "bounded_sample": {
+        "first": [
+          1788975180000,
+          "78787.69869565",
+          "78800.12195652",
+          "78779.04456522",
+          "78798.99369565",
+          "0",
+          1788975239999,
+          "0",
+          60,
+          "0",
+          "0",
+          "0"
+        ],
+        "last": [
+          1788975420000,
+          "78824.70630435",
+          "78824.70630435",
+          "78803.25326087",
+          "78808.07369565",
+          "0",
+          1788975479999,
+          "0",
+          60,
+          "0",
+          "0",
+          "0"
+        ]
+      },
+      "row_count": 5,
+      "first_time_ms": 1788975180000,
+      "last_time_ms": 1788975420000
+    },
+    {
+      "semantic_id": "rest:index_price_kline:ETHUSDT:gap",
+      "attempt": 1,
+      "method": "GET",
+      "endpoint": "/fapi/v1/indexPriceKlines",
+      "url": "https://fapi.binance.com/fapi/v1/indexPriceKlines?pair=ETHUSDT&interval=1m&startTime=1788975180000&endTime=1788975479999&limit=5",
+      "normalized_params": {
+        "pair": "ETHUSDT",
+        "interval": "1m",
+        "startTime": 1788975180000,
+        "endTime": 1788975479999,
+        "limit": 5
+      },
+      "family": "index_price_kline",
+      "subject_kind": "pair",
+      "subject": "ETHUSDT",
+      "window_kind": "gap",
+      "observed_at": "2026-09-09T18:33:39.681945Z",
+      "http_status": 200,
+      "response_complete": true,
+      "response_bytes": 586,
+      "response_sha256": "c8703db8d702ccee58c8830c7a3ad0ab098bb89d54907cd0054694da82c97b24",
+      "headers": {
+        "date": "Wed, 09 Sep 2026 18:33:42 GMT",
+        "content-type": "application/json",
+        "content-length": "586",
+        "x-mbx-used-weight-1m": "13"
+      },
+      "transport_failure": null,
+      "redirects_followed": 0,
+      "proxy_enforcement": {
+        "source": "HTTPS_PROXY",
+        "curl_config_disabled": true,
+        "no_proxy_bypass_disabled": true,
+        "direct_fallback": "disabled",
+        "proxy_value_recorded": false
+      },
+      "local_full_response_file": "rest-index_price_kline-ETHUSDT-gap-attempt-1.body",
+      "budget_after": {
+        "http_requests": 15,
+        "total_response_bytes": 53324,
+        "elapsed_seconds": 9.129503
+      },
+      "classification": "supported",
+      "bounded_sample": {
+        "first": [
+          1788975180000,
+          "2494.25023256",
+          "2494.36348837",
+          "2493.51627907",
+          "2494.18906977",
+          "0",
+          1788975239999,
+          "0",
+          60,
+          "0",
+          "0",
+          "0"
+        ],
+        "last": [
+          1788975420000,
+          "2495.17674419",
+          "2495.43558140",
+          "2494.55372093",
+          "2494.57395349",
+          "0",
+          1788975479999,
+          "0",
+          60,
+          "0",
+          "0",
+          "0"
+        ]
+      },
+      "row_count": 5,
+      "first_time_ms": 1788975180000,
+      "last_time_ms": 1788975420000
+    },
+    {
+      "semantic_id": "rest:settled_funding_rate:BTCUSDT:gap",
+      "attempt": 1,
+      "method": "GET",
+      "endpoint": "/fapi/v1/fundingRate",
+      "url": "https://fapi.binance.com/fapi/v1/fundingRate?symbol=BTCUSDT&startTime=1788393600000&endTime=1788397199999&limit=100",
+      "normalized_params": {
+        "symbol": "BTCUSDT",
+        "startTime": 1788393600000,
+        "endTime": 1788397199999,
+        "limit": 100
+      },
+      "family": "settled_funding_rate",
+      "subject_kind": "symbol",
+      "subject": "BTCUSDT",
+      "window_kind": "gap",
+      "observed_at": "2026-09-09T18:33:39.998536Z",
+      "http_status": 200,
+      "response_complete": true,
+      "response_bytes": 127,
+      "response_sha256": "39ac0b55d6acae3de0e0be633edbfabdc37a227fa913027fe2e63c547abda401",
+      "headers": {
+        "date": "Wed, 09 Sep 2026 18:33:42 GMT",
+        "content-type": "application/json;charset=UTF-8",
+        "content-length": "127"
+      },
+      "transport_failure": null,
+      "redirects_followed": 0,
+      "proxy_enforcement": {
+        "source": "HTTPS_PROXY",
+        "curl_config_disabled": true,
+        "no_proxy_bypass_disabled": true,
+        "direct_fallback": "disabled",
+        "proxy_value_recorded": false
+      },
+      "local_full_response_file": "rest-settled_funding_rate-BTCUSDT-gap-attempt-1.body",
+      "budget_after": {
+        "http_requests": 16,
+        "total_response_bytes": 53451,
+        "elapsed_seconds": 9.810351
+      },
+      "classification": "supported",
+      "bounded_sample": {
+        "first": {
+          "symbol": "BTCUSDT",
+          "fundingTime": 1788393600000,
+          "fundingRate": "0.00007287",
+          "markPrice": "77301.45594203",
+          "rateType": "Regular"
+        },
+        "last": {
+          "symbol": "BTCUSDT",
+          "fundingTime": 1788393600000,
+          "fundingRate": "0.00007287",
+          "markPrice": "77301.45594203",
+          "rateType": "Regular"
+        }
+      },
+      "row_count": 1,
+      "first_time_ms": 1788393600000,
+      "last_time_ms": 1788393600000
+    },
+    {
+      "semantic_id": "rest:settled_funding_rate:ETHUSDT:gap",
+      "attempt": 1,
+      "method": "GET",
+      "endpoint": "/fapi/v1/fundingRate",
+      "url": "https://fapi.binance.com/fapi/v1/fundingRate?symbol=ETHUSDT&startTime=1788393600000&endTime=1788397199999&limit=100",
+      "normalized_params": {
+        "symbol": "ETHUSDT",
+        "startTime": 1788393600000,
+        "endTime": 1788397199999,
+        "limit": 100
+      },
+      "family": "settled_funding_rate",
+      "subject_kind": "symbol",
+      "subject": "ETHUSDT",
+      "window_kind": "gap",
+      "observed_at": "2026-09-09T18:33:40.679377Z",
+      "http_status": 200,
+      "response_complete": true,
+      "response_bytes": 126,
+      "response_sha256": "b862855ea7296ca550dc3aac55c34e2e907cb993aa5749efaedd4409b4cf1ac1",
+      "headers": {
+        "date": "Wed, 09 Sep 2026 18:33:43 GMT",
+        "content-type": "application/json;charset=UTF-8",
+        "content-length": "126"
+      },
+      "transport_failure": null,
+      "redirects_followed": 0,
+      "proxy_enforcement": {
+        "source": "HTTPS_PROXY",
+        "curl_config_disabled": true,
+        "no_proxy_bypass_disabled": true,
+        "direct_fallback": "disabled",
+        "proxy_value_recorded": false
+      },
+      "local_full_response_file": "rest-settled_funding_rate-ETHUSDT-gap-attempt-1.body",
+      "budget_after": {
+        "http_requests": 17,
+        "total_response_bytes": 53577,
+        "elapsed_seconds": 10.05063
+      },
+      "classification": "supported",
+      "bounded_sample": {
+        "first": {
+          "symbol": "ETHUSDT",
+          "fundingTime": 1788393600000,
+          "fundingRate": "0.00008972",
+          "markPrice": "2390.91482171",
+          "rateType": "Regular"
+        },
+        "last": {
+          "symbol": "ETHUSDT",
+          "fundingTime": 1788393600000,
+          "fundingRate": "0.00008972",
+          "markPrice": "2390.91482171",
+          "rateType": "Regular"
+        }
+      },
+      "row_count": 1,
+      "first_time_ms": 1788393600000,
+      "last_time_ms": 1788393600000
+    }
+  ],
+  "core_units": [
+    {
+      "semantic_id": "rest:contract_kline:BTCUSDT:recent",
+      "family": "contract_kline",
+      "subject_kind": "symbol",
+      "subject": "BTCUSDT",
+      "window_kind": "recent",
+      "attempt_ids": [
+        "rest:contract_kline:BTCUSDT:recent:attempt:1"
+      ],
+      "final_attempt": 1,
+      "validation": {
+        "valid": true,
+        "errors": [],
+        "row_count": 60,
+        "first_open_time_ms": 1788975180000,
+        "first_open_time_utc": "2026-09-09T17:33:00.000Z",
+        "last_open_time_ms": 1788978720000,
+        "last_open_time_utc": "2026-09-09T18:32:00.000Z",
+        "duplicate_count": 0,
+        "non_increasing_count": 0,
+        "missing_minute_count": 0,
+        "all_rows_12_elements": true,
+        "price_fields": [
+          1,
+          2,
+          3,
+          4
+        ],
+        "transaction_fields_semantic": true,
+        "bounded_sample": {
+          "first": [
+            1788975180000,
+            "78745.80",
+            "78768.90",
+            "78736.40",
+            "78768.90",
+            "34.600",
+            1788975239999,
+            "2724821.57470",
+            1324,
+            "15.361",
+            "1209770.02020",
+            "0"
+          ],
+          "last": [
+            1788978720000,
+            "78590.70",
+            "78590.70",
+            "78544.00",
+            "78567.30",
+            "38.825",
+            1788978779999,
+            "3050120.02140",
+            1587,
+            "19.473",
+            "1529665.58520",
+            "0"
+          ]
+        }
+      },
+      "status": "supported",
+      "classification": "supported",
+      "reason": "actual response satisfied the bounded request and schema checks"
+    },
+    {
+      "semantic_id": "rest:contract_kline:ETHUSDT:recent",
+      "family": "contract_kline",
+      "subject_kind": "symbol",
+      "subject": "ETHUSDT",
+      "window_kind": "recent",
+      "attempt_ids": [
+        "rest:contract_kline:ETHUSDT:recent:attempt:1"
+      ],
+      "final_attempt": 1,
+      "validation": {
+        "valid": true,
+        "errors": [],
+        "row_count": 60,
+        "first_open_time_ms": 1788975180000,
+        "first_open_time_utc": "2026-09-09T17:33:00.000Z",
+        "last_open_time_ms": 1788978720000,
+        "last_open_time_utc": "2026-09-09T18:32:00.000Z",
+        "duplicate_count": 0,
+        "non_increasing_count": 0,
+        "missing_minute_count": 0,
+        "all_rows_12_elements": true,
+        "price_fields": [
+          1,
+          2,
+          3,
+          4
+        ],
+        "transaction_fields_semantic": true,
+        "bounded_sample": {
+          "first": [
+            1788975180000,
+            "2493.02",
+            "2493.49",
+            "2492.24",
+            "2493.37",
+            "796.590",
+            1788975239999,
+            "1985766.94105",
+            2103,
+            "406.690",
+            "1013800.28556",
+            "0"
+          ],
+          "last": [
+            1788978720000,
+            "2489.88",
+            "2489.88",
+            "2488.52",
+            "2489.35",
+            "791.453",
+            1788978779999,
+            "1969990.08557",
+            1649,
+            "550.703",
+            "1370690.39963",
+            "0"
+          ]
+        }
+      },
+      "status": "supported",
+      "classification": "supported",
+      "reason": "actual response satisfied the bounded request and schema checks"
+    },
+    {
+      "semantic_id": "rest:mark_price_kline:BTCUSDT:recent",
+      "family": "mark_price_kline",
+      "subject_kind": "symbol",
+      "subject": "BTCUSDT",
+      "window_kind": "recent",
+      "attempt_ids": [
+        "rest:mark_price_kline:BTCUSDT:recent:attempt:1"
+      ],
+      "final_attempt": 1,
+      "validation": {
+        "valid": true,
+        "errors": [],
+        "row_count": 60,
+        "first_open_time_ms": 1788975180000,
+        "first_open_time_utc": "2026-09-09T17:33:00.000Z",
+        "last_open_time_ms": 1788978720000,
+        "last_open_time_utc": "2026-09-09T18:32:00.000Z",
+        "duplicate_count": 0,
+        "non_increasing_count": 0,
+        "missing_minute_count": 0,
+        "all_rows_12_elements": true,
+        "price_fields": [
+          1,
+          2,
+          3,
+          4
+        ],
+        "transaction_fields_semantic": false,
+        "bounded_sample": {
+          "first": [
+            1788975180000,
+            "78745.80000000",
+            "78767.70000000",
+            "78736.40000000",
+            "78767.10000000",
+            "0",
+            1788975239999,
+            "0",
+            60,
+            "0",
+            "0",
+            "0"
+          ],
+          "last": [
+            1788978720000,
+            "78590.80000000",
+            "78590.80000000",
+            "78547.10000000",
+            "78567.20000000",
+            "0",
+            1788978779999,
+            "0",
+            60,
+            "0",
+            "0",
+            "0"
+          ]
+        },
+        "placeholder_fields": {
+          "5": [
+            "0"
+          ],
+          "7": [
+            "0"
+          ],
+          "8": [
+            "60"
+          ],
+          "9": [
+            "0"
+          ],
+          "10": [
+            "0"
+          ],
+          "11": [
+            "0"
+          ]
+        }
+      },
+      "status": "supported",
+      "classification": "supported",
+      "reason": "actual response satisfied the bounded request and schema checks"
+    },
+    {
+      "semantic_id": "rest:mark_price_kline:ETHUSDT:recent",
+      "family": "mark_price_kline",
+      "subject_kind": "symbol",
+      "subject": "ETHUSDT",
+      "window_kind": "recent",
+      "attempt_ids": [
+        "rest:mark_price_kline:ETHUSDT:recent:attempt:1"
+      ],
+      "final_attempt": 1,
+      "validation": {
+        "valid": true,
+        "errors": [],
+        "row_count": 60,
+        "first_open_time_ms": 1788975180000,
+        "first_open_time_utc": "2026-09-09T17:33:00.000Z",
+        "last_open_time_ms": 1788978720000,
+        "last_open_time_utc": "2026-09-09T18:32:00.000Z",
+        "duplicate_count": 0,
+        "non_increasing_count": 0,
+        "missing_minute_count": 0,
+        "all_rows_12_elements": true,
+        "price_fields": [
+          1,
+          2,
+          3,
+          4
+        ],
+        "transaction_fields_semantic": false,
+        "bounded_sample": {
+          "first": [
+            1788975180000,
+            "2493.16840310",
+            "2493.49000000",
+            "2492.61921812",
+            "2493.37000000",
+            "0",
+            1788975239999,
+            "0",
+            60,
+            "0",
+            "0",
+            "0"
+          ],
+          "last": [
+            1788978720000,
+            "2489.88000000",
+            "2489.88000000",
+            "2488.68638733",
+            "2489.35000000",
+            "0",
+            1788978779999,
+            "0",
+            60,
+            "0",
+            "0",
+            "0"
+          ]
+        },
+        "placeholder_fields": {
+          "5": [
+            "0"
+          ],
+          "7": [
+            "0"
+          ],
+          "8": [
+            "60"
+          ],
+          "9": [
+            "0"
+          ],
+          "10": [
+            "0"
+          ],
+          "11": [
+            "0"
+          ]
+        }
+      },
+      "status": "supported",
+      "classification": "supported",
+      "reason": "actual response satisfied the bounded request and schema checks"
+    },
+    {
+      "semantic_id": "rest:index_price_kline:BTCUSDT:recent",
+      "family": "index_price_kline",
+      "subject_kind": "pair",
+      "subject": "BTCUSDT",
+      "window_kind": "recent",
+      "attempt_ids": [
+        "rest:index_price_kline:BTCUSDT:recent:attempt:1"
+      ],
+      "final_attempt": 1,
+      "validation": {
+        "valid": true,
+        "errors": [],
+        "row_count": 60,
+        "first_open_time_ms": 1788975180000,
+        "first_open_time_utc": "2026-09-09T17:33:00.000Z",
+        "last_open_time_ms": 1788978720000,
+        "last_open_time_utc": "2026-09-09T18:32:00.000Z",
+        "duplicate_count": 0,
+        "non_increasing_count": 0,
+        "missing_minute_count": 0,
+        "all_rows_12_elements": true,
+        "price_fields": [
+          1,
+          2,
+          3,
+          4
+        ],
+        "transaction_fields_semantic": false,
+        "bounded_sample": {
+          "first": [
+            1788975180000,
+            "78787.69869565",
+            "78800.12195652",
+            "78779.04456522",
+            "78798.99369565",
+            "0",
+            1788975239999,
+            "0",
+            60,
+            "0",
+            "0",
+            "0"
+          ],
+          "last": [
+            1788978720000,
+            "78619.46891304",
+            "78619.46891304",
+            "78587.34086957",
+            "78598.87239130",
+            "0",
+            1788978779999,
+            "0",
+            60,
+            "0",
+            "0",
+            "0"
+          ]
+        },
+        "placeholder_fields": {
+          "5": [
+            "0"
+          ],
+          "7": [
+            "0"
+          ],
+          "8": [
+            "60"
+          ],
+          "9": [
+            "0"
+          ],
+          "10": [
+            "0"
+          ],
+          "11": [
+            "0"
+          ]
+        }
+      },
+      "status": "supported",
+      "classification": "supported",
+      "reason": "actual response satisfied the bounded request and schema checks"
+    },
+    {
+      "semantic_id": "rest:index_price_kline:ETHUSDT:recent",
+      "family": "index_price_kline",
+      "subject_kind": "pair",
+      "subject": "ETHUSDT",
+      "window_kind": "recent",
+      "attempt_ids": [
+        "rest:index_price_kline:ETHUSDT:recent:attempt:1"
+      ],
+      "final_attempt": 1,
+      "validation": {
+        "valid": true,
+        "errors": [],
+        "row_count": 60,
+        "first_open_time_ms": 1788975180000,
+        "first_open_time_utc": "2026-09-09T17:33:00.000Z",
+        "last_open_time_ms": 1788978720000,
+        "last_open_time_utc": "2026-09-09T18:32:00.000Z",
+        "duplicate_count": 0,
+        "non_increasing_count": 0,
+        "missing_minute_count": 0,
+        "all_rows_12_elements": true,
+        "price_fields": [
+          1,
+          2,
+          3,
+          4
+        ],
+        "transaction_fields_semantic": false,
+        "bounded_sample": {
+          "first": [
+            1788975180000,
+            "2494.25023256",
+            "2494.36348837",
+            "2493.51627907",
+            "2494.18906977",
+            "0",
+            1788975239999,
+            "0",
+            60,
+            "0",
+            "0",
+            "0"
+          ],
+          "last": [
+            1788978720000,
+            "2490.86139535",
+            "2490.86139535",
+            "2489.86465116",
+            "2490.47255814",
+            "0",
+            1788978779999,
+            "0",
+            60,
+            "0",
+            "0",
+            "0"
+          ]
+        },
+        "placeholder_fields": {
+          "5": [
+            "0"
+          ],
+          "7": [
+            "0"
+          ],
+          "8": [
+            "60"
+          ],
+          "9": [
+            "0"
+          ],
+          "10": [
+            "0"
+          ],
+          "11": [
+            "0"
+          ]
+        }
+      },
+      "status": "supported",
+      "classification": "supported",
+      "reason": "actual response satisfied the bounded request and schema checks"
+    },
+    {
+      "semantic_id": "rest:settled_funding_rate:BTCUSDT:recent",
+      "family": "settled_funding_rate",
+      "subject_kind": "symbol",
+      "subject": "BTCUSDT",
+      "window_kind": "recent",
+      "attempt_ids": [
+        "rest:settled_funding_rate:BTCUSDT:recent:attempt:1"
+      ],
+      "final_attempt": 1,
+      "validation": {
+        "valid": true,
+        "errors": [],
+        "row_count": 21,
+        "first_funding_time_ms": 1788393600000,
+        "first_funding_time_utc": "2026-09-03T00:00:00.000Z",
+        "last_funding_time_ms": 1788969600002,
+        "last_funding_time_utc": "2026-09-09T16:00:00.002Z",
+        "duplicate_count": 0,
+        "non_increasing_count": 0,
+        "required_fields": [
+          "symbol",
+          "fundingRate",
+          "fundingTime"
+        ],
+        "optional_field_presence_count": {
+          "markPrice": 21,
+          "rateType": 21
+        },
+        "optional_field_null_count": {
+          "markPrice": 0,
+          "rateType": 0
+        },
+        "unknown_fields": [],
+        "settled_interpretation": "historical funding-rate records at fundingTime; no predicted value synthesized",
+        "bounded_sample": {
+          "first": {
+            "symbol": "BTCUSDT",
+            "fundingTime": 1788393600000,
+            "fundingRate": "0.00007287",
+            "markPrice": "77301.45594203",
+            "rateType": "Regular"
+          },
+          "last": {
+            "symbol": "BTCUSDT",
+            "fundingTime": 1788969600002,
+            "fundingRate": "0.00004815",
+            "markPrice": "78569.90000000",
+            "rateType": "Regular"
+          }
+        }
+      },
+      "status": "supported",
+      "classification": "supported",
+      "reason": "actual response satisfied the bounded request and schema checks"
+    },
+    {
+      "semantic_id": "rest:settled_funding_rate:ETHUSDT:recent",
+      "family": "settled_funding_rate",
+      "subject_kind": "symbol",
+      "subject": "ETHUSDT",
+      "window_kind": "recent",
+      "attempt_ids": [
+        "rest:settled_funding_rate:ETHUSDT:recent:attempt:1"
+      ],
+      "final_attempt": 1,
+      "validation": {
+        "valid": true,
+        "errors": [],
+        "row_count": 21,
+        "first_funding_time_ms": 1788393600000,
+        "first_funding_time_utc": "2026-09-03T00:00:00.000Z",
+        "last_funding_time_ms": 1788969600002,
+        "last_funding_time_utc": "2026-09-09T16:00:00.002Z",
+        "duplicate_count": 0,
+        "non_increasing_count": 0,
+        "required_fields": [
+          "symbol",
+          "fundingRate",
+          "fundingTime"
+        ],
+        "optional_field_presence_count": {
+          "markPrice": 21,
+          "rateType": 21
+        },
+        "optional_field_null_count": {
+          "markPrice": 0,
+          "rateType": 0
+        },
+        "unknown_fields": [],
+        "settled_interpretation": "historical funding-rate records at fundingTime; no predicted value synthesized",
+        "bounded_sample": {
+          "first": {
+            "symbol": "ETHUSDT",
+            "fundingTime": 1788393600000,
+            "fundingRate": "0.00008972",
+            "markPrice": "2390.91482171",
+            "rateType": "Regular"
+          },
+          "last": {
+            "symbol": "ETHUSDT",
+            "fundingTime": 1788969600002,
+            "fundingRate": "0.00003070",
+            "markPrice": "2488.97000000",
+            "rateType": "Regular"
+          }
+        }
+      },
+      "status": "supported",
+      "classification": "supported",
+      "reason": "actual response satisfied the bounded request and schema checks"
+    },
+    {
+      "semantic_id": "rest:contract_kline:BTCUSDT:gap",
+      "family": "contract_kline",
+      "subject_kind": "symbol",
+      "subject": "BTCUSDT",
+      "window_kind": "gap",
+      "attempt_ids": [
+        "rest:contract_kline:BTCUSDT:gap:attempt:1"
+      ],
+      "final_attempt": 1,
+      "validation": {
+        "valid": true,
+        "errors": [],
+        "row_count": 5,
+        "first_open_time_ms": 1788975180000,
+        "first_open_time_utc": "2026-09-09T17:33:00.000Z",
+        "last_open_time_ms": 1788975420000,
+        "last_open_time_utc": "2026-09-09T17:37:00.000Z",
+        "duplicate_count": 0,
+        "non_increasing_count": 0,
+        "missing_minute_count": 0,
+        "all_rows_12_elements": true,
+        "price_fields": [
+          1,
+          2,
+          3,
+          4
+        ],
+        "transaction_fields_semantic": true,
+        "bounded_sample": {
+          "first": [
+            1788975180000,
+            "78745.80",
+            "78768.90",
+            "78736.40",
+            "78768.90",
+            "34.600",
+            1788975239999,
+            "2724821.57470",
+            1324,
+            "15.361",
+            "1209770.02020",
+            "0"
+          ],
+          "last": [
+            1788975420000,
+            "78795.60",
+            "78795.60",
+            "78764.30",
+            "78770.30",
+            "34.370",
+            1788975479999,
+            "2707636.89380",
+            1372,
+            "15.490",
+            "1220175.22490",
+            "0"
+          ]
+        }
+      },
+      "status": "supported",
+      "classification": "supported",
+      "reason": "actual response satisfied the bounded request and schema checks"
+    },
+    {
+      "semantic_id": "rest:contract_kline:ETHUSDT:gap",
+      "family": "contract_kline",
+      "subject_kind": "symbol",
+      "subject": "ETHUSDT",
+      "window_kind": "gap",
+      "attempt_ids": [
+        "rest:contract_kline:ETHUSDT:gap:attempt:1"
+      ],
+      "final_attempt": 1,
+      "validation": {
+        "valid": true,
+        "errors": [],
+        "row_count": 5,
+        "first_open_time_ms": 1788975180000,
+        "first_open_time_utc": "2026-09-09T17:33:00.000Z",
+        "last_open_time_ms": 1788975420000,
+        "last_open_time_utc": "2026-09-09T17:37:00.000Z",
+        "duplicate_count": 0,
+        "non_increasing_count": 0,
+        "missing_minute_count": 0,
+        "all_rows_12_elements": true,
+        "price_fields": [
+          1,
+          2,
+          3,
+          4
+        ],
+        "transaction_fields_semantic": true,
+        "bounded_sample": {
+          "first": [
+            1788975180000,
+            "2493.02",
+            "2493.49",
+            "2492.24",
+            "2493.37",
+            "796.590",
+            1788975239999,
+            "1985766.94105",
+            2103,
+            "406.690",
+            "1013800.28556",
+            "0"
+          ],
+          "last": [
+            1788975420000,
+            "2494.21",
+            "2494.57",
+            "2492.97",
+            "2493.31",
+            "2100.186",
+            1788975479999,
+            "5236928.09795",
+            2689,
+            "156.360",
+            "389938.30821",
+            "0"
+          ]
+        }
+      },
+      "status": "supported",
+      "classification": "supported",
+      "reason": "actual response satisfied the bounded request and schema checks"
+    },
+    {
+      "semantic_id": "rest:mark_price_kline:BTCUSDT:gap",
+      "family": "mark_price_kline",
+      "subject_kind": "symbol",
+      "subject": "BTCUSDT",
+      "window_kind": "gap",
+      "attempt_ids": [
+        "rest:mark_price_kline:BTCUSDT:gap:attempt:1"
+      ],
+      "final_attempt": 1,
+      "validation": {
+        "valid": true,
+        "errors": [],
+        "row_count": 5,
+        "first_open_time_ms": 1788975180000,
+        "first_open_time_utc": "2026-09-09T17:33:00.000Z",
+        "last_open_time_ms": 1788975420000,
+        "last_open_time_utc": "2026-09-09T17:37:00.000Z",
+        "duplicate_count": 0,
+        "non_increasing_count": 0,
+        "missing_minute_count": 0,
+        "all_rows_12_elements": true,
+        "price_fields": [
+          1,
+          2,
+          3,
+          4
+        ],
+        "transaction_fields_semantic": false,
+        "bounded_sample": {
+          "first": [
+            1788975180000,
+            "78745.80000000",
+            "78767.70000000",
+            "78736.40000000",
+            "78767.10000000",
+            "0",
+            1788975239999,
+            "0",
+            60,
+            "0",
+            "0",
+            "0"
+          ],
+          "last": [
+            1788975420000,
+            "78806.25352174",
+            "78806.25352174",
+            "78769.68550725",
+            "78773.92715142",
+            "0",
+            1788975479999,
+            "0",
+            60,
+            "0",
+            "0",
+            "0"
+          ]
+        },
+        "placeholder_fields": {
+          "5": [
+            "0"
+          ],
+          "7": [
+            "0"
+          ],
+          "8": [
+            "60"
+          ],
+          "9": [
+            "0"
+          ],
+          "10": [
+            "0"
+          ],
+          "11": [
+            "0"
+          ]
+        }
+      },
+      "status": "supported",
+      "classification": "supported",
+      "reason": "actual response satisfied the bounded request and schema checks"
+    },
+    {
+      "semantic_id": "rest:mark_price_kline:ETHUSDT:gap",
+      "family": "mark_price_kline",
+      "subject_kind": "symbol",
+      "subject": "ETHUSDT",
+      "window_kind": "gap",
+      "attempt_ids": [
+        "rest:mark_price_kline:ETHUSDT:gap:attempt:1"
+      ],
+      "final_attempt": 1,
+      "validation": {
+        "valid": true,
+        "errors": [],
+        "row_count": 5,
+        "first_open_time_ms": 1788975180000,
+        "first_open_time_utc": "2026-09-09T17:33:00.000Z",
+        "last_open_time_ms": 1788975420000,
+        "last_open_time_utc": "2026-09-09T17:37:00.000Z",
+        "duplicate_count": 0,
+        "non_increasing_count": 0,
+        "missing_minute_count": 0,
+        "all_rows_12_elements": true,
+        "price_fields": [
+          1,
+          2,
+          3,
+          4
+        ],
+        "transaction_fields_semantic": false,
+        "bounded_sample": {
+          "first": [
+            1788975180000,
+            "2493.16840310",
+            "2493.49000000",
+            "2492.61921812",
+            "2493.37000000",
+            "0",
+            1788975239999,
+            "0",
+            60,
+            "0",
+            "0",
+            "0"
+          ],
+          "last": [
+            1788975420000,
+            "2494.61040310",
+            "2494.61040310",
+            "2493.50888132",
+            "2493.50888132",
+            "0",
+            1788975479999,
+            "0",
+            60,
+            "0",
+            "0",
+            "0"
+          ]
+        },
+        "placeholder_fields": {
+          "5": [
+            "0"
+          ],
+          "7": [
+            "0"
+          ],
+          "8": [
+            "60"
+          ],
+          "9": [
+            "0"
+          ],
+          "10": [
+            "0"
+          ],
+          "11": [
+            "0"
+          ]
+        }
+      },
+      "status": "supported",
+      "classification": "supported",
+      "reason": "actual response satisfied the bounded request and schema checks"
+    },
+    {
+      "semantic_id": "rest:index_price_kline:BTCUSDT:gap",
+      "family": "index_price_kline",
+      "subject_kind": "pair",
+      "subject": "BTCUSDT",
+      "window_kind": "gap",
+      "attempt_ids": [
+        "rest:index_price_kline:BTCUSDT:gap:attempt:1"
+      ],
+      "final_attempt": 1,
+      "validation": {
+        "valid": true,
+        "errors": [],
+        "row_count": 5,
+        "first_open_time_ms": 1788975180000,
+        "first_open_time_utc": "2026-09-09T17:33:00.000Z",
+        "last_open_time_ms": 1788975420000,
+        "last_open_time_utc": "2026-09-09T17:37:00.000Z",
+        "duplicate_count": 0,
+        "non_increasing_count": 0,
+        "missing_minute_count": 0,
+        "all_rows_12_elements": true,
+        "price_fields": [
+          1,
+          2,
+          3,
+          4
+        ],
+        "transaction_fields_semantic": false,
+        "bounded_sample": {
+          "first": [
+            1788975180000,
+            "78787.69869565",
+            "78800.12195652",
+            "78779.04456522",
+            "78798.99369565",
+            "0",
+            1788975239999,
+            "0",
+            60,
+            "0",
+            "0",
+            "0"
+          ],
+          "last": [
+            1788975420000,
+            "78824.70630435",
+            "78824.70630435",
+            "78803.25326087",
+            "78808.07369565",
+            "0",
+            1788975479999,
+            "0",
+            60,
+            "0",
+            "0",
+            "0"
+          ]
+        },
+        "placeholder_fields": {
+          "5": [
+            "0"
+          ],
+          "7": [
+            "0"
+          ],
+          "8": [
+            "60"
+          ],
+          "9": [
+            "0"
+          ],
+          "10": [
+            "0"
+          ],
+          "11": [
+            "0"
+          ]
+        }
+      },
+      "status": "supported",
+      "classification": "supported",
+      "reason": "actual response satisfied the bounded request and schema checks"
+    },
+    {
+      "semantic_id": "rest:index_price_kline:ETHUSDT:gap",
+      "family": "index_price_kline",
+      "subject_kind": "pair",
+      "subject": "ETHUSDT",
+      "window_kind": "gap",
+      "attempt_ids": [
+        "rest:index_price_kline:ETHUSDT:gap:attempt:1"
+      ],
+      "final_attempt": 1,
+      "validation": {
+        "valid": true,
+        "errors": [],
+        "row_count": 5,
+        "first_open_time_ms": 1788975180000,
+        "first_open_time_utc": "2026-09-09T17:33:00.000Z",
+        "last_open_time_ms": 1788975420000,
+        "last_open_time_utc": "2026-09-09T17:37:00.000Z",
+        "duplicate_count": 0,
+        "non_increasing_count": 0,
+        "missing_minute_count": 0,
+        "all_rows_12_elements": true,
+        "price_fields": [
+          1,
+          2,
+          3,
+          4
+        ],
+        "transaction_fields_semantic": false,
+        "bounded_sample": {
+          "first": [
+            1788975180000,
+            "2494.25023256",
+            "2494.36348837",
+            "2493.51627907",
+            "2494.18906977",
+            "0",
+            1788975239999,
+            "0",
+            60,
+            "0",
+            "0",
+            "0"
+          ],
+          "last": [
+            1788975420000,
+            "2495.17674419",
+            "2495.43558140",
+            "2494.55372093",
+            "2494.57395349",
+            "0",
+            1788975479999,
+            "0",
+            60,
+            "0",
+            "0",
+            "0"
+          ]
+        },
+        "placeholder_fields": {
+          "5": [
+            "0"
+          ],
+          "7": [
+            "0"
+          ],
+          "8": [
+            "60"
+          ],
+          "9": [
+            "0"
+          ],
+          "10": [
+            "0"
+          ],
+          "11": [
+            "0"
+          ]
+        }
+      },
+      "status": "supported",
+      "classification": "supported",
+      "reason": "actual response satisfied the bounded request and schema checks"
+    },
+    {
+      "semantic_id": "rest:settled_funding_rate:BTCUSDT:gap",
+      "family": "settled_funding_rate",
+      "subject_kind": "symbol",
+      "subject": "BTCUSDT",
+      "window_kind": "gap",
+      "attempt_ids": [
+        "rest:settled_funding_rate:BTCUSDT:gap:attempt:1"
+      ],
+      "final_attempt": 1,
+      "validation": {
+        "valid": true,
+        "errors": [],
+        "row_count": 1,
+        "first_funding_time_ms": 1788393600000,
+        "first_funding_time_utc": "2026-09-03T00:00:00.000Z",
+        "last_funding_time_ms": 1788393600000,
+        "last_funding_time_utc": "2026-09-03T00:00:00.000Z",
+        "duplicate_count": 0,
+        "non_increasing_count": 0,
+        "required_fields": [
+          "symbol",
+          "fundingRate",
+          "fundingTime"
+        ],
+        "optional_field_presence_count": {
+          "markPrice": 1,
+          "rateType": 1
+        },
+        "optional_field_null_count": {
+          "markPrice": 0,
+          "rateType": 0
+        },
+        "unknown_fields": [],
+        "settled_interpretation": "historical funding-rate records at fundingTime; no predicted value synthesized",
+        "bounded_sample": {
+          "first": {
+            "symbol": "BTCUSDT",
+            "fundingTime": 1788393600000,
+            "fundingRate": "0.00007287",
+            "markPrice": "77301.45594203",
+            "rateType": "Regular"
+          },
+          "last": {
+            "symbol": "BTCUSDT",
+            "fundingTime": 1788393600000,
+            "fundingRate": "0.00007287",
+            "markPrice": "77301.45594203",
+            "rateType": "Regular"
+          }
+        }
+      },
+      "status": "supported",
+      "classification": "supported",
+      "reason": "actual response satisfied the bounded request and schema checks"
+    },
+    {
+      "semantic_id": "rest:settled_funding_rate:ETHUSDT:gap",
+      "family": "settled_funding_rate",
+      "subject_kind": "symbol",
+      "subject": "ETHUSDT",
+      "window_kind": "gap",
+      "attempt_ids": [
+        "rest:settled_funding_rate:ETHUSDT:gap:attempt:1"
+      ],
+      "final_attempt": 1,
+      "validation": {
+        "valid": true,
+        "errors": [],
+        "row_count": 1,
+        "first_funding_time_ms": 1788393600000,
+        "first_funding_time_utc": "2026-09-03T00:00:00.000Z",
+        "last_funding_time_ms": 1788393600000,
+        "last_funding_time_utc": "2026-09-03T00:00:00.000Z",
+        "duplicate_count": 0,
+        "non_increasing_count": 0,
+        "required_fields": [
+          "symbol",
+          "fundingRate",
+          "fundingTime"
+        ],
+        "optional_field_presence_count": {
+          "markPrice": 1,
+          "rateType": 1
+        },
+        "optional_field_null_count": {
+          "markPrice": 0,
+          "rateType": 0
+        },
+        "unknown_fields": [],
+        "settled_interpretation": "historical funding-rate records at fundingTime; no predicted value synthesized",
+        "bounded_sample": {
+          "first": {
+            "symbol": "ETHUSDT",
+            "fundingTime": 1788393600000,
+            "fundingRate": "0.00008972",
+            "markPrice": "2390.91482171",
+            "rateType": "Regular"
+          },
+          "last": {
+            "symbol": "ETHUSDT",
+            "fundingTime": 1788393600000,
+            "fundingRate": "0.00008972",
+            "markPrice": "2390.91482171",
+            "rateType": "Regular"
+          }
+        }
+      },
+      "status": "supported",
+      "classification": "supported",
+      "reason": "actual response satisfied the bounded request and schema checks"
+    }
+  ],
+  "status_vocabulary": {
+    "supported": "complete HTTP 200 response satisfies the bounded schema and window checks",
+    "legal_empty": "complete HTTP 200 response is JSON [] and is not positive coverage",
+    "unsupported": "actual complete response conflicts with the required schema or window contract",
+    "unknown": "request was not executed, did not complete successfully, or lacked derivation evidence"
+  },
+  "prior_evidence": {
+    "issue_279": {
+      "observation_set_id": "issue-279-probe-run-2026-09-09T10:58:43.717234Z",
+      "manifest_path": "docs/research/binance-usdm-feature11-window-probes.json",
+      "report_path": "docs/research/binance-usdm-feature11-window-supplement.md",
+      "manifest_sha256": "c4080de0dff862cebd1ad3363c8048c67805316a1700c4ff9e2b1621eaeb64d6",
+      "report_sha256": "930338128b144bccedbc052553b8b64e7ce3ea2831333daca5c3e360cd7dbfa2",
+      "server_time_attempt": {
+        "http_status": 451,
+        "response_sha256": "79c1db471a4cdc1c8565b5dfc52e0ed2d29962738ee4d28597696fcd0920e348",
+        "result": "unknown"
+      },
+      "preservation": "referenced without downloading prior archive objects or changing prior artifacts/outcome"
+    },
+    "issue_191_manifest": {
+      "path": "docs/research/binance-usdm-public-history-probe-manifest.json",
+      "sha256": "cffaed42b5b5e65d58c67052e3517db56f54b7e9a06b0d6c8c2a7e0960c310c4",
+      "rest_boundary_observed_at": "2026-08-30T18:34:10.828640Z",
+      "server_time_response_sha256": "61f71a5c2de47e7bb153b7b61bc7a9a2ee2f40234bd56d51c36895c0bd27b186",
+      "use": "historical schema comparison only; not current REST availability evidence"
+    }
+  },
+  "consumer_decisions": {
+    "issue_282_kline_rest": {
+      "decision": "IMPLEMENT",
+      "coverage_source": "issue-295-probe-run-2026-09-09T18:33:30.868474Z",
+      "artifact_reference": "docs/research/binance-usdm-feature11-rest-window-follow-up-probes.json",
+      "required_cells": "three kline families x BTCUSDT/ETHUSDT x recent/gap",
+      "recent_window_utc_half_open_ms": [
+        1788975180000,
+        1788978780000
+      ],
+      "gap_window_utc_half_open_ms": [
+        1788975180000,
+        1788975480000
+      ],
+      "constraints": "contract and mark use instrument/symbol; index uses price-index pair/pair; interval=1m; do not extend the observed range by current date"
+    },
+    "issue_283_funding_rest": {
+      "decision": "IMPLEMENT",
+      "coverage_source": "issue-295-probe-run-2026-09-09T18:33:30.868474Z",
+      "artifact_reference": "docs/research/binance-usdm-feature11-rest-window-follow-up-probes.json",
+      "required_cells": "settled funding x BTCUSDT/ETHUSDT x recent/gap",
+      "recent_window_utc_half_open_ms": [
+        1788374012658,
+        1788978812658
+      ],
+      "gap_window_utc_half_open_ms": [
+        1788393600000,
+        1788397200000
+      ],
+      "constraints": "symbol is the instrument; preserve point-event coverage and actual optional fields; do not synthesize a continuous funding calendar"
+    }
+  },
+  "official_documentation": {
+    "observed_on": "2026-09-09",
+    "server_time": "https://developers.binance.com/docs/derivatives/usds-margined-futures/market-data/rest-api/Check-Server-Time",
+    "contract_kline": "https://developers.binance.com/docs/derivatives/usds-margined-futures/market-data/rest-api/Kline-Candlestick-Data",
+    "mark_price_kline": "https://developers.binance.com/docs/derivatives/usds-margined-futures/market-data/rest-api/Mark-Price-Kline-Candlestick-Data",
+    "index_price_kline": "https://developers.binance.com/docs/derivatives/usds-margined-futures/market-data/rest-api/Index-Price-Kline-Candlestick-Data",
+    "funding_rate": "https://developers.binance.com/docs/derivatives/usds-margined-futures/market-data/rest-api/Get-Funding-Rate-History"
+  },
+  "limitations": [
+    "This bounded observation establishes only the exact recorded windows and does not prove all-history or future availability.",
+    "Full response bodies remain only in the ignored local evidence directory; the versioned manifest stores digests and bounded projections.",
+    "HTTP Date and the local clock were not used as T0."
+  ]
+}

--- a/docs/research/binance-usdm-feature11-rest-window-follow-up.md
+++ b/docs/research/binance-usdm-feature11-rest-window-follow-up.md
@@ -1,0 +1,124 @@
+# Binance USDⓈ-M Feature #11 REST recent/gap 有限窗口补证
+
+Research Outcome: IMPLEMENT
+
+> 本次正式 observation 通过维护者当前配置的 HTTPS 代理、且禁止直连回退，取得合法
+> Binance USDⓈ-M `serverTime`，并实际执行 BTCUSDT/ETHUSDT 的 contract、mark、index
+> 1m Kline 与 settled funding 共 8 个 recent 和 8 个 gap 请求。全部 16 个核心请求均为
+> HTTP 200、非空且通过有界 schema/窗口校验；因此 #282 与 #283 所需实际来源证据已足够，
+> 后续实现建议确定为 **IMPLEMENT**。
+
+本报告与 [probe manifest](./binance-usdm-feature11-rest-window-follow-up-probes.json)
+共享 observation set ID
+`issue-295-probe-run-2026-09-09T18:33:30.868474Z`。manifest 保存每次请求的精确 URL、
+规范参数、UTC observation、HTTP 状态、允许的响应 headers、实际 bytes、response SHA-256、
+bounded first/last sample、行数、首尾时间、校验结果和逐次预算。完整响应只保留在 Git 忽略的
+本地证据目录；版本化产物不包含代理 URL、凭据或完整响应库。
+
+## 1. 冻结请求与预算结果
+
+请求清单在首个 HTTP 请求前于 `2026-09-09T18:33:30.868474Z` 冻结：1 个
+`serverTime`、8 个 recent、最多 8 个派生 gap，另留 17 个合规重试槽，总请求上限 34。
+观测器显式读取 `HTTPS_PROXY`，禁用 curl 用户配置与 `no_proxy` 绕过，禁止直连 fallback，
+不跟随 redirect。非 serverTime 请求只有 transport/timeout/5xx 才可重试；429 和其他 4xx
+停止对应路径。
+
+实际从 `2026-09-09T18:33:30.868907Z` 执行到
+`2026-09-09T18:33:40.919630Z`，monotonic elapsed 为 10.050724 秒：
+
+- 17 次 HTTP 请求，17 次 HTTP 200，0 次重试，0 次 redirect；
+- 累计响应 53,577 bytes，最大单响应 7,935 bytes；
+- 未触及 34 次、32 MiB、单响应 16 MiB、5 分钟或单次 10 秒上限；
+- 没有 transport failure、HTTP error、legal empty、unsupported 或未执行项。
+
+首次 `GET https://fapi.binance.com/fapi/v1/time` 即返回唯一合法 int64
+`serverTime=1788978812658`（`2026-09-09T18:33:32.658Z`），response bytes 为 28，
+SHA-256 为 `851a5d31443821735ad0bec300b011143e432f1ffd24d22c3d08fb4e73d2420d`。
+该响应冻结为 T0；M 为 `1788978780000`（`2026-09-09T18:33:00.000Z`）。未使用
+HTTP Date、本机时间、Kline 时间或旧 `serverTime` 替代 T0。
+
+## 2. 十六个核心请求
+
+Kline recent 固定为 `[1788975180000,1788978780000)`，向 endpoint 发送
+`startTime=1788975180000,endTime=1788978779999,limit=60,interval=1m`；gap 固定为
+`[1788975180000,1788975480000)`，发送
+`startTime=1788975180000,endTime=1788975479999,limit=5,interval=1m`。Contract/mark
+使用 `symbol`，index 使用独立 `pair`。
+
+| 数据族 | subject 参数 | recent 结果（rows；首尾 UTC；SHA-256） | gap 结果（rows；首尾 UTC；SHA-256） |
+|---|---|---|---|
+| contract kline | `symbol=BTCUSDT` | supported（60；17:33→18:32；`a253a934a1ba…`） | supported（5；17:33→17:37；`1087f26b529e…`） |
+| contract kline | `symbol=ETHUSDT` | supported（60；17:33→18:32；`82d2a49a6751…`） | supported（5；17:33→17:37；`2f73448e36f9…`） |
+| mark-price kline | `symbol=BTCUSDT` | supported（60；17:33→18:32；`32c273674980…`） | supported（5；17:33→17:37；`f82e8808b2d7…`） |
+| mark-price kline | `symbol=ETHUSDT` | supported（60；17:33→18:32；`c7163b4f125e…`） | supported（5；17:33→17:37；`24de765be36e…`） |
+| index-price kline | `pair=BTCUSDT` | supported（60；17:33→18:32；`e66727e9d38c…`） | supported（5；17:33→17:37；`8e28c4123a10…`） |
+| index-price kline | `pair=ETHUSDT` | supported（60；17:33→18:32；`e87aad187eae…`） | supported（5；17:33→17:37；`c8703db8d702…`） |
+
+表内 Kline 时间均为 `2026-09-09` UTC。每个响应的全部行均为 12 元素数组；open time
+分钟对齐、close time 为 `open+59999ms`，严格升序，无重复、缺分钟或越界。Contract 的
+OHLC、volume、quote volume、trade count 与 taker volume 字段均为实际数值。Mark/index
+的 `[0..4]` 为对应价格 OHLC；本轮所有行的 `[5]`、`[7]`、`[9..11]` 均为字符串 `"0"`，
+`[8]` 均为整数 `60`，继续按 placeholder/ignore 处理，不能发布为成交量或成交笔数。
+
+Funding recent 固定为 `[1788374012658,1788978812658)`，发送
+`startTime=1788374012658,endTime=1788978812657,limit=1000`。BTCUSDT 与 ETHUSDT 各返回
+21 条严格升序 settled record，实际首尾为 `2026-09-03T00:00:00.000Z` 至
+`2026-09-09T16:00:00.002Z`。从各自第一条 `fundingTime=1788393600000` 派生的 gap 为
+`[1788393600000,1788397200000)`，发送 `endTime=1788397199999,limit=100`，各返回 1 条：
+
+| subject | recent SHA-256 | gap SHA-256 | schema 结果 |
+|---|---|---|---|
+| `symbol=BTCUSDT` | `2bd472efeb5b2d6336fda340914d77770151589cb3a14ff419e1ed149ef41f71` | `39ac0b55d6acae3de0e0be633edbfabdc37a227fa913027fe2e63c547abda401` | supported |
+| `symbol=ETHUSDT` | `368852dd6686fce1fac1d940f7153dc5099acc8125c7ae8bac4d4b0ece24cace` | `b862855ea7296ca550dc3aac55c34e2e907cb993aa5749efaedd4409b4cf1ac1` | supported |
+
+每条 funding object 的 `symbol` 与请求一致，`fundingTime` 为窗口内 int64，
+`fundingRate` 为有限数值字符串；无重复、逆序或越界。`markPrice` 与 `rateType` 在两个
+recent 的 42 条及两个 gap 的 2 条记录中全部存在且非 null，`markPrice` 为有限数值字符串，
+`rateType` 实测为字符串 `"Regular"`；未观察到额外字段。它们是实际可选字段，不得由 archive
+补造；settled identity/value 仍由 `symbol,fundingTime,fundingRate` 构成，也不从返回间隔推导
+永久 8 小时日历。
+
+## 3. 旧证据保持与对照
+
+本轮不重新下载 #279 的 14 个 ZIP/CHECKSUM，也不改写旧报告、manifest、response 或
+`NEEDS MORE EVIDENCE` 结论：
+
+- #279 observation set ID 为
+  `issue-279-probe-run-2026-09-09T10:58:43.717234Z`；旧 serverTime HTTP 451 response
+  SHA-256 `79c1db471a4cdc1c8565b5dfc52e0ed2d29962738ee4d28597696fcd0920e348` 继续保留。
+  其 manifest/report 当前 SHA-256 分别为
+  `c4080de0dff862cebd1ad3363c8048c67805316a1700c4ff9e2b1621eaeb64d6` 与
+  `930338128b144bccedbc052553b8b64e7ce3ea2831333daca5c3e360cd7dbfa2`。
+- #191 REST-boundary observation 为 `2026-08-30T18:34:10.828640Z`，旧 serverTime
+  response SHA-256 为
+  `61f71a5c2de47e7bb153b7b61bc7a9a2ee2f40234bd56d51c36895c0bd27b186`；其 probe manifest
+  当前 SHA-256 为 `cffaed42b5b5e65d58c67052e3517db56f54b7e9a06b0d6c8c2a7e0960c310c4`。
+
+上述旧 digest 仅用于身份/语义对照。本轮的 current availability、funding REST-only 字段与
+recent/gap 覆盖全部来自本轮实际 REST response，不从 archive 或旧窗口外推。新的正向结论是
+独立补证，不追溯修改 #279 在其执行环境与时点下的准确结论。
+
+## 4. 下游可执行 coverage 决策
+
+| 消费者 | 决策 | 可接受的 coverage 输入 | 必须保留的限制 |
+|---|---|---|---|
+| #282 contract kline | IMPLEMENT | endpoint `/fapi/v1/klines`；`instrument/symbol` 为 BTCUSDT 或 ETHUSDT；1m；本轮 exact recent/gap；本 observation ID + manifest 引用 | 仅 exact observed window，不随当前日期延长；12 元素 contract 交易字段语义 |
+| #282 mark-price kline | IMPLEMENT | endpoint `/fapi/v1/markPriceKlines`；`instrument/symbol` 为 BTCUSDT 或 ETHUSDT；1m；同上 | `[5,7,8,9,10,11]` 均为 ignore/placeholder，不发布成交语义 |
+| #282 index-price kline | IMPLEMENT | endpoint `/fapi/v1/indexPriceKlines`；`price-index pair/pair` 为 BTCUSDT 或 ETHUSDT；1m；同上 | pair 与 perpetual symbol eligibility 分离；placeholder 同 mark |
+| #283 settled funding | IMPLEMENT | endpoint `/fapi/v1/fundingRate`；`instrument/symbol` 为 BTCUSDT 或 ETHUSDT；本轮 exact recent/gap；本 observation ID + manifest 引用 | point-event coverage 不冒充连续日历；核心三字段，实际 optional 字段保留原值 |
+
+实现方应把 manifest 中对应 family/subject/window 的 exact normalized params、response digest、
+观测时间和实际范围绑定到 coverage；缺失引用、错 endpoint/subject、超出观测窗口或把一个族的
+证据借给另一族时仍须在访问前返回 `rest_boundary_unknown`/unsupported。合成 fixture 只能验证
+代码行为，不能替代这里的实际来源 evidence。
+
+## 5. 结论与限制
+
+最终唯一 Research Outcome 为 **IMPLEMENT**。本轮不存在因未执行或环境失败造成的必需
+unknown，也未发现请求、subject、12 元素 Kline schema、funding schema、1m 时间或窗口合同
+冲突；#282 与 #283 可以按上表的精确 coverage 决策实施。
+
+该结论只证明本 observation 绑定的 BTCUSDT/ETHUSDT exact recent/gap 窗口与当前实际响应，
+不证明全历史无缺口、未来 endpoint/schema 永不变化、其他 symbol/interval、USDC、COIN-M、
+Spot 或其他域名。HTTP 200 `[]` 若未来出现仍必须记录为 `legal_empty`，不得当作正向覆盖；
+transport、429、其他 4xx、5xx、schema 或边界失败仍须保持独立状态并按有限预算 fail closed。


### PR DESCRIPTION
Closes #295

## Summary
Add the bounded Issue #295 proxy-only Binance USD-M REST observation manifest and report, validating T0 plus all 8 recent and 8 derived gap requests for BTCUSDT/ETHUSDT kline and settled funding consumers with Research Outcome IMPLEMENT.

## Validation
- Formal Delivery validation: pass

## Risks / limitations
Evidence is limited to the exact observed windows and current responses; it does not prove all-history, future availability, other symbols, intervals, markets, or schema stability. Full response bodies remain only in the ignored local evidence directory.
