### PR TITLE
[Documentation] Register the completed NautilusTrader capability validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,12 @@ backfilled or replayed typed lifecycle receipts.
   engineering workflows are explicitly exempt.
 - [Technical baseline](docs/architecture/technical-baseline.md): current
   implementation facts and explicitly deferred research/trading architecture.
+- [NautilusTrader primary-runtime ADR](docs/architecture/adr-0001-nautilustrader-primary-runtime.md):
+  accepted v2 trading-runtime selection, ownership boundary, and closed Live
+  gate.
+- [NautilusTrader capability validation baseline](docs/research/nautilustrader-capability-validation-2026-09-12.md):
+  fixed source identities, evidence levels, completed runtime results,
+  limitations, and later Demo/restart/soak gates.
 - [Repository structure](docs/architecture/repository-structure.md): current
   tree, dependency direction, and future boundary rules.
 - [Initial public domain models](docs/architecture/domain-models.md): model

--- a/docs/architecture/adr-0001-nautilustrader-primary-runtime.md
+++ b/docs/architecture/adr-0001-nautilustrader-primary-runtime.md
@@ -1,0 +1,100 @@
+# ADR-0001: NautilusTrader is the primary trading runtime for v2
+
+- **Status:** Accepted
+- **Decision date:** 2026-09-12
+- **Decision:** `NAUTILUS_PRIMARY`
+- **Live status:** `LIVE_NOT_APPROVED`
+- **Validated baseline:** NautilusTrader `v2.0.0rc4`, commit
+  `a0400251110653b6d8ae6a9b5b89c4543fa85a2d`
+- **Evidence:** [NautilusTrader capability validation baseline](../research/nautilustrader-capability-validation-2026-09-12.md)
+
+## Context
+
+The TraceQuant v1 retirement gate reached
+[`V1_RETIREMENT_COMPLETE`](../research/tracequant-v1-retirement-gate-2026-09-12.md).
+The completed foundation-selection work compared trading runtimes and then
+reviewed the selected NautilusTrader version through fixed-source inspection,
+official tests, and an official synthetic backtest. Issue #316 registers that
+already completed work; it does not reopen framework selection.
+
+TraceQuant needs one owner for trading-domain types and mutable trading state.
+Research libraries may be composed around that owner, but they must not create
+a competing Order, Position, Portfolio, Risk, Execution, or Reconciliation
+domain.
+
+## Decision
+
+NautilusTrader v2 is the primary trading runtime for TraceQuant v2. The first
+development and backtest baseline is pinned to `v2.0.0rc4` at commit
+`a0400251110653b6d8ae6a9b5b89c4543fa85a2d`.
+
+The decision state is:
+
+```text
+NAUTILUS_PRIMARY
+VERSION_PINNED=v2.0.0rc4/a0400251110653b6d8ae6a9b5b89c4543fa85a2d
+DEVELOPMENT_AND_BACKTEST_ALLOWED
+BINANCE_DEMO_OBSERVATION_REQUIRED
+LIVE_NOT_APPROVED
+```
+
+This is an architecture selection, not a claim that NautilusTrader is already
+integrated into this repository. The current implementation baseline remains
+authoritative for installed and callable TraceQuant capabilities. Adding the
+dependency, integrating it, or crossing an Offline, Shadow, Demo, or Live
+boundary requires separately scoped Issues and validation.
+
+## Ownership boundary
+
+| Capability | Primary owner | TraceQuant responsibility |
+| --- | --- | --- |
+| Trading data types and instrument semantics | NautilusTrader | Universe allowlists, source provenance, and read-only research mappings |
+| Trading-history catalog and runtime aggregation | NautilusTrader | Raw-source acquisition, checksums, coverage QA, and research-derived views |
+| Common indicator primitives | NautilusTrader | Feature definitions, parameters, causality, and research/runtime parity |
+| Strategy and Actor lifecycle | NautilusTrader | Alpha, model loading and inference, and strategy configuration |
+| Orders, positions, account, and portfolio | NautilusTrader | Strategy intent and acceptance assertions; no shadow trading ledger |
+| Core pre-trade risk | NautilusTrader | Thresholds and only verified missing policies such as daily loss or stale-data stops |
+| Backtest fills, fees, funding, accounting, and reports | NautilusTrader | Scenarios, assumptions, comparisons, and acceptance criteria |
+| Binance market data and execution | NautilusTrader adapter | Configuration, credentials boundary, symbol allowlist, and black-box acceptance |
+| Cache, restart, and reconciliation | NautilusTrader | Persistence configuration, acceptance, alerting, and Live admission |
+| Deployment and monitoring | TraceQuant operations | Environment isolation, least privilege, rollback, SLOs, alerts, and runbooks |
+
+Polars, Jupyter, scikit-learn, GBDT libraries, PyTorch, DuckDB, MLflow,
+Optuna, Redis/PostgreSQL, and observability tools remain companion components
+used only when a scoped requirement justifies them. None becomes a second
+trading-domain owner.
+
+## Consequences
+
+- Do not build a TraceQuant trading engine, generic backtester, exchange order
+  state machine, Binance execution adapter, Portfolio/Account ledger, generic
+  RiskEngine, or reconciliation engine alongside NautilusTrader.
+- Keep raw source evidence, read-only research tables, and Nautilus trading
+  data as distinct layers. A file format does not own trading semantics.
+- Implement production strategies through NautilusTrader Strategy/Actor and
+  order APIs. A model output is research or strategy intent, not an order fact.
+- Prefer a reproducible upstream fix when a NautilusTrader defect is confirmed;
+  do not maintain a parallel shadow state machine as a workaround.
+- Do not repeat the completed framework-selection exercise as a prerequisite
+  for v2 design. Re-evaluate a version only for a scoped upgrade or a failed
+  acceptance gate.
+
+## Live admission remains closed
+
+The pinned release candidate has framework capability evidence but no
+TraceQuant Binance Demo or Live proof. Live remains prohibited until separate
+work verifies at least:
+
+1. the target version's production recommendation or an explicit risk
+   acceptance if it is still a release candidate;
+2. Binance Demo market, limit, cancel, reduce-only, stop, partial-fill, and
+   position/margin-mode behavior;
+3. warm and cold restart with open orders and positions, plus reconciliation
+   with no unexplained venue/local drift;
+4. funding, fees, balances, and positions against venue observations;
+5. disconnect/reconnect behavior, fail-closed controls, alerts, and runbooks;
+6. an engineering soak followed by a longer Demo observation period; and
+7. explicit human approval for any later tiny-capital canary.
+
+Failure or missing evidence at any gate keeps the system in Demo. No date or
+completion of earlier development automatically authorizes Live trading.

--- a/docs/research/nautilustrader-capability-validation-2026-09-12.md
+++ b/docs/research/nautilustrader-capability-validation-2026-09-12.md
@@ -1,0 +1,179 @@
+# NautilusTrader capability validation baseline
+
+- **Evidence date:** 2026-09-12
+- **Status:** Completed foundation-selection evidence
+- **Conclusion:** `NAUTILUS_PRIMARY`, `LIVE_NOT_APPROVED`
+- **Decision:** [ADR-0001](../architecture/adr-0001-nautilustrader-primary-runtime.md)
+- **Prerequisite:**
+  [`V1_RETIREMENT_COMPLETE`](tracequant-v1-retirement-gate-2026-09-12.md)
+
+## Purpose and claim boundary
+
+This is the canonical, portable repository record of the completed external
+foundation-selection and NautilusTrader capability validation. It preserves
+the conclusion without requiring the external audit workspaces to remain
+available and without making the completed selection investigation a future
+v2 prerequisite.
+
+The evidence supports selecting a framework baseline for v2 development and
+backtesting. It does **not** prove that TraceQuant has integrated
+NautilusTrader, that Binance Demo behavior works for TraceQuant, or that Live
+trading is safe or approved.
+
+| Claim | Evidence state on 2026-09-12 |
+| --- | --- |
+| Fixed NautilusTrader wheel, selected Python tests, and official synthetic backtest execute | `RUNTIME_VERIFIED` |
+| The fixed source contains the inspected trading-domain and Binance USD-M capability surfaces | `SOURCE_VERIFIED` |
+| TraceQuant has integrated the selected runtime | `NOT_VERIFIED`; not implemented by this documentation item |
+| Binance Demo order, restart, and reconciliation behavior | `NOT_VERIFIED`; later acceptance gate |
+| Live readiness | Not approved; `LIVE_NOT_APPROVED` |
+
+## Evidence vocabulary
+
+The source audit used these levels. They must remain distinct in later design
+and acceptance work:
+
+| Canonical label | Meaning |
+| --- | --- |
+| `RUNTIME_VERIFIED` | An existing official test, example, or tool was run and its result observed. |
+| `SOURCE_VERIFIED` | The behavior or interface exists in the fixed source or official test source. It was not necessarily executed. |
+| `DOC_VERIFIED` (documentation-verified) | Fixed-version official documentation states the behavior. It is not runtime proof. |
+| `ISSUE_EVIDENCE` | An official upstream Issue records a report and status. It is not a local reproduction. |
+| `NOT_VERIFIED` | The environment, credentials, or allowed audit scope could not verify the claim. |
+| `UNSUPPORTED` | Fixed source explicitly rejects the capability or the required path is absent with corroborating evidence. |
+
+No lower level is promoted to `RUNTIME_VERIFIED`, and framework evidence is
+never promoted to TraceQuant integration, Demo, or Live evidence.
+
+## Fixed subject identities
+
+| Subject | Official source | Audited identity | Notes |
+| --- | --- | --- | --- |
+| NautilusTrader | `https://github.com/nautechsystems/nautilus_trader.git` | tag `v2.0.0rc4`; commit `a0400251110653b6d8ae6a9b5b89c4543fa85a2d`; 2026-09-02 | Detached fixed checkout; Python `2.0.0rc4`; Rust crates `0.63.0` |
+| LEAN Engine | `https://github.com/QuantConnect/Lean.git` | commit `6eb389012d73c364547d61546ff822fc8432dee2`; describe `18084`; 2026-09-11 | Comparison subject; runtime reported `v2.5.0.0` |
+| LEAN Binance plugin | `https://github.com/QuantConnect/Lean.Brokerages.Binance.git` | commit `9696fc025972314d73008f879d595df5c67bca28`; describe `17864`; 2026-06-19 | Comparison subject; resolved `QuantConnect.Brokerages 2.5.18042` |
+
+The three source checkouts were clean after their audit commands. They and
+their environments remain external evidence inputs and are not repository
+dependencies or committed artifacts.
+
+## Runtime-verified results
+
+The fixed NautilusTrader wheel reported version `2.0.0rc4` and core commit
+prefix `a04002511106` under Python 3.12.14. The selected official test total was:
+
+```text
+318 passed, 6 skipped, 0 failed
+```
+
+That total consists of:
+
+| Official test surface | Result |
+| --- | ---: |
+| `python/tests/unit/model/test_funding.py` | 11 passed |
+| `python/tests/acceptance_tests` | 33 passed, 6 skipped |
+| Selected backtest engine/config/node/model, execution, risk, portfolio, serialization, Binance factory, and migration units | 274 passed |
+
+The acceptance suite used its supported `TEST_DATA_ROOT_PATH` setting to point
+at the fixed checkout. Earlier missing-test-data failures were therefore
+classified as environment setup, not framework defects; no candidate source
+was changed.
+
+The official `examples/backtest/synthetic_data_pnl_test.py` example exited
+successfully with 12 bars, two market orders, one position, per-contract fees,
+margin, and realized PnL of `$70.00`.
+
+These results prove that the selected build and core synthetic backtest path
+were executable in the audit environment. They are **not** Binance Demo,
+exchange-protocol, restart/reconciliation, strategy-profitability, or Live
+proof.
+
+## Capability evidence and limits
+
+Fixed-source review found NautilusTrader-owned surfaces for typed trading data
+and instruments, `ParquetDataCatalog`, runtime bar aggregation and common
+indicators, Strategy/Actor lifecycle, orders, positions, portfolio/accounting,
+core risk, backtest fills/fees/funding/reports, Binance USD-M data and
+execution, cache persistence, and reconciliation. In particular, the Binance
+source exposed GTX post-only, reduce-only, one-way/hedge position semantics,
+per-symbol leverage and cross/isolated margin configuration, mark/index/funding
+data, native amend paths, and dedicated reconciliation behavior.
+
+This is primarily `SOURCE_VERIFIED`, with fixed documentation supplying
+`DOC_VERIFIED` support. The selected runtime executions above cover only their
+stated official Python test and synthetic example surfaces.
+
+The architectural ownership derived from this evidence is canonical in
+[ADR-0001](../architecture/adr-0001-nautilustrader-primary-runtime.md). In
+summary, NautilusTrader owns trading-domain types and mutable state; TraceQuant
+owns source provenance, read-only research semantics, features and labels,
+models and strategy intent, policy values, acceptance, operations, and the Live
+gate.
+
+## Known gaps and unverified claims
+
+The completed audit did not verify:
+
+- NautilusTrader Rust Binance adapter tests, because the audit host lacked the
+  Rust toolchain;
+- any Binance Demo or private API path, because no Demo credentials were used
+  and no order was submitted;
+- warm or cold restart with venue orders or positions;
+- long-running disconnect/reconnect behavior or a Demo soak;
+- real funding, commission, balance, and position reconciliation;
+- RTX 5090 model training or inference coexistence; or
+- TraceQuant-specific data, Strategy, risk-policy, or runtime integration.
+
+The fixed rc4 Python `ParquetDataCatalog` binding did not directly expose the
+Rust backend's FundingRate write/query surface. Historical mark/index/funding
+coverage and research lineage remain TraceQuant integration work, not evidence
+that a second trading-data platform is needed.
+
+Upstream Issue evidence included a then-open warm-restart NETTING
+reconciliation report, nautechsystems/nautilus_trader#4736, and a then-open
+Futures OCO/bracket capability gap, #4043. `ISSUE_EVIDENCE` does not claim local
+reproduction, but the restart report remains a Live blocker until a selected
+version and TraceQuant Demo acceptance evidence resolve it.
+
+## Required later gates
+
+The completed selection tests are not repeated as a prerequisite for beginning
+v2 design. New evidence must instead be produced at the boundary it concerns:
+
+1. **Integration:** pin and integrate the dependency through a scoped Issue;
+   verify TraceQuant data, Strategy, risk, accounting, and reproducibility
+   contracts without creating a second trading domain.
+2. **Demo execution:** first use official Binance Futures data/exec testers,
+   then verify market/limit/cancel/reduce-only/stop, partial and complete fills,
+   selected position and margin modes, and strict symbol allowlists.
+3. **Restart and reconciliation:** exercise warm/cold restart with open orders,
+   open positions, partial fills, disconnect/reconnect, and persistent cache;
+   unexplained venue/local state must fail closed.
+4. **Accounting:** compare fees, funding, balances, orders, fills, and positions
+   with venue observations across relevant boundaries.
+5. **Soak and operations:** pass an initial 24–72 hour engineering soak, then a
+   longer Demo observation period driven by anomaly rate and change frequency;
+   validate alerts, runbooks, secret controls, rollback, and kill behavior.
+6. **Live decision:** re-check the target release's production recommendation,
+   resolve or accept all blockers explicitly, and require human approval before
+   any separately scoped tiny-capital canary.
+
+Until all applicable gates pass, missing or contradictory evidence preserves
+`LIVE_NOT_APPROVED` and the system remains Offline or Demo-only.
+
+## External report register
+
+The four completed reports remain outside the repository. Their filenames and
+SHA-256 digests preserve exact source identity without committing audit source
+checkouts, virtual environments, dependency caches, or machine-specific paths.
+
+| External report | SHA-256 |
+| --- | --- |
+| `TraceQuant 开源技术栈与自研边界深度研究.md` | `5fc90e347c8115301c673f4f98dde6070555332062f40fb5c55451b72ee9b88a` |
+| `TraceQuant Trading Runtime Read-Only Review.md` | `93f607c0adef9f6f27e96f4a835c4e258902ce546c62d433bc4d0a8d74d26179` |
+| `TraceQuant Nautilus 技术栈与自研边界复审.md` | `954edd7b2f7439b261225d0c46266e68fa6bba7ce33ab8feacf50779b8dea89e` |
+| `TraceQuant 分阶段推进计划.md` | `6710bb0505d19971ea46959cf0644cef97720a8a348326e826929d841dd76001` |
+
+This register identifies the completed inputs; those external files are not
+runtime dependencies and do not have to be reacquired or rerun for ordinary v2
+design work.


### PR DESCRIPTION
Closes #316

## Summary
Add the canonical NautilusTrader primary-runtime ADR and portable capability-validation evidence baseline, including fixed source identities, evidence levels, runtime results, ownership boundaries, known gaps, and later Demo/restart/soak gates; link both from the README documentation map.

## Validation
- Formal Delivery validation: pass

## Risks / limitations
Documentation records a selected release-candidate baseline only. NautilusTrader is not yet integrated, Binance Demo and restart/reconciliation remain unverified, and Live remains explicitly unapproved.
