### PR TITLE
[Task] 实现 Binance 已结算资金费率 REST 有界获取与 page Raw 发布

### DIFF
--- a/docs/architecture/technical-baseline.md
+++ b/docs/architecture/technical-baseline.md
@@ -172,11 +172,13 @@ public exchange data
 ```
 
 Only the first, narrow part of this flow currently exists: callers can retrieve
-approved Binance USDⓈ-M BTCUSDT/ETHUSDT 1m contract-Kline, mark-price-Kline, or
-index-price-Kline archives and publish immutable Raw Parquet objects with
-manifests. There is no general Binance or private API client, REST recent/gap
+approved Binance USDⓈ-M BTCUSDT/ETHUSDT 1m contract-Kline, mark-price-Kline,
+index-price-Kline, and monthly settled-funding archives, and can acquire
+source-evidence-bound Kline or settled-funding REST pages. Valid responses are
+published as immutable Raw Parquet objects with exact response provenance and
+manifests. There is no general Binance or private API client, rolling REST
 synchronization, canonical schema, data repair, feature pipeline, label
-pipeline, or future-data-leakage check. Each adapter validates missing,
+pipeline, or future-data-leakage check. Each Kline adapter validates missing,
 duplicate, and out-of-order minutes before publication. The preserved 12-field
 wire values are Raw source data and must not be treated as a canonical schema;
 mark/index volume, quote, count, taker, and ignore fields have explicit
@@ -221,10 +223,12 @@ boundaries until such an Issue is implemented and reviewed.
 ## 8. Research and trading scope limits
 
 The current public-data capability is limited to explicitly requested Binance
-USDⓈ-M BTCUSDT/ETHUSDT 1m contract-Kline, mark-price-Kline, and index-price-Kline
-archives and local immutable Raw artifacts. None of the following is currently
-available: private Binance API access, REST recent/gap synchronization, funding
-ingestion, USDC archive acquisition, multi-timeframe aggregation, factors,
+USDⓈ-M BTCUSDT/ETHUSDT 1m contract-Kline, mark-price-Kline, index-price-Kline,
+and settled-funding archive/REST inputs plus local immutable Raw artifacts.
+REST requests remain restricted to frozen observed windows and are not a
+rolling synchronizer or a claim of continuous event coverage. None of the
+following is currently available: private Binance API access, general REST
+synchronization, USDC archive acquisition, multi-timeframe aggregation, factors,
 models, backtests, Demo orders, Live orders, private API credentials, database
 state, or multi-exchange production execution.
 

--- a/docs/guides/binance-funding-rate-rest-acquisition.md
+++ b/docs/guides/binance-funding-rate-rest-acquisition.md
@@ -1,0 +1,145 @@
+# Binance USDⓈ-M settled-funding REST acquisition
+
+`BinanceFundingRateRestAcquisition.run(request, coverage, budget)` is the
+bounded public entry point for settled funding-rate pages. It accepts only the
+USDⓈ-M `/fapi/v1/fundingRate` endpoint with a typed BTCUSDT or ETHUSDT
+`InstrumentId`; funding requests use `symbol` and set `interval=None`.
+
+The caller supplies a timezone-aware UTC half-open `[start, end)` range.
+`BinanceRestPageRequest` converts it once to inclusive `startTime` and
+`endTime=end-1`, enforces the endpoint's `limit <= 1000`, and retains the same
+caller range on every page. Pagination advances from the actual last
+`fundingTime + 1ms`; it never assumes a permanent eight-hour schedule or
+invents events between observed timestamps.
+
+## Frozen coverage and finite budget
+
+`BinanceFundingRateRestCoverage` is source evidence, not permission to probe a
+new date. A supported value must match the endpoint, typed instrument, request
+range, and one exact funding recent/gap observation from the #279 follow-up
+Research in #295. The binding contains the normalized source parameters,
+response digest, observation time and actual point range, plus:
+
+- evidence version:
+  `issue-295-probe-run-2026-09-09T18:33:30.868474Z`;
+- reference:
+  `docs/research/binance-usdm-feature11-rest-window-follow-up-probes.json`;
+- reference SHA-256:
+  `30682f83b887514ef2a0e20ec21203cff70529ac1518fb538277ae0881920b45`.
+
+Only the two frozen observations per instrument are recognized: the seven-day
+recent request `[2026-09-02T18:33:32.658Z,
+2026-09-09T18:33:32.658Z)` and the one-hour positive gap observation
+`[2026-09-03T00:00:00Z, 2026-09-03T01:00:00Z)`. Coverage may narrow one of
+those windows but may not extend it. Missing, unknown, wrong-subject,
+unrecognized, or out-of-window evidence fails before HTTP access. Current time
+never expands a frozen observation.
+
+The funding-named budget/status/result types are aliases of the shared REST
+executor types. Timeout, response-size, page/attempt, total elapsed-time,
+backoff and `Retry-After` limits therefore have exactly the same semantics as
+the Kline REST path and are not reset between funding pages.
+
+```python
+from datetime import UTC, datetime
+from pathlib import Path
+
+from tracequant.data import (
+    BinanceFundingRateRestAcquisition,
+    BinanceFundingRateRestBudget,
+    BinanceFundingRateRestCoverage,
+    BinanceFundingRateRestCoverageStatus,
+    BinanceRestEndpoint,
+    BinanceRestPageRequest,
+    RawStore,
+)
+from tracequant.domain import InstrumentId, TimeRange
+
+requested = TimeRange(
+    start=datetime(2026, 9, 3, 0, 0, tzinfo=UTC),
+    end=datetime(2026, 9, 3, 1, 0, tzinfo=UTC),
+)
+request = BinanceRestPageRequest(
+    endpoint=BinanceRestEndpoint.FUNDING_RATE_HISTORY,
+    subject=InstrumentId("BTCUSDT"),
+    caller_range=requested,
+    interval=None,
+    limit=100,
+)
+coverage = BinanceFundingRateRestCoverage(
+    status=BinanceFundingRateRestCoverageStatus.SUPPORTED,
+    endpoint=request.endpoint,
+    subject=request.subject,
+    allowed_range=requested,
+    evidence_version="issue-295-probe-run-2026-09-09T18:33:30.868474Z",
+    evidence_reference=(
+        "docs/research/binance-usdm-feature11-rest-window-follow-up-probes.json"
+    ),
+    evidence_sha256=(
+        "30682f83b887514ef2a0e20ec21203cff70529ac1518fb538277ae0881920b45"
+    ),
+    observed_at=datetime(2026, 9, 9, 18, 33, 39, 998536, tzinfo=UTC),
+    normalized_params={
+        "symbol": "BTCUSDT",
+        "startTime": 1788393600000,
+        "endTime": 1788397199999,
+        "limit": 100,
+    },
+    response_sha256=(
+        "39ac0b55d6acae3de0e0be633edbfabdc37a227fa913027fe2e63c547abda401"
+    ),
+    actual_range=TimeRange(
+        start=datetime(2026, 9, 3, 0, 0, tzinfo=UTC),
+        end=datetime(2026, 9, 3, 0, 0, 0, 1000, tzinfo=UTC),
+    ),
+)
+budget = BinanceFundingRateRestBudget(
+    timeout_seconds=10,
+    maximum_pages=4,
+    maximum_attempts_per_page=2,
+    maximum_elapsed_seconds=30,
+    maximum_response_bytes=16 * 1024 * 1024,
+)
+
+result = BinanceFundingRateRestAcquisition(RawStore(Path("data"))).run(
+    request, coverage, budget
+)
+```
+
+## Settled schema, Raw revisions, and coverage limits
+
+Every response must be a strict JSON array of objects. `symbol`, `fundingTime`
+and `fundingRate` are required: the symbol must match the request, time must be
+a boundary-contained int64 millisecond value, and the rate remains its original
+finite numeric string, including negative values and zero. Records must be
+strictly time-increasing across and within pages; duplicates, conflicts,
+out-of-order values, boundary violations, or a non-advancing cursor stop the
+run without sorting, deduplicating, or dropping rows.
+
+The Raw schema is
+`binance.um.settled-funding-rate.rest-json.v1`. It retains the source names
+`symbol`, `fundingTime`, `fundingRate`, `markPrice`, and `rateType`.
+`markPricePresent` and `rateTypePresent` distinguish a missing optional field
+from an explicit JSON null. The only currently confirmed non-null `rateType`
+is `Regular`; an unconfirmed value or new funding-semantic field is rejected
+instead of being published as settled data. Benign unknown fields are named in
+`unknownFields`, while their exact names and values remain in `response.json`.
+Archive-only `calc_time`, `funding_interval_hours`, and
+`last_funding_rate` are never synthesized.
+
+Each valid non-empty page is independently and atomically published with
+`data.parquet`, `manifest.json`, and its exact `response.json`. Identical
+request bytes are idempotent; a new response digest creates a new immutable
+revision and leaves older revisions readable. A later-page or local-storage
+failure does not erase pages already published, but the whole run remains
+incomplete.
+
+A short or empty response may terminate pagination under the confirmed
+ascending bounded endpoint semantics. An empty response is stored only as
+acquisition evidence and never as a zero-row Raw artifact. `COMPLETE` means
+that the bounded response sequence terminated normally; it does not prove a
+continuous calendar range, the absence of unreported exchange events, the
+earliest available history, or that an external gap-repair objective is
+satisfied. Callers must compare returned point events and `actual_record_range`
+with their own coverage requirement rather than treating the request envelope
+as continuous event coverage.

--- a/docs/guides/binance-funding-rate-rest-acquisition.md
+++ b/docs/guides/binance-funding-rate-rest-acquisition.md
@@ -136,10 +136,10 @@ incomplete.
 
 A short or empty response may terminate pagination under the confirmed
 ascending bounded endpoint semantics. An empty response is stored only as
-acquisition evidence and never as a zero-row Raw artifact. `COMPLETE` means
-that the bounded response sequence terminated normally; it does not prove a
-continuous calendar range, the absence of unreported exchange events, the
-earliest available history, or that an external gap-repair objective is
-satisfied. Callers must compare returned point events and `actual_record_range`
-with their own coverage requirement rather than treating the request envelope
-as continuous event coverage.
+acquisition evidence and never as a zero-row Raw artifact. It returns
+`LEGAL_EMPTY`, keeps `complete` false, and reports the range from the current
+cursor as unmet; it does not prove a gap repaired or the earliest available
+history. `COMPLETE` is reserved for a request whose full range is satisfied by
+published point events. Even then, callers must not treat the request envelope
+as continuous event coverage or proof that the exchange never omitted an
+event.

--- a/docs/guides/binance-kline-rest-acquisition.md
+++ b/docs/guides/binance-kline-rest-acquisition.md
@@ -150,9 +150,9 @@ returning `BinanceRestPageParsed`, and a Raw schema identifier; the shared
 executor owns URL construction, bounded HTTP/retry/wait behavior, elapsed and
 page budgets, failure evidence, result assembly, and immutable page
 publication. A point-event adapter may return a terminal parsed page, including
-a terminal empty page with no Raw publication, once its response proves the
-requested range has been exhausted. This lets L05 advance by the last actual
-`fundingTime + 1ms` and complete after a legal empty response without pretending
-that sparse events cover a continuous bar grid. This Task does not itself
-implement funding parsing, a CLI, archive fallback, source refresh, gap repair,
-scheduling, or another provider.
+a terminal empty page with no Raw publication. The executor reports that page
+as `LEGAL_EMPTY` and leaves the range from the current cursor unmet; an empty
+response alone does not prove the requested range has been exhausted. A
+point-event adapter advances only by the last actual event timestamp. This Task
+does not itself implement funding parsing, a CLI, archive fallback, source
+refresh, gap repair, scheduling, or another provider.

--- a/src/tracequant/data/__init__.py
+++ b/src/tracequant/data/__init__.py
@@ -19,6 +19,16 @@ from tracequant.data.binance_funding_rate import (
     BinanceFundingRateStatus,
     plan_binance_funding_rate_archives,
 )
+from tracequant.data.binance_funding_rate_rest import (
+    BinanceFundingRateRestAcquisition,
+    BinanceFundingRateRestAttemptResult,
+    BinanceFundingRateRestBudget,
+    BinanceFundingRateRestCoverage,
+    BinanceFundingRateRestCoverageStatus,
+    BinanceFundingRateRestPageResult,
+    BinanceFundingRateRestRunResult,
+    BinanceFundingRateRestStatus,
+)
 from tracequant.data.binance_index_price_kline import (
     BinanceIndexPriceKlineBackfill,
     BinanceIndexPriceKlineCoverageGapPlan,
@@ -120,6 +130,14 @@ __all__ = [
     "BinanceFundingRateObjectResult",
     "BinanceFundingRateRunResult",
     "BinanceFundingRateStatus",
+    "BinanceFundingRateRestAcquisition",
+    "BinanceFundingRateRestAttemptResult",
+    "BinanceFundingRateRestBudget",
+    "BinanceFundingRateRestCoverage",
+    "BinanceFundingRateRestCoverageStatus",
+    "BinanceFundingRateRestPageResult",
+    "BinanceFundingRateRestRunResult",
+    "BinanceFundingRateRestStatus",
     "BinanceKlineInterval",
     "BinanceKlineRestAcquisition",
     "BinanceKlineRestAttemptResult",

--- a/src/tracequant/data/binance_funding_rate_rest.py
+++ b/src/tracequant/data/binance_funding_rate_rest.py
@@ -1,0 +1,538 @@
+"""Bounded Binance USDⓈ-M settled-funding REST acquisition.
+
+The adapter consumes one frozen, per-window source observation.  It reuses the
+shared REST executor for HTTP, retry, budget, failure evidence, and immutable
+page publication without treating sparse funding events as a continuous grid.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import Decimal, InvalidOperation
+from typing import Final
+
+import polars as pl
+
+from tracequant.data.binance_kline_rest import (
+    BinanceKlineRestAttemptResult,
+    BinanceKlineRestBudget,
+    BinanceKlineRestCoverage,
+    BinanceKlineRestCoverageStatus,
+    BinanceKlineRestHttpGet,
+    BinanceKlineRestPageResult,
+    BinanceKlineRestRunResult,
+    BinanceKlineRestStatus,
+    BinanceRestPageAcquisition,
+    BinanceRestPageParsed,
+    BinanceRestPageParseError,
+)
+from tracequant.data.public_history_rest import (
+    BinanceRestEndpoint,
+    BinanceRestPageRequest,
+)
+from tracequant.data.raw_store import RawStore
+from tracequant.domain import InstrumentId, TimeRange
+
+__all__ = [
+    "BinanceFundingRateRestAcquisition",
+    "BinanceFundingRateRestAttemptResult",
+    "BinanceFundingRateRestBudget",
+    "BinanceFundingRateRestCoverage",
+    "BinanceFundingRateRestCoverageStatus",
+    "BinanceFundingRateRestPageResult",
+    "BinanceFundingRateRestRunResult",
+    "BinanceFundingRateRestStatus",
+]
+
+BinanceFundingRateRestAttemptResult = BinanceKlineRestAttemptResult
+BinanceFundingRateRestBudget = BinanceKlineRestBudget
+BinanceFundingRateRestCoverageStatus = BinanceKlineRestCoverageStatus
+BinanceFundingRateRestPageResult = BinanceKlineRestPageResult
+BinanceFundingRateRestRunResult = BinanceKlineRestRunResult
+BinanceFundingRateRestStatus = BinanceKlineRestStatus
+
+_APPROVED_COVERAGE_VERSION: Final = "issue-295-probe-run-2026-09-09T18:33:30.868474Z"
+_APPROVED_COVERAGE_REFERENCE: Final = (
+    "docs/research/binance-usdm-feature11-rest-window-follow-up-probes.json"
+)
+_APPROVED_COVERAGE_SHA256: Final = (
+    "30682f83b887514ef2a0e20ec21203cff70529ac1518fb538277ae0881920b45"
+)
+_RAW_SCHEMA_IDENTIFIER: Final = "binance.um.settled-funding-rate.rest-json.v1"
+_ALLOWED_INSTRUMENTS: Final = frozenset({"BTCUSDT", "ETHUSDT"})
+_CORE_FIELDS: Final = frozenset({"symbol", "fundingTime", "fundingRate"})
+_KNOWN_FIELDS: Final = _CORE_FIELDS | {"markPrice", "rateType"}
+_CONFIRMED_RATE_TYPE: Final = "Regular"
+_CRITICAL_UNKNOWN_TOKENS: Final = (
+    "funding",
+    "rate",
+    "settle",
+    "predict",
+    "forecast",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class BinanceFundingRateRestCoverage(BinanceKlineRestCoverage):
+    """Finite funding endpoint/instrument/window source evidence."""
+
+
+@dataclass(frozen=True, slots=True)
+class _FundingObservation:
+    subject: str
+    requested_range: TimeRange
+    normalized_params: Mapping[str, str | int]
+    observed_at: datetime
+    response_sha256: str
+    actual_range: TimeRange
+
+
+def _utc_ms(value: int) -> datetime:
+    return datetime.fromtimestamp(value / 1_000, tz=UTC)
+
+
+_RECENT_START_MS: Final = 1_788_374_012_658
+_RECENT_END_MS: Final = 1_788_978_812_658
+_GAP_START_MS: Final = 1_788_393_600_000
+_GAP_END_MS: Final = 1_788_397_200_000
+_RECENT_ACTUAL_END_MS: Final = 1_788_969_600_003
+
+_APPROVED_OBSERVATIONS: Final = (
+    _FundingObservation(
+        subject="BTCUSDT",
+        requested_range=TimeRange(
+            start=_utc_ms(_RECENT_START_MS), end=_utc_ms(_RECENT_END_MS)
+        ),
+        normalized_params={
+            "symbol": "BTCUSDT",
+            "startTime": _RECENT_START_MS,
+            "endTime": _RECENT_END_MS - 1,
+            "limit": 1000,
+        },
+        observed_at=datetime(2026, 9, 9, 18, 33, 33, 964227, tzinfo=UTC),
+        response_sha256=(
+            "2bd472efeb5b2d6336fda340914d77770151589cb3a14ff419e1ed149ef41f71"
+        ),
+        actual_range=TimeRange(
+            start=_utc_ms(_GAP_START_MS), end=_utc_ms(_RECENT_ACTUAL_END_MS)
+        ),
+    ),
+    _FundingObservation(
+        subject="ETHUSDT",
+        requested_range=TimeRange(
+            start=_utc_ms(_RECENT_START_MS), end=_utc_ms(_RECENT_END_MS)
+        ),
+        normalized_params={
+            "symbol": "ETHUSDT",
+            "startTime": _RECENT_START_MS,
+            "endTime": _RECENT_END_MS - 1,
+            "limit": 1000,
+        },
+        observed_at=datetime(2026, 9, 9, 18, 33, 35, 109386, tzinfo=UTC),
+        response_sha256=(
+            "368852dd6686fce1fac1d940f7153dc5099acc8125c7ae8bac4d4b0ece24cace"
+        ),
+        actual_range=TimeRange(
+            start=_utc_ms(_GAP_START_MS), end=_utc_ms(_RECENT_ACTUAL_END_MS)
+        ),
+    ),
+    _FundingObservation(
+        subject="BTCUSDT",
+        requested_range=TimeRange(
+            start=_utc_ms(_GAP_START_MS), end=_utc_ms(_GAP_END_MS)
+        ),
+        normalized_params={
+            "symbol": "BTCUSDT",
+            "startTime": _GAP_START_MS,
+            "endTime": _GAP_END_MS - 1,
+            "limit": 100,
+        },
+        observed_at=datetime(2026, 9, 9, 18, 33, 39, 998536, tzinfo=UTC),
+        response_sha256=(
+            "39ac0b55d6acae3de0e0be633edbfabdc37a227fa913027fe2e63c547abda401"
+        ),
+        actual_range=TimeRange(
+            start=_utc_ms(_GAP_START_MS), end=_utc_ms(_GAP_START_MS + 1)
+        ),
+    ),
+    _FundingObservation(
+        subject="ETHUSDT",
+        requested_range=TimeRange(
+            start=_utc_ms(_GAP_START_MS), end=_utc_ms(_GAP_END_MS)
+        ),
+        normalized_params={
+            "symbol": "ETHUSDT",
+            "startTime": _GAP_START_MS,
+            "endTime": _GAP_END_MS - 1,
+            "limit": 100,
+        },
+        observed_at=datetime(2026, 9, 9, 18, 33, 40, 679377, tzinfo=UTC),
+        response_sha256=(
+            "b862855ea7296ca550dc3aac55c34e2e907cb993aa5749efaedd4409b4cf1ac1"
+        ),
+        actual_range=TimeRange(
+            start=_utc_ms(_GAP_START_MS), end=_utc_ms(_GAP_START_MS + 1)
+        ),
+    ),
+)
+
+
+def _require_int64(value: object, *, field: str) -> int:
+    if type(value) is not int or not 0 <= value <= 2**63 - 1:
+        raise BinanceRestPageParseError(
+            f"{field} must be a non-negative signed 64-bit integer"
+        )
+    return value
+
+
+def _require_numeric_string(value: object, *, field: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise BinanceRestPageParseError(f"{field} must be a finite numeric string")
+    try:
+        number = Decimal(value)
+    except InvalidOperation as error:
+        raise BinanceRestPageParseError(
+            f"{field} must be a finite numeric string"
+        ) from error
+    if not number.is_finite():
+        raise BinanceRestPageParseError(f"{field} must be a finite numeric string")
+    return value
+
+
+def _strict_json_array(body: bytes) -> list[object]:
+    try:
+        payload = json.loads(
+            body.decode("utf-8"),
+            parse_constant=lambda value: (_ for _ in ()).throw(
+                ValueError(f"invalid JSON constant {value}")
+            ),
+        )
+    except (
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+        RecursionError,
+        ValueError,
+    ) as error:
+        raise BinanceRestPageParseError(
+            "response body is not strict UTF-8 JSON"
+        ) from error
+    if not isinstance(payload, list):
+        raise BinanceRestPageParseError(
+            "response JSON must be an array, not an error object"
+        )
+    return payload
+
+
+def _is_critical_unknown(name: str) -> bool:
+    lowered = name.casefold()
+    return any(token in lowered for token in _CRITICAL_UNKNOWN_TOKENS)
+
+
+class _FundingRateRestPageAdapter:
+    def request_failure(
+        self, request: BinanceRestPageRequest, now: datetime
+    ) -> tuple[BinanceKlineRestStatus, str] | None:
+        del now
+        if request.endpoint is not BinanceRestEndpoint.FUNDING_RATE_HISTORY:
+            return (
+                BinanceKlineRestStatus.UNSUPPORTED,
+                "only settled funding-rate history is supported",
+            )
+        if not isinstance(request.subject, InstrumentId):
+            return (
+                BinanceKlineRestStatus.UNSUPPORTED,
+                "settled funding history requires a typed instrument/symbol",
+            )
+        if str(request.subject) not in _ALLOWED_INSTRUMENTS:
+            return (
+                BinanceKlineRestStatus.UNSUPPORTED,
+                "only BTCUSDT and ETHUSDT are supported",
+            )
+        if request.interval is not None:
+            return (
+                BinanceKlineRestStatus.INVALID_REQUEST,
+                "settled funding history does not use a Kline interval",
+            )
+        if request.page_boundary != request.caller_bounds:
+            return (
+                BinanceKlineRestStatus.INVALID_REQUEST,
+                "public run must start at the complete normalized caller range",
+            )
+        return None
+
+    def coverage_failure(
+        self, request: BinanceRestPageRequest, coverage: object | None
+    ) -> tuple[BinanceKlineRestStatus, str] | None:
+        if coverage is None:
+            return (
+                BinanceKlineRestStatus.REST_BOUNDARY_UNKNOWN,
+                "REST coverage evidence is missing",
+            )
+        if not isinstance(coverage, BinanceFundingRateRestCoverage):
+            raise TypeError("coverage must be a BinanceFundingRateRestCoverage or None")
+        if coverage.status is BinanceKlineRestCoverageStatus.UNKNOWN:
+            return (
+                BinanceKlineRestStatus.REST_BOUNDARY_UNKNOWN,
+                "REST coverage conclusion is unknown",
+            )
+        if coverage.status is BinanceKlineRestCoverageStatus.UNSUPPORTED:
+            return (
+                BinanceKlineRestStatus.UNSUPPORTED,
+                "REST coverage conclusion is unsupported",
+            )
+        if request.endpoint != coverage.endpoint or request.subject != coverage.subject:
+            return (
+                BinanceKlineRestStatus.REST_BOUNDARY_UNKNOWN,
+                "coverage endpoint or typed instrument does not match the request",
+            )
+        if (
+            coverage.evidence_version != _APPROVED_COVERAGE_VERSION
+            or coverage.evidence_reference != _APPROVED_COVERAGE_REFERENCE
+            or coverage.evidence_sha256 != _APPROVED_COVERAGE_SHA256
+        ):
+            return (
+                BinanceKlineRestStatus.REST_BOUNDARY_UNKNOWN,
+                "coverage evidence binding is missing or unrecognized",
+            )
+
+        matched: _FundingObservation | None = None
+        for observation in _APPROVED_OBSERVATIONS:
+            if observation.subject != str(coverage.subject):
+                continue
+            if (
+                dict(coverage.normalized_params) == dict(observation.normalized_params)
+                and coverage.observed_at == observation.observed_at
+                and coverage.response_sha256 == observation.response_sha256
+                and coverage.actual_range == observation.actual_range
+            ):
+                matched = observation
+                break
+        if matched is None:
+            return (
+                BinanceKlineRestStatus.REST_BOUNDARY_UNKNOWN,
+                "per-window funding observation is missing or unrecognized",
+            )
+        if (
+            coverage.allowed_range.start < matched.requested_range.start
+            or coverage.allowed_range.end > matched.requested_range.end
+        ):
+            return (
+                BinanceKlineRestStatus.REST_BOUNDARY_UNKNOWN,
+                "coverage range extends beyond its bound funding observation",
+            )
+        if (
+            request.caller_range.start < coverage.allowed_range.start
+            or request.caller_range.end > coverage.allowed_range.end
+        ):
+            return (
+                BinanceKlineRestStatus.REST_BOUNDARY_UNKNOWN,
+                "request range is outside the supplied coverage range",
+            )
+        return None
+
+    def parse_page(
+        self,
+        request: BinanceRestPageRequest,
+        body: bytes,
+        prior_records: Mapping[int, tuple[object, ...]],
+    ) -> BinanceRestPageParsed:
+        payload = _strict_json_array(body)
+        assert request.page_boundary is not None
+        if not payload:
+            empty_frame = pl.DataFrame(
+                schema={
+                    "symbol": pl.String,
+                    "fundingTime": pl.Int64,
+                    "fundingRate": pl.String,
+                    "markPrice": pl.String,
+                    "markPricePresent": pl.Boolean,
+                    "rateType": pl.String,
+                    "rateTypePresent": pl.Boolean,
+                    "unknownFields": pl.List(pl.String),
+                }
+            )
+            return BinanceRestPageParsed(
+                frame=empty_frame,
+                actual_record_range=None,
+                records={},
+                next_cursor_ms=request.page_boundary.end_time_ms + 1,
+                terminal=True,
+            )
+        if len(payload) > request.limit:
+            raise BinanceRestPageParseError(
+                "response contains more records than the page limit"
+            )
+
+        rows: list[tuple[object, ...]] = []
+        records: dict[int, tuple[object, ...]] = {}
+        previous_time: int | None = None
+        for row_number, raw_record in enumerate(payload):
+            if not isinstance(raw_record, dict):
+                raise BinanceRestPageParseError(
+                    f"record {row_number} must be a JSON object"
+                )
+            missing = sorted(_CORE_FIELDS - raw_record.keys())
+            if missing:
+                raise BinanceRestPageParseError(
+                    f"record {row_number} is missing required fields: {', '.join(missing)}"
+                )
+            symbol = raw_record["symbol"]
+            if not isinstance(symbol, str) or symbol != str(request.subject):
+                raise BinanceRestPageParseError(
+                    f"record {row_number} symbol does not match the requested instrument"
+                )
+            funding_time = _require_int64(
+                raw_record["fundingTime"], field=f"record {row_number} fundingTime"
+            )
+            funding_rate = _require_numeric_string(
+                raw_record["fundingRate"], field=f"record {row_number} fundingRate"
+            )
+
+            mark_price_present = "markPrice" in raw_record
+            raw_mark_price = raw_record.get("markPrice")
+            mark_price = (
+                None
+                if raw_mark_price is None
+                else _require_numeric_string(
+                    raw_mark_price, field=f"record {row_number} markPrice"
+                )
+            )
+            rate_type_present = "rateType" in raw_record
+            raw_rate_type = raw_record.get("rateType")
+            if raw_rate_type is None:
+                rate_type = None
+            elif not isinstance(raw_rate_type, str):
+                raise BinanceRestPageParseError(
+                    f"record {row_number} rateType must be a string or null"
+                )
+            elif raw_rate_type != _CONFIRMED_RATE_TYPE:
+                raise BinanceRestPageParseError(
+                    f"record {row_number} rateType has unconfirmed settled semantics"
+                )
+            else:
+                rate_type = raw_rate_type
+
+            unknown_fields = sorted(set(raw_record) - _KNOWN_FIELDS)
+            critical_unknowns = [
+                name for name in unknown_fields if _is_critical_unknown(name)
+            ]
+            if critical_unknowns:
+                raise BinanceRestPageParseError(
+                    "record "
+                    f"{row_number} contains unconfirmed funding-semantic fields: "
+                    f"{', '.join(critical_unknowns)}"
+                )
+
+            frozen_record = (
+                json.dumps(
+                    raw_record,
+                    allow_nan=False,
+                    ensure_ascii=True,
+                    separators=(",", ":"),
+                    sort_keys=True,
+                ),
+            )
+            prior = prior_records.get(funding_time)
+            if prior is not None:
+                detail = (
+                    "conflicting duplicate" if prior != frozen_record else "duplicate"
+                )
+                raise BinanceRestPageParseError(
+                    f"record {row_number} has a cross-page {detail} fundingTime"
+                )
+            duplicate = records.get(funding_time)
+            if duplicate is not None:
+                detail = (
+                    "conflicting duplicate"
+                    if duplicate != frozen_record
+                    else "duplicate"
+                )
+                raise BinanceRestPageParseError(
+                    f"record {row_number} has a {detail} fundingTime"
+                )
+            if previous_time is not None and funding_time < previous_time:
+                raise BinanceRestPageParseError(
+                    f"record {row_number} fundingTime is out of order"
+                )
+            if not (
+                request.page_boundary.start_time_ms
+                <= funding_time
+                <= request.page_boundary.end_time_ms
+            ):
+                raise BinanceRestPageParseError(
+                    f"record {row_number} fundingTime is outside the page boundary"
+                )
+            previous_time = funding_time
+            records[funding_time] = frozen_record
+            rows.append(
+                (
+                    symbol,
+                    funding_time,
+                    funding_rate,
+                    mark_price,
+                    mark_price_present,
+                    rate_type,
+                    rate_type_present,
+                    unknown_fields,
+                )
+            )
+
+        try:
+            frame = pl.DataFrame(
+                rows,
+                schema={
+                    "symbol": pl.String,
+                    "fundingTime": pl.Int64,
+                    "fundingRate": pl.String,
+                    "markPrice": pl.String,
+                    "markPricePresent": pl.Boolean,
+                    "rateType": pl.String,
+                    "rateTypePresent": pl.Boolean,
+                    "unknownFields": pl.List(pl.String),
+                },
+                orient="row",
+            )
+        except Exception as error:
+            raise BinanceRestPageParseError(
+                "response fields cannot be represented by the funding Raw schema"
+            ) from error
+        first_time = int(frame["fundingTime"][0])
+        last_time = int(frame["fundingTime"][-1])
+        return BinanceRestPageParsed(
+            frame=frame,
+            actual_record_range=TimeRange(
+                start=_utc_ms(first_time), end=_utc_ms(last_time + 1)
+            ),
+            records=records,
+            next_cursor_ms=last_time + 1,
+            terminal=frame.height < request.limit,
+        )
+
+    def raw_schema_identifier(self, request: BinanceRestPageRequest) -> str:
+        del request
+        return _RAW_SCHEMA_IDENTIFIER
+
+
+class BinanceFundingRateRestAcquisition(BinanceRestPageAcquisition):
+    """Acquire settled funding pages through the shared bounded REST executor."""
+
+    def __init__(
+        self,
+        store: RawStore,
+        *,
+        http_get: BinanceKlineRestHttpGet | None = None,
+        clock: Callable[[], datetime] | None = None,
+        wait: Callable[[float], None] | None = None,
+        monotonic_clock: Callable[[], float] | None = None,
+    ) -> None:
+        super().__init__(
+            store,
+            adapter=_FundingRateRestPageAdapter(),
+            http_get=http_get,
+            clock=clock,
+            wait=wait,
+            monotonic_clock=monotonic_clock,
+        )

--- a/src/tracequant/data/binance_funding_rate_rest.py
+++ b/src/tracequant/data/binance_funding_rate_rest.py
@@ -202,6 +202,17 @@ def _require_numeric_string(value: object, *, field: str) -> str:
     return value
 
 
+def _reject_duplicate_object_members(
+    pairs: list[tuple[str, object]],
+) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for name, value in pairs:
+        if name in result:
+            raise ValueError(f"duplicate JSON object member {name!r}")
+        result[name] = value
+    return result
+
+
 def _strict_json_array(body: bytes) -> list[object]:
     try:
         payload = json.loads(
@@ -209,6 +220,7 @@ def _strict_json_array(body: bytes) -> list[object]:
             parse_constant=lambda value: (_ for _ in ()).throw(
                 ValueError(f"invalid JSON constant {value}")
             ),
+            object_pairs_hook=_reject_duplicate_object_members,
         )
     except (
         UnicodeDecodeError,

--- a/src/tracequant/data/binance_kline_rest.py
+++ b/src/tracequant/data/binance_kline_rest.py
@@ -2047,15 +2047,11 @@ class BinanceRestPageAcquisition:
                     )
                 )
                 return self._finish(
-                    status=(
-                        BinanceKlineRestStatus.COMPLETE
-                        if status is BinanceKlineRestStatus.LEGAL_EMPTY
-                        else status
-                    ),
+                    status=status,
                     request=request,
                     pages=pages,
                     tracker=tracker,
-                    cursor_ms=(caller_end_ms if parsed.terminal else cursor_ms),
+                    cursor_ms=cursor_ms,
                     reason=detail,
                 )
 

--- a/tests/data/test_binance_funding_rate_rest_acquisition.py
+++ b/tests/data/test_binance_funding_rate_rest_acquisition.py
@@ -1,0 +1,667 @@
+import json
+from dataclasses import replace
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import cast
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+
+from tracequant.data import (
+    BinanceFundingRateRestAcquisition,
+    BinanceFundingRateRestBudget,
+    BinanceFundingRateRestCoverage,
+    BinanceFundingRateRestCoverageStatus,
+    BinanceFundingRateRestStatus,
+    BinanceKlineRestHttpResponse,
+    BinanceRestEndpoint,
+    BinanceRestPageRequest,
+    RawObjectIdentity,
+    RawStore,
+)
+from tracequant.domain import InstrumentId, TimeRange
+
+EVIDENCE_VERSION = "issue-295-probe-run-2026-09-09T18:33:30.868474Z"
+EVIDENCE_REFERENCE = (
+    "docs/research/binance-usdm-feature11-rest-window-follow-up-probes.json"
+)
+EVIDENCE_SHA256 = "30682f83b887514ef2a0e20ec21203cff70529ac1518fb538277ae0881920b45"
+RECENT_START_MS = 1_788_374_012_658
+RECENT_END_MS = 1_788_978_812_658
+FIRST_FUNDING_MS = 1_788_393_600_000
+OBSERVED_LAST_MS = 1_788_969_600_002
+NOW = datetime(2026, 9, 9, 19, 0, tzinfo=UTC)
+
+CELL_EVIDENCE = {
+    "BTCUSDT": (
+        datetime(2026, 9, 9, 18, 33, 33, 964227, tzinfo=UTC),
+        "2bd472efeb5b2d6336fda340914d77770151589cb3a14ff419e1ed149ef41f71",
+    ),
+    "ETHUSDT": (
+        datetime(2026, 9, 9, 18, 33, 35, 109386, tzinfo=UTC),
+        "368852dd6686fce1fac1d940f7153dc5099acc8125c7ae8bac4d4b0ece24cace",
+    ),
+}
+GAP_CELL_EVIDENCE = {
+    "BTCUSDT": (
+        datetime(2026, 9, 9, 18, 33, 39, 998536, tzinfo=UTC),
+        "39ac0b55d6acae3de0e0be633edbfabdc37a227fa913027fe2e63c547abda401",
+    ),
+    "ETHUSDT": (
+        datetime(2026, 9, 9, 18, 33, 40, 679377, tzinfo=UTC),
+        "b862855ea7296ca550dc3aac55c34e2e907cb993aa5749efaedd4409b4cf1ac1",
+    ),
+}
+
+
+def _at(milliseconds: int) -> datetime:
+    return datetime.fromtimestamp(milliseconds / 1_000, tz=UTC)
+
+
+def _request(
+    symbol: str = "BTCUSDT",
+    *,
+    start_ms: int = FIRST_FUNDING_MS,
+    end_ms: int = FIRST_FUNDING_MS + 28 * 60 * 60 * 1_000 + 1,
+    limit: int = 2,
+) -> BinanceRestPageRequest:
+    return BinanceRestPageRequest(
+        endpoint=BinanceRestEndpoint.FUNDING_RATE_HISTORY,
+        subject=InstrumentId(symbol),
+        caller_range=TimeRange(start=_at(start_ms), end=_at(end_ms)),
+        interval=None,
+        limit=limit,
+    )
+
+
+def _coverage(
+    request: BinanceRestPageRequest,
+    *,
+    status: BinanceFundingRateRestCoverageStatus = (
+        BinanceFundingRateRestCoverageStatus.SUPPORTED
+    ),
+    allowed_range: TimeRange | None = None,
+) -> BinanceFundingRateRestCoverage:
+    symbol = str(request.subject)
+    observed_at, response_sha256 = CELL_EVIDENCE.get(symbol, CELL_EVIDENCE["BTCUSDT"])
+    return BinanceFundingRateRestCoverage(
+        status=status,
+        endpoint=BinanceRestEndpoint.FUNDING_RATE_HISTORY,
+        subject=request.subject,
+        allowed_range=allowed_range
+        or TimeRange(start=_at(RECENT_START_MS), end=_at(RECENT_END_MS)),
+        evidence_version=EVIDENCE_VERSION,
+        evidence_reference=EVIDENCE_REFERENCE,
+        evidence_sha256=EVIDENCE_SHA256,
+        observed_at=observed_at,
+        normalized_params={
+            "symbol": symbol,
+            "startTime": RECENT_START_MS,
+            "endTime": RECENT_END_MS - 1,
+            "limit": 1000,
+        },
+        response_sha256=response_sha256,
+        actual_range=TimeRange(
+            start=_at(FIRST_FUNDING_MS), end=_at(OBSERVED_LAST_MS + 1)
+        ),
+    )
+
+
+def _budget(
+    *, pages: int = 8, attempts: int = 3, elapsed: float = 30.0
+) -> BinanceFundingRateRestBudget:
+    return BinanceFundingRateRestBudget(
+        timeout_seconds=5,
+        maximum_pages=pages,
+        maximum_attempts_per_page=attempts,
+        maximum_elapsed_seconds=elapsed,
+        maximum_response_bytes=1_000_000,
+    )
+
+
+def _gap_coverage(request: BinanceRestPageRequest) -> BinanceFundingRateRestCoverage:
+    symbol = str(request.subject)
+    observed_at, response_sha256 = GAP_CELL_EVIDENCE[symbol]
+    gap_end_ms = FIRST_FUNDING_MS + 60 * 60 * 1_000
+    return BinanceFundingRateRestCoverage(
+        status=BinanceFundingRateRestCoverageStatus.SUPPORTED,
+        endpoint=request.endpoint,
+        subject=request.subject,
+        allowed_range=TimeRange(start=_at(FIRST_FUNDING_MS), end=_at(gap_end_ms)),
+        evidence_version=EVIDENCE_VERSION,
+        evidence_reference=EVIDENCE_REFERENCE,
+        evidence_sha256=EVIDENCE_SHA256,
+        observed_at=observed_at,
+        normalized_params={
+            "symbol": symbol,
+            "startTime": FIRST_FUNDING_MS,
+            "endTime": gap_end_ms - 1,
+            "limit": 100,
+        },
+        response_sha256=response_sha256,
+        actual_range=TimeRange(
+            start=_at(FIRST_FUNDING_MS), end=_at(FIRST_FUNDING_MS + 1)
+        ),
+    )
+
+
+def _records(symbol: str, *, variant: int = 0) -> list[dict[str, object]]:
+    times = [
+        FIRST_FUNDING_MS,
+        FIRST_FUNDING_MS + 8 * 60 * 60 * 1_000,
+        FIRST_FUNDING_MS + 16 * 60 * 60 * 1_000,
+        FIRST_FUNDING_MS + 20 * 60 * 60 * 1_000,
+        FIRST_FUNDING_MS + 28 * 60 * 60 * 1_000,
+    ]
+    rates = (
+        ["0.00010000", "-0.00020000", "0", "0.00030000", "-0.00040000"]
+        if symbol == "BTCUSDT"
+        else ["-0.00001000", "0", "0.00002000", "-0.00003000", "0.00004000"]
+    )
+    if variant:
+        rates[0] = "0.00090000"
+    return [
+        {
+            "symbol": symbol,
+            "fundingTime": times[0],
+            "fundingRate": rates[0],
+            "markPrice": "70000.00000000",
+            "rateType": "Regular",
+        },
+        {
+            "symbol": symbol,
+            "fundingTime": times[1],
+            "fundingRate": rates[1],
+            "markPrice": None,
+        },
+        {
+            "symbol": symbol,
+            "fundingTime": times[2],
+            "fundingRate": rates[2],
+            "rateType": None,
+        },
+        {
+            "symbol": symbol,
+            "fundingTime": times[3],
+            "fundingRate": rates[3],
+            "markPrice": "71000.00000000",
+            "rateType": "Regular",
+            "sourceNote": {"revision": 1},
+        },
+        {
+            "symbol": symbol,
+            "fundingTime": times[4],
+            "fundingRate": rates[4],
+            "markPrice": "72000.00000000",
+            "rateType": "Regular",
+        },
+    ]
+
+
+class _FundingTransport:
+    def __init__(self, *, variant: int = 0) -> None:
+        self.variant = variant
+        self.calls: list[str] = []
+        self.bodies: dict[str, bytes] = {}
+
+    def __call__(
+        self, url: str, timeout: float, maximum_response_bytes: int
+    ) -> BinanceKlineRestHttpResponse:
+        del timeout, maximum_response_bytes
+        self.calls.append(url)
+        parsed = urlsplit(url)
+        assert parsed.path == BinanceRestEndpoint.FUNDING_RATE_HISTORY.value
+        params = parse_qs(parsed.query)
+        assert "interval" not in params
+        symbol = params["symbol"][0]
+        start_ms = int(params["startTime"][0])
+        end_ms = int(params["endTime"][0])
+        limit = int(params["limit"][0])
+        selected = [
+            record
+            for record in _records(symbol, variant=self.variant)
+            if start_ms <= cast(int, record["fundingTime"]) <= end_ms
+        ][:limit]
+        body = json.dumps(selected, separators=(",", ":")).encode()
+        self.bodies[url] = body
+        return BinanceKlineRestHttpResponse(
+            status=200,
+            body=body,
+            headers={"Content-Type": "application/json", "X-MBX-USED-WEIGHT-1M": "1"},
+        )
+
+
+def test_funding_rest_run_publishes_verified_page_raw(tmp_path: Path) -> None:
+    store = RawStore(tmp_path, clock=lambda: NOW)
+
+    for symbol in ("BTCUSDT", "ETHUSDT"):
+        transport = _FundingTransport()
+        acquisition = BinanceFundingRateRestAcquisition(
+            store,
+            http_get=transport,
+            clock=lambda: NOW,
+            monotonic_clock=lambda: 0.0,
+        )
+        request = _request(symbol)
+        result = acquisition.run(request, _coverage(request), _budget())
+
+        assert result.status is BinanceFundingRateRestStatus.COMPLETE
+        assert result.complete
+        assert result.unmet_range is None
+        assert result.actual_record_range == request.caller_range
+        assert [page.record_count for page in result.pages] == [2, 2, 1]
+        assert [page.short_page for page in result.pages] == [False, False, True]
+        assert len(transport.calls) == 3
+        starts = [
+            int(parse_qs(urlsplit(url).query)["startTime"][0])
+            for url in transport.calls
+        ]
+        source_times = [cast(int, record["fundingTime"]) for record in _records(symbol)]
+        assert starts == [source_times[0], source_times[1] + 1, source_times[3] + 1]
+        assert all(
+            int(parse_qs(urlsplit(url).query)["endTime"][0]) == source_times[-1]
+            for url in transport.calls
+        )
+
+        frames = []
+        raw_bodies = []
+        first_revisions = []
+        for page, url in zip(result.pages, transport.calls, strict=True):
+            revision = page.revision
+            assert revision is not None
+            first_revisions.append(revision)
+            artifact = store.read_exact_revision(revision.logical_identity, revision)
+            frames.append(artifact.frame)
+            raw_bodies.append(artifact.response_path.read_bytes())
+            assert artifact.response_path.read_bytes() == transport.bodies[url]
+            assert artifact.manifest.raw_schema_identifier == (
+                "binance.um.settled-funding-rate.rest-json.v1"
+            )
+            assert artifact.manifest.rest_provenance is not None
+            assert artifact.manifest.rest_provenance.request.normalized_params == (
+                page.request.normalized_params
+            )
+
+        assert raw_bodies
+        assert [value for frame in frames for value in frame["fundingRate"]] == [
+            record["fundingRate"] for record in _records(symbol)
+        ]
+        assert frames[0]["markPricePresent"].to_list() == [True, True]
+        assert frames[0]["markPrice"].to_list() == ["70000.00000000", None]
+        assert frames[1]["markPricePresent"].to_list() == [False, True]
+        assert frames[1]["rateTypePresent"].to_list() == [True, True]
+        assert frames[1]["rateType"].to_list() == [None, "Regular"]
+        assert frames[1]["unknownFields"].to_list() == [[], ["sourceNote"]]
+
+        repeated = acquisition.run(request, _coverage(request), _budget())
+        assert repeated.status is BinanceFundingRateRestStatus.COMPLETE
+        assert [page.revision for page in repeated.pages] == first_revisions
+        for revision in first_revisions:
+            assert store.read_exact_revision(revision.logical_identity, revision)
+
+
+def test_funding_rest_new_digest_keeps_old_revision(tmp_path: Path) -> None:
+    store = RawStore(tmp_path, clock=lambda: NOW)
+    request = _request(end_ms=FIRST_FUNDING_MS + 1, limit=100)
+    original = BinanceFundingRateRestAcquisition(
+        store,
+        http_get=_FundingTransport(),
+        clock=lambda: NOW,
+        monotonic_clock=lambda: 0.0,
+    ).run(request, _coverage(request), _budget())
+    replacement = BinanceFundingRateRestAcquisition(
+        store,
+        http_get=_FundingTransport(variant=1),
+        clock=lambda: NOW,
+        monotonic_clock=lambda: 0.0,
+    ).run(request, _coverage(request), _budget())
+
+    first_revision = original.pages[0].revision
+    second_revision = replacement.pages[0].revision
+    assert first_revision is not None
+    assert second_revision is not None
+    assert first_revision != second_revision
+    assert store.read_exact_revision(
+        first_revision.logical_identity, first_revision
+    ).frame["fundingRate"].to_list() == ["0.00010000"]
+    assert store.read_exact_revision(
+        second_revision.logical_identity, second_revision
+    ).frame["fundingRate"].to_list() == ["0.00090000"]
+
+
+@pytest.mark.parametrize("symbol", ["BTCUSDT", "ETHUSDT"])
+def test_funding_gap_observation_returns_point_range_not_calendar_coverage(
+    tmp_path: Path, symbol: str
+) -> None:
+    request = _request(
+        symbol,
+        start_ms=FIRST_FUNDING_MS,
+        end_ms=FIRST_FUNDING_MS + 60 * 60 * 1_000,
+        limit=100,
+    )
+    result = BinanceFundingRateRestAcquisition(
+        RawStore(tmp_path),
+        http_get=_FundingTransport(),
+        clock=lambda: NOW,
+        monotonic_clock=lambda: 0.0,
+    ).run(request, _gap_coverage(request), _budget())
+
+    assert result.status is BinanceFundingRateRestStatus.COMPLETE
+    assert result.pages[0].record_count == 1
+    assert result.actual_record_range == TimeRange(
+        start=_at(FIRST_FUNDING_MS), end=_at(FIRST_FUNDING_MS + 1)
+    )
+    assert result.actual_record_range != result.requested_range
+
+
+@pytest.mark.parametrize(
+    ("mutate", "expected_status", "detail"),
+    [
+        (
+            lambda coverage: replace(
+                coverage, status=BinanceFundingRateRestCoverageStatus.UNKNOWN
+            ),
+            BinanceFundingRateRestStatus.REST_BOUNDARY_UNKNOWN,
+            "unknown",
+        ),
+        (
+            lambda coverage: replace(
+                coverage, status=BinanceFundingRateRestCoverageStatus.UNSUPPORTED
+            ),
+            BinanceFundingRateRestStatus.UNSUPPORTED,
+            "unsupported",
+        ),
+        (
+            lambda coverage: replace(coverage, evidence_sha256="0" * 64),
+            BinanceFundingRateRestStatus.REST_BOUNDARY_UNKNOWN,
+            "binding",
+        ),
+        (
+            lambda coverage: replace(
+                coverage,
+                normalized_params={**coverage.normalized_params, "limit": 999},
+            ),
+            BinanceFundingRateRestStatus.REST_BOUNDARY_UNKNOWN,
+            "observation",
+        ),
+        (
+            lambda coverage: replace(
+                coverage,
+                allowed_range=TimeRange(
+                    start=_at(RECENT_START_MS - 1), end=_at(RECENT_END_MS)
+                ),
+            ),
+            BinanceFundingRateRestStatus.REST_BOUNDARY_UNKNOWN,
+            "extends",
+        ),
+    ],
+)
+def test_funding_coverage_fails_closed_before_http(
+    tmp_path: Path,
+    mutate: object,
+    expected_status: BinanceFundingRateRestStatus,
+    detail: str,
+) -> None:
+    request = _request()
+    calls = 0
+
+    def transport(
+        url: str, timeout: float, maximum_response_bytes: int
+    ) -> BinanceKlineRestHttpResponse:
+        del url, timeout, maximum_response_bytes
+        nonlocal calls
+        calls += 1
+        return BinanceKlineRestHttpResponse(200, b"[]", {})
+
+    assert callable(mutate)
+    coverage = mutate(_coverage(request))
+    result = BinanceFundingRateRestAcquisition(
+        RawStore(tmp_path), http_get=transport, clock=lambda: NOW
+    ).run(request, coverage, _budget())
+
+    assert result.status is expected_status
+    assert detail in result.termination_reason
+    assert result.pages == ()
+    assert calls == 0
+
+
+def test_missing_coverage_and_unsupported_instrument_do_not_access_http(
+    tmp_path: Path,
+) -> None:
+    calls = 0
+
+    def transport(
+        url: str, timeout: float, maximum_response_bytes: int
+    ) -> BinanceKlineRestHttpResponse:
+        del url, timeout, maximum_response_bytes
+        nonlocal calls
+        calls += 1
+        return BinanceKlineRestHttpResponse(200, b"[]", {})
+
+    acquisition = BinanceFundingRateRestAcquisition(
+        RawStore(tmp_path), http_get=transport, clock=lambda: NOW
+    )
+    request = _request()
+    missing = acquisition.run(request, None, _budget())
+    unsupported_request = _request("BTCUSDC")
+    unsupported = acquisition.run(
+        unsupported_request, _coverage(unsupported_request), _budget()
+    )
+
+    assert missing.status is BinanceFundingRateRestStatus.REST_BOUNDARY_UNKNOWN
+    assert unsupported.status is BinanceFundingRateRestStatus.UNSUPPORTED
+    assert calls == 0
+
+
+@pytest.mark.parametrize(
+    ("payload", "detail"),
+    [
+        ({"code": -1}, "must be an array"),
+        ([{"symbol": "BTCUSDT"}], "missing required fields"),
+        (
+            [
+                {
+                    "symbol": "ETHUSDT",
+                    "fundingTime": FIRST_FUNDING_MS,
+                    "fundingRate": "0.1",
+                }
+            ],
+            "symbol does not match",
+        ),
+        (
+            [
+                {
+                    "symbol": "BTCUSDT",
+                    "fundingTime": FIRST_FUNDING_MS,
+                    "fundingRate": "NaN",
+                }
+            ],
+            "finite numeric string",
+        ),
+        (
+            [
+                {
+                    "symbol": "BTCUSDT",
+                    "fundingTime": FIRST_FUNDING_MS,
+                    "fundingRate": "0.1",
+                    "markPrice": "Infinity",
+                }
+            ],
+            "finite numeric string",
+        ),
+        (
+            [
+                {
+                    "symbol": "BTCUSDT",
+                    "fundingTime": FIRST_FUNDING_MS,
+                    "fundingRate": "0.1",
+                    "rateType": "Predicted",
+                }
+            ],
+            "unconfirmed settled semantics",
+        ),
+        (
+            [
+                {
+                    "symbol": "BTCUSDT",
+                    "fundingTime": FIRST_FUNDING_MS,
+                    "fundingRate": "0.1",
+                    "predictedFundingRate": "0.2",
+                }
+            ],
+            "unconfirmed funding-semantic fields",
+        ),
+        (
+            [
+                {
+                    "symbol": "BTCUSDT",
+                    "fundingTime": FIRST_FUNDING_MS + 1,
+                    "fundingRate": "0.1",
+                },
+                {
+                    "symbol": "BTCUSDT",
+                    "fundingTime": FIRST_FUNDING_MS,
+                    "fundingRate": "0.2",
+                },
+            ],
+            "out of order",
+        ),
+        (
+            [
+                {
+                    "symbol": "BTCUSDT",
+                    "fundingTime": FIRST_FUNDING_MS,
+                    "fundingRate": "0.1",
+                },
+                {
+                    "symbol": "BTCUSDT",
+                    "fundingTime": FIRST_FUNDING_MS,
+                    "fundingRate": "0.1",
+                },
+            ],
+            "duplicate fundingTime",
+        ),
+    ],
+)
+def test_malformed_or_unsettled_funding_response_is_not_published(
+    tmp_path: Path, payload: object, detail: str
+) -> None:
+    body = json.dumps(payload, separators=(",", ":")).encode()
+
+    def transport(
+        url: str, timeout: float, maximum_response_bytes: int
+    ) -> BinanceKlineRestHttpResponse:
+        del url, timeout, maximum_response_bytes
+        return BinanceKlineRestHttpResponse(200, body, {})
+
+    request = _request(end_ms=FIRST_FUNDING_MS + 2, limit=10)
+    result = BinanceFundingRateRestAcquisition(
+        RawStore(tmp_path),
+        http_get=transport,
+        clock=lambda: NOW,
+        monotonic_clock=lambda: 0.0,
+    ).run(request, _coverage(request), _budget())
+
+    assert result.status is BinanceFundingRateRestStatus.INVALID_RESPONSE
+    assert detail in result.termination_reason
+    assert result.pages[0].revision is None
+    assert not list(tmp_path.rglob("data.parquet"))
+
+
+def test_empty_response_records_evidence_without_zero_row_raw(tmp_path: Path) -> None:
+    def transport(
+        url: str, timeout: float, maximum_response_bytes: int
+    ) -> BinanceKlineRestHttpResponse:
+        del url, timeout, maximum_response_bytes
+        return BinanceKlineRestHttpResponse(200, b"[]", {})
+
+    request = _request(end_ms=FIRST_FUNDING_MS + 1, limit=100)
+    result = BinanceFundingRateRestAcquisition(
+        RawStore(tmp_path),
+        http_get=transport,
+        clock=lambda: NOW,
+        monotonic_clock=lambda: 0.0,
+    ).run(request, _coverage(request), _budget())
+
+    assert result.status is BinanceFundingRateRestStatus.COMPLETE
+    assert result.pages[0].status is BinanceFundingRateRestStatus.LEGAL_EMPTY
+    assert result.pages[0].response_sha256 is not None
+    assert result.pages[0].revision is None
+    assert result.actual_record_range is None
+    assert not list(tmp_path.rglob("data.parquet"))
+    assert list(tmp_path.rglob("response.json"))
+
+
+def test_shared_retry_budget_and_failure_evidence_apply_to_funding(
+    tmp_path: Path,
+) -> None:
+    valid_body = json.dumps([_records("BTCUSDT")[0]], separators=(",", ":")).encode()
+    responses: list[BinanceKlineRestHttpResponse | BaseException] = [
+        BinanceKlineRestHttpResponse(429, b"limited", {"Retry-After": "1"}),
+        TimeoutError("timed out"),
+        BinanceKlineRestHttpResponse(200, valid_body, {}),
+    ]
+    calls: list[str] = []
+    waits: list[float] = []
+
+    def transport(
+        url: str, timeout: float, maximum_response_bytes: int
+    ) -> BinanceKlineRestHttpResponse:
+        del timeout, maximum_response_bytes
+        calls.append(url)
+        response = responses.pop(0)
+        if isinstance(response, BaseException):
+            raise response
+        return response
+
+    store = RawStore(tmp_path)
+    request = _request(end_ms=FIRST_FUNDING_MS + 1, limit=100)
+    result = BinanceFundingRateRestAcquisition(
+        store,
+        http_get=transport,
+        clock=lambda: NOW,
+        wait=waits.append,
+        monotonic_clock=lambda: 0.0,
+    ).run(request, _coverage(request), _budget(attempts=3))
+
+    assert result.status is BinanceFundingRateRestStatus.COMPLETE
+    assert len(set(calls)) == 1
+    assert waits == [1, 2.0]
+    assert [attempt.outcome for attempt in result.pages[0].attempts] == [
+        "retryable_http",
+        "transport_error",
+        "received",
+    ]
+    identity = RawObjectIdentity.from_rest_page_request(request)
+    assert len(store.list_acquisition_manifests(identity)) == 2
+
+
+def test_cross_page_conflict_keeps_the_valid_first_page(tmp_path: Path) -> None:
+    records = _records("BTCUSDT")
+    bodies = [
+        json.dumps(records[:2], separators=(",", ":")).encode(),
+        json.dumps([records[1]], separators=(",", ":")).encode(),
+    ]
+
+    def transport(
+        url: str, timeout: float, maximum_response_bytes: int
+    ) -> BinanceKlineRestHttpResponse:
+        del url, timeout, maximum_response_bytes
+        return BinanceKlineRestHttpResponse(200, bodies.pop(0), {})
+
+    store = RawStore(tmp_path)
+    request = _request()
+    result = BinanceFundingRateRestAcquisition(
+        store,
+        http_get=transport,
+        clock=lambda: NOW,
+        monotonic_clock=lambda: 0.0,
+    ).run(request, _coverage(request), _budget())
+
+    assert result.status is BinanceFundingRateRestStatus.INVALID_RESPONSE
+    assert "cross-page duplicate" in result.termination_reason
+    assert result.unmet_range is not None
+    first_revision = result.pages[0].revision
+    assert first_revision is not None
+    assert store.read_exact_revision(first_revision.logical_identity, first_revision)
+    assert result.pages[1].revision is None

--- a/tests/data/test_binance_funding_rate_rest_acquisition.py
+++ b/tests/data/test_binance_funding_rate_rest_acquisition.py
@@ -583,13 +583,51 @@ def test_empty_response_records_evidence_without_zero_row_raw(tmp_path: Path) ->
         monotonic_clock=lambda: 0.0,
     ).run(request, _coverage(request), _budget())
 
-    assert result.status is BinanceFundingRateRestStatus.COMPLETE
+    assert result.status is BinanceFundingRateRestStatus.LEGAL_EMPTY
+    assert not result.complete
     assert result.pages[0].status is BinanceFundingRateRestStatus.LEGAL_EMPTY
     assert result.pages[0].response_sha256 is not None
     assert result.pages[0].revision is None
     assert result.actual_record_range is None
+    assert result.unmet_range == request.caller_range
     assert not list(tmp_path.rglob("data.parquet"))
     assert list(tmp_path.rglob("response.json"))
+
+
+def test_duplicate_json_object_members_are_rejected_and_preserved(
+    tmp_path: Path,
+) -> None:
+    body = (
+        b'[{"symbol":"ETHUSDT","symbol":"BTCUSDT",'
+        b'"fundingTime":1788393600000,"fundingRate":"0.1",'
+        b'"fundingRate":"0.9"}]'
+    )
+
+    def transport(
+        url: str, timeout: float, maximum_response_bytes: int
+    ) -> BinanceKlineRestHttpResponse:
+        del url, timeout, maximum_response_bytes
+        return BinanceKlineRestHttpResponse(200, body, {})
+
+    store = RawStore(tmp_path)
+    request = _request(end_ms=FIRST_FUNDING_MS + 1, limit=100)
+    result = BinanceFundingRateRestAcquisition(
+        store,
+        http_get=transport,
+        clock=lambda: NOW,
+        monotonic_clock=lambda: 0.0,
+    ).run(request, _coverage(request), _budget())
+
+    assert result.status is BinanceFundingRateRestStatus.INVALID_RESPONSE
+    assert "strict UTF-8 JSON" in result.termination_reason
+    assert result.unmet_range == request.caller_range
+    assert result.pages[0].revision is None
+    identity = RawObjectIdentity.from_rest_page_request(request)
+    records = store.list_acquisition_manifests(identity)
+    assert len(records) == 1
+    evidence_path = store.acquisition_path_for(identity) / records[0].record_id
+    assert (evidence_path / "response.json").read_bytes() == body
+    assert not list(tmp_path.rglob("data.parquet"))
 
 
 def test_shared_retry_budget_and_failure_evidence_apply_to_funding(

--- a/tests/data/test_binance_kline_rest_acquisition.py
+++ b/tests/data/test_binance_kline_rest_acquisition.py
@@ -518,9 +518,12 @@ def test_shared_rest_page_executor_accepts_funding_adapter(tmp_path: Path) -> No
 
     result = acquisition.run(request, "verified-funding-coverage", _budget())
 
-    assert result.status is BinanceKlineRestStatus.COMPLETE
+    assert result.status is BinanceKlineRestStatus.LEGAL_EMPTY
     assert result.attempts_used == 3
-    assert result.unmet_range is None
+    assert result.unmet_range == TimeRange(
+        start=START + timedelta(hours=8, milliseconds=1),
+        end=request.caller_range.end,
+    )
     assert len(result.pages) == 2
     assert [len(page.attempts) for page in result.pages] == [2, 1]
     assert result.pages[1].status is BinanceKlineRestStatus.LEGAL_EMPTY


### PR DESCRIPTION
Closes #283

## Summary
Add a settled-funding REST facade that reuses the shared bounded executor, binds BTCUSDT/ETHUSDT coverage to the frozen issue-295 observations, validates sparse settled events, and publishes immutable page Raw with exact response provenance; add focused tests and documentation.

## Validation
- Critical Outcome: pass
- Formal Delivery validation: pass

## Risks / limitations
Coverage remains limited to the frozen issue-295 recent/gap observations; normal response-sequence completion does not prove continuous calendar coverage, earliest history, or external gap satisfaction.
