### PR TITLE
[Task] 建立 Binance 公共历史获取的统一受控执行边界

### DIFF
--- a/src/tracequant/data/__init__.py
+++ b/src/tracequant/data/__init__.py
@@ -68,6 +68,15 @@ from tracequant.data.binance_public_archive import (
     BinanceArchiveParseResult,
     BinancePublicArchiveAcquisition,
 )
+from tracequant.data.binance_public_history_execution import (
+    BinancePublicHistoryExecutionContext,
+    BinancePublicHistoryExecutionLimits,
+    BinancePublicHistoryExecutionSnapshot,
+    BinancePublicHistoryExecutionStopped,
+    BinancePublicHistoryExecutionStopReason,
+    BinancePublicHistoryHttpAllowance,
+    BinancePublicHistoryRequestAttempts,
+)
 from tracequant.data.public_history import (
     BinanceArchiveObjectBoundary,
     BinanceArchiveObjectGranularity,
@@ -176,6 +185,13 @@ __all__ = [
     "BinancePublicHistorySourceKind",
     "BinancePublicHistorySubjectKind",
     "BinancePublicArchiveAcquisition",
+    "BinancePublicHistoryExecutionContext",
+    "BinancePublicHistoryExecutionLimits",
+    "BinancePublicHistoryExecutionSnapshot",
+    "BinancePublicHistoryExecutionStopReason",
+    "BinancePublicHistoryExecutionStopped",
+    "BinancePublicHistoryHttpAllowance",
+    "BinancePublicHistoryRequestAttempts",
     "PublicHistoryContractError",
     "RawArtifact",
     "RawArtifactAmbiguousError",

--- a/src/tracequant/data/_binance_archive_http_worker.py
+++ b/src/tracequant/data/_binance_archive_http_worker.py
@@ -1,0 +1,87 @@
+"""Private process boundary for one bounded Binance archive HTTP response."""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import BinaryIO
+
+from tracequant.data.binance_public_archive import _urllib_http_get
+
+
+def _write_json(path: Path, payload: Mapping[str, object]) -> None:
+    path.write_text(
+        json.dumps(payload, separators=(",", ":"), sort_keys=True),
+        encoding="utf-8",
+    )
+
+
+def _main(arguments: Sequence[str]) -> int:
+    if len(arguments) != 6:
+        return 2
+    (
+        url,
+        timeout_text,
+        maximum_response_bytes_text,
+        body_text,
+        metadata_text,
+        result_text,
+    ) = arguments
+    body_path = Path(body_text)
+    metadata_path = Path(metadata_text)
+    result_path = Path(result_text)
+    body_stream: BinaryIO | None = None
+
+    def report_progress(
+        kind: str, status: int, headers: Mapping[str, str], body: bytes
+    ) -> None:
+        nonlocal body_stream
+        if kind == "start":
+            _write_json(
+                metadata_path,
+                {"kind": "response", "status": status, "headers": dict(headers)},
+            )
+            body_stream = body_path.open("wb")
+            return
+        if body_stream is None:
+            raise RuntimeError("archive response body preceded response metadata")
+        body_stream.write(body)
+        body_stream.flush()
+
+    try:
+        maximum_response_bytes = (
+            None
+            if maximum_response_bytes_text == "none"
+            else int(maximum_response_bytes_text)
+        )
+        response = _urllib_http_get(
+            url,
+            float(timeout_text),
+            maximum_response_bytes=maximum_response_bytes,
+            progress=report_progress,
+        )
+        if body_stream is not None:
+            body_stream.close()
+            body_stream = None
+        result: dict[str, object] = {
+            "kind": "response",
+            "status": response.status,
+            "headers": dict(response.headers),
+            "complete": response.complete,
+        }
+    except BaseException as error:
+        if body_stream is not None:
+            body_stream.close()
+        result = {
+            "kind": "failure",
+            "error_type": type(error).__name__,
+            "detail": str(error)[:4096],
+        }
+    _write_json(result_path, result)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main(sys.argv[1:]))

--- a/src/tracequant/data/binance_contract_kline.py
+++ b/src/tracequant/data/binance_contract_kline.py
@@ -27,6 +27,9 @@ from tracequant.data.binance_public_archive import (
     _coverage_gap,
     _invalid_content,
 )
+from tracequant.data.binance_public_history_execution import (
+    BinancePublicHistoryExecutionContext,
+)
 from tracequant.data.public_history import (
     BinanceArchiveObjectBoundary,
     BinanceKlineInterval,
@@ -437,16 +440,21 @@ class BinanceContractKlineBackfill:
         )
 
     def run(
-        self, instrument: InstrumentId, request_range: TimeRange
+        self,
+        instrument: InstrumentId,
+        request_range: TimeRange,
+        execution_context: BinancePublicHistoryExecutionContext | None = None,
     ) -> BinanceContractKlineRunResult:
         plans = plan_binance_contract_kline_archives(instrument, request_range)
-        results = tuple(self._process(plan) for plan in plans)
+        results = tuple(self._process(plan, execution_context) for plan in plans)
         return BinanceContractKlineRunResult(
             request_range=request_range, objects=results
         )
 
     def _process(
-        self, plan: BinanceContractKlinePlan
+        self,
+        plan: BinanceContractKlinePlan,
+        execution_context: BinancePublicHistoryExecutionContext | None = None,
     ) -> BinanceContractKlineObjectResult:
         if isinstance(plan, BinanceArchiveCoverageGapPlan):
             outcome = self._acquisition.record_failure(
@@ -455,7 +463,12 @@ class BinanceContractKlineBackfill:
                 plan.detail,
             )
         else:
-            outcome = self._acquisition.acquire(plan, _ContractKlineArchiveAdapter())
+            adapter = _ContractKlineArchiveAdapter()
+            outcome = (
+                self._acquisition.acquire(plan, adapter)
+                if execution_context is None
+                else self._acquisition.acquire(plan, adapter, execution_context)
+            )
         return BinanceContractKlineObjectResult(
             plan,
             outcome.status,

--- a/src/tracequant/data/binance_funding_rate.py
+++ b/src/tracequant/data/binance_funding_rate.py
@@ -31,6 +31,9 @@ from tracequant.data.binance_public_archive import (
     _coverage_gap,
     _invalid_content,
 )
+from tracequant.data.binance_public_history_execution import (
+    BinancePublicHistoryExecutionContext,
+)
 from tracequant.data.public_history import (
     BinanceArchiveObjectBoundary,
     BinancePublicHistoryDataType,
@@ -438,16 +441,23 @@ class BinanceFundingRateBackfill:
         )
 
     def run(
-        self, instrument: InstrumentId, request_range: TimeRange
+        self,
+        instrument: InstrumentId,
+        request_range: TimeRange,
+        execution_context: BinancePublicHistoryExecutionContext | None = None,
     ) -> BinanceFundingRateRunResult:
         plans = plan_binance_funding_rate_archives(instrument, request_range)
-        results = tuple(self._process(plan) for plan in plans)
+        results = tuple(self._process(plan, execution_context) for plan in plans)
         return BinanceFundingRateRunResult(
             request_range=request_range,
             objects=results,
         )
 
-    def _process(self, plan: BinanceFundingRatePlan) -> BinanceFundingRateObjectResult:
+    def _process(
+        self,
+        plan: BinanceFundingRatePlan,
+        execution_context: BinancePublicHistoryExecutionContext | None = None,
+    ) -> BinanceFundingRateObjectResult:
         if isinstance(plan, BinanceFundingRateCoverageGapPlan):
             outcome = self._acquisition.record_failure(
                 plan.request,
@@ -455,7 +465,12 @@ class BinanceFundingRateBackfill:
                 plan.detail,
             )
         else:
-            outcome = self._acquisition.acquire(plan, _FundingRateArchiveAdapter())
+            adapter = _FundingRateArchiveAdapter()
+            outcome = (
+                self._acquisition.acquire(plan, adapter)
+                if execution_context is None
+                else self._acquisition.acquire(plan, adapter, execution_context)
+            )
         return BinanceFundingRateObjectResult(
             plan=plan,
             status=outcome.status,

--- a/src/tracequant/data/binance_index_price_kline.py
+++ b/src/tracequant/data/binance_index_price_kline.py
@@ -27,6 +27,9 @@ from tracequant.data.binance_public_archive import (
     _coverage_gap,
     _invalid_content,
 )
+from tracequant.data.binance_public_history_execution import (
+    BinancePublicHistoryExecutionContext,
+)
 from tracequant.data.public_history import (
     BinanceArchiveObjectBoundary,
     BinanceKlineInterval,
@@ -459,16 +462,21 @@ class BinanceIndexPriceKlineBackfill:
         )
 
     def run(
-        self, pair: BinancePriceIndexId, request_range: TimeRange
+        self,
+        pair: BinancePriceIndexId,
+        request_range: TimeRange,
+        execution_context: BinancePublicHistoryExecutionContext | None = None,
     ) -> BinanceIndexPriceKlineRunResult:
         plans = plan_binance_index_price_kline_archives(pair, request_range)
-        results = tuple(self._process(plan) for plan in plans)
+        results = tuple(self._process(plan, execution_context) for plan in plans)
         return BinanceIndexPriceKlineRunResult(
             request_range=request_range, objects=results
         )
 
     def _process(
-        self, plan: BinanceIndexPriceKlinePlan
+        self,
+        plan: BinanceIndexPriceKlinePlan,
+        execution_context: BinancePublicHistoryExecutionContext | None = None,
     ) -> BinanceIndexPriceKlineObjectResult:
         if isinstance(plan, BinanceIndexPriceKlineCoverageGapPlan):
             outcome = self._acquisition.record_failure(
@@ -477,7 +485,12 @@ class BinanceIndexPriceKlineBackfill:
                 plan.detail,
             )
         else:
-            outcome = self._acquisition.acquire(plan, _IndexPriceKlineArchiveAdapter())
+            adapter = _IndexPriceKlineArchiveAdapter()
+            outcome = (
+                self._acquisition.acquire(plan, adapter)
+                if execution_context is None
+                else self._acquisition.acquire(plan, adapter, execution_context)
+            )
         return BinanceIndexPriceKlineObjectResult(
             plan,
             outcome.status,

--- a/src/tracequant/data/binance_kline_rest.py
+++ b/src/tracequant/data/binance_kline_rest.py
@@ -14,6 +14,7 @@ import json
 import math
 import subprocess
 import sys
+import tempfile
 import time
 import urllib.error
 import urllib.parse
@@ -31,6 +32,12 @@ from typing import Final, Protocol
 import polars as pl
 
 from tracequant.core.time import to_utc
+from tracequant.data.binance_public_history_execution import (
+    BinancePublicHistoryExecutionContext,
+    BinancePublicHistoryExecutionSnapshot,
+    BinancePublicHistoryExecutionStopped,
+    BinancePublicHistoryExecutionStopReason,
+)
 from tracequant.data.public_history import (
     BinanceKlineInterval,
     BinancePriceIndexId,
@@ -264,6 +271,17 @@ class BinanceKlineRestHttpGet(Protocol):
     ) -> BinanceKlineRestHttpResponse: ...
 
 
+class _RestTransportInterrupted(InterruptedError):
+    def __init__(
+        self,
+        message: str,
+        *,
+        response: BinanceKlineRestHttpResponse | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.response = response
+
+
 class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
     def redirect_request(
         self,
@@ -425,11 +443,15 @@ def _worker_http_response(
 
 
 def _default_http_get(
-    url: str, timeout: float, maximum_response_bytes: int
+    url: str,
+    timeout: float,
+    maximum_response_bytes: int,
+    *,
+    cancelled: Callable[[], bool] | None = None,
 ) -> BinanceKlineRestHttpResponse:
     """Read one response in a worker that cannot outlive the attempt deadline."""
-    try:
-        completed = subprocess.run(
+    with tempfile.TemporaryFile() as output:
+        process = subprocess.Popen(
             [
                 sys.executable,
                 "-m",
@@ -438,30 +460,58 @@ def _default_http_get(
                 repr(timeout),
                 str(maximum_response_bytes),
             ],
-            check=False,
-            capture_output=True,
-            timeout=timeout,
+            stdout=output,
+            stderr=subprocess.DEVNULL,
         )
-    except subprocess.TimeoutExpired as error:
-        partial_output = error.stdout if isinstance(error.stdout, bytes) else b""
+        deadline = time.monotonic() + timeout
+        interruption: str | None = None
         try:
+            while process.poll() is None:
+                if cancelled is not None and cancelled():
+                    interruption = "REST HTTP attempt was cancelled"
+                    break
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    interruption = (
+                        "HTTP attempt exceeded its absolute elapsed-time deadline"
+                    )
+                    break
+                try:
+                    process.wait(timeout=min(0.05, remaining))
+                except subprocess.TimeoutExpired:
+                    continue
+        except BaseException:
+            if process.poll() is None:
+                process.kill()
+            process.wait()
+            raise
+        if interruption is not None:
+            if process.poll() is None:
+                process.kill()
+            process.wait()
+        output.seek(0)
+        worker_output = output.read()
+        if interruption is None:
+            if process.returncode != 0:
+                raise OSError("HTTP worker exited without a valid result")
             return _worker_http_response(
-                partial_output,
+                worker_output,
+                maximum_response_bytes,
+                allow_incomplete_stream=False,
+            )
+        try:
+            response = _worker_http_response(
+                worker_output,
                 maximum_response_bytes,
                 allow_incomplete_stream=True,
             )
         except OSError:
-            pass
-        raise TimeoutError(
-            "HTTP attempt exceeded its absolute elapsed-time deadline"
-        ) from error
-    if completed.returncode != 0:
-        raise OSError("HTTP worker exited without a valid result")
-    return _worker_http_response(
-        completed.stdout,
-        maximum_response_bytes,
-        allow_incomplete_stream=False,
-    )
+            response = None
+        if interruption == "REST HTTP attempt was cancelled":
+            raise _RestTransportInterrupted(interruption, response=response)
+        if response is not None:
+            return response
+        raise TimeoutError(interruption)
 
 
 class BinanceKlineRestCoverageStatus(StrEnum):
@@ -593,6 +643,7 @@ class BinanceKlineRestStatus(StrEnum):
     RETRYABLE_FAILURE = "retryable_failure"
     RETRY_EXHAUSTED = "retry_exhausted"
     BUDGET_EXHAUSTED = "budget_exhausted"
+    CANCELLED = "cancelled"
     LOCAL_FAILURE = "local_failure"
     CONFLICT = "conflict"
 
@@ -641,6 +692,7 @@ class BinanceKlineRestRunResult:
     attempts_used: int
     pages_used: int
     elapsed_seconds: float
+    execution: BinancePublicHistoryExecutionSnapshot | None = None
 
     @property
     def complete(self) -> bool:
@@ -653,6 +705,7 @@ class _BudgetTracker:
     coverage: object | None
     monotonic_clock: Callable[[], float]
     started_at: float
+    execution: BinancePublicHistoryExecutionContext | None = None
     transport_seconds: float = 0.0
     waited_seconds: float = 0.0
     attempts: int = 0
@@ -1107,6 +1160,7 @@ class BinanceRestPageAcquisition:
         self._adapter = adapter
         self._store = store
         self._http_get = http_get or _default_http_get
+        self._uses_default_http_get = http_get is None
         self._clock = clock or (lambda: datetime.now(UTC))
         self._wait = wait or time.sleep
         self._monotonic_clock = monotonic_clock or time.monotonic
@@ -1214,6 +1268,89 @@ class BinanceRestPageAcquisition:
             attempts_used=tracker.attempts,
             pages_used=tracker.pages,
             elapsed_seconds=tracker.elapsed,
+            execution=(
+                tracker.execution.snapshot() if tracker.execution is not None else None
+            ),
+        )
+
+    @staticmethod
+    def _execution_status(
+        stopped: BinancePublicHistoryExecutionStopped,
+    ) -> BinanceKlineRestStatus:
+        if stopped.reason is BinancePublicHistoryExecutionStopReason.CANCELLED:
+            return BinanceKlineRestStatus.CANCELLED
+        return BinanceKlineRestStatus.BUDGET_EXHAUSTED
+
+    def _wait_for_retry(
+        self,
+        seconds: float,
+        execution_context: BinancePublicHistoryExecutionContext | None,
+    ) -> None:
+        if execution_context is None:
+            self._wait(seconds)
+        else:
+            execution_context.wait_for_retry(seconds)
+
+    def _finish_execution_stop(
+        self,
+        *,
+        stopped: BinancePublicHistoryExecutionStopped,
+        request: BinanceRestPageRequest,
+        current: BinanceRestPageRequest,
+        pages: list[BinanceKlineRestPageResult],
+        attempts: list[BinanceKlineRestAttemptResult],
+        tracker: _BudgetTracker,
+        cursor_ms: int,
+        response: BinanceKlineRestHttpResponse | None = None,
+        http_started: bool = False,
+    ) -> BinanceKlineRestRunResult:
+        status = self._execution_status(stopped)
+        detail = str(stopped)
+        digest = _response_digest(response.body) if response is not None else None
+        if http_started:
+            attempts.append(
+                BinanceKlineRestAttemptResult(
+                    attempt_number=tracker.attempts,
+                    page_attempt_number=max(1, len(attempts) + 1),
+                    outcome=status.value,
+                    http_status=response.status if response is not None else None,
+                    response_sha256=digest,
+                    detail=detail,
+                )
+            )
+        if response is not None:
+            try:
+                self._record_attempt(
+                    current,
+                    status=status,
+                    detail=detail,
+                    source_url=self._request_url(current),
+                    response=response,
+                )
+            except (RawStoreError, OSError, ValueError) as store_error:
+                status = BinanceKlineRestStatus.LOCAL_FAILURE
+                detail = f"failed to persist bounded response evidence: {store_error}"
+        pages.append(
+            BinanceKlineRestPageResult(
+                request=current,
+                attempts=tuple(attempts),
+                status=status,
+                short_page=False,
+                record_count=0,
+                actual_record_range=None,
+                response_sha256=digest,
+                revision=None,
+                artifact_path=None,
+                detail=detail,
+            )
+        )
+        return self._finish(
+            status=status,
+            request=request,
+            pages=pages,
+            tracker=tracker,
+            cursor_ms=cursor_ms,
+            reason=detail,
         )
 
     def run(
@@ -1221,21 +1358,42 @@ class BinanceRestPageAcquisition:
         request: BinanceRestPageRequest,
         coverage: object | None,
         budget: BinanceKlineRestBudget,
+        execution_context: BinancePublicHistoryExecutionContext | None = None,
     ) -> BinanceKlineRestRunResult:
         """Fetch, validate, and publish every page needed for the caller range."""
         if not isinstance(request, BinanceRestPageRequest):
             raise TypeError("request must be a BinanceRestPageRequest")
         if not isinstance(budget, BinanceKlineRestBudget):
             raise TypeError("budget must be a BinanceKlineRestBudget")
+        if execution_context is not None and not isinstance(
+            execution_context, BinancePublicHistoryExecutionContext
+        ):
+            raise TypeError(
+                "execution_context must be BinancePublicHistoryExecutionContext"
+            )
         tracker = _BudgetTracker(
             budget=budget,
             coverage=coverage,
             monotonic_clock=self._monotonic_clock,
             started_at=self._monotonic_clock(),
+            execution=execution_context,
         )
         pages: list[BinanceKlineRestPageResult] = []
         observed_rows: dict[int, tuple[object, ...]] = {}
         cursor_ms = request.caller_bounds.start_time_ms
+
+        if execution_context is not None:
+            try:
+                execution_context.check()
+            except BinancePublicHistoryExecutionStopped as stopped:
+                return self._finish(
+                    status=self._execution_status(stopped),
+                    request=request,
+                    pages=pages,
+                    tracker=tracker,
+                    cursor_ms=cursor_ms,
+                    reason=str(stopped),
+                )
 
         failure = self._adapter.request_failure(request, self._now())
         if failure is None:
@@ -1263,6 +1421,19 @@ class BinanceRestPageAcquisition:
                     cursor_ms=cursor_ms,
                     reason="page or total elapsed-time budget exhausted",
                 )
+            if execution_context is not None:
+                try:
+                    execution_context.begin_rest_page()
+                except BinancePublicHistoryExecutionStopped as stopped:
+                    return self._finish_execution_stop(
+                        stopped=stopped,
+                        request=request,
+                        current=current,
+                        pages=pages,
+                        attempts=[],
+                        tracker=tracker,
+                        cursor_ms=cursor_ms,
+                    )
             tracker.pages += 1
             attempts: list[BinanceKlineRestAttemptResult] = []
             response: BinanceKlineRestHttpResponse | None = None
@@ -1296,14 +1467,87 @@ class BinanceRestPageAcquisition:
                         cursor_ms=cursor_ms,
                         reason="total elapsed-time budget exhausted before HTTP attempt",
                     )
-                tracker.attempts += 1
-                started = self._monotonic_clock()
+                timeout_seconds = min(budget.timeout_seconds, tracker.remaining)
+                response_bytes = budget.maximum_response_bytes
                 try:
-                    response = self._http_get(
-                        url,
-                        min(budget.timeout_seconds, tracker.remaining),
-                        budget.maximum_response_bytes,
+                    if execution_context is not None:
+                        allowance = execution_context.begin_http_attempt(
+                            f"rest:{current.identity.logical_id}",
+                            timeout_seconds=timeout_seconds,
+                        )
+                        timeout_seconds = min(
+                            timeout_seconds, allowance.timeout_seconds
+                        )
+                        response_bytes = min(
+                            response_bytes, allowance.maximum_response_bytes
+                        )
+                    tracker.attempts += 1
+                    started = self._monotonic_clock()
+                    if execution_context is not None and self._uses_default_http_get:
+                        response = _default_http_get(
+                            url,
+                            timeout_seconds,
+                            response_bytes,
+                            cancelled=execution_context.cancellation_requested,
+                        )
+                    else:
+                        response = self._http_get(url, timeout_seconds, response_bytes)
+                    if execution_context is not None:
+                        execution_context.record_response_bytes(len(response.body))
+                        execution_context.check()
+                except BinancePublicHistoryExecutionStopped as stopped:
+                    return self._finish_execution_stop(
+                        stopped=stopped,
+                        request=request,
+                        current=current,
+                        pages=pages,
+                        attempts=attempts,
+                        tracker=tracker,
+                        cursor_ms=cursor_ms,
+                        response=response,
+                        http_started=response is not None,
                     )
+                except _RestTransportInterrupted as error:
+                    tracker.transport_seconds += max(
+                        0.0, self._monotonic_clock() - started
+                    )
+                    response = error.response
+                    if execution_context is None:
+                        raise AssertionError(
+                            "cancellable REST transport requires an execution context"
+                        ) from error
+                    if response is not None:
+                        try:
+                            execution_context.record_response_bytes(len(response.body))
+                        except BinancePublicHistoryExecutionStopped as stopped:
+                            return self._finish_execution_stop(
+                                stopped=stopped,
+                                request=request,
+                                current=current,
+                                pages=pages,
+                                attempts=attempts,
+                                tracker=tracker,
+                                cursor_ms=cursor_ms,
+                                response=response,
+                                http_started=True,
+                            )
+                    try:
+                        execution_context.raise_stop(
+                            BinancePublicHistoryExecutionStopReason.CANCELLED,
+                            str(error),
+                        )
+                    except BinancePublicHistoryExecutionStopped as stopped:
+                        return self._finish_execution_stop(
+                            stopped=stopped,
+                            request=request,
+                            current=current,
+                            pages=pages,
+                            attempts=attempts,
+                            tracker=tracker,
+                            cursor_ms=cursor_ms,
+                            response=response,
+                            http_started=True,
+                        )
                 except (
                     TimeoutError,
                     ConnectionError,
@@ -1314,6 +1558,20 @@ class BinanceRestPageAcquisition:
                     tracker.transport_seconds += max(
                         0.0, self._monotonic_clock() - started
                     )
+                    if execution_context is not None:
+                        try:
+                            execution_context.check()
+                        except BinancePublicHistoryExecutionStopped as stopped:
+                            return self._finish_execution_stop(
+                                stopped=stopped,
+                                request=request,
+                                current=current,
+                                pages=pages,
+                                attempts=attempts,
+                                tracker=tracker,
+                                cursor_ms=cursor_ms,
+                                http_started=True,
+                            )
                     detail = str(error).strip() or type(error).__name__
                     delay = float(min(2 ** (page_attempt - 1), 60))
                     will_retry = page_attempt < budget.maximum_attempts_per_page
@@ -1390,7 +1648,17 @@ class BinanceRestPageAcquisition:
                             reason="retry wait cannot fit in the elapsed-time budget",
                         )
                     try:
-                        self._wait(delay)
+                        self._wait_for_retry(delay, execution_context)
+                    except BinancePublicHistoryExecutionStopped as stopped:
+                        return self._finish_execution_stop(
+                            stopped=stopped,
+                            request=request,
+                            current=current,
+                            pages=pages,
+                            attempts=attempts,
+                            tracker=tracker,
+                            cursor_ms=cursor_ms,
+                        )
                     except Exception as wait_error:
                         detail = f"retry wait failed: {wait_error}"
                         pages.append(
@@ -1661,7 +1929,17 @@ class BinanceRestPageAcquisition:
                                 ),
                             )
                         try:
-                            self._wait(retry_delay)
+                            self._wait_for_retry(retry_delay, execution_context)
+                        except BinancePublicHistoryExecutionStopped as stopped:
+                            return self._finish_execution_stop(
+                                stopped=stopped,
+                                request=request,
+                                current=current,
+                                pages=pages,
+                                attempts=attempts,
+                                tracker=tracker,
+                                cursor_ms=cursor_ms,
+                            )
                         except Exception as error:
                             detail = f"retry wait failed: {error}"
                             pages.append(
@@ -1856,7 +2134,17 @@ class BinanceRestPageAcquisition:
                                 reason="retry wait cannot fit in the elapsed-time budget",
                             )
                         try:
-                            self._wait(retry_delay)
+                            self._wait_for_retry(retry_delay, execution_context)
+                        except BinancePublicHistoryExecutionStopped as stopped:
+                            return self._finish_execution_stop(
+                                stopped=stopped,
+                                request=request,
+                                current=current,
+                                pages=pages,
+                                attempts=attempts,
+                                tracker=tracker,
+                                cursor_ms=cursor_ms,
+                            )
                         except Exception as error:
                             detail = f"retry wait failed: {error}"
                             pages.append(
@@ -2018,6 +2306,21 @@ class BinanceRestPageAcquisition:
                     reason=detail,
                 )
 
+            if execution_context is not None:
+                try:
+                    execution_context.check()
+                except BinancePublicHistoryExecutionStopped as stopped:
+                    return self._finish_execution_stop(
+                        stopped=stopped,
+                        request=request,
+                        current=current,
+                        pages=pages,
+                        attempts=attempts,
+                        tracker=tracker,
+                        cursor_ms=cursor_ms,
+                        response=response,
+                    )
+
             if frame.is_empty():
                 detail = "adapter declared a terminal legal-empty page"
                 status = BinanceKlineRestStatus.LEGAL_EMPTY
@@ -2178,6 +2481,19 @@ class BinanceRestPageAcquisition:
                     reason=detail,
                 )
             observed_rows.update(page_rows)
+
+            if execution_context is not None:
+                try:
+                    execution_context.check()
+                except BinancePublicHistoryExecutionStopped as stopped:
+                    return self._finish(
+                        status=self._execution_status(stopped),
+                        request=request,
+                        pages=pages,
+                        tracker=tracker,
+                        cursor_ms=parsed.next_cursor_ms,
+                        reason=(f"{stopped}; completed REST pages were preserved"),
+                    )
 
             next_cursor = parsed.next_cursor_ms
             if next_cursor <= cursor_ms:

--- a/src/tracequant/data/binance_kline_rest.py
+++ b/src/tracequant/data/binance_kline_rest.py
@@ -20,7 +20,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from collections.abc import Callable, Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from decimal import Decimal, InvalidOperation
 from email.utils import parsedate_to_datetime
@@ -37,6 +37,7 @@ from tracequant.data.binance_public_history_execution import (
     BinancePublicHistoryExecutionSnapshot,
     BinancePublicHistoryExecutionStopped,
     BinancePublicHistoryExecutionStopReason,
+    BinancePublicHistoryHttpAllowance,
 )
 from tracequant.data.public_history import (
     BinanceKlineInterval,
@@ -1285,11 +1286,23 @@ class BinanceRestPageAcquisition:
         self,
         seconds: float,
         execution_context: BinancePublicHistoryExecutionContext | None,
+        *,
+        attempts: list[BinanceKlineRestAttemptResult],
+        tracker: _BudgetTracker,
     ) -> None:
-        if execution_context is None:
-            self._wait(seconds)
-        else:
-            execution_context.wait_for_retry(seconds)
+        started = self._monotonic_clock()
+        try:
+            if execution_context is None:
+                self._wait(seconds)
+            else:
+                execution_context.wait_for_retry(seconds)
+        except BaseException:
+            waited = min(seconds, max(0.0, self._monotonic_clock() - started))
+            attempts[-1] = replace(attempts[-1], waited_seconds=waited)
+            tracker.waited_seconds += waited
+            raise
+        attempts[-1] = replace(attempts[-1], waited_seconds=seconds)
+        tracker.waited_seconds += seconds
 
     def _finish_execution_stop(
         self,
@@ -1469,6 +1482,7 @@ class BinanceRestPageAcquisition:
                     )
                 timeout_seconds = min(budget.timeout_seconds, tracker.remaining)
                 response_bytes = budget.maximum_response_bytes
+                allowance: BinancePublicHistoryHttpAllowance | None = None
                 try:
                     if execution_context is not None:
                         allowance = execution_context.begin_http_attempt(
@@ -1493,7 +1507,15 @@ class BinanceRestPageAcquisition:
                     else:
                         response = self._http_get(url, timeout_seconds, response_bytes)
                     if execution_context is not None:
-                        execution_context.record_response_bytes(len(response.body))
+                        settled_allowance = allowance
+                        if settled_allowance is None:
+                            raise AssertionError(
+                                "HTTP attempt allowance was not reserved"
+                            )
+                        execution_context.record_response_bytes(
+                            settled_allowance, len(response.body)
+                        )
+                        allowance = None
                         execution_context.check()
                 except BinancePublicHistoryExecutionStopped as stopped:
                     return self._finish_execution_stop(
@@ -1516,21 +1538,27 @@ class BinanceRestPageAcquisition:
                         raise AssertionError(
                             "cancellable REST transport requires an execution context"
                         ) from error
-                    if response is not None:
-                        try:
-                            execution_context.record_response_bytes(len(response.body))
-                        except BinancePublicHistoryExecutionStopped as stopped:
-                            return self._finish_execution_stop(
-                                stopped=stopped,
-                                request=request,
-                                current=current,
-                                pages=pages,
-                                attempts=attempts,
-                                tracker=tracker,
-                                cursor_ms=cursor_ms,
-                                response=response,
-                                http_started=True,
-                            )
+                    settled_allowance = allowance
+                    allowance = None
+                    if settled_allowance is None:
+                        raise AssertionError("HTTP attempt allowance was not reserved")
+                    try:
+                        execution_context.record_response_bytes(
+                            settled_allowance,
+                            len(response.body) if response is not None else 0,
+                        )
+                    except BinancePublicHistoryExecutionStopped as stopped:
+                        return self._finish_execution_stop(
+                            stopped=stopped,
+                            request=request,
+                            current=current,
+                            pages=pages,
+                            attempts=attempts,
+                            tracker=tracker,
+                            cursor_ms=cursor_ms,
+                            response=response,
+                            http_started=True,
+                        )
                     try:
                         execution_context.raise_stop(
                             BinancePublicHistoryExecutionStopReason.CANCELLED,
@@ -1559,6 +1587,13 @@ class BinanceRestPageAcquisition:
                         0.0, self._monotonic_clock() - started
                     )
                     if execution_context is not None:
+                        settled_allowance = allowance
+                        allowance = None
+                        if settled_allowance is None:
+                            raise AssertionError(
+                                "HTTP attempt allowance was not reserved"
+                            )
+                        execution_context.record_response_bytes(settled_allowance, 0)
                         try:
                             execution_context.check()
                         except BinancePublicHistoryExecutionStopped as stopped:
@@ -1648,7 +1683,12 @@ class BinanceRestPageAcquisition:
                             reason="retry wait cannot fit in the elapsed-time budget",
                         )
                     try:
-                        self._wait_for_retry(delay, execution_context)
+                        self._wait_for_retry(
+                            delay,
+                            execution_context,
+                            attempts=attempts,
+                            tracker=tracker,
+                        )
                     except BinancePublicHistoryExecutionStopped as stopped:
                         return self._finish_execution_stop(
                             stopped=stopped,
@@ -1683,8 +1723,11 @@ class BinanceRestPageAcquisition:
                             cursor_ms=cursor_ms,
                             reason=detail,
                         )
-                    tracker.waited_seconds += delay
                     continue
+                except BaseException:
+                    if execution_context is not None and allowance is not None:
+                        execution_context.record_response_bytes(allowance, 0)
+                    raise
                 else:
                     tracker.transport_seconds += max(
                         0.0, self._monotonic_clock() - started
@@ -1929,7 +1972,12 @@ class BinanceRestPageAcquisition:
                                 ),
                             )
                         try:
-                            self._wait_for_retry(retry_delay, execution_context)
+                            self._wait_for_retry(
+                                retry_delay,
+                                execution_context,
+                                attempts=attempts,
+                                tracker=tracker,
+                            )
                         except BinancePublicHistoryExecutionStopped as stopped:
                             return self._finish_execution_stop(
                                 stopped=stopped,
@@ -1964,7 +2012,6 @@ class BinanceRestPageAcquisition:
                                 cursor_ms=cursor_ms,
                                 reason=detail,
                             )
-                        tracker.waited_seconds += retry_delay
                         continue
 
                     if tracker.remaining <= 0:
@@ -2134,7 +2181,12 @@ class BinanceRestPageAcquisition:
                                 reason="retry wait cannot fit in the elapsed-time budget",
                             )
                         try:
-                            self._wait_for_retry(retry_delay, execution_context)
+                            self._wait_for_retry(
+                                retry_delay,
+                                execution_context,
+                                attempts=attempts,
+                                tracker=tracker,
+                            )
                         except BinancePublicHistoryExecutionStopped as stopped:
                             return self._finish_execution_stop(
                                 stopped=stopped,
@@ -2169,7 +2221,6 @@ class BinanceRestPageAcquisition:
                                 cursor_ms=cursor_ms,
                                 reason=detail,
                             )
-                        tracker.waited_seconds += retry_delay
                         response = None
                         continue
                     break

--- a/src/tracequant/data/binance_kline_rest.py
+++ b/src/tracequant/data/binance_kline_rest.py
@@ -38,6 +38,8 @@ from tracequant.data.binance_public_history_execution import (
     BinancePublicHistoryExecutionStopped,
     BinancePublicHistoryExecutionStopReason,
     BinancePublicHistoryHttpAllowance,
+    _ControlledTransportInterrupted,
+    _run_controlled_transport,
 )
 from tracequant.data.public_history import (
     BinanceKlineInterval,
@@ -452,6 +454,7 @@ def _default_http_get(
 ) -> BinanceKlineRestHttpResponse:
     """Read one response in a worker that cannot outlive the attempt deadline."""
     with tempfile.TemporaryFile() as output:
+        deadline = time.monotonic() + timeout
         process = subprocess.Popen(
             [
                 sys.executable,
@@ -464,7 +467,6 @@ def _default_http_get(
             stdout=output,
             stderr=subprocess.DEVNULL,
         )
-        deadline = time.monotonic() + timeout
         interruption: str | None = None
         try:
             while process.poll() is None:
@@ -1504,6 +1506,21 @@ class BinanceRestPageAcquisition:
                             response_bytes,
                             cancelled=execution_context.cancellation_requested,
                         )
+                    elif execution_context is not None:
+                        controlled = _run_controlled_transport(
+                            self._http_get,
+                            (url, timeout_seconds, response_bytes),
+                            timeout_seconds=timeout_seconds,
+                            maximum_response_bytes=response_bytes,
+                            cancelled=execution_context.cancellation_requested,
+                            label="REST",
+                        )
+                        response = BinanceKlineRestHttpResponse(
+                            controlled.status,
+                            controlled.body,
+                            controlled.headers,
+                            complete=controlled.complete,
+                        )
                     else:
                         response = self._http_get(url, timeout_seconds, response_bytes)
                     if execution_context is not None:
@@ -1529,7 +1546,10 @@ class BinanceRestPageAcquisition:
                         response=response,
                         http_started=response is not None,
                     )
-                except _RestTransportInterrupted as error:
+                except (
+                    _RestTransportInterrupted,
+                    _ControlledTransportInterrupted,
+                ) as error:
                     tracker.transport_seconds += max(
                         0.0, self._monotonic_clock() - started
                     )

--- a/src/tracequant/data/binance_mark_price_kline.py
+++ b/src/tracequant/data/binance_mark_price_kline.py
@@ -27,6 +27,9 @@ from tracequant.data.binance_public_archive import (
     _coverage_gap,
     _invalid_content,
 )
+from tracequant.data.binance_public_history_execution import (
+    BinancePublicHistoryExecutionContext,
+)
 from tracequant.data.public_history import (
     BinanceArchiveObjectBoundary,
     BinanceKlineInterval,
@@ -463,16 +466,21 @@ class BinanceMarkPriceKlineBackfill:
         )
 
     def run(
-        self, instrument: InstrumentId, request_range: TimeRange
+        self,
+        instrument: InstrumentId,
+        request_range: TimeRange,
+        execution_context: BinancePublicHistoryExecutionContext | None = None,
     ) -> BinanceMarkPriceKlineRunResult:
         plans = plan_binance_mark_price_kline_archives(instrument, request_range)
-        results = tuple(self._process(plan) for plan in plans)
+        results = tuple(self._process(plan, execution_context) for plan in plans)
         return BinanceMarkPriceKlineRunResult(
             request_range=request_range, objects=results
         )
 
     def _process(
-        self, plan: BinanceMarkPriceKlinePlan
+        self,
+        plan: BinanceMarkPriceKlinePlan,
+        execution_context: BinancePublicHistoryExecutionContext | None = None,
     ) -> BinanceMarkPriceKlineObjectResult:
         if isinstance(plan, BinanceMarkPriceKlineCoverageGapPlan):
             outcome = self._acquisition.record_failure(
@@ -481,7 +489,12 @@ class BinanceMarkPriceKlineBackfill:
                 plan.detail,
             )
         else:
-            outcome = self._acquisition.acquire(plan, _MarkPriceKlineArchiveAdapter())
+            adapter = _MarkPriceKlineArchiveAdapter()
+            outcome = (
+                self._acquisition.acquire(plan, adapter)
+                if execution_context is None
+                else self._acquisition.acquire(plan, adapter, execution_context)
+            )
         return BinanceMarkPriceKlineObjectResult(
             plan,
             outcome.status,

--- a/src/tracequant/data/binance_public_archive.py
+++ b/src/tracequant/data/binance_public_archive.py
@@ -12,8 +12,13 @@ import csv
 import hashlib
 import http.client
 import io
+import json
 import math
 import re
+import subprocess
+import sys
+import tempfile
+import time
 import urllib.error
 import urllib.request
 import zipfile
@@ -26,6 +31,11 @@ from typing import Final, Protocol
 
 import polars as pl
 
+from tracequant.data.binance_public_history_execution import (
+    BinancePublicHistoryExecutionContext,
+    BinancePublicHistoryExecutionStopped,
+    BinancePublicHistoryExecutionStopReason,
+)
 from tracequant.data.public_history import (
     BinancePublicHistoryRequest,
     BinancePublicHistorySourceKind,
@@ -43,6 +53,7 @@ from tracequant.data.raw_store import (
     RawSourceObject,
     RawSourceProvenance,
     RawStore,
+    RawStoreError,
 )
 from tracequant.domain import TimeRange
 
@@ -71,6 +82,17 @@ class ArchiveHttpResponse:
     status: int
     body: bytes
     headers: Mapping[str, str]
+    complete: bool = True
+
+    def __post_init__(self) -> None:
+        if type(self.status) is not int or not 100 <= self.status <= 599:
+            raise ValueError("status must be an HTTP status code")
+        if not isinstance(self.body, bytes):
+            raise TypeError("body must be bytes")
+        if not isinstance(self.headers, Mapping):
+            raise TypeError("headers must be a mapping")
+        if not isinstance(self.complete, bool):
+            raise TypeError("complete must be a bool")
 
 
 class ArchiveHttpGet(Protocol):
@@ -137,6 +159,8 @@ class BinanceArchiveAcquisitionStatus(StrEnum):
     NOT_FOUND = "not_found"
     CHECKSUM_NOT_FOUND = "checksum_not_found"
     RETRYABLE_FAILURE = "retryable_failure"
+    BUDGET_EXHAUSTED = "budget_exhausted"
+    CANCELLED = "cancelled"
     INVALID_CONTENT = "invalid_content"
     LOCAL_FAILURE = "local_failure"
     CONFLICT = "conflict"
@@ -184,6 +208,34 @@ class _RetryableDownloadError(RuntimeError):
         self.response = response
 
 
+class _ExecutionDownloadError(RuntimeError):
+    def __init__(
+        self,
+        stopped: BinancePublicHistoryExecutionStopped,
+        *,
+        resource: str,
+        response: ArchiveHttpResponse | None = None,
+    ) -> None:
+        super().__init__(str(stopped))
+        self.stopped = stopped
+        self.resource = resource
+        self.response = response
+
+
+class _ArchiveTransportInterrupted(InterruptedError):
+    def __init__(
+        self, message: str, *, response: ArchiveHttpResponse | None = None
+    ) -> None:
+        super().__init__(message)
+        self.response = response
+
+
+class _RecordedLocalFailure(RuntimeError):
+    def __init__(self, outcome: BinanceArchiveAcquisitionOutcome) -> None:
+        super().__init__(outcome.detail)
+        self.outcome = outcome
+
+
 @dataclass(frozen=True, slots=True)
 class _DownloadedResponse:
     body: bytes
@@ -204,26 +256,215 @@ class _DownloadNotFoundError(FileNotFoundError):
         self.response = response
 
 
-def _default_http_get(url: str, timeout: float) -> ArchiveHttpResponse:
+def _urllib_http_get(
+    url: str,
+    timeout: float,
+    *,
+    maximum_response_bytes: int | None = None,
+    progress: Callable[[str, int, Mapping[str, str], bytes], None] | None = None,
+) -> ArchiveHttpResponse:
+    limit = (
+        _MAX_ARCHIVE_BYTES
+        if maximum_response_bytes is None
+        else min(maximum_response_bytes, _MAX_ARCHIVE_BYTES)
+    )
+
+    def consume(
+        stream: object,
+        status: int,
+        headers: Mapping[str, str],
+        *,
+        body_limit: int = limit,
+    ) -> ArchiveHttpResponse:
+        if progress is not None:
+            progress("start", status, headers, b"")
+        body = bytearray()
+        while len(body) <= body_limit:
+            amount = min(64 * 1024, body_limit + 1 - len(body))
+            if amount <= 0:
+                break
+            try:
+                read1 = getattr(stream, "read1", None)
+                chunk = (
+                    read1(amount)
+                    if callable(read1)
+                    else getattr(stream, "read")(amount)
+                )
+            except http.client.IncompleteRead as error:
+                chunk = bytes(error.partial)[:amount]
+                if chunk:
+                    body.extend(chunk)
+                    if progress is not None:
+                        progress("body", status, headers, chunk)
+                return ArchiveHttpResponse(status, bytes(body), headers, complete=False)
+            except (TimeoutError, OSError, http.client.HTTPException):
+                return ArchiveHttpResponse(status, bytes(body), headers, complete=False)
+            if not isinstance(chunk, bytes):
+                raise TypeError("HTTP response body reader must return bytes")
+            if not chunk:
+                remaining = getattr(stream, "length", None)
+                complete = not (type(remaining) is int and remaining > 0)
+                return ArchiveHttpResponse(
+                    status, bytes(body), headers, complete=complete
+                )
+            body.extend(chunk)
+            if progress is not None:
+                progress("body", status, headers, chunk)
+        return ArchiveHttpResponse(status, bytes(body), headers, complete=False)
+
     request = urllib.request.Request(url, headers={"User-Agent": _PRODUCER_VERSION})
     try:
         with urllib.request.urlopen(request, timeout=timeout) as response:
-            body = response.read(_MAX_ARCHIVE_BYTES + 1)
-            if len(body) > _MAX_ARCHIVE_BYTES:
-                raise _InvalidContentError("archive response exceeds the size limit")
-            return ArchiveHttpResponse(
-                status=response.status,
-                body=body,
-                headers=dict(response.headers.items()),
+            return consume(
+                response,
+                response.status,
+                dict(response.headers.items()),
             )
     except urllib.error.HTTPError as error:
-        return ArchiveHttpResponse(
-            status=error.code,
-            body=error.read(4096),
-            headers=dict(error.headers.items()) if error.headers is not None else {},
-        )
+        try:
+            return consume(
+                error,
+                error.code,
+                dict(error.headers.items()) if error.headers is not None else {},
+                body_limit=min(limit, 4096),
+            )
+        finally:
+            error.close()
     except (TimeoutError, urllib.error.URLError):
         raise
+
+
+def _terminate_http_worker(process: subprocess.Popen[bytes]) -> None:
+    if process.poll() is None:
+        process.kill()
+    process.wait()
+
+
+def _archive_worker_response(
+    body_path: Path,
+    metadata_path: Path,
+    result_path: Path,
+    maximum_response_bytes: int | None,
+    *,
+    allow_partial: bool,
+) -> ArchiveHttpResponse:
+    payload_path = result_path if result_path.is_file() else metadata_path
+    if not payload_path.is_file():
+        raise OSError("archive HTTP worker exited without a valid result")
+    try:
+        payload = json.loads(payload_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise OSError("archive HTTP worker returned an invalid result") from error
+    if payload.get("kind") == "failure":
+        detail = str(payload.get("detail", "archive HTTP worker failed"))
+        raise OSError(detail)
+    try:
+        status = payload["status"]
+        headers = payload["headers"]
+        complete = payload.get("complete", False)
+    except KeyError as error:
+        raise OSError("archive HTTP worker returned an invalid result") from error
+    if (
+        type(status) is not int
+        or not isinstance(headers, dict)
+        or not isinstance(complete, bool)
+        or any(
+            not isinstance(name, str) or not isinstance(value, str)
+            for name, value in headers.items()
+        )
+    ):
+        raise OSError("archive HTTP worker returned an invalid result")
+    try:
+        body = body_path.read_bytes() if body_path.is_file() else b""
+    except OSError as error:
+        raise OSError("archive HTTP worker response body is unreadable") from error
+    limit = (
+        _MAX_ARCHIVE_BYTES
+        if maximum_response_bytes is None
+        else min(maximum_response_bytes, _MAX_ARCHIVE_BYTES)
+    )
+    if len(body) > limit + 1:
+        raise OSError("archive HTTP worker exceeded its bounded response size")
+    return ArchiveHttpResponse(
+        status=status,
+        body=body,
+        headers=headers,
+        complete=complete and not allow_partial,
+    )
+
+
+def _default_http_get(
+    url: str,
+    timeout: float,
+    *,
+    maximum_response_bytes: int | None = None,
+    cancelled: Callable[[], bool] | None = None,
+) -> ArchiveHttpResponse:
+    """Read one response in a process that cannot outlive its absolute timeout."""
+    with tempfile.TemporaryDirectory(prefix="tracequant-archive-http-") as directory:
+        root = Path(directory)
+        body_path = root / "body.bin"
+        metadata_path = root / "metadata.json"
+        result_path = root / "result.json"
+        process = subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "tracequant.data._binance_archive_http_worker",
+                url,
+                repr(timeout),
+                (
+                    "none"
+                    if maximum_response_bytes is None
+                    else str(maximum_response_bytes)
+                ),
+                str(body_path),
+                str(metadata_path),
+                str(result_path),
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        deadline = time.monotonic() + timeout
+        interruption: str | None = None
+        try:
+            while process.poll() is None:
+                if cancelled is not None and cancelled():
+                    interruption = "archive HTTP attempt was cancelled"
+                    break
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    interruption = "archive HTTP attempt exceeded its absolute elapsed-time deadline"
+                    break
+                try:
+                    process.wait(timeout=min(0.05, remaining))
+                except subprocess.TimeoutExpired:
+                    continue
+        except BaseException:
+            _terminate_http_worker(process)
+            raise
+        if interruption is not None:
+            _terminate_http_worker(process)
+            try:
+                response = _archive_worker_response(
+                    body_path,
+                    metadata_path,
+                    result_path,
+                    maximum_response_bytes,
+                    allow_partial=True,
+                )
+            except OSError:
+                response = None
+            raise _ArchiveTransportInterrupted(interruption, response=response)
+        if process.returncode != 0:
+            raise OSError("archive HTTP worker exited without a valid result")
+        return _archive_worker_response(
+            body_path,
+            metadata_path,
+            result_path,
+            maximum_response_bytes,
+            allow_partial=False,
+        )
 
 
 def _download(
@@ -261,6 +502,16 @@ def _download(
         )
     if not response.body:
         raise _InvalidContentError(f"empty response for {url}", response=response)
+    if not response.complete:
+        if len(response.body) > _MAX_ARCHIVE_BYTES:
+            raise _InvalidContentError(
+                "archive response exceeds the size limit", response=response
+            )
+        raise _RetryableDownloadError(
+            f"incomplete response for {url}",
+            resource=resource,
+            response=response,
+        )
     return _DownloadedResponse(
         body=response.body,
         status=response.status,
@@ -319,6 +570,7 @@ class BinancePublicArchiveAcquisition:
             raise ValueError("timeout must be finite and greater than zero")
         self._store = store
         self._http_get = http_get or _default_http_get
+        self._uses_default_http_get = http_get is None
         self._timeout = timeout
         self._clock = clock or (lambda: datetime.now(UTC))
 
@@ -376,11 +628,19 @@ class BinancePublicArchiveAcquisition:
                 checksum_response.body_sha256 if checksum_response is not None else None
             ),
         )
-        self._store.write_acquisition_manifest(
-            manifest,
-            source_response=source_response,
-            checksum_response=checksum_response,
-        )
+        try:
+            self._store.write_acquisition_manifest(
+                manifest,
+                source_response=source_response,
+                checksum_response=checksum_response,
+            )
+        except (RawStoreError, OSError, ValueError) as error:
+            return BinanceArchiveAcquisitionOutcome(
+                status=BinanceArchiveAcquisitionStatus.LOCAL_FAILURE,
+                artifact_path=artifact_path,
+                detail=f"failed to persist acquisition evidence: {error}",
+                actual_record_range=actual_record_range,
+            )
         return BinanceArchiveAcquisitionOutcome(
             status=status,
             artifact_path=artifact_path,
@@ -460,14 +720,157 @@ class BinancePublicArchiveAcquisition:
                     )
         return existing, None
 
+    @staticmethod
+    def _execution_status(
+        stopped: BinancePublicHistoryExecutionStopped,
+    ) -> BinanceArchiveAcquisitionStatus:
+        if stopped.reason is BinancePublicHistoryExecutionStopReason.CANCELLED:
+            return BinanceArchiveAcquisitionStatus.CANCELLED
+        return BinanceArchiveAcquisitionStatus.BUDGET_EXHAUSTED
+
+    def _controlled_download(
+        self,
+        plan: BinanceArchiveObjectPlan,
+        url: str,
+        *,
+        resource: str,
+        execution_context: BinancePublicHistoryExecutionContext,
+    ) -> _DownloadedResponse:
+        request_key = f"archive:{plan.object_key}:{resource}"
+        while True:
+            try:
+                allowance = execution_context.begin_http_attempt(
+                    request_key, timeout_seconds=self._timeout
+                )
+            except BinancePublicHistoryExecutionStopped as stopped:
+                raise _ExecutionDownloadError(stopped, resource=resource) from stopped
+            response: ArchiveHttpResponse | None = None
+            try:
+                if self._uses_default_http_get:
+                    response = _default_http_get(
+                        url,
+                        allowance.timeout_seconds,
+                        maximum_response_bytes=allowance.maximum_response_bytes,
+                        cancelled=execution_context.cancellation_requested,
+                    )
+                else:
+                    response = self._http_get(url, allowance.timeout_seconds)
+            except _ArchiveTransportInterrupted as error:
+                response = error.response
+                if response is not None:
+                    try:
+                        execution_context.record_response_bytes(len(response.body))
+                    except BinancePublicHistoryExecutionStopped as stopped:
+                        raise _ExecutionDownloadError(
+                            stopped, resource=resource, response=response
+                        ) from stopped
+                try:
+                    execution_context.check()
+                except BinancePublicHistoryExecutionStopped as stopped:
+                    raise _ExecutionDownloadError(
+                        stopped, resource=resource, response=response
+                    ) from stopped
+                retryable = _RetryableDownloadError(
+                    str(error), resource=resource, response=response
+                )
+            except (
+                TimeoutError,
+                ConnectionError,
+                OSError,
+                http.client.HTTPException,
+            ) as error:
+                try:
+                    execution_context.check()
+                except BinancePublicHistoryExecutionStopped as stopped:
+                    raise _ExecutionDownloadError(
+                        stopped, resource=resource
+                    ) from stopped
+                detail = str(error).strip() or type(error).__name__
+                retryable = _RetryableDownloadError(detail, resource=resource)
+            else:
+                try:
+                    execution_context.record_response_bytes(len(response.body))
+                    execution_context.check()
+                except BinancePublicHistoryExecutionStopped as stopped:
+                    raise _ExecutionDownloadError(
+                        stopped, resource=resource, response=response
+                    ) from stopped
+                try:
+                    return _download(
+                        lambda unused_url, unused_timeout: response,
+                        url,
+                        allowance.timeout_seconds,
+                        resource=resource,
+                    )
+                except _RetryableDownloadError as error:
+                    retryable = error
+
+            recorded = self.record_failure(
+                plan.request,
+                BinanceArchiveAcquisitionStatus.RETRYABLE_FAILURE,
+                str(retryable),
+                source_url=plan.url,
+                checksum_url=plan.checksum_url,
+                source_response=(
+                    self._to_raw_response(retryable.response)
+                    if resource == "archive"
+                    else None
+                ),
+                checksum_response=(
+                    self._to_raw_response(retryable.response)
+                    if resource == "checksum"
+                    else None
+                ),
+            )
+            if recorded.status is BinanceArchiveAcquisitionStatus.LOCAL_FAILURE:
+                raise _RecordedLocalFailure(recorded)
+            if (
+                allowance.request_attempt_number
+                >= execution_context.limits.maximum_attempts_per_request
+            ):
+                try:
+                    execution_context.raise_stop(
+                        BinancePublicHistoryExecutionStopReason.REQUEST_ATTEMPTS_EXHAUSTED,
+                        "maximum_attempts_per_request exhausted",
+                    )
+                except BinancePublicHistoryExecutionStopped as stopped:
+                    raise _ExecutionDownloadError(
+                        stopped, resource=resource, response=retryable.response
+                    ) from retryable
+            delay = float(min(2 ** (allowance.request_attempt_number - 1), 60))
+            try:
+                execution_context.wait_for_retry(delay)
+            except BinancePublicHistoryExecutionStopped as stopped:
+                raise _ExecutionDownloadError(
+                    stopped, resource=resource, response=retryable.response
+                ) from stopped
+
     def acquire(
         self,
         plan: BinanceArchiveObjectPlan,
         adapter: BinanceArchiveDatasetAdapter,
+        execution_context: BinancePublicHistoryExecutionContext | None = None,
     ) -> BinanceArchiveAcquisitionOutcome:
         """Download, verify, parse, and revision-aware publish one object."""
         if not isinstance(plan, BinanceArchiveObjectPlan):
             raise TypeError("plan must be a BinanceArchiveObjectPlan")
+        if execution_context is not None and not isinstance(
+            execution_context, BinancePublicHistoryExecutionContext
+        ):
+            raise TypeError(
+                "execution_context must be BinancePublicHistoryExecutionContext"
+            )
+        if execution_context is not None:
+            try:
+                execution_context.begin_archive_object()
+            except BinancePublicHistoryExecutionStopped as stopped:
+                return self.record_failure(
+                    plan.request,
+                    self._execution_status(stopped),
+                    str(stopped),
+                    source_url=plan.url,
+                    checksum_url=plan.checksum_url,
+                )
         existing, early = self._existing_artifact(plan, adapter)
         if early is not None:
             return early
@@ -478,21 +881,39 @@ class BinancePublicArchiveAcquisition:
         archive_response: RawAcquisitionResponse | None = None
         resource = "checksum"
         try:
-            checksum_payload = _download(
-                self._http_get,
-                plan.checksum_url,
-                self._timeout,
-                resource="checksum",
+            checksum_payload = (
+                _download(
+                    self._http_get,
+                    plan.checksum_url,
+                    self._timeout,
+                    resource="checksum",
+                )
+                if execution_context is None
+                else self._controlled_download(
+                    plan,
+                    plan.checksum_url,
+                    resource="checksum",
+                    execution_context=execution_context,
+                )
             )
             declared = _declared_checksum(
                 checksum_payload.body, plan.url.rsplit("/", 1)[-1]
             )
             resource = "archive"
-            archive_payload = _download(
-                self._http_get,
-                plan.url,
-                self._timeout,
-                resource="archive",
+            archive_payload = (
+                _download(
+                    self._http_get,
+                    plan.url,
+                    self._timeout,
+                    resource="archive",
+                )
+                if execution_context is None
+                else self._controlled_download(
+                    plan,
+                    plan.url,
+                    resource="archive",
+                    execution_context=execution_context,
+                )
             )
             actual = hashlib.sha256(archive_payload.body).hexdigest()
             if actual != declared:
@@ -501,6 +922,20 @@ class BinancePublicArchiveAcquisition:
                 )
             member_payload = _extract_expected_member(plan, archive_payload.body)
             parsed = adapter.parse_member(plan, member_payload)
+            if execution_context is not None:
+                try:
+                    execution_context.check()
+                except BinancePublicHistoryExecutionStopped as stopped:
+                    return self.record_failure(
+                        plan.request,
+                        self._execution_status(stopped),
+                        str(stopped),
+                        source_url=plan.url,
+                        checksum_url=plan.checksum_url,
+                        source_response=self._to_raw_response(archive_payload),
+                        checksum_response=self._to_raw_response(checksum_payload),
+                        actual_record_range=parsed.actual_record_range,
+                    )
             source = RawSourceObject(
                 request=plan.request,
                 rows=parsed.rows,
@@ -547,6 +982,21 @@ class BinancePublicArchiveAcquisition:
             else:
                 matching_existing = existing
             artifact = self._store.write(source)
+            if execution_context is not None:
+                try:
+                    execution_context.check()
+                except BinancePublicHistoryExecutionStopped as stopped:
+                    return self.record_failure(
+                        plan.request,
+                        self._execution_status(stopped),
+                        f"{stopped}; completed archive object was preserved",
+                        source_url=plan.url,
+                        checksum_url=plan.checksum_url,
+                        artifact_path=artifact.path,
+                        source_response=self._to_raw_response(archive_payload),
+                        checksum_response=self._to_raw_response(checksum_payload),
+                        actual_record_range=parsed.actual_record_range,
+                    )
         except _DownloadNotFoundError as error:
             if error.resource == "checksum":
                 checksum_response = self._to_raw_response(error.response)
@@ -575,6 +1025,24 @@ class BinancePublicArchiveAcquisition:
             return self.record_failure(
                 plan.request,
                 BinanceArchiveAcquisitionStatus.RETRYABLE_FAILURE,
+                str(error),
+                source_url=plan.url,
+                checksum_url=plan.checksum_url,
+                source_response=self._to_raw_response(archive_payload)
+                or archive_response,
+                checksum_response=self._to_raw_response(checksum_payload)
+                or checksum_response,
+            )
+        except _RecordedLocalFailure as error:
+            return error.outcome
+        except _ExecutionDownloadError as error:
+            if error.resource == "checksum":
+                checksum_response = self._to_raw_response(error.response)
+            else:
+                archive_response = self._to_raw_response(error.response)
+            return self.record_failure(
+                plan.request,
+                self._execution_status(error.stopped),
                 str(error),
                 source_url=plan.url,
                 checksum_url=plan.checksum_url,

--- a/src/tracequant/data/binance_public_archive.py
+++ b/src/tracequant/data/binance_public_archive.py
@@ -757,13 +757,14 @@ class BinancePublicArchiveAcquisition:
                     response = self._http_get(url, allowance.timeout_seconds)
             except _ArchiveTransportInterrupted as error:
                 response = error.response
-                if response is not None:
-                    try:
-                        execution_context.record_response_bytes(len(response.body))
-                    except BinancePublicHistoryExecutionStopped as stopped:
-                        raise _ExecutionDownloadError(
-                            stopped, resource=resource, response=response
-                        ) from stopped
+                try:
+                    execution_context.record_response_bytes(
+                        allowance, len(response.body) if response is not None else 0
+                    )
+                except BinancePublicHistoryExecutionStopped as stopped:
+                    raise _ExecutionDownloadError(
+                        stopped, resource=resource, response=response
+                    ) from stopped
                 try:
                     execution_context.check()
                 except BinancePublicHistoryExecutionStopped as stopped:
@@ -779,6 +780,7 @@ class BinancePublicArchiveAcquisition:
                 OSError,
                 http.client.HTTPException,
             ) as error:
+                execution_context.record_response_bytes(allowance, 0)
                 try:
                     execution_context.check()
                 except BinancePublicHistoryExecutionStopped as stopped:
@@ -787,9 +789,14 @@ class BinancePublicArchiveAcquisition:
                     ) from stopped
                 detail = str(error).strip() or type(error).__name__
                 retryable = _RetryableDownloadError(detail, resource=resource)
+            except BaseException:
+                execution_context.record_response_bytes(allowance, 0)
+                raise
             else:
                 try:
-                    execution_context.record_response_bytes(len(response.body))
+                    execution_context.record_response_bytes(
+                        allowance, len(response.body)
+                    )
                     execution_context.check()
                 except BinancePublicHistoryExecutionStopped as stopped:
                     raise _ExecutionDownloadError(

--- a/src/tracequant/data/binance_public_archive.py
+++ b/src/tracequant/data/binance_public_archive.py
@@ -35,6 +35,8 @@ from tracequant.data.binance_public_history_execution import (
     BinancePublicHistoryExecutionContext,
     BinancePublicHistoryExecutionStopped,
     BinancePublicHistoryExecutionStopReason,
+    _ControlledTransportInterrupted,
+    _run_controlled_transport,
 )
 from tracequant.data.public_history import (
     BinancePublicHistoryRequest,
@@ -406,6 +408,7 @@ def _default_http_get(
         body_path = root / "body.bin"
         metadata_path = root / "metadata.json"
         result_path = root / "result.json"
+        deadline = time.monotonic() + timeout
         process = subprocess.Popen(
             [
                 sys.executable,
@@ -425,7 +428,6 @@ def _default_http_get(
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )
-        deadline = time.monotonic() + timeout
         interruption: str | None = None
         try:
             while process.poll() is None:
@@ -754,8 +756,24 @@ class BinancePublicArchiveAcquisition:
                         cancelled=execution_context.cancellation_requested,
                     )
                 else:
-                    response = self._http_get(url, allowance.timeout_seconds)
-            except _ArchiveTransportInterrupted as error:
+                    controlled = _run_controlled_transport(
+                        self._http_get,
+                        (url, allowance.timeout_seconds),
+                        timeout_seconds=allowance.timeout_seconds,
+                        maximum_response_bytes=allowance.maximum_response_bytes,
+                        cancelled=execution_context.cancellation_requested,
+                        label="archive",
+                    )
+                    response = ArchiveHttpResponse(
+                        controlled.status,
+                        controlled.body,
+                        controlled.headers,
+                        complete=controlled.complete,
+                    )
+            except (
+                _ArchiveTransportInterrupted,
+                _ControlledTransportInterrupted,
+            ) as error:
                 response = error.response
                 try:
                     execution_context.record_response_bytes(

--- a/src/tracequant/data/binance_public_history_execution.py
+++ b/src/tracequant/data/binance_public_history_execution.py
@@ -145,8 +145,11 @@ class BinancePublicHistoryExecutionContext:
         self._monotonic_clock = monotonic_clock or time.monotonic
         self._sleeper = sleeper or time.sleep
         self._lock = threading.Lock()
+        self._attempt_condition = threading.Condition(self._lock)
         self._http_attempts = 0
         self._response_bytes = 0
+        self._reserved_response_bytes = 0
+        self._response_byte_reservations: dict[int, int] = {}
         self._archive_objects = 0
         self._rest_pages = 0
         self._request_attempts: dict[str, int] = {}
@@ -245,50 +248,74 @@ class BinancePublicHistoryExecutionContext:
             raise TypeError("timeout_seconds must be a number")
         if not math.isfinite(timeout_seconds) or timeout_seconds <= 0:
             raise ValueError("timeout_seconds must be finite and greater than zero")
-        cancelled = self.cancellation_requested()
-        now = self._now()
-        with self._lock:
-            self._check_control_locked(now, cancelled)
-            if self._http_attempts >= self._limits.maximum_http_attempts:
-                raise self._stop(
-                    BinancePublicHistoryExecutionStopReason.HTTP_ATTEMPTS_EXHAUSTED,
-                    "maximum_http_attempts exhausted",
+        while True:
+            cancelled = self.cancellation_requested()
+            now = self._now()
+            with self._attempt_condition:
+                self._check_control_locked(now, cancelled)
+                if self._response_byte_reservations:
+                    self._attempt_condition.wait(
+                        timeout=min(0.05, self._limits.deadline_monotonic - now)
+                    )
+                    continue
+                if self._http_attempts >= self._limits.maximum_http_attempts:
+                    raise self._stop(
+                        BinancePublicHistoryExecutionStopReason.HTTP_ATTEMPTS_EXHAUSTED,
+                        "maximum_http_attempts exhausted",
+                    )
+                request_attempts = self._request_attempts.get(request_key, 0)
+                if request_attempts >= self._limits.maximum_attempts_per_request:
+                    raise self._stop(
+                        BinancePublicHistoryExecutionStopReason.REQUEST_ATTEMPTS_EXHAUSTED,
+                        "maximum_attempts_per_request exhausted",
+                    )
+                remaining_bytes = (
+                    self._limits.maximum_total_response_bytes
+                    - self._response_bytes
+                    - self._reserved_response_bytes
                 )
-            request_attempts = self._request_attempts.get(request_key, 0)
-            if request_attempts >= self._limits.maximum_attempts_per_request:
-                raise self._stop(
-                    BinancePublicHistoryExecutionStopReason.REQUEST_ATTEMPTS_EXHAUSTED,
-                    "maximum_attempts_per_request exhausted",
+                if remaining_bytes <= 0:
+                    raise self._stop(
+                        BinancePublicHistoryExecutionStopReason.TOTAL_RESPONSE_BYTES_EXHAUSTED,
+                        "maximum_total_response_bytes exhausted",
+                    )
+                self._http_attempts += 1
+                request_attempts += 1
+                self._request_attempts[request_key] = request_attempts
+                allowance = BinancePublicHistoryHttpAllowance(
+                    timeout_seconds=min(
+                        float(timeout_seconds), self._limits.deadline_monotonic - now
+                    ),
+                    maximum_response_bytes=min(
+                        self._limits.maximum_response_bytes, remaining_bytes
+                    ),
+                    attempt_number=self._http_attempts,
+                    request_attempt_number=request_attempts,
                 )
-            remaining_bytes = (
-                self._limits.maximum_total_response_bytes - self._response_bytes
-            )
-            if remaining_bytes <= 0:
-                raise self._stop(
-                    BinancePublicHistoryExecutionStopReason.TOTAL_RESPONSE_BYTES_EXHAUSTED,
-                    "maximum_total_response_bytes exhausted",
+                self._reserved_response_bytes += allowance.maximum_response_bytes
+                self._response_byte_reservations[allowance.attempt_number] = (
+                    allowance.maximum_response_bytes
                 )
-            self._http_attempts += 1
-            request_attempts += 1
-            self._request_attempts[request_key] = request_attempts
-            return BinancePublicHistoryHttpAllowance(
-                timeout_seconds=min(
-                    float(timeout_seconds), self._limits.deadline_monotonic - now
-                ),
-                maximum_response_bytes=min(
-                    self._limits.maximum_response_bytes, remaining_bytes
-                ),
-                attempt_number=self._http_attempts,
-                request_attempt_number=request_attempts,
-            )
+                return allowance
 
-    def record_response_bytes(self, amount: int) -> None:
-        """Charge bytes actually returned/read, including a one-byte overflow probe."""
+    def record_response_bytes(
+        self, allowance: BinancePublicHistoryHttpAllowance, amount: int
+    ) -> None:
+        """Settle one attempt's reservation with bytes actually returned/read."""
+        if not isinstance(allowance, BinancePublicHistoryHttpAllowance):
+            raise TypeError("allowance must be BinancePublicHistoryHttpAllowance")
         if type(amount) is not int:
             raise TypeError("amount must be an integer")
         if amount < 0:
             raise ValueError("amount must not be negative")
-        with self._lock:
+        with self._attempt_condition:
+            reserved = self._response_byte_reservations.pop(
+                allowance.attempt_number, None
+            )
+            if reserved is None or reserved != allowance.maximum_response_bytes:
+                raise ValueError("allowance is not an outstanding reservation")
+            self._reserved_response_bytes -= reserved
+            self._attempt_condition.notify_all()
             self._response_bytes += amount
             if amount > self._limits.maximum_response_bytes:
                 raise self._stop(

--- a/src/tracequant/data/binance_public_history_execution.py
+++ b/src/tracequant/data/binance_public_history_execution.py
@@ -7,12 +7,20 @@ or orchestrating fallback between them.
 
 from __future__ import annotations
 
+import json
 import math
+import multiprocessing
+import os
+import signal
+import tempfile
 import threading
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import StrEnum
+from multiprocessing.process import BaseProcess
+from pathlib import Path
+from types import MappingProxyType
 from typing import Never
 
 __all__ = [
@@ -24,6 +32,204 @@ __all__ = [
     "BinancePublicHistoryHttpAllowance",
     "BinancePublicHistoryRequestAttempts",
 ]
+
+
+@dataclass(frozen=True, slots=True)
+class _ControlledHttpResponse:
+    status: int
+    body: bytes
+    headers: MappingProxyType[str, str]
+    complete: bool
+
+
+class _ControlledTransportInterrupted(InterruptedError):
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.response: None = None
+
+
+def _controlled_transport_worker(
+    ready_path: Path,
+    body_path: Path,
+    result_path: Path,
+    transport: Callable[..., object],
+    arguments: tuple[object, ...],
+    maximum_response_bytes: int,
+) -> None:
+    """Run an injected transport in an independently terminable process."""
+    try:
+        os.setsid()
+        ready_path.touch()
+        response = transport(*arguments)
+        status = getattr(response, "status")
+        body = getattr(response, "body")
+        headers = getattr(response, "headers")
+        complete = getattr(response, "complete")
+        if type(status) is not int or not 100 <= status <= 599:
+            raise ValueError("status must be an HTTP status code")
+        if not isinstance(body, bytes):
+            raise TypeError("body must be bytes")
+        if not isinstance(headers, dict) and not hasattr(headers, "items"):
+            raise TypeError("headers must be a mapping")
+        normalized_headers = dict(headers.items())
+        if any(
+            not isinstance(name, str) or not isinstance(value, str)
+            for name, value in normalized_headers.items()
+        ):
+            raise TypeError("HTTP header names and values must be strings")
+        if not isinstance(complete, bool):
+            raise TypeError("complete must be a bool")
+        bounded_body = body[: maximum_response_bytes + 1]
+        body_path.write_bytes(bounded_body)
+        result_path.write_text(
+            json.dumps(
+                {
+                    "kind": "response",
+                    "status": status,
+                    "headers": normalized_headers,
+                    "complete": complete and len(body) <= maximum_response_bytes,
+                },
+                sort_keys=True,
+            ),
+            encoding="utf-8",
+        )
+    except BaseException as error:
+        try:
+            result_path.write_text(
+                json.dumps(
+                    {
+                        "kind": "failure",
+                        "error_type": type(error).__name__,
+                        "detail": str(error).strip() or type(error).__name__,
+                    },
+                    sort_keys=True,
+                ),
+                encoding="utf-8",
+            )
+        except BaseException:
+            return
+
+
+def _terminate_controlled_transport(
+    process: BaseProcess, *, session_ready: bool
+) -> None:
+    if process.is_alive():
+        if session_ready:
+            process_id = process.pid
+            if process_id is None:
+                raise RuntimeError("started controlled transport has no process id")
+            try:
+                os.killpg(process_id, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+        else:
+            process.kill()
+    process.join()
+
+
+def _run_controlled_transport(
+    transport: Callable[..., object],
+    arguments: tuple[object, ...],
+    *,
+    timeout_seconds: float,
+    maximum_response_bytes: int,
+    cancelled: Callable[[], bool],
+    label: str,
+) -> _ControlledHttpResponse:
+    """Enforce cancellation, elapsed time, and response bytes around injection."""
+    try:
+        process_context = multiprocessing.get_context("fork")
+    except ValueError as error:
+        raise OSError("controlled HTTP injection requires fork support") from error
+    hard_deadline = time.monotonic() + timeout_seconds
+    with tempfile.TemporaryDirectory(prefix="tracequant-http-injection-") as directory:
+        root = Path(directory)
+        ready_path = root / "ready"
+        body_path = root / "body.bin"
+        result_path = root / "result.json"
+        process = process_context.Process(
+            target=_controlled_transport_worker,
+            args=(
+                ready_path,
+                body_path,
+                result_path,
+                transport,
+                arguments,
+                maximum_response_bytes,
+            ),
+        )
+        process.start()
+        interruption: str | None = None
+        try:
+            while process.is_alive():
+                if cancelled():
+                    interruption = f"{label} HTTP attempt was cancelled"
+                    break
+                remaining = hard_deadline - time.monotonic()
+                if remaining <= 0:
+                    interruption = (
+                        f"{label} HTTP attempt exceeded its absolute elapsed-time "
+                        "deadline"
+                    )
+                    break
+                process.join(timeout=min(0.05, remaining))
+        except BaseException:
+            _terminate_controlled_transport(process, session_ready=ready_path.is_file())
+            raise
+        if interruption is not None:
+            _terminate_controlled_transport(process, session_ready=ready_path.is_file())
+            if interruption == f"{label} HTTP attempt was cancelled":
+                raise _ControlledTransportInterrupted(interruption)
+            raise TimeoutError(interruption)
+        process.join()
+        if process.exitcode != 0 or not result_path.is_file():
+            raise OSError(f"{label} injected HTTP transport exited without a result")
+        try:
+            result = json.loads(result_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as error:
+            raise OSError(
+                f"{label} injected HTTP transport returned an invalid result"
+            ) from error
+        if result.get("kind") == "failure":
+            detail = str(result.get("detail", "injected HTTP transport failed"))
+            error_type = result.get("error_type")
+            if error_type == "TimeoutError":
+                raise TimeoutError(detail)
+            if error_type == "ConnectionError":
+                raise ConnectionError(detail)
+            raise OSError(detail)
+        try:
+            status = result["status"]
+            headers = result["headers"]
+            complete = result["complete"]
+        except KeyError as error:
+            raise OSError(
+                f"{label} injected HTTP transport returned an invalid result"
+            ) from error
+        if (
+            type(status) is not int
+            or not isinstance(headers, dict)
+            or not isinstance(complete, bool)
+            or any(
+                not isinstance(name, str) or not isinstance(value, str)
+                for name, value in headers.items()
+            )
+        ):
+            raise OSError(f"{label} injected HTTP transport returned an invalid result")
+        try:
+            body = body_path.read_bytes()
+        except OSError as error:
+            raise OSError(
+                f"{label} injected HTTP transport response body is unreadable"
+            ) from error
+        if len(body) > maximum_response_bytes + 1:
+            raise OSError(f"{label} injected HTTP transport exceeded its byte bound")
+        return _ControlledHttpResponse(
+            status=status,
+            body=body,
+            headers=MappingProxyType(dict(headers)),
+            complete=complete,
+        )
 
 
 class BinancePublicHistoryExecutionStopReason(StrEnum):

--- a/src/tracequant/data/binance_public_history_execution.py
+++ b/src/tracequant/data/binance_public_history_execution.py
@@ -1,0 +1,342 @@
+"""Finite execution context shared by Binance public-history adapters.
+
+The context is deliberately provider- and adapter-specific.  It coordinates the
+existing Binance archive and REST executors without deciding which source to use
+or orchestrating fallback between them.
+"""
+
+from __future__ import annotations
+
+import math
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Never
+
+__all__ = [
+    "BinancePublicHistoryExecutionContext",
+    "BinancePublicHistoryExecutionLimits",
+    "BinancePublicHistoryExecutionSnapshot",
+    "BinancePublicHistoryExecutionStopReason",
+    "BinancePublicHistoryExecutionStopped",
+    "BinancePublicHistoryHttpAllowance",
+    "BinancePublicHistoryRequestAttempts",
+]
+
+
+class BinancePublicHistoryExecutionStopReason(StrEnum):
+    """Stable reasons why the shared execution boundary refused more work."""
+
+    CANCELLED = "cancelled"
+    DEADLINE_EXHAUSTED = "deadline_exhausted"
+    HTTP_ATTEMPTS_EXHAUSTED = "http_attempts_exhausted"
+    RESPONSE_BYTES_EXHAUSTED = "response_bytes_exhausted"
+    TOTAL_RESPONSE_BYTES_EXHAUSTED = "total_response_bytes_exhausted"
+    ARCHIVE_OBJECTS_EXHAUSTED = "archive_objects_exhausted"
+    REST_PAGES_EXHAUSTED = "rest_pages_exhausted"
+    REQUEST_ATTEMPTS_EXHAUSTED = "request_attempts_exhausted"
+
+
+class BinancePublicHistoryExecutionStopped(RuntimeError):
+    """Internal control signal translated to an adapter result at public entries."""
+
+    def __init__(
+        self, reason: BinancePublicHistoryExecutionStopReason, detail: str
+    ) -> None:
+        super().__init__(detail)
+        self.reason = reason
+
+
+@dataclass(frozen=True, slots=True)
+class BinancePublicHistoryExecutionLimits:
+    """Immutable finite limits for one composable Binance execution ledger."""
+
+    deadline_monotonic: float
+    maximum_http_attempts: int
+    maximum_total_response_bytes: int
+    maximum_response_bytes: int
+    maximum_archive_objects: int
+    maximum_rest_pages: int
+    maximum_attempts_per_request: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.deadline_monotonic, (int, float)) or isinstance(
+            self.deadline_monotonic, bool
+        ):
+            raise TypeError("deadline_monotonic must be a number")
+        if not math.isfinite(self.deadline_monotonic):
+            raise ValueError("deadline_monotonic must be finite")
+        object.__setattr__(self, "deadline_monotonic", float(self.deadline_monotonic))
+        for field in (
+            "maximum_http_attempts",
+            "maximum_total_response_bytes",
+            "maximum_response_bytes",
+            "maximum_archive_objects",
+            "maximum_rest_pages",
+            "maximum_attempts_per_request",
+        ):
+            value = getattr(self, field)
+            if type(value) is not int:
+                raise TypeError(f"{field} must be an integer")
+            if value <= 0:
+                raise ValueError(f"{field} must be greater than zero")
+
+
+@dataclass(frozen=True, slots=True)
+class BinancePublicHistoryRequestAttempts:
+    """Attempt count for one stable semantic archive resource or REST page."""
+
+    request_key: str
+    attempts: int
+
+
+@dataclass(frozen=True, slots=True)
+class BinancePublicHistoryExecutionSnapshot:
+    """Immutable, auditable view of the current shared ledger."""
+
+    deadline_monotonic: float
+    observed_monotonic: float
+    cancelled: bool
+    http_attempts: int
+    response_bytes: int
+    archive_objects: int
+    rest_pages: int
+    request_attempts: tuple[BinancePublicHistoryRequestAttempts, ...]
+    stop_reason: BinancePublicHistoryExecutionStopReason | None
+
+    @property
+    def remaining_seconds(self) -> float:
+        return max(0.0, self.deadline_monotonic - self.observed_monotonic)
+
+
+@dataclass(frozen=True, slots=True)
+class BinancePublicHistoryHttpAllowance:
+    """Bounded allowance reserved immediately before a real HTTP attempt."""
+
+    timeout_seconds: float
+    maximum_response_bytes: int
+    attempt_number: int
+    request_attempt_number: int
+
+
+class BinancePublicHistoryExecutionContext:
+    """Thread-safe finite ledger shared across archive and REST calls."""
+
+    def __init__(
+        self,
+        limits: BinancePublicHistoryExecutionLimits,
+        *,
+        cancelled: Callable[[], bool] | None = None,
+        monotonic_clock: Callable[[], float] | None = None,
+        sleeper: Callable[[float], None] | None = None,
+    ) -> None:
+        if not isinstance(limits, BinancePublicHistoryExecutionLimits):
+            raise TypeError("limits must be BinancePublicHistoryExecutionLimits")
+        if cancelled is not None and not callable(cancelled):
+            raise TypeError("cancelled must be callable")
+        if monotonic_clock is not None and not callable(monotonic_clock):
+            raise TypeError("monotonic_clock must be callable")
+        if sleeper is not None and not callable(sleeper):
+            raise TypeError("sleeper must be callable")
+        self._limits = limits
+        self._cancelled = cancelled or (lambda: False)
+        self._monotonic_clock = monotonic_clock or time.monotonic
+        self._sleeper = sleeper or time.sleep
+        self._lock = threading.Lock()
+        self._http_attempts = 0
+        self._response_bytes = 0
+        self._archive_objects = 0
+        self._rest_pages = 0
+        self._request_attempts: dict[str, int] = {}
+        self._stop_reason: BinancePublicHistoryExecutionStopReason | None = None
+
+    @property
+    def limits(self) -> BinancePublicHistoryExecutionLimits:
+        return self._limits
+
+    def _now(self) -> float:
+        value = self._monotonic_clock()
+        if not isinstance(value, (int, float)) or isinstance(value, bool):
+            raise TypeError("monotonic_clock must return a number")
+        if not math.isfinite(value):
+            raise ValueError("monotonic_clock must return a finite value")
+        return float(value)
+
+    def cancellation_requested(self) -> bool:
+        value = self._cancelled()
+        if not isinstance(value, bool):
+            raise TypeError("cancelled must return a bool")
+        return value
+
+    def _stop(
+        self, reason: BinancePublicHistoryExecutionStopReason, detail: str
+    ) -> BinancePublicHistoryExecutionStopped:
+        self._stop_reason = reason
+        return BinancePublicHistoryExecutionStopped(reason, detail)
+
+    def _check_control_locked(self, now: float, cancelled: bool) -> None:
+        if cancelled:
+            raise self._stop(
+                BinancePublicHistoryExecutionStopReason.CANCELLED,
+                "Binance public-history execution was cancelled",
+            )
+        if now >= self._limits.deadline_monotonic:
+            raise self._stop(
+                BinancePublicHistoryExecutionStopReason.DEADLINE_EXHAUSTED,
+                "Binance public-history absolute deadline was exhausted",
+            )
+
+    def check(self) -> None:
+        cancelled = self.cancellation_requested()
+        now = self._now()
+        with self._lock:
+            self._check_control_locked(now, cancelled)
+
+    def raise_stop(
+        self, reason: BinancePublicHistoryExecutionStopReason, detail: str
+    ) -> Never:
+        """Record and raise a terminal stop discovered by an adapter boundary."""
+        if not isinstance(reason, BinancePublicHistoryExecutionStopReason):
+            raise TypeError("reason must be BinancePublicHistoryExecutionStopReason")
+        if not isinstance(detail, str) or not detail:
+            raise ValueError("detail must be a non-empty string")
+        with self._lock:
+            raise self._stop(reason, detail)
+
+    @property
+    def remaining_seconds(self) -> float:
+        return max(0.0, self._limits.deadline_monotonic - self._now())
+
+    def begin_archive_object(self) -> None:
+        cancelled = self.cancellation_requested()
+        now = self._now()
+        with self._lock:
+            self._check_control_locked(now, cancelled)
+            if self._archive_objects >= self._limits.maximum_archive_objects:
+                raise self._stop(
+                    BinancePublicHistoryExecutionStopReason.ARCHIVE_OBJECTS_EXHAUSTED,
+                    "maximum_archive_objects exhausted",
+                )
+            self._archive_objects += 1
+
+    def begin_rest_page(self) -> None:
+        cancelled = self.cancellation_requested()
+        now = self._now()
+        with self._lock:
+            self._check_control_locked(now, cancelled)
+            if self._rest_pages >= self._limits.maximum_rest_pages:
+                raise self._stop(
+                    BinancePublicHistoryExecutionStopReason.REST_PAGES_EXHAUSTED,
+                    "maximum_rest_pages exhausted",
+                )
+            self._rest_pages += 1
+
+    def begin_http_attempt(
+        self, request_key: str, *, timeout_seconds: float
+    ) -> BinancePublicHistoryHttpAllowance:
+        """Reserve counters immediately before entering the transport callable."""
+        if not isinstance(request_key, str) or not request_key:
+            raise ValueError("request_key must be a non-empty string")
+        if not isinstance(timeout_seconds, (int, float)) or isinstance(
+            timeout_seconds, bool
+        ):
+            raise TypeError("timeout_seconds must be a number")
+        if not math.isfinite(timeout_seconds) or timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be finite and greater than zero")
+        cancelled = self.cancellation_requested()
+        now = self._now()
+        with self._lock:
+            self._check_control_locked(now, cancelled)
+            if self._http_attempts >= self._limits.maximum_http_attempts:
+                raise self._stop(
+                    BinancePublicHistoryExecutionStopReason.HTTP_ATTEMPTS_EXHAUSTED,
+                    "maximum_http_attempts exhausted",
+                )
+            request_attempts = self._request_attempts.get(request_key, 0)
+            if request_attempts >= self._limits.maximum_attempts_per_request:
+                raise self._stop(
+                    BinancePublicHistoryExecutionStopReason.REQUEST_ATTEMPTS_EXHAUSTED,
+                    "maximum_attempts_per_request exhausted",
+                )
+            remaining_bytes = (
+                self._limits.maximum_total_response_bytes - self._response_bytes
+            )
+            if remaining_bytes <= 0:
+                raise self._stop(
+                    BinancePublicHistoryExecutionStopReason.TOTAL_RESPONSE_BYTES_EXHAUSTED,
+                    "maximum_total_response_bytes exhausted",
+                )
+            self._http_attempts += 1
+            request_attempts += 1
+            self._request_attempts[request_key] = request_attempts
+            return BinancePublicHistoryHttpAllowance(
+                timeout_seconds=min(
+                    float(timeout_seconds), self._limits.deadline_monotonic - now
+                ),
+                maximum_response_bytes=min(
+                    self._limits.maximum_response_bytes, remaining_bytes
+                ),
+                attempt_number=self._http_attempts,
+                request_attempt_number=request_attempts,
+            )
+
+    def record_response_bytes(self, amount: int) -> None:
+        """Charge bytes actually returned/read, including a one-byte overflow probe."""
+        if type(amount) is not int:
+            raise TypeError("amount must be an integer")
+        if amount < 0:
+            raise ValueError("amount must not be negative")
+        with self._lock:
+            self._response_bytes += amount
+            if amount > self._limits.maximum_response_bytes:
+                raise self._stop(
+                    BinancePublicHistoryExecutionStopReason.RESPONSE_BYTES_EXHAUSTED,
+                    "maximum_response_bytes exceeded",
+                )
+            if self._response_bytes > self._limits.maximum_total_response_bytes:
+                raise self._stop(
+                    BinancePublicHistoryExecutionStopReason.TOTAL_RESPONSE_BYTES_EXHAUSTED,
+                    "maximum_total_response_bytes exceeded",
+                )
+
+    def wait_for_retry(self, seconds: float) -> None:
+        """Wait in bounded slices so deadline and cancellation remain observable."""
+        if not isinstance(seconds, (int, float)) or isinstance(seconds, bool):
+            raise TypeError("seconds must be a number")
+        if not math.isfinite(seconds) or seconds < 0:
+            raise ValueError("seconds must be finite and non-negative")
+        self.check()
+        if seconds > self.remaining_seconds:
+            with self._lock:
+                raise self._stop(
+                    BinancePublicHistoryExecutionStopReason.DEADLINE_EXHAUSTED,
+                    "retry wait exceeds remaining absolute deadline",
+                )
+        remaining = float(seconds)
+        while remaining > 0:
+            self.check()
+            interval = min(0.05, remaining)
+            self._sleeper(interval)
+            remaining -= interval
+        self.check()
+
+    def snapshot(self) -> BinancePublicHistoryExecutionSnapshot:
+        cancelled = self.cancellation_requested()
+        now = self._now()
+        with self._lock:
+            return BinancePublicHistoryExecutionSnapshot(
+                deadline_monotonic=self._limits.deadline_monotonic,
+                observed_monotonic=now,
+                cancelled=cancelled,
+                http_attempts=self._http_attempts,
+                response_bytes=self._response_bytes,
+                archive_objects=self._archive_objects,
+                rest_pages=self._rest_pages,
+                request_attempts=tuple(
+                    BinancePublicHistoryRequestAttempts(key, attempts)
+                    for key, attempts in sorted(self._request_attempts.items())
+                ),
+                stop_reason=self._stop_reason,
+            )

--- a/tests/data/test_binance_public_history_execution.py
+++ b/tests/data/test_binance_public_history_execution.py
@@ -29,6 +29,7 @@ from tracequant.data import (
     BinancePublicHistoryExecutionContext,
     BinancePublicHistoryExecutionLimits,
     BinancePublicHistoryExecutionStopReason,
+    BinancePublicHistoryHttpAllowance,
     BinanceRestEndpoint,
     BinanceRestPageRequest,
     RawObjectIdentity,
@@ -226,6 +227,40 @@ def test_shared_execution_context_bounds_archive_and_rest_attempts(
     assert [attempt.attempts for attempt in snapshot.request_attempts] == [1, 1, 1]
 
 
+def test_shared_context_serializes_total_byte_allowances() -> None:
+    second_started = threading.Event()
+
+    def cancelled() -> bool:
+        if threading.current_thread().name == "second-attempt":
+            second_started.set()
+        return False
+
+    context = BinancePublicHistoryExecutionContext(
+        replace(_context(total_bytes=10, http_attempts=2).limits),
+        cancelled=cancelled,
+        monotonic_clock=lambda: 0,
+    )
+    first = context.begin_http_attempt("archive:first", timeout_seconds=5)
+    second: list[BinancePublicHistoryHttpAllowance] = []
+
+    def begin_second() -> None:
+        second.append(context.begin_http_attempt("rest:second", timeout_seconds=5))
+
+    thread = threading.Thread(target=begin_second, name="second-attempt", daemon=True)
+    thread.start()
+    assert second_started.wait(1)
+    context.record_response_bytes(first, 4)
+    thread.join(timeout=1)
+
+    assert not thread.is_alive()
+    assert len(second) == 1
+    assert second[0].maximum_response_bytes == 6
+    context.record_response_bytes(second[0], 6)
+    snapshot = context.snapshot()
+    assert snapshot.http_attempts == 2
+    assert snapshot.response_bytes == 10
+
+
 def test_no_io_conclusion_and_pre_request_exhaustion_do_not_charge_http(
     tmp_path: Path,
 ) -> None:
@@ -328,6 +363,8 @@ def test_rest_retry_wait_cancellation_is_terminal_and_keeps_attempt(
     assert [attempt.outcome for attempt in result.pages[0].attempts] == [
         "retryable_http"
     ]
+    assert result.pages[0].attempts[0].waited_seconds == 0
+    assert result.elapsed_seconds == 0
     snapshot = context.snapshot()
     assert snapshot.http_attempts == 1
     assert snapshot.response_bytes == len(b"retry")

--- a/tests/data/test_binance_public_history_execution.py
+++ b/tests/data/test_binance_public_history_execution.py
@@ -1,6 +1,8 @@
 import hashlib
 import io
 import json
+import multiprocessing
+import subprocess
 import threading
 import time
 import zipfile
@@ -8,7 +10,7 @@ from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 
 import pytest
 
@@ -36,6 +38,7 @@ from tracequant.data import (
     RawStore,
     plan_binance_contract_kline_archives,
 )
+from tracequant.data import binance_kline_rest as rest_module
 from tracequant.data import binance_public_archive as archive_module
 from tracequant.domain import InstrumentId, TimeRange
 
@@ -167,23 +170,25 @@ def test_shared_execution_context_bounds_archive_and_rest_attempts(
     checksum = (
         f"{hashlib.sha256(archive).hexdigest()}  {plan.url.rsplit('/', 1)[-1]}\n"
     ).encode()
-    archive_calls: list[str] = []
+    archive_calls_path = tmp_path.parent / f"{tmp_path.name}-archive-calls"
 
     def archive_get(url: str, timeout: float) -> ArchiveHttpResponse:
         assert 0 < timeout <= 5
-        archive_calls.append(url)
+        with archive_calls_path.open("a", encoding="utf-8") as calls:
+            calls.write(f"{url}\n")
         body = checksum if url == plan.checksum_url else archive
         return ArchiveHttpResponse(200, body, {})
 
     rest_body = _rest_body()
-    rest_calls: list[str] = []
+    rest_calls_path = tmp_path.parent / f"{tmp_path.name}-rest-calls"
 
     def rest_get(
         url: str, timeout: float, maximum_response_bytes: int
     ) -> BinanceKlineRestHttpResponse:
         assert 0 < timeout <= 5
         assert maximum_response_bytes == len(rest_body)
-        rest_calls.append(url)
+        with rest_calls_path.open("a", encoding="utf-8") as calls:
+            calls.write(f"{url}\n")
         return BinanceKlineRestHttpResponse(200, rest_body, {}, complete=True)
 
     context = _context(
@@ -214,8 +219,11 @@ def test_shared_execution_context_bounds_archive_and_rest_attempts(
     assert len(rest_result.pages) == 1
     assert exhausted.status is BinanceKlineRestStatus.BUDGET_EXHAUSTED
     assert exhausted.pages[0].attempts == ()
-    assert archive_calls == [plan.checksum_url, plan.url]
-    assert len(rest_calls) == 1
+    assert archive_calls_path.read_text(encoding="utf-8").splitlines() == [
+        plan.checksum_url,
+        plan.url,
+    ]
+    assert len(rest_calls_path.read_text(encoding="utf-8").splitlines()) == 1
     snapshot = context.snapshot()
     assert snapshot.http_attempts == 3
     assert snapshot.response_bytes == len(checksum) + len(archive) + len(rest_body)
@@ -296,11 +304,11 @@ def test_archive_http_exhaustion_preserves_received_checksum(
         plan_binance_contract_kline_archives(InstrumentId("BTCUSDT"), request_range)[0],
     )
     checksum = f"{'0' * 64}  {plan.url.rsplit('/', 1)[-1]}\n".encode()
-    calls: list[str] = []
+    calls_path = tmp_path.parent / f"{tmp_path.name}-calls"
 
     def checksum_only(url: str, timeout: float) -> ArchiveHttpResponse:
         del timeout
-        calls.append(url)
+        calls_path.write_text(url, encoding="utf-8")
         return ArchiveHttpResponse(200, checksum, {})
 
     context = _context(total_bytes=1_000, http_attempts=1)
@@ -310,7 +318,7 @@ def test_archive_http_exhaustion_preserves_received_checksum(
     ).run(InstrumentId("BTCUSDT"), request_range, context)
 
     assert result.objects[0].status is BinanceArchiveAcquisitionStatus.BUDGET_EXHAUSTED
-    assert calls == [plan.checksum_url]
+    assert calls_path.read_text(encoding="utf-8") == plan.checksum_url
     assert context.snapshot().http_attempts == 1
     assert context.snapshot().response_bytes == len(checksum)
     manifests = store.list_acquisition_manifests(
@@ -326,14 +334,13 @@ def test_rest_retry_wait_cancellation_is_terminal_and_keeps_attempt(
 ) -> None:
     request = _rest_request()
     cancellation = threading.Event()
-    calls = 0
+    calls_path = tmp_path.parent / f"{tmp_path.name}-calls"
 
     def unavailable(
         url: str, timeout: float, maximum_response_bytes: int
     ) -> BinanceKlineRestHttpResponse:
         del url, timeout, maximum_response_bytes
-        nonlocal calls
-        calls += 1
+        calls_path.write_text("called", encoding="utf-8")
         return BinanceKlineRestHttpResponse(503, b"retry", {})
 
     context = BinancePublicHistoryExecutionContext(
@@ -358,7 +365,7 @@ def test_rest_retry_wait_cancellation_is_terminal_and_keeps_attempt(
     ).run(request, _rest_coverage(request), _rest_budget(), context)
 
     assert result.status is BinanceKlineRestStatus.CANCELLED
-    assert calls == 1
+    assert calls_path.read_text(encoding="utf-8") == "called"
     assert len(result.pages) == 1
     assert [attempt.outcome for attempt in result.pages[0].attempts] == [
         "retryable_http"
@@ -377,19 +384,19 @@ def test_final_rest_response_stops_before_publication_and_keeps_evidence(
     stop: str,
 ) -> None:
     request = _rest_request()
-    cancellation = threading.Event()
-    monotonic = 0.0
+    process_context = multiprocessing.get_context("fork")
+    cancellation = process_context.Event()
+    monotonic = process_context.Value("d", 0.0)
     body = _rest_body()
 
     def final_response(
         url: str, timeout: float, maximum_response_bytes: int
     ) -> BinanceKlineRestHttpResponse:
         del url, timeout, maximum_response_bytes
-        nonlocal monotonic
         if stop == "cancelled":
             cancellation.set()
         else:
-            monotonic = 101
+            monotonic.value = 101
         return BinanceKlineRestHttpResponse(200, body, {})
 
     context = BinancePublicHistoryExecutionContext(
@@ -403,14 +410,14 @@ def test_final_rest_response_stops_before_publication_and_keeps_evidence(
             maximum_attempts_per_request=1,
         ),
         cancelled=cancellation.is_set,
-        monotonic_clock=lambda: monotonic,
+        monotonic_clock=lambda: monotonic.value,
     )
     store = RawStore(tmp_path, clock=lambda: _NOW)
     result = BinanceKlineRestAcquisition(
         store,
         http_get=final_response,
         clock=lambda: _NOW,
-        monotonic_clock=lambda: monotonic,
+        monotonic_clock=lambda: monotonic.value,
     ).run(request, _rest_coverage(request), _rest_budget(), context)
 
     expected = (
@@ -582,6 +589,182 @@ def test_inflight_default_archive_cancellation_terminates_worker_and_maps_result
     assert reached_request.is_set()
     assert context.snapshot().http_attempts == 1
     assert elapsed < 2
+
+
+def test_inflight_injected_archive_cancellation_terminates_transport(
+    tmp_path: Path,
+) -> None:
+    cancellation = threading.Event()
+
+    def blocking_transport(url: str, timeout: float) -> ArchiveHttpResponse:
+        del url, timeout
+        time.sleep(5)
+        return ArchiveHttpResponse(200, b"late", {})
+
+    context = BinancePublicHistoryExecutionContext(
+        BinancePublicHistoryExecutionLimits(
+            deadline_monotonic=time.monotonic() + 5,
+            maximum_http_attempts=1,
+            maximum_total_response_bytes=100,
+            maximum_response_bytes=100,
+            maximum_archive_objects=1,
+            maximum_rest_pages=1,
+            maximum_attempts_per_request=1,
+        ),
+        cancelled=cancellation.is_set,
+    )
+    timer = threading.Timer(0.1, cancellation.set)
+    children_before = {child.pid for child in multiprocessing.active_children()}
+    timer.start()
+    started = time.monotonic()
+    try:
+        result = BinanceContractKlineBackfill(
+            RawStore(tmp_path), http_get=blocking_transport, clock=lambda: _NOW
+        ).run(
+            InstrumentId("BTCUSDT"),
+            TimeRange(
+                start=datetime(2024, 2, 29, tzinfo=UTC),
+                end=datetime(2024, 2, 29, 0, 1, tzinfo=UTC),
+            ),
+            context,
+        )
+        elapsed = time.monotonic() - started
+    finally:
+        timer.cancel()
+        timer.join()
+
+    assert result.objects[0].status is BinanceArchiveAcquisitionStatus.CANCELLED
+    assert context.snapshot().http_attempts == 1
+    assert elapsed < 1
+    assert {child.pid for child in multiprocessing.active_children()} == children_before
+
+
+def test_inflight_injected_rest_deadline_terminates_transport(tmp_path: Path) -> None:
+    def blocking_transport(
+        url: str, timeout: float, maximum_response_bytes: int
+    ) -> BinanceKlineRestHttpResponse:
+        del url, timeout, maximum_response_bytes
+        time.sleep(5)
+        return BinanceKlineRestHttpResponse(200, _rest_body(), {})
+
+    context = BinancePublicHistoryExecutionContext(
+        BinancePublicHistoryExecutionLimits(
+            deadline_monotonic=time.monotonic() + 0.15,
+            maximum_http_attempts=1,
+            maximum_total_response_bytes=1_000,
+            maximum_response_bytes=1_000,
+            maximum_archive_objects=1,
+            maximum_rest_pages=1,
+            maximum_attempts_per_request=1,
+        )
+    )
+    children_before = {child.pid for child in multiprocessing.active_children()}
+    started = time.monotonic()
+    result = BinanceKlineRestAcquisition(
+        RawStore(tmp_path), http_get=blocking_transport, clock=lambda: _NOW
+    ).run(_rest_request(), _rest_coverage(_rest_request()), _rest_budget(), context)
+    elapsed = time.monotonic() - started
+
+    assert result.status is BinanceKlineRestStatus.BUDGET_EXHAUSTED
+    assert context.snapshot().http_attempts == 1
+    assert elapsed < 1
+    assert {child.pid for child in multiprocessing.active_children()} == children_before
+
+
+def test_injected_archive_response_is_capped_before_parent_receives_it(
+    tmp_path: Path,
+) -> None:
+    def oversized_transport(url: str, timeout: float) -> ArchiveHttpResponse:
+        del url, timeout
+        return ArchiveHttpResponse(200, b"x" * 1_000_000, {})
+
+    context = BinancePublicHistoryExecutionContext(
+        BinancePublicHistoryExecutionLimits(
+            deadline_monotonic=time.monotonic() + 5,
+            maximum_http_attempts=1,
+            maximum_total_response_bytes=10,
+            maximum_response_bytes=10,
+            maximum_archive_objects=1,
+            maximum_rest_pages=1,
+            maximum_attempts_per_request=1,
+        )
+    )
+    result = BinanceContractKlineBackfill(
+        RawStore(tmp_path), http_get=oversized_transport, clock=lambda: _NOW
+    ).run(
+        InstrumentId("BTCUSDT"),
+        TimeRange(
+            start=datetime(2024, 2, 29, tzinfo=UTC),
+            end=datetime(2024, 2, 29, 0, 1, tzinfo=UTC),
+        ),
+        context,
+    )
+
+    assert result.objects[0].status is BinanceArchiveAcquisitionStatus.BUDGET_EXHAUSTED
+    snapshot = context.snapshot()
+    assert snapshot.http_attempts == 1
+    assert snapshot.response_bytes == 11
+    assert snapshot.stop_reason is (
+        BinancePublicHistoryExecutionStopReason.RESPONSE_BYTES_EXHAUSTED
+    )
+
+
+def test_default_workers_do_not_rebase_timeout_after_process_startup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class ProgressingHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            self.send_response(200)
+            self.send_header("Content-Length", "10000")
+            self.end_headers()
+            try:
+                for _ in range(1000):
+                    self.wfile.write(b"x")
+                    self.wfile.flush()
+                    time.sleep(0.01)
+            except (BrokenPipeError, ConnectionResetError):
+                return
+
+        def log_message(self, unused_format: str, *unused_args: object) -> None:
+            return None
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), ProgressingHandler)
+    server.daemon_threads = True
+    server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+    server_thread.start()
+    real_popen = subprocess.Popen
+    launched: list[subprocess.Popen[bytes]] = []
+
+    def delayed_popen(*args: Any, **kwargs: Any) -> subprocess.Popen[bytes]:
+        time.sleep(0.15)
+        process = cast("subprocess.Popen[bytes]", real_popen(*args, **kwargs))
+        launched.append(process)
+        return process
+
+    monkeypatch.setattr(subprocess, "Popen", delayed_popen)
+    url = f"http://127.0.0.1:{server.server_port}/progress"
+    elapsed: list[float] = []
+    try:
+        for get in (
+            lambda: archive_module._default_http_get(
+                url, 0.2, maximum_response_bytes=1000
+            ),
+            lambda: rest_module._default_http_get(url, 0.2, 1000),
+        ):
+            started = time.monotonic()
+            try:
+                get()
+            except (TimeoutError, InterruptedError):
+                pass
+            elapsed.append(time.monotonic() - started)
+    finally:
+        server.shutdown()
+        server.server_close()
+        server_thread.join()
+
+    assert len(launched) == 2
+    assert all(process.poll() is not None for process in launched)
+    assert all(duration < 0.3 for duration in elapsed)
 
 
 @pytest.mark.parametrize("declared_length", [False, True])

--- a/tests/data/test_binance_public_history_execution.py
+++ b/tests/data/test_binance_public_history_execution.py
@@ -1,0 +1,601 @@
+import hashlib
+import io
+import json
+import threading
+import time
+import zipfile
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from tracequant.data import (
+    ArchiveHttpResponse,
+    BinanceArchiveAcquisitionStatus,
+    BinanceArchiveObjectPlan,
+    BinanceArchiveParseResult,
+    BinanceContractKlineBackfill,
+    BinanceKlineInterval,
+    BinanceKlineRestAcquisition,
+    BinanceKlineRestBudget,
+    BinanceKlineRestCoverage,
+    BinanceKlineRestCoverageStatus,
+    BinanceKlineRestHttpResponse,
+    BinanceKlineRestStatus,
+    BinancePublicArchiveAcquisition,
+    BinancePublicHistoryExecutionContext,
+    BinancePublicHistoryExecutionLimits,
+    BinancePublicHistoryExecutionStopReason,
+    BinanceRestEndpoint,
+    BinanceRestPageRequest,
+    RawObjectIdentity,
+    RawStore,
+    plan_binance_contract_kline_archives,
+)
+from tracequant.data import binance_public_archive as archive_module
+from tracequant.domain import InstrumentId, TimeRange
+
+_REST_START = datetime(2026, 9, 9, 17, 33, tzinfo=UTC)
+_REST_END = _REST_START + timedelta(minutes=1)
+_NOW = datetime(2026, 9, 9, 19, tzinfo=UTC)
+
+
+def _archive(member_name: str, start_open_time: int) -> bytes:
+    header = (
+        "open_time,open,high,low,close,volume,close_time,quote_volume,count,"
+        "taker_buy_volume,taker_buy_quote_volume,ignore\n"
+    )
+    rows = "".join(
+        f"{start_open_time + offset * 60_000},61000.0,61020.0,60990.0,"
+        f"61010.0,12.5,{start_open_time + offset * 60_000 + 59_999},"
+        "762500.0,42,6.0,366000.0,0\n"
+        for offset in range(24 * 60)
+    )
+    output = io.BytesIO()
+    with zipfile.ZipFile(output, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr(member_name, (header + rows).encode())
+    return output.getvalue()
+
+
+def _rest_request() -> BinanceRestPageRequest:
+    return BinanceRestPageRequest(
+        endpoint=BinanceRestEndpoint.CONTRACT_KLINES,
+        subject=InstrumentId("BTCUSDT"),
+        caller_range=TimeRange(start=_REST_START, end=_REST_END),
+        interval=BinanceKlineInterval.ONE_MINUTE,
+        limit=1,
+    )
+
+
+def _rest_coverage(request: BinanceRestPageRequest) -> BinanceKlineRestCoverage:
+    approved_start = datetime(2026, 9, 9, 17, 33, tzinfo=UTC)
+    approved_end = datetime(2026, 9, 9, 18, 33, tzinfo=UTC)
+    return BinanceKlineRestCoverage(
+        status=BinanceKlineRestCoverageStatus.SUPPORTED,
+        endpoint=request.endpoint,
+        subject=request.subject,
+        allowed_range=TimeRange(start=approved_start, end=approved_end),
+        evidence_version="issue-295-probe-run-2026-09-09T18:33:30.868474Z",
+        evidence_reference=(
+            "docs/research/binance-usdm-feature11-rest-window-follow-up-probes.json"
+        ),
+        evidence_sha256=(
+            "30682f83b887514ef2a0e20ec21203cff70529ac1518fb538277ae0881920b45"
+        ),
+        observed_at=datetime(2026, 9, 9, 18, 33, 31, 368694, tzinfo=UTC),
+        normalized_params={
+            "symbol": "BTCUSDT",
+            "interval": "1m",
+            "startTime": int(approved_start.timestamp() * 1_000),
+            "endTime": int(approved_end.timestamp() * 1_000) - 1,
+            "limit": 60,
+        },
+        response_sha256=(
+            "a253a934a1badc71edda32c22ab9204e8aee257109f7dc9473662b1c55a0c976"
+        ),
+        actual_range=TimeRange(start=approved_start, end=approved_end),
+    )
+
+
+def _rest_body() -> bytes:
+    start_ms = int(_REST_START.timestamp() * 1_000)
+    return json.dumps(
+        [
+            [
+                start_ms,
+                "100.00000000",
+                "102.00000000",
+                "99.00000000",
+                "101.00000000",
+                "12.50000000",
+                start_ms + 59_999,
+                "1262.50000000",
+                7,
+                "6.00000000",
+                "606.00000000",
+                "0",
+            ]
+        ],
+        separators=(",", ":"),
+    ).encode()
+
+
+def _rest_budget() -> BinanceKlineRestBudget:
+    return BinanceKlineRestBudget(
+        timeout_seconds=5,
+        maximum_pages=2,
+        maximum_attempts_per_page=2,
+        maximum_elapsed_seconds=30,
+        maximum_response_bytes=1_000_000,
+    )
+
+
+def _context(
+    *, total_bytes: int, http_attempts: int = 10
+) -> BinancePublicHistoryExecutionContext:
+    return BinancePublicHistoryExecutionContext(
+        BinancePublicHistoryExecutionLimits(
+            deadline_monotonic=100,
+            maximum_http_attempts=http_attempts,
+            maximum_total_response_bytes=total_bytes,
+            maximum_response_bytes=total_bytes,
+            maximum_archive_objects=2,
+            maximum_rest_pages=3,
+            maximum_attempts_per_request=2,
+        ),
+        monotonic_clock=lambda: 0,
+        sleeper=lambda unused_seconds: None,
+    )
+
+
+def test_shared_execution_context_bounds_archive_and_rest_attempts(
+    tmp_path: Path,
+) -> None:
+    archive_range = TimeRange(
+        start=datetime(2024, 2, 29, tzinfo=UTC),
+        end=datetime(2024, 2, 29, 0, 1, tzinfo=UTC),
+    )
+    plan = cast(
+        BinanceArchiveObjectPlan,
+        plan_binance_contract_kline_archives(InstrumentId("BTCUSDT"), archive_range)[0],
+    )
+    archive = _archive(plan.member_name, 1_709_164_800_000)
+    checksum = (
+        f"{hashlib.sha256(archive).hexdigest()}  {plan.url.rsplit('/', 1)[-1]}\n"
+    ).encode()
+    archive_calls: list[str] = []
+
+    def archive_get(url: str, timeout: float) -> ArchiveHttpResponse:
+        assert 0 < timeout <= 5
+        archive_calls.append(url)
+        body = checksum if url == plan.checksum_url else archive
+        return ArchiveHttpResponse(200, body, {})
+
+    rest_body = _rest_body()
+    rest_calls: list[str] = []
+
+    def rest_get(
+        url: str, timeout: float, maximum_response_bytes: int
+    ) -> BinanceKlineRestHttpResponse:
+        assert 0 < timeout <= 5
+        assert maximum_response_bytes == len(rest_body)
+        rest_calls.append(url)
+        return BinanceKlineRestHttpResponse(200, rest_body, {}, complete=True)
+
+    context = _context(
+        total_bytes=len(checksum) + len(archive) + len(rest_body),
+        http_attempts=3,
+    )
+    store = RawStore(tmp_path, clock=lambda: _NOW)
+
+    archive_result = BinanceContractKlineBackfill(
+        store, http_get=archive_get, timeout=5, clock=lambda: _NOW
+    ).run(InstrumentId("BTCUSDT"), archive_range, context)
+    request = _rest_request()
+    rest_acquisition = BinanceKlineRestAcquisition(
+        store,
+        http_get=rest_get,
+        clock=lambda: _NOW,
+        monotonic_clock=lambda: 0,
+    )
+    rest_result = rest_acquisition.run(
+        request, _rest_coverage(request), _rest_budget(), context
+    )
+    exhausted = rest_acquisition.run(
+        request, _rest_coverage(request), _rest_budget(), context
+    )
+
+    assert archive_result.completed
+    assert rest_result.complete
+    assert len(rest_result.pages) == 1
+    assert exhausted.status is BinanceKlineRestStatus.BUDGET_EXHAUSTED
+    assert exhausted.pages[0].attempts == ()
+    assert archive_calls == [plan.checksum_url, plan.url]
+    assert len(rest_calls) == 1
+    snapshot = context.snapshot()
+    assert snapshot.http_attempts == 3
+    assert snapshot.response_bytes == len(checksum) + len(archive) + len(rest_body)
+    assert snapshot.archive_objects == 1
+    assert snapshot.rest_pages == 2
+    assert snapshot.stop_reason is (
+        BinancePublicHistoryExecutionStopReason.HTTP_ATTEMPTS_EXHAUSTED
+    )
+    assert [attempt.attempts for attempt in snapshot.request_attempts] == [1, 1, 1]
+
+
+def test_no_io_conclusion_and_pre_request_exhaustion_do_not_charge_http(
+    tmp_path: Path,
+) -> None:
+    request = _rest_request()
+    context = _context(total_bytes=100, http_attempts=1)
+
+    def forbidden_rest(
+        url: str, timeout: float, maximum_response_bytes: int
+    ) -> BinanceKlineRestHttpResponse:
+        raise AssertionError((url, timeout, maximum_response_bytes))
+
+    result = BinanceKlineRestAcquisition(
+        RawStore(tmp_path),
+        http_get=forbidden_rest,
+        clock=lambda: _NOW,
+        monotonic_clock=lambda: 0,
+    ).run(request, None, _rest_budget(), context)
+
+    assert result.status is BinanceKlineRestStatus.REST_BOUNDARY_UNKNOWN
+    assert context.snapshot().http_attempts == 0
+    assert context.snapshot().rest_pages == 0
+
+
+def test_archive_http_exhaustion_preserves_received_checksum(
+    tmp_path: Path,
+) -> None:
+    request_range = TimeRange(
+        start=datetime(2024, 2, 29, tzinfo=UTC),
+        end=datetime(2024, 2, 29, 0, 1, tzinfo=UTC),
+    )
+    plan = cast(
+        BinanceArchiveObjectPlan,
+        plan_binance_contract_kline_archives(InstrumentId("BTCUSDT"), request_range)[0],
+    )
+    checksum = f"{'0' * 64}  {plan.url.rsplit('/', 1)[-1]}\n".encode()
+    calls: list[str] = []
+
+    def checksum_only(url: str, timeout: float) -> ArchiveHttpResponse:
+        del timeout
+        calls.append(url)
+        return ArchiveHttpResponse(200, checksum, {})
+
+    context = _context(total_bytes=1_000, http_attempts=1)
+    store = RawStore(tmp_path, clock=lambda: _NOW)
+    result = BinanceContractKlineBackfill(
+        store, http_get=checksum_only, clock=lambda: _NOW
+    ).run(InstrumentId("BTCUSDT"), request_range, context)
+
+    assert result.objects[0].status is BinanceArchiveAcquisitionStatus.BUDGET_EXHAUSTED
+    assert calls == [plan.checksum_url]
+    assert context.snapshot().http_attempts == 1
+    assert context.snapshot().response_bytes == len(checksum)
+    manifests = store.list_acquisition_manifests(
+        RawObjectIdentity.from_request(plan.request)
+    )
+    assert len(manifests) == 1
+    assert manifests[0].checksum_http_status == 200
+    assert manifests[0].checksum_response_sha256 == hashlib.sha256(checksum).hexdigest()
+
+
+def test_rest_retry_wait_cancellation_is_terminal_and_keeps_attempt(
+    tmp_path: Path,
+) -> None:
+    request = _rest_request()
+    cancellation = threading.Event()
+    calls = 0
+
+    def unavailable(
+        url: str, timeout: float, maximum_response_bytes: int
+    ) -> BinanceKlineRestHttpResponse:
+        del url, timeout, maximum_response_bytes
+        nonlocal calls
+        calls += 1
+        return BinanceKlineRestHttpResponse(503, b"retry", {})
+
+    context = BinancePublicHistoryExecutionContext(
+        BinancePublicHistoryExecutionLimits(
+            deadline_monotonic=100,
+            maximum_http_attempts=3,
+            maximum_total_response_bytes=100,
+            maximum_response_bytes=100,
+            maximum_archive_objects=1,
+            maximum_rest_pages=1,
+            maximum_attempts_per_request=3,
+        ),
+        cancelled=cancellation.is_set,
+        monotonic_clock=lambda: 0,
+        sleeper=lambda unused_seconds: cancellation.set(),
+    )
+    result = BinanceKlineRestAcquisition(
+        RawStore(tmp_path),
+        http_get=unavailable,
+        clock=lambda: _NOW,
+        monotonic_clock=lambda: 0,
+    ).run(request, _rest_coverage(request), _rest_budget(), context)
+
+    assert result.status is BinanceKlineRestStatus.CANCELLED
+    assert calls == 1
+    assert len(result.pages) == 1
+    assert [attempt.outcome for attempt in result.pages[0].attempts] == [
+        "retryable_http"
+    ]
+    snapshot = context.snapshot()
+    assert snapshot.http_attempts == 1
+    assert snapshot.response_bytes == len(b"retry")
+    assert snapshot.stop_reason is BinancePublicHistoryExecutionStopReason.CANCELLED
+
+
+@pytest.mark.parametrize("stop", ["cancelled", "deadline"])
+def test_final_rest_response_stops_before_publication_and_keeps_evidence(
+    tmp_path: Path,
+    stop: str,
+) -> None:
+    request = _rest_request()
+    cancellation = threading.Event()
+    monotonic = 0.0
+    body = _rest_body()
+
+    def final_response(
+        url: str, timeout: float, maximum_response_bytes: int
+    ) -> BinanceKlineRestHttpResponse:
+        del url, timeout, maximum_response_bytes
+        nonlocal monotonic
+        if stop == "cancelled":
+            cancellation.set()
+        else:
+            monotonic = 101
+        return BinanceKlineRestHttpResponse(200, body, {})
+
+    context = BinancePublicHistoryExecutionContext(
+        BinancePublicHistoryExecutionLimits(
+            deadline_monotonic=100,
+            maximum_http_attempts=1,
+            maximum_total_response_bytes=len(body),
+            maximum_response_bytes=len(body),
+            maximum_archive_objects=1,
+            maximum_rest_pages=1,
+            maximum_attempts_per_request=1,
+        ),
+        cancelled=cancellation.is_set,
+        monotonic_clock=lambda: monotonic,
+    )
+    store = RawStore(tmp_path, clock=lambda: _NOW)
+    result = BinanceKlineRestAcquisition(
+        store,
+        http_get=final_response,
+        clock=lambda: _NOW,
+        monotonic_clock=lambda: monotonic,
+    ).run(request, _rest_coverage(request), _rest_budget(), context)
+
+    expected = (
+        BinanceKlineRestStatus.CANCELLED
+        if stop == "cancelled"
+        else BinanceKlineRestStatus.BUDGET_EXHAUSTED
+    )
+    assert result.status is expected
+    assert result.pages[0].response_sha256 == hashlib.sha256(body).hexdigest()
+    assert (
+        store.list_verified_revisions(RawObjectIdentity.from_rest_page_request(request))
+        == ()
+    )
+    manifest = store.list_acquisition_manifests(
+        RawObjectIdentity.from_rest_page_request(request)
+    )[0]
+    assert manifest.source_body_sha256 == hashlib.sha256(body).hexdigest()
+
+
+def test_inflight_default_rest_cancellation_terminates_worker(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    request = _rest_request()
+    cancellation = threading.Event()
+    reached_request = threading.Event()
+
+    class BlockingHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            reached_request.set()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", "100")
+            self.end_headers()
+            self.wfile.write(b"[")
+            self.wfile.flush()
+            time.sleep(5)
+
+        def log_message(self, unused_format: str, *unused_args: object) -> None:
+            return None
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), BlockingHandler)
+    server.daemon_threads = True
+    server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+    server_thread.start()
+
+    def cancel_inflight() -> None:
+        if reached_request.wait(2):
+            cancellation.set()
+
+    cancellation_thread = threading.Thread(target=cancel_inflight, daemon=True)
+    cancellation_thread.start()
+    monkeypatch.setattr(
+        "tracequant.data.binance_kline_rest._BASE_URL",
+        f"http://127.0.0.1:{server.server_port}",
+    )
+    context = BinancePublicHistoryExecutionContext(
+        BinancePublicHistoryExecutionLimits(
+            deadline_monotonic=time.monotonic() + 5,
+            maximum_http_attempts=1,
+            maximum_total_response_bytes=100,
+            maximum_response_bytes=100,
+            maximum_archive_objects=1,
+            maximum_rest_pages=1,
+            maximum_attempts_per_request=1,
+        ),
+        cancelled=cancellation.is_set,
+    )
+    started = time.monotonic()
+    try:
+        result = BinanceKlineRestAcquisition(
+            RawStore(tmp_path), clock=lambda: _NOW
+        ).run(request, _rest_coverage(request), _rest_budget(), context)
+        elapsed = time.monotonic() - started
+    finally:
+        server.shutdown()
+        server.server_close()
+        server_thread.join()
+        cancellation_thread.join()
+
+    assert result.status is BinanceKlineRestStatus.CANCELLED
+    assert reached_request.is_set()
+    assert context.snapshot().http_attempts == 1
+    assert elapsed < 2
+
+
+def test_inflight_default_archive_cancellation_terminates_worker_and_maps_result(
+    tmp_path: Path,
+) -> None:
+    cancellation = threading.Event()
+    reached_request = threading.Event()
+
+    class BlockingHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            reached_request.set()
+            self.send_response(200)
+            self.send_header("Content-Length", "100")
+            self.end_headers()
+            self.wfile.write(b"x")
+            self.wfile.flush()
+            time.sleep(5)
+
+        def log_message(self, unused_format: str, *unused_args: object) -> None:
+            return None
+
+    class UnusedAdapter:
+        raw_schema_identifier = "unused"
+
+        def parse_member(
+            self, plan: BinanceArchiveObjectPlan, payload: bytes
+        ) -> BinanceArchiveParseResult:
+            raise AssertionError((plan, payload))
+
+        def validate_complete_object_coverage(
+            self, plan: BinanceArchiveObjectPlan, actual_range: TimeRange
+        ) -> None:
+            raise AssertionError((plan, actual_range))
+
+        def validate_required_coverage(
+            self, plan: BinanceArchiveObjectPlan, actual_range: TimeRange
+        ) -> None:
+            raise AssertionError((plan, actual_range))
+
+    request_range = TimeRange(
+        start=datetime(2024, 2, 29, tzinfo=UTC),
+        end=datetime(2024, 2, 29, 0, 1, tzinfo=UTC),
+    )
+    planned = cast(
+        BinanceArchiveObjectPlan,
+        plan_binance_contract_kline_archives(InstrumentId("BTCUSDT"), request_range)[0],
+    )
+    server = ThreadingHTTPServer(("127.0.0.1", 0), BlockingHandler)
+    server.daemon_threads = True
+    server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+    server_thread.start()
+
+    def cancel_inflight() -> None:
+        if reached_request.wait(2):
+            cancellation.set()
+
+    cancellation_thread = threading.Thread(target=cancel_inflight, daemon=True)
+    cancellation_thread.start()
+    local_url = f"http://127.0.0.1:{server.server_port}/object"
+    plan = replace(planned, url=local_url, checksum_url=f"{local_url}.CHECKSUM")
+    context = BinancePublicHistoryExecutionContext(
+        BinancePublicHistoryExecutionLimits(
+            deadline_monotonic=time.monotonic() + 5,
+            maximum_http_attempts=1,
+            maximum_total_response_bytes=100,
+            maximum_response_bytes=100,
+            maximum_archive_objects=1,
+            maximum_rest_pages=1,
+            maximum_attempts_per_request=1,
+        ),
+        cancelled=cancellation.is_set,
+    )
+    started = time.monotonic()
+    try:
+        result = BinancePublicArchiveAcquisition(
+            RawStore(tmp_path), clock=lambda: _NOW
+        ).acquire(plan, UnusedAdapter(), context)
+        elapsed = time.monotonic() - started
+    finally:
+        server.shutdown()
+        server.server_close()
+        server_thread.join()
+        cancellation_thread.join()
+
+    assert result.status is BinanceArchiveAcquisitionStatus.CANCELLED
+    assert reached_request.is_set()
+    assert context.snapshot().http_attempts == 1
+    assert elapsed < 2
+
+
+@pytest.mark.parametrize("declared_length", [False, True])
+@pytest.mark.parametrize(
+    ("payload", "expected_body", "complete"),
+    [
+        (b"1234", b"1234", True),
+        (b"12345", b"12345", True),
+        (b"123456", b"123456", False),
+    ],
+)
+def test_archive_reader_distinguishes_exact_eof_from_overflow(
+    monkeypatch: pytest.MonkeyPatch,
+    declared_length: bool,
+    payload: bytes,
+    expected_body: bytes,
+    complete: bool,
+) -> None:
+    class Response:
+        status = 200
+
+        def __init__(self) -> None:
+            self.headers = (
+                {"Content-Length": str(len(payload))} if declared_length else {}
+            )
+            self.offset = 0
+
+        def __enter__(self) -> "Response":
+            return self
+
+        def __exit__(self, *unused_args: object) -> None:
+            return None
+
+        def read(self, amount: int) -> bytes:
+            chunk = payload[self.offset : self.offset + amount]
+            self.offset += len(chunk)
+            return chunk
+
+        def read1(self, amount: int) -> bytes:
+            return self.read(min(amount, 2))
+
+    monkeypatch.setattr(
+        "tracequant.data.binance_public_archive.urllib.request.urlopen",
+        lambda request, timeout: Response(),
+    )
+
+    response = archive_module._urllib_http_get(
+        "https://example.invalid/archive.zip",
+        5,
+        maximum_response_bytes=5,
+    )
+
+    assert response.body == expected_body
+    assert response.complete is complete


### PR DESCRIPTION
Closes #302

## Summary
Add a shared finite Binance public-history execution context and ledger consumed by all existing archive backfills and shared REST executors, with exact HTTP/byte accounting, per-object/page/request limits, absolute deadlines, cancellation, bounded retry waits, killable default transports, preserved failure evidence, and compatibility coverage.

## Validation
- Critical Outcome: pass
- Formal Delivery validation: pass

## Risks / limitations
Production default archive and REST transports are forcibly bounded through subprocesses; injected custom transports remain responsible for honoring their supplied timeout/response-size contract while their returned bytes and post-response cancellation are still accounted deterministically.
