### PR TITLE
[Documentation] Define the NautilusTrader import and update policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,6 +472,9 @@ backfilled or replayed typed lifecycle receipts.
 - [NautilusTrader primary-runtime ADR](docs/architecture/adr-0001-nautilustrader-primary-runtime.md):
   accepted v2 trading-runtime selection, ownership boundary, and closed Live
   gate.
+- [NautilusTrader import and update policy](docs/guides/nautilustrader-import-and-update-policy.md):
+  exact package/import identity, wheel-only acquisition, integration boundary,
+  versioned persistent roots, upgrade gates, promotion, and rollback.
 - [NautilusTrader capability validation baseline](docs/research/nautilustrader-capability-validation-2026-09-12.md):
   fixed source identities, evidence levels, completed runtime results,
   limitations, and later Demo/restart/soak gates.

--- a/docs/architecture/repository-structure.md
+++ b/docs/architecture/repository-structure.md
@@ -141,11 +141,16 @@ independent Console deployment creates sustained operational value.
 
 ## Approved v2 target structure
 
-The v2 bootstrap must create only the tracked skeleton described here. It must
-not copy v1 modules into that skeleton, install dependencies, initialize
-runtime data, or imply that Offline, Shadow, Demo, or Live operation is
-available. Empty directories are represented by a short `README.md` only when
-the bootstrap needs to preserve a boundary in Git.
+The v2 bootstrap must create only the tracked skeleton described here. As part
+of that skeleton it establishes the declared Python baseline, the exact
+official NautilusTrader wheel dependency, the uv source-build policy, the
+committed lock, and the minimal integration seam needed to prove package and
+import ownership. It may resolve and install the locked wheel into a generated,
+disposable project environment solely for bootstrap acceptance. It must not
+copy v1 modules into that skeleton, initialize persistent runtime data,
+implement a trading workflow, or imply that Offline, Shadow, Demo, or Live
+operation is available. Empty directories are represented by a short
+`README.md` only when the bootstrap needs to preserve a boundary in Git.
 
 ### Classification vocabulary
 
@@ -179,92 +184,105 @@ invent another top-level product-code root.
 | `tests/` | Product tests mirroring `src/tracequant`; test support is not a production import source | TraceQuant engineering | Tracked |
 | `.env.example` | Names and safe placeholders for supported environment variables; never values or automatic dotenv loading | TraceQuant configuration owner | Tracked |
 | `.gitignore` | Exhaustive checkout-local generated-path exclusions and secret-shaped local files | Maintainers | Tracked |
-| `.python-version` | Project Python toolchain selection | Maintainers | Tracked |
+| `.python-version` | Exact initial v2 interpreter selection: CPython `3.13` | Maintainers | Tracked |
 | `LICENSE` | TraceQuant source license | Maintainers | Tracked |
 | `README.md` | Project entry point, safety status, and links to current documentation | Maintainers | Tracked |
-| `pyproject.toml` | Build metadata, the `tracequant` package declaration, dependency groups, tool configuration, and console entry-point declarations | Maintainers | Tracked |
+| `pyproject.toml` | Build metadata, the `tracequant` package declaration, `requires-python = ">=3.13,<3.14"`, dependency groups, tool configuration, and any explicitly scoped console entry points | Maintainers | Tracked |
+| `uv.toml` | uv installation policy, including the NautilusTrader wheel-only constraint; never a machine-specific or LCK cache location | Maintainers | Tracked |
 | `uv.lock` | Reproducible Python dependency resolution | Maintainers | Tracked |
 
 There is no top-level `apps/`, `packages/`, `scripts/`, `runtime/`, `data/`,
 `artifacts/`, or `vendor/` product root in v2. Operational Python entry points
-are declared in `pyproject.toml` and resolve to `tracequant.entrypoints.*`.
-Non-Python deployment material is added only by a later scoped Issue; it does
-not justify a second Python source tree.
+are declared in `pyproject.toml` only when a scoped capability needs them and
+resolve to a function in the owning boundary; they do not justify a generic
+entrypoint or orchestration framework. Non-Python deployment material is added
+only by a later scoped Issue; it does not justify a second Python source tree.
 
 ### `src/tracequant` layout and ownership
 
 All importable, self-developed production Python belongs below the single
-`tracequant` namespace. The following directories are ownership boundaries,
-not permission to pre-create implementations:
+`tracequant` namespace. The bootstrap creates only the dependency boundary
+needed to prove that separation:
 
 ```text
 src/tracequant/
   __init__.py
-  entrypoints/                 explicit CLI/process composition roots
-  orchestration/               lifecycle and mode coordination
-  strategies/                  alpha and portfolio intent
-  risk/                        final allow/reduce/reject policy
-  data/
-    contracts/                 source, dataset, and point-in-time schemas
-    acquisition/               raw-source acquisition policies
-    research/                  read-only derived research views
   integrations/
-    nautilus/                  thin approved NautilusTrader boundary only
-  config/                      typed configuration parsing and validation
-  observability/               project metrics, alerts, and audit emission
+    __init__.py
+    nautilus/
+      __init__.py              external distribution identity and import seam
+```
+
+Later scoped Issues may add only the following product boundaries when their
+capability is actually implemented. They are not bootstrap scaffolding and do
+not authorize framework-like abstractions:
+
+```text
+src/tracequant/
+  source_data/                 raw provenance, acquisition, checksum, coverage
+  research/                    views, features, labels, models, artifacts
+  integrations/
+    nautilus/
+      strategies/             concrete Nautilus Strategy/Actor implementations
+      configuration/          Nautilus backtest/node/venue/risk configuration
+  operations/                  admission, external observation, alerts, release
 ```
 
 | Boundary | Owns | Must not own |
 | --- | --- | --- |
-| `tracequant.entrypoints` | Argument parsing and explicit construction of an Offline, Shadow, Demo, or eventually approved Live process | Business logic, credentials, mutable global clients, or import-time startup |
-| `tracequant.orchestration` | Run lifecycle, mode gates, sequencing of strategy intent -> risk decision -> runtime action, and stop/reconciliation coordination | Alpha rules, duplicate order/account state, or bypasses around risk |
-| `tracequant.strategies` | Features consumed by a strategy, model inference, portfolio intent, and project-owned immutable `OrderIntent`-like requests | Exchange clients, Nautilus adapter imports, order submission/cancel/modify calls, or final risk decisions |
-| `tracequant.risk` | Project thresholds and the final `ALLOW`, `REDUCE`, or `REJECT` decision before any action reaches the runtime boundary | Alpha generation, exchange transport, or a parallel Nautilus `RiskEngine`, account, portfolio, or order ledger |
-| `tracequant.data.contracts` | Raw-source provenance, immutable dataset identities, coverage/quality outcomes, and point-in-time research schemas | Nautilus trading-domain types, network transport, mutable runtime state, or implicit missing-value repair |
-| `tracequant.data.acquisition` | Explicit raw acquisition use cases and source validation | Strategy, order, account, or execution behavior |
-| `tracequant.data.research` | Read-only transformations from verified raw identities into causal research inputs | Raw mutation, runtime catalog ownership, or future-observation access |
-| `tracequant.integrations.nautilus` | The smallest composition and translation layer needed to invoke the pinned upstream runtime and expose project-approved ports | A copied upstream package tree, parallel trading-domain models/state machines, alpha logic, or independent venue semantics already owned upstream |
-| `tracequant.config` | Typed, explicit configuration parsing and fail-closed mode/runtime identity validation | Secret storage, implicit environment reads on import, or Live defaults |
-| `tracequant.observability` | TraceQuant-specific metrics, alerts, structured audit events, and redaction policy | A second trading/account truth or credential values |
-| NautilusTrader in environment `site-packages` | Trading data/instrument types, Strategy/Actor runtime, orders, positions, account/portfolio state, core pre-trade risk, fills/accounting, Binance adapter, cache, restart, and reconciliation | TraceQuant alpha, project risk thresholds, source provenance, environment admission, or operator approval |
+| `tracequant.source_data` | Source URL/version, immutable raw bytes, checksums, acquisition policy, gap/coverage QA, and missing-data acquisition | A Binance exchange adapter, canonical trading-data schema, Nautilus catalog implementation, or trading-domain types |
+| `tracequant.research` | Read-only research views, feature/label semantics, causal lineage, training/evaluation, and model artifacts | Mutable trading state, Order/Position/Portfolio types, a trading engine, or writes back into the Nautilus catalog |
+| `tracequant.integrations.nautilus` | Direct use of the pinned public Nautilus APIs, source-to-Nautilus conversion, concrete Nautilus-native Strategy/Actor implementations, model loading/inference inside those implementations, and Nautilus configuration | A generic Strategy Adapter, model-to-runtime middleware, project Order/Position DTOs, a copied upstream package tree, or parallel trading state machines |
+| `tracequant.operations` | Demo/Live admission, external black-box observation, alerts, redaction, release/rollback policy, and later deployment assets | Trading-state correction, a reconciliation engine, credential values, or a second account/order truth |
+| Dedicated tests below `tests/` | Public-API compatibility, research/runtime parity, backtest and Demo acceptance, restart/reconciliation observation, and architecture enforcement | Production runtime code, shadow ledgers, or corrective trading behavior |
+| NautilusTrader in environment `site-packages` | Trading data/instrument types, `ParquetDataCatalog`, runtime Bar aggregation and indicators, Strategy/Actor lifecycle, orders, positions, account/portfolio state, core pre-trade risk, fills/accounting/reports, Binance adapter, cache, restart, and reconciliation | TraceQuant research semantics, source provenance, model artifacts, project-specific policy thresholds, environment admission, or operator approval |
 
 `tracequant.integrations.nautilus` is a boundary, not a vendor fork. It should
-contain a few use-case-shaped adapters or composition objects, not directories
-named after NautilusTrader's internal packages. Upstream modules, generated
-bindings, examples, fixtures, and tests stay in the installed distribution in
-the environment's `site-packages`; none may appear under `src/`, `tests/`, or
-`vendor/`.
+contain concrete, small Nautilus-native implementations and configuration, not
+a generic adapter/port framework or directories named after NautilusTrader's
+internal packages. Upstream modules, generated bindings, examples, fixtures,
+and tests stay in the installed distribution in the environment's
+`site-packages`; none may appear under `src/`, `tests/`, or `vendor/`.
 
 ### Dependency and order-authority direction
 
 The allowed product flow is:
 
 ```text
-tracequant.entrypoints
-  -> tracequant.orchestration
-       -> tracequant.strategies -> tracequant.data.contracts
-       -> tracequant.risk       -> project-owned intent/context contracts
-       -> tracequant.integrations.nautilus -> installed nautilus_trader
-  -> tracequant.config
-  -> tracequant.observability
+source_data -> tracequant.integrations.nautilus data conversion
+                                      |
+                                      v
+                 installed nautilus_trader typed objects / ParquetDataCatalog
+                                      |
+                                      v
+                           read-only research views
+                                      |
+                                      v
+                           model/feature artifacts
+                                      |
+                                      v
+tracequant.integrations.nautilus.strategies -> Nautilus backtest / Demo / Live
+
+tracequant.operations -----------------------> observe, gate, alert, release
 ```
 
-Data acquisition and research may depend inward on `data.contracts`; they do
-not depend on strategy, risk, orchestration, entrypoint, or integration code.
-Strategy and risk code are peers: neither imports the other. Orchestration
-passes immutable strategy intent and current risk context to risk, and only an
-`ALLOW` or `REDUCE` result may be translated at the Nautilus boundary. A
-`REJECT`, missing/unknown decision, stale data, local/exchange disagreement, or
-unreconciled order state produces no opening order. Reduction may only reduce
-the requested exposure. NautilusTrader's core pre-trade risk remains an
-independent downstream veto: neither layer may turn the other's rejection into
-an approval.
+Production strategy/model behavior is implemented directly as a thin public
+Nautilus `Strategy` or `Actor` below
+`tracequant.integrations.nautilus.strategies`. Model loading and inference stay
+with the concrete strategy that consumes them; there is no generic
+model-to-runtime middleware, parallel strategy runtime, or project-owned Order,
+Position, Portfolio, or Account DTO layer. Orders are created and submitted
+only through Nautilus `OrderFactory` and Strategy APIs, never through a
+TraceQuant exchange client.
 
-Strategies therefore never submit exchange orders directly. The upstream
-runtime may host the outer Strategy/Actor lifecycle, but the concrete host and
-order API calls live at the integration boundary; project alpha code only
-produces intent. Risk remains the final project authority and cannot be skipped
-by an entry point, strategy, adapter, retry, or recovery path.
+Nautilus `RiskEngine` owns core pre-trade validation, throttles, notional
+limits, and trading state. TraceQuant supplies reviewed thresholds and only
+small, confirmed-missing strategy/portfolio policies such as daily loss, total
+exposure, or stale-data stops. Such a policy may reject or reduce a proposed
+action before it reaches Nautilus but must not become a generic second
+RiskEngine. Neither the project policy nor Nautilus may turn the other's veto
+into approval. Missing/unknown policy state, stale data, local/exchange
+disagreement, or unreconciled order state produces no opening order.
 
 Live is absent or disabled by default in every tracked example. Adding a Live
 entry point requires a separate Issue, explicit configuration, the admission
@@ -283,9 +301,9 @@ not permission to read environment variables on import.
 | Logical root | Required version/identity partition | Contents and owner | Classification |
 | --- | --- | --- | --- |
 | `raw_root` | `raw-contract/<contract_version>/<source>/<dataset_identity>/<revision>/` | Immutable response bytes/Parquet, checksums, provenance, and completion manifests; TraceQuant data owner | External/versioned |
-| `catalog_root` | `nautilus/<package_version>+<source_commit>/<catalog_schema_id>/<environment>/` | Nautilus-compatible catalog generated from verified raw revisions; Nautilus runtime owns catalog semantics, TraceQuant records conversion provenance | External/versioned |
-| `cache_root` | `nautilus/<package_version>+<source_commit>/<cache_schema_id>/<environment>/<instance_id>/` | Nautilus cache/restart/reconciliation state; Nautilus runtime owner | External/versioned |
-| `run_root` | `<environment>/<code_version>/nautilus/<package_version>+<source_commit>/<environment_lock_digest>/<mode>/<run_id>/` | Logs, reports, temporary run artifacts, and an immutable run manifest; TraceQuant orchestration owner | External/versioned |
+| `catalog_root` | `nautilus/<package_version>+<upstream_release_or_commit>/<catalog_schema_id>/<environment>/` | Nautilus-compatible catalog generated from verified raw revisions; Nautilus runtime owns catalog semantics, TraceQuant records conversion provenance | External/versioned |
+| `cache_root` | `nautilus/<package_version>+<upstream_release_or_commit>/<cache_schema_id>/<environment>/<instance_id>/` | Nautilus cache/restart/reconciliation state; Nautilus runtime owner | External/versioned |
+| `run_root` | `<environment>/<code_version>/nautilus/<package_version>+<upstream_release_or_commit>/<environment_lock_digest>/<mode>/<run_id>/` | Logs, reports, temporary run artifacts, and an immutable run manifest; TraceQuant operations owner | External/versioned |
 | `evidence_root` | `<environment>/<evidence_schema_version>/<subject_identity>/<revision>/` | Research, backtest, Demo, and acceptance evidence with digests; producing capability owner | External/versioned |
 | `audit_root` | `<environment>/<audit_schema_version>/<account_or_system_identity>/<date_partition>/` | Append-only operational decisions/events with retention and access control; TraceQuant operations owner | External/versioned |
 | `environment_root` | `<environment_lock_digest>/` | Reproducible environment exports, wheel/source caches if retained, SBOMs, and license material; dependency owner | External/versioned |
@@ -297,16 +315,18 @@ digests are immutable identifiers, not mutable aliases such as `latest`.
 Secrets live in a secret manager or injected process boundary, never in any of
 these roots' manifests.
 
-The exact Nautilus runtime identity is at least the normalized package version
-plus the locked source commit when available. Catalog, cache, and run creation
-records that identity and the applicable schema or environment-lock identifier
-in both the path and a manifest. On open, TraceQuant compares configured
-identity, manifest identity, and imported NautilusTrader identity. A missing
-value or mismatch is a hard error: it must not open, migrate, copy, or silently
-reuse the state. An upgrade gets a new partition and an explicit, separately
-validated migration or rebuild. This prevents persistent runtime data from
-crossing NautilusTrader version identities silently. The complete acquisition,
-upgrade, promotion, and rollback rules are defined by the
+The exact Nautilus runtime identity is the normalized package version plus the
+reviewed upstream release identity or exact source commit, using the canonical
+form defined by the NautilusTrader import and update policy. Catalog, cache, and
+run creation records that identity and the applicable schema or
+environment-lock identifier in both the path and a manifest. On open,
+TraceQuant compares configured identity, manifest identity, and imported
+NautilusTrader identity. A missing value or mismatch is a hard error: it must
+not open, migrate, copy, or silently reuse the state. An upgrade gets a new
+partition and an explicit, separately validated migration or rebuild. This
+prevents persistent runtime data from crossing NautilusTrader version
+identities silently. The complete acquisition, upgrade, promotion, and rollback
+rules are defined by the
 [NautilusTrader import and update policy](../guides/nautilustrader-import-and-update-policy.md).
 
 Raw data is versioned by its TraceQuant source contract rather than by a
@@ -382,30 +402,42 @@ review convention:
 2. Python outside `src/tracequant` is test code below `tests/` only. Tests may
    import `tracequant` public/test-support APIs; production code never imports
    `tests`.
-3. Only `tracequant.integrations.nautilus` directly imports
-   `nautilus_trader`. Strategy, risk, data-contract, configuration, and
-   observability modules cannot import that distribution or the integration
-   package.
-4. Import-graph checks enforce the dependency direction above, including no
-   strategy -> risk/integration, risk -> strategy/integration, or
-   data -> strategy/risk/orchestration/entrypoint/integration edge.
-5. AST/static checks reject order submit/cancel/modify API calls and exchange
-   client construction below `tracequant.strategies`; behavior tests prove a
-   rejected, unknown, stale, divergent, or unreconciled decision cannot reach
-   the integration submit port, and a reduction cannot increase exposure.
-6. Tree-policy checks reject all LCK paths/dependencies listed above, a copied
+3. `pyproject.toml` pins the exact approved official `nautilus-trader` wheel,
+   the new v2 `uv.toml` rejects a NautilusTrader source build and contains no
+   v1/LCK cache location, and `uv.lock` resolves the distribution from standard
+   PyPI without a Git, path, editable, workspace, or source override. A clean,
+   disposable environment can sync the committed lock and verify the installed
+   distribution and module origin without an upstream source checkout.
+4. Only `tracequant.integrations.nautilus` directly imports
+   `nautilus_trader`; dedicated acceptance tests may also import the public
+   symbols they verify. Source-data, research, and operations code cannot
+   directly import that distribution. Any concrete catalog conversion,
+   Nautilus-native strategy, or runtime configuration that needs the public
+   upstream API belongs inside the integration boundary.
+5. Tree and import checks reject a separate `tracequant.strategies`,
+   `tracequant.risk`, or generic orchestration/adapter/port framework, along
+   with project-owned trading-domain DTOs, exchange clients, RiskEngine,
+   portfolio/account ledger, backtest engine, or reconciliation state machine.
+6. The bootstrap contains no strategy, order, or exchange behavior. When a
+   later scoped Issue adds a concrete strategy, static and behavior checks must
+   confine it to the Nautilus integration boundary, require public Nautilus
+   Strategy/OrderFactory APIs, reject exchange-client construction and risk
+   bypasses, and prove rejected, unknown, stale, divergent, or unreconciled
+   state cannot open a position.
+7. Tree-policy checks reject all LCK paths/dependencies listed above, a copied
    NautilusTrader source/test layout, secret files, and repository-local
    persistent-root fallbacks.
-7. Configuration tests require absolute external roots, explicit environment
+8. Configuration tests require absolute external roots, explicit environment
    and mode, and exact Nautilus package/source/schema identity for catalog and
    cache opens. Missing/mismatched identity fails closed and never selects a
    legacy or `latest` directory.
-8. Import-safety tests prove package imports perform no I/O, environment reads,
+9. Import-safety tests prove package imports perform no I/O, environment reads,
    directory creation, client construction, background startup, or singleton
    caching. Live remains unavailable or explicitly disabled without all later
    admission gates.
 
-Bootstrap completion establishes only the repository skeleton and these
-guards. It does not authorize dependency installation, data migration,
-NautilusTrader integration, exchange connectivity, order submission, or Live
-trading.
+Bootstrap completion establishes only the repository skeleton, a verified clean
+installation of the exact wheel-only NautilusTrader dependency and lock, the
+minimal integration seam, and these guards. It does not authorize
+persistent-data migration, strategy or backtest implementation, exchange
+connectivity, order submission, Demo, or Live trading.

--- a/docs/architecture/repository-structure.md
+++ b/docs/architecture/repository-structure.md
@@ -285,7 +285,7 @@ not permission to read environment variables on import.
 | `raw_root` | `raw-contract/<contract_version>/<source>/<dataset_identity>/<revision>/` | Immutable response bytes/Parquet, checksums, provenance, and completion manifests; TraceQuant data owner | External/versioned |
 | `catalog_root` | `nautilus/<package_version>+<source_commit>/<catalog_schema_id>/<environment>/` | Nautilus-compatible catalog generated from verified raw revisions; Nautilus runtime owns catalog semantics, TraceQuant records conversion provenance | External/versioned |
 | `cache_root` | `nautilus/<package_version>+<source_commit>/<cache_schema_id>/<environment>/<instance_id>/` | Nautilus cache/restart/reconciliation state; Nautilus runtime owner | External/versioned |
-| `run_root` | `<environment>/<code_version>/<environment_lock_digest>/<mode>/<run_id>/` | Logs, reports, temporary run artifacts, and an immutable run manifest; TraceQuant orchestration owner | External/versioned |
+| `run_root` | `<environment>/<code_version>/nautilus/<package_version>+<source_commit>/<environment_lock_digest>/<mode>/<run_id>/` | Logs, reports, temporary run artifacts, and an immutable run manifest; TraceQuant orchestration owner | External/versioned |
 | `evidence_root` | `<environment>/<evidence_schema_version>/<subject_identity>/<revision>/` | Research, backtest, Demo, and acceptance evidence with digests; producing capability owner | External/versioned |
 | `audit_root` | `<environment>/<audit_schema_version>/<account_or_system_identity>/<date_partition>/` | Append-only operational decisions/events with retention and access control; TraceQuant operations owner | External/versioned |
 | `environment_root` | `<environment_lock_digest>/` | Reproducible environment exports, wheel/source caches if retained, SBOMs, and license material; dependency owner | External/versioned |
@@ -298,14 +298,16 @@ Secrets live in a secret manager or injected process boundary, never in any of
 these roots' manifests.
 
 The exact Nautilus runtime identity is at least the normalized package version
-plus the locked source commit when available. Catalog/cache creation records
-that identity and the applicable schema identifier in both the path and a
-manifest. On open, TraceQuant compares configured identity, manifest identity,
-and imported NautilusTrader identity. A missing value or mismatch is a hard
-error: it must not open, migrate, copy, or silently reuse the state. An upgrade
-gets a new partition and an explicit, separately validated migration or
-rebuild. This prevents persistent runtime data from crossing NautilusTrader
-version identities silently.
+plus the locked source commit when available. Catalog, cache, and run creation
+records that identity and the applicable schema or environment-lock identifier
+in both the path and a manifest. On open, TraceQuant compares configured
+identity, manifest identity, and imported NautilusTrader identity. A missing
+value or mismatch is a hard error: it must not open, migrate, copy, or silently
+reuse the state. An upgrade gets a new partition and an explicit, separately
+validated migration or rebuild. This prevents persistent runtime data from
+crossing NautilusTrader version identities silently. The complete acquisition,
+upgrade, promotion, and rollback rules are defined by the
+[NautilusTrader import and update policy](../guides/nautilustrader-import-and-update-policy.md).
 
 Raw data is versioned by its TraceQuant source contract rather than by a
 Nautilus version so that upstream evidence remains immutable and runtime

--- a/docs/guides/nautilustrader-import-and-update-policy.md
+++ b/docs/guides/nautilustrader-import-and-update-policy.md
@@ -1,0 +1,303 @@
+# NautilusTrader import and update policy
+
+- **Policy status:** approved for future NautilusTrader integration work
+- **Initial approved identity:** `nautilus-trader==2.0.0rc4`
+- **Import namespace:** `nautilus_trader`
+- **Upstream release identity:** tag `v2.0.0rc4`, commit
+  `a0400251110653b6d8ae6a9b5b89c4543fa85a2d`
+- **Architecture decision:**
+  [ADR-0001](../architecture/adr-0001-nautilustrader-primary-runtime.md)
+- **Safety state:** `LIVE_NOT_APPROVED`
+
+## Purpose and current boundary
+
+This policy freezes how TraceQuant acquires, identifies, imports, upgrades, and
+rolls back NautilusTrader. It also keeps upstream source and version-sensitive
+persistent state separate from TraceQuant-owned code.
+
+This document does not install NautilusTrader or claim that the runtime is
+integrated. The current implementation facts remain in the
+[technical baseline](../architecture/technical-baseline.md). Adding the
+dependency, integration code, persistent roots, or an environment beyond
+Offline requires separately scoped implementation and acceptance work.
+
+The keywords **MUST**, **MUST NOT**, **SHOULD**, and **MAY** are normative.
+
+## Distribution, lock, and import identity
+
+The only approved initial package declaration is the official PyPI project
+`nautilus-trader`, pinned with the exact direct requirement:
+
+```toml
+dependencies = [
+    "nautilus-trader==2.0.0rc4",
+]
+```
+
+The installed Python namespace is `nautilus_trader`. Distribution names use a
+hyphen and import names use an underscore; code and verification MUST NOT treat
+them as interchangeable strings.
+
+The integration change that adds this dependency MUST also commit the resulting
+`uv.lock`. It MUST configure uv to reject a NautilusTrader source build:
+
+```toml
+[tool.uv]
+no-build-package = ["nautilus-trader"]
+```
+
+The lock entry MUST resolve `nautilus-trader` from the standard PyPI registry,
+not from a Git URL, direct URL, local directory, editable install, workspace,
+or `tool.uv.sources` override. The official
+[PyPI release record](https://pypi.org/project/nautilus-trader/2.0.0rc4/) and
+the locked wheel hash are the package acquisition evidence. The upstream tag
+and commit identify the reviewed source release; an upstream checkout is never
+an installation source for TraceQuant.
+
+TraceQuant supports a Python/platform target for NautilusTrader only when all
+of these conditions hold:
+
+1. the target is inside TraceQuant's declared CPython and deployment matrix;
+2. upstream publishes an official compatible wheel for the exact pinned
+   version and target;
+3. a clean, disposable environment installs the committed lock with
+   `uv sync --locked --dev --no-build-package nautilus-trader --no-cache`;
+4. installation did not invoke a NautilusTrader build backend; and
+5. the distribution and import identity checks below pass.
+
+The `--no-cache` check prevents a locally built cached wheel from satisfying
+the clean-install gate. The committed `no-build-package` setting makes normal
+syncs fail when no compatible wheel exists. A missing wheel, unsupported
+CPython, unsupported platform, resolution failure, or install failure is a
+hard failure; it MUST NOT trigger a source build or a relaxed target matrix.
+The uv behavior is defined by its official
+[`no-build-package` setting](https://docs.astral.sh/uv/reference/settings/#no-build-package).
+
+The integration acceptance suite MUST mechanically prove that:
+
+- `importlib.metadata.version("nautilus-trader")` equals the exact direct pin;
+- `import nautilus_trader` succeeds in the locked environment;
+- the imported module resolves from the installed distribution in that
+  environment, not from the repository, an upstream checkout, `PYTHONPATH`, or
+  another injected source root;
+- `uv lock --check` succeeds and the lock has no NautilusTrader Git, path,
+  editable, workspace, or source override; and
+- the wheel filename, PyPI index identity, wheel SHA-256, Python/platform tag,
+  upstream release/tag and commit, and lock digest are captured in the
+  acceptance record.
+
+These checks are additions to the repository's canonical quality commands,
+not a replacement command set.
+
+## Source and environment isolation
+
+Upstream source checkouts, official-source audits, develop/nightly experiments,
+wheel downloads retained for evidence, unpacked wheels, compiler output, and
+build artifacts MUST live outside both the TraceQuant repository and its
+project environment. They MUST NOT be committed or placed under `src/`,
+`tests/`, `docs/`, `vendor/`, `.venv`, or another repository-local path.
+
+The repository MUST NOT contain or depend on any of the following:
+
+- a vendored copy of NautilusTrader source, generated bindings, examples,
+  fixtures, or tests;
+- a NautilusTrader Git submodule;
+- a Git, local-path, editable, workspace, or source-checkout dependency;
+- imports from a private module or a name documented as internal upstream;
+- a monkey patch of an upstream class, function, module, or global; or
+- an unapproved fork, repackaged wheel, or private package index substitute.
+
+An audit MAY inspect a fixed upstream checkout in a disposable external
+workspace. Its result MUST record the exact tag/commit and remain evidence; the
+checkout never becomes application input or import state.
+
+## Code ownership and import boundary
+
+The authoritative code boundary is the approved v2
+[repository structure](../architecture/repository-structure.md). Direct
+production imports of `nautilus_trader` are confined to
+`tracequant.integrations.nautilus`. Dedicated NautilusTrader acceptance tests
+MAY import the public upstream symbols they verify. A static import-boundary
+test MUST reject direct or dynamic upstream imports elsewhere.
+
+Strategy behavior is project-owned, but it reaches NautilusTrader only through
+explicit strategy contracts and the thin integration boundary:
+
+```text
+tracequant.strategies -> project-owned intent/ports
+                     -> tracequant.integrations.nautilus
+                     -> installed nautilus_trader distribution
+```
+
+Strategy code MUST NOT construct an exchange client or submit, cancel, or
+modify an order. Integration code MUST remain use-case-shaped and MUST NOT
+mirror upstream package directories. Acceptance code MUST verify public API
+compatibility, import ownership, risk vetoes, order behavior, persistence, and
+reconciliation without becoming production code.
+
+NautilusTrader owns its trading data/instrument types, Strategy/Actor runtime,
+orders, positions, account/portfolio state, core risk, fills/accounting,
+Binance adapter, cache, restart, and reconciliation semantics. TraceQuant owns
+raw-source provenance, causal research data, features and labels, model and
+strategy intent, project risk thresholds and final project risk decisions,
+environment admission, acceptance evidence, and operator approval. TraceQuant
+MUST NOT copy or wrap upstream domain objects into a parallel mutable trading
+domain.
+
+## Persistent identity and migration
+
+Every catalog, cache, and run root created after integration MUST be partitioned
+by an immutable Nautilus identity:
+
+```text
+<package_version>+<upstream_release_or_commit>
+```
+
+For the initial baseline this is
+`2.0.0rc4+a0400251110653b6d8ae6a9b5b89c4543fa85a2d`. Each root manifest MUST
+repeat the full identity, applicable schema identity, TraceQuant code version,
+and environment lock digest. On open, configured, imported, path, and manifest
+identities MUST agree exactly. A missing identity or mismatch is a hard error.
+
+An upgrade MUST allocate new catalog, cache, and run partitions before it can
+read or write persistent state. It MUST NOT use `latest`, `current`, an
+unversioned fallback, or the last-known-good partition as its candidate write
+target. The last-known-good partitions remain immutable during candidate
+validation and until an explicit later retention decision.
+
+Schema or data migration is never an in-place operation. A reviewed migration
+MUST read an immutable prior partition and write a new candidate-identity and
+schema-identity partition, or rebuild the new partition from immutable raw
+inputs. It MUST record input/output identities and digests, migration code
+version, result, and rollback point. An interrupted, failed, or partial
+migration leaves the previous partition active and the candidate partition
+inactive.
+
+Promotion changes explicit configuration to select a fully qualified identity;
+directory renames, mutable aliases, and implicit discovery are prohibited.
+
+## Candidate upgrade procedure
+
+NautilusTrader upgrades are one-package, separately reviewed changes. An
+automatic dependency updater, broad `uv lock --upgrade`, unrelated dependency
+change, or opportunistic lock refresh MUST NOT change its direct pin. The exact
+pin makes such drift mechanically visible.
+
+An upgrade candidate follows this sequence:
+
+1. **Propose one exact version.** Change only the direct
+   `nautilus-trader==<candidate>` requirement, then run the bounded
+   `uv lock --upgrade-package 'nautilus-trader==<candidate>'` operation. Any
+   transitive lock changes MUST be necessary for that candidate and explained;
+   unrelated changes are removed or split.
+2. **Identify the release.** Record the package version, upstream tag and exact
+   commit when available, release date, official PyPI project, wheel filename
+   and SHA-256, supported CPython/platform tags, and resulting lock digest.
+3. **Review upstream change.** Inspect official release notes/changelog, public
+   API and deprecation changes, catalog/cache/schema migrations, security
+   advisories, license or packaging changes, and unresolved defects relevant to
+   the selected version.
+4. **Review Binance behavior.** Inspect changes to Binance USD-M market data,
+   instruments, orders, post-only/reduce-only behavior, position and margin
+   modes, fills, funding/fees, cache, restart, and reconciliation. Missing or
+   contradictory evidence fails the affected gate.
+5. **Install in isolation.** Use a clean disposable environment and cache
+   outside the repository. Pass the wheel-only resolution, lock, import, and
+   provenance checks. Develop/nightly wheels do not qualify.
+6. **Run compatibility and migration tests.** Exercise the required matrix
+   below against new candidate roots, never against last-known-good roots.
+7. **Compare results.** Compare candidate evidence with the last-known-good
+   result using predeclared tolerances. Unexplained differences fail; they are
+   not accepted as version noise.
+8. **Promote explicitly.** A maintainer-approved, independently reviewed change
+   commits the exact pin, lock, compatibility record, and explicit selected
+   identity. Merely passing tests does not promote a candidate or authorize
+   Live.
+
+The compatibility matrix MUST cover every currently implemented affected
+surface and, when applicable:
+
+- clean wheel-only install, distribution/import identity, public API imports,
+  and static import ownership;
+- TraceQuant data conversion and catalog read/write against immutable fixtures;
+- deterministic strategy, risk-veto, backtest, fills, fees, funding,
+  accounting, and report comparisons;
+- Binance adapter configuration and protocol acceptance, without submitting a
+  Live order;
+- cache open, warm/cold restart, unknown-order handling, and reconciliation;
+- new-partition migration or rebuild plus mismatch/failure injection; and
+- the repository's canonical tests, lint, format, type, lock, and security
+  checks.
+
+Only gates whose supported surface exists are run, but absence of an
+integration, Demo, restart, or Live surface is recorded as `NOT_VERIFIED`, not
+as a pass. The Live admission requirements in ADR-0001 remain closed until
+separate evidence and human approval satisfy them.
+
+## Upgrade record and promotion decision
+
+Every candidate that is accepted MUST add a versioned repository record. The
+record MUST contain:
+
+- candidate package version and prior active version;
+- upstream tag/release and exact commit when available;
+- PyPI project URL, wheel filename, Python/platform tag, and wheel SHA-256;
+- `pyproject.toml` pin, `uv.lock` digest, TraceQuant commit, and environment
+  lock digest;
+- release, migration, security, license/packaging, and Binance review results;
+- each compatibility command or test target, result artifact/digest, and
+  explicit last-known-good comparison;
+- candidate catalog/cache/run and schema identities;
+- explicit promotion decision, approver, date, and unresolved limitations;
+  and
+- Git rollback point and persistent-data rollback identity.
+
+A rejected or incomplete candidate MAY retain bounded evidence, but it MUST be
+marked inactive and MUST NOT change the selected version or roots.
+
+## Failure and rollback
+
+Failure at resolution, install, provenance, review, security, migration,
+compatibility, comparison, or promotion leaves the prior exact version and its
+catalog/cache/run roots active. Candidate code and state MUST NOT be partially
+promoted.
+
+Rollback has two independent parts:
+
+1. **Code and environment:** revert to the recorded last-known-good Git point,
+   which restores both `pyproject.toml` and `uv.lock`; create/sync a clean
+   environment from that lock with NautilusTrader source builds disabled; and
+   verify the recorded distribution/import identity.
+2. **Persistent state:** select the recorded last-known-good fully qualified
+   catalog/cache/run identities. Never down-migrate, rewrite, or copy candidate
+   state over those partitions.
+
+If either rollback part cannot be verified, the runtime remains stopped. Local
+and exchange state disagreement, unknown order state, or failed reconciliation
+also prevents new positions until separately resolved. Rollback never enables
+Live or bypasses risk authority.
+
+## Develop, nightly, and fork policy
+
+Develop/nightly wheels are permitted only for upstream investigation in a
+disposable external environment. They MUST NOT modify `pyproject.toml`,
+`uv.lock`, the project environment, accepted evidence, or any catalog/cache/run
+root. Results are exploratory and cannot promote a version.
+
+A fork requires a separate accepted architecture decision before any fork
+artifact is used. That decision MUST name the defect or requirement, why an
+upstream release cannot satisfy it, fork repository/commit and patch digest,
+security and maintenance owner, package/import identity, compatibility scope,
+expiry or review date, upstream issue or pull request, and an explicit exit
+plan back to upstream. Without all of those items, the fork remains prohibited.
+
+## Acceptance mapping
+
+| Required outcome | Mechanical or review evidence |
+| --- | --- |
+| Official exact wheel resolves without a source checkout | Exact direct pin and committed lock; clean `--no-cache --no-build-package` install; PyPI wheel provenance receipt |
+| Source and import ownership are unambiguous | Distribution/import identity test, module-origin assertion, static import-boundary and tree-policy tests |
+| Unrelated updates cannot introduce a new version | Exact direct pin; no source override; candidate-only lock diff; prohibition on automatic/broad upgrade promotion |
+| Candidate cannot overwrite last-known-good roots | Fully qualified identity partitions, new candidate roots, immutable prior manifests, mismatch/failure tests |
+| Accepted upgrade is auditable | Required versioned upgrade record with upstream, wheel, lock, compatibility, comparison, promotion, and rollback identities |
+| Any failed gate preserves the prior version | No partial promotion; independent Git/environment and persistent-state rollback; fail-closed runtime admission |

--- a/docs/guides/nautilustrader-import-and-update-policy.md
+++ b/docs/guides/nautilustrader-import-and-update-policy.md
@@ -2,6 +2,7 @@
 
 - **Policy status:** approved for future NautilusTrader integration work
 - **Initial approved identity:** `nautilus-trader==2.0.0rc4`
+- **Initial Python baseline:** CPython `3.13` (`>=3.13,<3.14`)
 - **Import namespace:** `nautilus_trader`
 - **Upstream release identity:** tag `v2.0.0rc4`, commit
   `a0400251110653b6d8ae6a9b5b89c4543fa85a2d`
@@ -39,12 +40,16 @@ hyphen and import names use an underscore; code and verification MUST NOT treat
 them as interchangeable strings.
 
 The integration change that adds this dependency MUST also commit the resulting
-`uv.lock`. It MUST configure uv to reject a NautilusTrader source build:
+`uv.lock` and a tracked v2 `uv.toml`. That `uv.toml` MUST configure uv to reject
+a NautilusTrader source build:
 
 ```toml
-[tool.uv]
 no-build-package = ["nautilus-trader"]
 ```
+
+The v2 `uv.toml` is repository policy, not machine-local state. It MUST NOT
+carry forward the v1/LCK `.workflow.local/uv-cache` location or introduce any
+other repository-local package, source, or audit cache.
 
 The lock entry MUST resolve `nautilus-trader` from the standard PyPI registry,
 not from a Git URL, direct URL, local directory, editable install, workspace,
@@ -120,29 +125,36 @@ production imports of `nautilus_trader` are confined to
 MAY import the public upstream symbols they verify. A static import-boundary
 test MUST reject direct or dynamic upstream imports elsewhere.
 
-Strategy behavior is project-owned, but it reaches NautilusTrader only through
-explicit strategy contracts and the thin integration boundary:
+TraceQuant production strategy/model behavior is implemented as concrete,
+Nautilus-native Strategy/Actor code inside that boundary:
 
 ```text
-tracequant.strategies -> project-owned intent/ports
-                     -> tracequant.integrations.nautilus
-                     -> installed nautilus_trader distribution
+TraceQuant research artifact
+  -> tracequant.integrations.nautilus.strategies
+       -> public Nautilus Strategy/Actor, OrderFactory, and runtime APIs
+            -> installed nautilus_trader distribution
 ```
 
-Strategy code MUST NOT construct an exchange client or submit, cancel, or
-modify an order. Integration code MUST remain use-case-shaped and MUST NOT
-mirror upstream package directories. Acceptance code MUST verify public API
-compatibility, import ownership, risk vetoes, order behavior, persistence, and
-reconciliation without becoming production code.
+Model loading and inference MUST live with the concrete strategy that consumes
+them. The repository MUST NOT introduce a generic Strategy Adapter,
+model-to-runtime middleware, project Order/Position DTOs, or a parallel strategy
+runtime. Concrete strategy code MAY create, submit, cancel, or modify orders
+only through public Nautilus Strategy and OrderFactory APIs; it MUST NOT
+construct an exchange client, bypass Nautilus risk/execution, or mutate upstream
+internals. Integration code MUST remain use-case-shaped and MUST NOT mirror
+upstream package directories. Acceptance code MUST verify public API
+compatibility, import ownership, policy and Nautilus risk vetoes, order
+behavior, persistence, and reconciliation without becoming production code.
 
 NautilusTrader owns its trading data/instrument types, Strategy/Actor runtime,
 orders, positions, account/portfolio state, core risk, fills/accounting,
 Binance adapter, cache, restart, and reconciliation semantics. TraceQuant owns
-raw-source provenance, causal research data, features and labels, model and
-strategy intent, project risk thresholds and final project risk decisions,
-environment admission, acceptance evidence, and operator approval. TraceQuant
-MUST NOT copy or wrap upstream domain objects into a parallel mutable trading
-domain.
+raw-source provenance, causal research data, features and labels, model
+artifacts and alpha, project risk thresholds and confirmed-missing policy
+extensions, environment admission, acceptance evidence, and operator approval.
+TraceQuant MUST NOT copy or wrap upstream domain objects into a parallel mutable
+trading domain or place a generic adapter layer between a concrete
+TraceQuant-owned Nautilus Strategy/Actor and the public upstream runtime.
 
 ## Persistent identity and migration
 
@@ -242,8 +254,8 @@ record MUST contain:
 - candidate package version and prior active version;
 - upstream tag/release and exact commit when available;
 - PyPI project URL, wheel filename, Python/platform tag, and wheel SHA-256;
-- `pyproject.toml` pin, `uv.lock` digest, TraceQuant commit, and environment
-  lock digest;
+- `pyproject.toml` pin, `uv.toml` source-build policy and digest, `uv.lock`
+  digest, TraceQuant commit, and environment lock digest;
 - release, migration, security, license/packaging, and Binance review results;
 - each compatibility command or test target, result artifact/digest, and
   explicit last-known-good comparison;
@@ -265,9 +277,9 @@ promoted.
 Rollback has two independent parts:
 
 1. **Code and environment:** revert to the recorded last-known-good Git point,
-   which restores both `pyproject.toml` and `uv.lock`; create/sync a clean
-   environment from that lock with NautilusTrader source builds disabled; and
-   verify the recorded distribution/import identity.
+   which restores `pyproject.toml`, `uv.toml`, and `uv.lock`; create/sync a
+   clean environment from that lock with NautilusTrader source builds disabled;
+   and verify the recorded distribution/import identity.
 2. **Persistent state:** select the recorded last-known-good fully qualified
    catalog/cache/run identities. Never down-migrate, rewrite, or copy candidate
    state over those partitions.
@@ -281,8 +293,8 @@ Live or bypasses risk authority.
 
 Develop/nightly wheels are permitted only for upstream investigation in a
 disposable external environment. They MUST NOT modify `pyproject.toml`,
-`uv.lock`, the project environment, accepted evidence, or any catalog/cache/run
-root. Results are exploratory and cannot promote a version.
+`uv.toml`, `uv.lock`, the project environment, accepted evidence, or any
+catalog/cache/run root. Results are exploratory and cannot promote a version.
 
 A fork requires a separate accepted architecture decision before any fork
 artifact is used. That decision MUST name the defect or requirement, why an
@@ -295,7 +307,7 @@ plan back to upstream. Without all of those items, the fork remains prohibited.
 
 | Required outcome | Mechanical or review evidence |
 | --- | --- |
-| Official exact wheel resolves without a source checkout | Exact direct pin and committed lock; clean `--no-cache --no-build-package` install; PyPI wheel provenance receipt |
+| Official exact wheel resolves without a source checkout | Exact direct pin, tracked `uv.toml` wheel-only policy, and committed lock; clean `--no-cache --no-build-package` install; PyPI wheel provenance receipt |
 | Source and import ownership are unambiguous | Distribution/import identity test, module-origin assertion, static import-boundary and tree-policy tests |
 | Unrelated updates cannot introduce a new version | Exact direct pin; no source override; candidate-only lock diff; prohibition on automatic/broad upgrade promotion |
 | Candidate cannot overwrite last-known-good roots | Fully qualified identity partitions, new candidate roots, immutable prior manifests, mismatch/failure tests |


### PR DESCRIPTION
Closes #313

## Summary
Define the canonical NautilusTrader package and import identity, wheel-only acquisition and source isolation rules, integration ownership boundary, identity-partitioned catalog/cache/run roots, gated one-package upgrades, promotion evidence, and independent code/data rollback; link the policy from README and align the repository structure contract.

## Validation
- Formal Delivery validation: pass

## Risks / limitations
Documentation-only: dependency installation, executable enforcement, compatibility evidence, and NautilusTrader integration remain separately scoped future work; Live remains unapproved.
