### PR TITLE
[Documentation] Publish the immutable TraceQuant v1 archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@ perpetual futures. The current repository is the Research MVP foundation: it
 contains a small, validated Python package and the engineering documentation
 around it. It does not contain a trading system or an executable strategy yet.
 
+The final validated v1 tracked snapshot is preserved by the immutable
+[`tracequant-v1-archive-2026-09-12`](https://github.com/PhoenixSss/tracequant/releases/tag/tracequant-v1-archive-2026-09-12)
+tag and GitHub Release at commit
+`27a9fdd877533f933cde4818eba9c186d286c529`. This is a historical,
+non-production recovery archive containing both the v1 business code and LCK;
+it is not a production-readiness or v2-completion claim. See the
+[post-publication record](docs/releases/tracequant-v1-archive-2026-09-12.md)
+for the exact identity, validation, scope, retained-asset boundary, and
+recovery notes.
+
 ## LCK: an engineering capability within TraceQuant
 
 While building and maintaining TraceQuant, the project is developing the Local

--- a/docs/guides/release-policy.md
+++ b/docs/guides/release-policy.md
@@ -248,10 +248,12 @@ The safe publication order is:
    digests, against the locally validated set.
 5. Publish the draft once, changing only its publication state.
 6. After publication, perform only read-only Release/tag/asset verification
-   and tracked documentation synchronization.
+   and tracked documentation synchronization unless a named, documented
+   archive-specific metadata exception in Section 9 applies.
 
 Post-publication asset replacement, deletion, tag reuse, and `--clobber` are
-prohibited. A correction requires a new immutable preview or patch identity.
+prohibited. Except for an archive-specific metadata exception in Section 9, a
+correction requires a new immutable preview or patch identity.
 
 Archive generation must be deterministic: use a stable normalized path order
 (with `/` separators), normalized archive metadata such as fixed UTC
@@ -381,16 +383,20 @@ preview/stable status are independent decisions.
 ## 9. Continuity, corrections, and withdrawal
 
 Release history is part of the artifact's audit trail. Each published release
-keeps its tag, source SHA, manifest, digest, notes, and status visible in the
-Git history or GitHub Release record. A later release must point to the
-identity it supersedes; "latest" is a convenience label, never an identity.
+keeps its tag, source SHA, manifest, digest, and an auditable record of its
+notes and status visible in the Git history or GitHub Release record. Published
+notes or status may change in place only under a named exception below that
+preserves the release's fixed recovery identity and records the correction. A
+later release must point to the identity it supersedes; "latest" is a
+convenience label, never an identity.
 
 The continuity rules are:
 
 - published tags and archive identities are immutable;
 - preview versions and later stable versions are monotonically identifiable;
 - every release remains traceable to one exact source commit and manifest;
-- a correction uses a new patch or preview identity and explains the defect,
+- unless a named archive-specific metadata exception below applies, a
+  correction uses a new patch or preview identity and explains the defect,
   impact, and relationship to the earlier release;
 - a changed archive digest, included path, or source commit is a new release,
   even when the human-readable version would otherwise look convenient; and
@@ -400,6 +406,18 @@ The continuity rules are:
   removing an asset or tag, the withdrawal record must preserve the former
   identity, date, reason, and replacement relationship as far as the hosting
   service permits.
+
+The only current archive-specific exception is the historical
+`tracequant-v1-archive-2026-09-12` Release. Its title, notes, or
+latest/prerelease metadata may receive a bounded in-place correction when the
+tag name, annotated tag object, peeled commit, source tree, Release target, and
+custom asset set are verified unchanged before and after the correction. The
+publication record must state what was corrected and preserve those fixed
+identity values. This exception never permits moving, deleting, or reusing the
+tag; changing the Release target; or adding, replacing, or deleting a custom
+asset. If a fixed value changes or cannot be verified, fail closed and use a
+new release identity. The exception does not apply to LCK previews or other
+TraceQuant releases.
 
 The policy does not require a floating compatibility promise. Adopters must
 select a named release, verify its digest, read its compatibility notes, and

--- a/docs/guides/release-policy.md
+++ b/docs/guides/release-policy.md
@@ -1,9 +1,10 @@
 # TraceQuant and LCK release policy
 
-> **Status:** Current release policy and published LCK preview record
+> **Status:** Current release policy, published v1 archive, and LCK preview record
+> **Published TraceQuant archive:** `tracequant-v1-archive-2026-09-12`
 > **Published LCK previews:** `lck-v0.1.0-preview.1`, `lck-v0.1.0-preview.2`
 > **Current corrected preview:** `lck-v0.1.0-preview.2` (GitHub pre-release)
-> **Last repository-state check:** 2026-09-03
+> **Last repository-state check:** 2026-09-12
 
 This policy defines how releases of the TraceQuant project and previews of the
 Local Control Kernel (LCK) are identified, checked, documented, and kept
@@ -36,6 +37,16 @@ other track's stability claim.
 | TraceQuant project | A reviewed TraceQuant repository state and, when applicable, its project package | `tracequant-v<MAJOR>.<MINOR>.<PATCH>`; the package version remains the value in `pyproject.toml` | A project release. It must not imply that planned quantitative or trading capabilities are implemented. |
 | LCK component preview | A deliberately scoped, manifest-backed LCK source archive, if one is published | `lck-v<MAJOR>.<MINOR>.<PATCH>-preview.<N>` | A versioned LCK snapshot for manual evaluation and adaptation inside TraceQuant's project context. |
 
+The retirement-specific
+[`tracequant-v1-archive-2026-09-12`](https://github.com/PhoenixSss/tracequant/releases/tag/tracequant-v1-archive-2026-09-12)
+identity is a deliberately named historical recovery archive, not a new
+semantic package version or production release. It binds the complete v1
+tracked tree, including business code and LCK, to commit
+`27a9fdd877533f933cde4818eba9c186d286c529`. Its
+[post-publication record](../releases/tracequant-v1-archive-2026-09-12.md)
+preserves the exact scope, validation, retained-asset boundary, and recovery
+facts without changing the archived commit.
+
 The first LCK preview, [`lck-v0.1.0-preview.1`](https://github.com/PhoenixSss/tracequant/releases/tag/lck-v0.1.0-preview.1),
 was published and remains an immutable historical release. The corrected
 [`lck-v0.1.0-preview.2`](https://github.com/PhoenixSss/tracequant/releases/tag/lck-v0.1.0-preview.2)
@@ -53,12 +64,15 @@ preview.
 
 ## 2. Current availability and source-of-truth boundaries
 
-At the state check recorded above, both previews are published GitHub
-pre-releases. `preview.1` is historical and superseded; `preview.2` is the
-current corrected pre-release and the supported versioned path for manual
-evaluation and repository-specific adaptation. The repository-copy path also
-remains available. A GitHub-generated source archive for an arbitrary commit,
-branch, or tag is not by itself an LCK release archive.
+At the state check recorded above, the TraceQuant v1 historical archive and
+both LCK previews are published. The v1 archive is non-production and preserves
+the complete tracked repository tree at its exact tag; it does not supersede
+the independently scoped LCK preview track. `preview.1` is historical and
+superseded; `preview.2` is the current corrected pre-release and the supported
+versioned path for manual LCK evaluation and repository-specific adaptation.
+The repository-copy path also remains available. A GitHub-generated source
+archive for an arbitrary commit, branch, or tag is not by itself an LCK release
+archive.
 
 The live [`preview.2` Release record](https://github.com/PhoenixSss/tracequant/releases/tag/lck-v0.1.0-preview.2)
 is authoritative for the exact current identity: it is not a draft, has

--- a/docs/releases/tracequant-v1-archive-2026-09-12.md
+++ b/docs/releases/tracequant-v1-archive-2026-09-12.md
@@ -1,0 +1,99 @@
+# TraceQuant v1 archive publication record
+
+## Publication identity
+
+The historical, non-production TraceQuant v1 archive was published once at
+`2026-09-12T09:20:14Z`:
+
+| Field | Exact value |
+| --- | --- |
+| GitHub Release | [`tracequant-v1-archive-2026-09-12`](https://github.com/PhoenixSss/tracequant/releases/tag/tracequant-v1-archive-2026-09-12) |
+| Release database ID | `387517006` |
+| Annotated tag object | `1ed4507486fbb5280f9bced5833713b26e7d3512` |
+| Peeled source commit | `27a9fdd877533f933cde4818eba9c186d286c529` |
+| Source tree | `8406076ce81a2476005e3c938abd4c5a088373c2` |
+| Package version in the archive | `0.1.0` |
+| Tracked scope | Complete 183-file Git tree at the source commit |
+| Custom Release assets | None |
+| GitHub classification | Published, non-draft, non-prerelease historical archive |
+
+The remote tag ref resolves to the annotated tag object above and peels to the
+same commit as the Release target. The tag, Release body, target, and asset set
+must not be rewritten or reused. GitHub's generated source archives are views
+of this tagged tracked tree; no separately prepared archive was uploaded.
+
+Creation and post-publication correction both requested `make_latest=false`.
+At the recorded verification time, GitHub's `releases/latest` convenience
+endpoint nevertheless resolved this archive because it was the repository's
+only published non-prerelease Release. That floating endpoint is not release
+identity or a recovery source; consumers must use the exact tag and URL above.
+
+## Validated tracked snapshot
+
+Immediately before tag creation, the tracked worktree was clean and
+`HEAD == main == origin/main == 27a9fdd877533f933cde4818eba9c186d286c529`.
+The exact tree passed the repository's `current-ci-equivalent` profile:
+
+| Validation fact | Value |
+| --- | --- |
+| Validation status | `pass` |
+| Runner version | `1.2.0` |
+| Commands passed | `6/6` |
+| Result SHA-256 | `6dc036755b21bafc0faef91eba1982b0c024700bf1e3ffdc21ca60e04ebdb465` |
+
+The exact tracked paths were also checked for sensitive filenames and common
+private-key/token signatures without emitting matching values. No content
+signature matched; `.env.example` was the sole sensitive-name match and is the
+documented configuration example. `detect-secrets` was unavailable in the
+publication environment, so this bounded check is not represented as a
+universal guarantee against secrets embedded in arbitrary free text.
+
+## Implemented and absent capabilities
+
+The archive contains the v1 configuration, logging, UTC and immutable domain
+foundation; typed Binance USDⓈ-M public-history contracts; immutable local Raw
+Parquet/manifest storage; bounded BTCUSDT/ETHUSDT 1m contract-, mark-price- and
+index-price-Kline archive/REST acquisition; and bounded settled-funding
+archive/REST acquisition.
+
+It also contains the complete v1 LCK facade and kernel, workflow policies,
+provider Skills, documentation, validation tooling, and tests. The tagged tree
+therefore recovers both the business implementation and LCK without depending
+on the later v2 tree.
+
+The archive has no general research or feature pipeline, canonical data repair,
+backtester, strategy, model training, experiment tracking, private exchange
+API, order execution, account/position ledger, risk engine, database service,
+Demo trading, Live trading, or multi-exchange production runtime. Live trading
+is neither approved nor enabled. The tracked `apps/`, `packages/`, and
+`deploy/` README files remain v1 future-boundary placeholders; they are not v2
+initialization. The archived dependency set does not include NautilusTrader.
+
+## External asset boundary
+
+The tracked safe record is
+[`tracequant-v1-retained-assets-manifest.json`](../research/tracequant-v1-retained-assets-manifest.json),
+whose archived SHA-256 is
+`582bed3de6a437335828c1e2918e8cec0f65a1d32539d2a93368dcb9406118e6`.
+It records 8,166 retained files and 175,513,200 logical bytes. The protected
+external archive SHA-256 is
+`03bfb00e9fc0165e68def8c3c5daa4839cac5e64088d7869e1c9c90c1efec0b0`;
+the protected full external manifest SHA-256 is
+`c7c3a33fc67161e17db259cc467cdc3f247e3fd2cae95174747719e0e82cc92a`.
+
+The retained payload, full path-level manifest, audit source checkouts, virtual
+environments, caches, local workflow state, and any Secret material remain
+outside Git and GitHub Release artifacts under the recovery owner's access
+controls.
+
+## Recovery
+
+Fetch the exact annotated tag, verify that it peels to the commit above, and
+inspect the tagged tree before use. The tag's `README.md`, technical baseline,
+release policy, LCK overview, and LCK adoption guide define the archived
+capabilities and limitations.
+
+External retained assets are a separate controlled recovery path. Verify the
+safe-manifest, protected-manifest, and archive digests before extracting them
+into a new restricted location. They are not required to recover the tracked
+business code or LCK from Git.

--- a/docs/releases/tracequant-v1-archive-2026-09-12.md
+++ b/docs/releases/tracequant-v1-archive-2026-09-12.md
@@ -18,15 +18,22 @@ The historical, non-production TraceQuant v1 archive was published once at
 | GitHub classification | Published, non-draft, non-prerelease historical archive |
 
 The remote tag ref resolves to the annotated tag object above and peels to the
-same commit as the Release target. The tag, Release body, target, and asset set
-must not be rewritten or reused. GitHub's generated source archives are views
-of this tagged tracked tree; no separately prepared archive was uploaded.
+same commit as the Release target. The tag name, annotated tag object, peeled
+commit, source tree, Release target, and custom asset set are the fixed recovery
+identity and must not be moved, rewritten, or reused. GitHub's generated source
+archives are views of this tagged tracked tree; no separately prepared archive
+was uploaded. The Release title, notes, and latest/prerelease metadata are not
+part of that fixed identity and may be corrected only under the bounded,
+recorded exception in the release policy.
 
-Creation and post-publication correction both requested `make_latest=false`.
-At the recorded verification time, GitHub's `releases/latest` convenience
-endpoint nevertheless resolved this archive because it was the repository's
-only published non-prerelease Release. That floating endpoint is not release
-identity or a recovery source; consumers must use the exact tag and URL above.
+Creation and a bounded post-publication correction both requested
+`make_latest=false`; that correction addressed only the requested floating
+latest classification and preserved every fixed recovery-identity value listed
+above. At the recorded verification time, GitHub's `releases/latest`
+convenience endpoint nevertheless resolved this archive because it was the
+repository's only published non-prerelease Release. That floating endpoint is
+not release identity or a recovery source; consumers must use the exact tag and
+URL above.
 
 ## Validated tracked snapshot
 


### PR DESCRIPTION
Closes #318

## Summary
Record the published v1 tag and Release identity, validation evidence, implemented and absent capabilities, LCK recovery boundary, external retained-asset manifest metadata, and archive links from README and release policy.

## Validation
- Formal Delivery validation: pass

## Risks / limitations
GitHub repository-level immutable-release enforcement reports false, so immutability remains enforced by the annotated tag and repository policy. GitHub still resolves this sole non-prerelease Release through its latest convenience endpoint after make_latest=false; consumers must use the exact tag. detect-secrets was unavailable, while bounded tracked-path and non-value-emitting signature checks passed.
