### PR TITLE
[Task] 从 Git 历史恢复最终 LCK 并按当前仓库结构重组

### DIFF
--- a/.agents/execution-profile.example.toml
+++ b/.agents/execution-profile.example.toml
@@ -1,0 +1,97 @@
+# Copy this file to .agents/execution-profile.local.toml and adjust it for
+# this workstation. The local file is ignored by Git and must not contain
+# credentials, usernames, private keys, tokens, or sensitive local paths.
+
+schema_version = 1
+default_route = "sandbox-first"
+
+[[rules]]
+name = "lck-status"
+executable = "uv"
+argument_prefix = ["run", "--frozen", "python", "-m", "tools.lck", "status"]
+route = "sandbox-first"
+reason = "LCK status resolves live facts without writing repository metadata"
+
+[[rules]]
+name = "lck-delivery-prepare"
+executable = "uv"
+argument_prefix = ["run", "--frozen", "python", "-m", "tools.lck", "delivery", "prepare"]
+route = "elevated-first"
+reason = "Repeated sandbox-denied Git metadata writes; branch bootstrap is LCK-authorized"
+
+[[rules]]
+name = "lck-delivery-complete"
+executable = "uv"
+argument_prefix = ["run", "--frozen", "python", "-m", "tools.lck", "delivery", "complete"]
+route = "elevated-first"
+reason = "Repeated sandbox-denied Git and lifecycle metadata writes; Delivery effects are LCK-authorized"
+
+[[rules]]
+name = "lck-review-prepare"
+executable = "uv"
+argument_prefix = ["run", "--frozen", "python", "-m", "tools.lck", "review", "prepare"]
+route = "sandbox-first"
+reason = "Review keeps the source repository read-only; its temporary clone is operation-owned"
+
+[[rules]]
+name = "lck-review-complete"
+executable = "uv"
+argument_prefix = ["run", "--frozen", "python", "-m", "tools.lck", "review", "complete"]
+route = "sandbox-first"
+reason = "Review completion keeps the source repository read-only and writes only ignored LCK state"
+
+[[rules]]
+name = "lck-remediation-prepare"
+executable = "uv"
+argument_prefix = ["run", "--frozen", "python", "-m", "tools.lck", "remediation", "prepare"]
+route = "elevated-first"
+reason = "Repeated sandbox-denied branch metadata writes when restoring or selecting the Task branch"
+
+[[rules]]
+name = "lck-remediation-no-change"
+executable = "uv"
+argument_prefix = ["run", "--frozen", "python", "-m", "tools.lck", "remediation", "no-change"]
+route = "sandbox-first"
+reason = "No-change closes only ignored LCK continuity state and does not alter Git metadata"
+
+[[rules]]
+name = "lck-remediation-complete"
+executable = "uv"
+argument_prefix = ["run", "--frozen", "python", "-m", "tools.lck", "remediation", "complete"]
+route = "elevated-first"
+reason = "Repeated sandbox-denied Git and lifecycle metadata writes; remediation effects are LCK-authorized"
+
+[[rules]]
+name = "lck-merge-preflight"
+executable = "uv"
+argument_prefix = ["run", "--frozen", "python", "-m", "tools.lck", "merge", "preflight"]
+route = "sandbox-first"
+reason = "Merge Preflight is a source-repository read-only gate"
+
+[[rules]]
+name = "lck-merge-preflight-alias"
+executable = "uv"
+argument_prefix = ["run", "--frozen", "python", "-m", "tools.lck", "merge-preflight"]
+route = "sandbox-first"
+reason = "Compatibility alias for the source-repository read-only Merge Preflight gate"
+
+[[rules]]
+name = "lck-closeout"
+executable = "uv"
+argument_prefix = ["run", "--frozen", "python", "-m", "tools.lck", "closeout"]
+route = "elevated-first"
+reason = "Repeated sandbox-denied Git and lifecycle metadata writes; closeout effects are LCK-authorized"
+
+[[rules]]
+name = "git-status"
+executable = "git"
+argument_prefix = ["status"]
+route = "sandbox-first"
+reason = "Read-only repository status normally works in sandbox"
+
+[[rules]]
+name = "git-diff"
+executable = "git"
+argument_prefix = ["diff"]
+route = "sandbox-first"
+reason = "Read-only diff inspection normally works in sandbox"

--- a/.agents/policies/command-execution.md
+++ b/.agents/policies/command-execution.md
@@ -1,0 +1,161 @@
+# Command execution policy
+
+## Authority
+
+The active Skill authorizes an operation. This policy selects the execution
+context for that already-authorized command; it never expands lifecycle, Git,
+GitHub, scope, or review permissions.
+
+Read the optional ignored `.agents/execution-profile.local.toml` when present.
+It may route only exact documented Runner invocations. Repository Rules and the
+Runner still validate full argv, cwd, repository, profile, and identity.
+
+## Deterministic workflow commands
+
+Normal lifecycle and validation commands are:
+
+```text
+uv run --frozen python -m tools.lck <phase> <operation> <task>
+uv run --frozen python -m tools.lck.wsl2_validation_runner <named-profile> <fixed-args>
+```
+
+Run them from the current repository root on the WSL2 Linux filesystem. Do not
+wrap them in `bash -c`, `sh -c`, command substitution, pipelines, redirection,
+or a generic shell string.
+
+Known heavyweight LCK operations (`delivery complete`, `review prepare`, and
+formal workflow validation) use a fixed 30-second wait window for the first
+wait and every subsequent still-running poll. A process that exits earlier is
+returned immediately; the 30-second value is a maximum wait window, not a
+minimum runtime. Adaptive polling intervals are not part of the workflow
+contract.
+
+The local profile may choose:
+
+```text
+sandbox-first   try normal execution; elevate only after a classified sandbox failure
+elevated-first  use the exact approved Runner argv when normal execution is known to fail
+prompt          request approval
+```
+
+A route is valid only for the exact LCK/validation contract. It cannot alter
+Task/PR IDs, base/head SHAs, repository, output paths, or profile semantics.
+
+## Authoritative LCK route contract
+
+The versioned execution-profile example contains one exact `uv run --frozen
+python -m tools.lck ...` rule for every supported LCK operation.
+The route classification is deterministic and is resolved before the command
+starts; an Agent must not probe the normal sandbox first when the matching rule
+is `elevated-first`.
+
+| LCK invocation | Route | Why |
+| --- | --- | --- |
+| `status` | `sandbox-first` | Resolves live facts without changing repository metadata |
+| `delivery prepare` | `elevated-first` | May create or switch the Task branch |
+| `delivery complete` | `elevated-first` | Commits, pushes, and performs the authorized PR/Project effects |
+| `review prepare` | `sandbox-first` | Keeps the source repository read-only; the temporary clone is operation-owned |
+| `review complete` | `sandbox-first` | Writes only ignored LCK continuity/evidence state in the source repository |
+| `remediation prepare` | `elevated-first` | May restore or switch the Task branch |
+| `remediation no-change` | `sandbox-first` | Writes only the ignored no-change receipt |
+| `remediation complete` | `elevated-first` | Reuses the authorized commit, push, and existing-PR effects |
+| `merge preflight` / `merge-preflight` | `sandbox-first` | Read-only merge gate; it never merges |
+| `closeout` | `elevated-first` | Performs the authorized main, lifecycle metadata, and exact-branch effects |
+
+`elevated-first` is reserved for operations whose already-authorized LCK path
+can write Git metadata or GitHub lifecycle state. The profile must not contain
+a generic `uv`, `python`, `git`, or `gh` write rule. Explicit read-only rules
+may remain `sandbox-first`, including the source-repository boundary of
+Independent Review. This table chooses how an active Skill-authorized LCK
+command runs; it never grants lifecycle, GitHub, commit, push, merge, or
+cleanup permission.
+
+## Failure classification
+
+Before retrying, classify the failure:
+
+- `sandbox-denied`: local process, network, or exact ignored output path blocked;
+- `credential-isolated`: credentials unavailable only in the current context;
+- `network-unavailable`: DNS/proxy/TCP failure;
+- `permission-denied`: GitHub or filesystem permission failure;
+- `command-failed`: the command ran and returned a real validation/evidence
+  failure;
+- `contract-invalid`: wrong argv, cwd, repository, profile, schema, or identity.
+
+Only `sandbox-denied` or `credential-isolated` may justify an exact-context
+retry. Do not retry a real command failure with broader permissions. Do not use
+an equivalent direct command chain as fallback.
+
+## Allowed local writes
+
+Mutable artifact ownership is explicit; these roots are not interchangeable fallbacks:
+
+```text
+.agents/evidence.local/            # legacy/non-LCK Evidence Runner output
+.agents/validation.local/          # Validation Runner output in a writable execution workspace
+.workflow.local/lck/               # source-repository LCK runtime state and durable Review evidence
+$TMPDIR/tracequant-lck-review-*    # operation-owned standalone Review clones only
+```
+
+Repository-local roots must be Git ignored. During Independent Review, the **source
+repository** may write only under `.workflow.local/lck/`; it MUST NOT write source
+`.agents/evidence.local/`, source `.agents/validation.local/`, the tracked tree, or source
+Git metadata. Formal Review validation may create `.agents/validation.local/` **inside the
+standalone temporary clone** because that directory is part of the disposable validation
+workspace; evidence that must survive clone deletion is copied to
+`.workflow.local/lck/review-validation/` in the source repository before cleanup.
+
+Temporary clones are owned by the Review operation, live only until Review Complete (or
+failed/interrupted Prepare cleanup), and MUST NOT register or mutate source
+`.git/worktrees`. Creating, sealing, or removing the Review clone is expected to work in
+the normal sandbox and is not by itself a reason to elevate the LCK command. A known
+required write route should be correct on the first formal call; do not intentionally run
+a known-failing sandbox probe before an approved exact route.
+
+## Git and GitHub boundaries
+
+LCK live-state collection and validation do not authorize writes by the Agent.
+The active Skill must separately authorize every Git or GitHub mutation; the
+LCK lifecycle command is the only formal mechanism allowed to perform the
+phase-owned effects.
+
+Always require explicit workflow authorization for:
+
+```text
+git fetch / switch / checkout / add / commit / push / branch deletion
+gh issue / pr / project writes
+worktree creation or removal
+```
+
+Never authorize:
+
+```text
+gh auth token
+force push
+--admin
+protection bypass
+git reset --hard
+git clean
+arbitrary branch deletion
+automatic Merge
+manual Issue close by a workflow Skill
+```
+
+Stage explicit paths; never use `git add .`. Branch cleanup must follow
+`task-closeout` exact identity and safety gates.
+
+## Independent Review
+
+Independent Review uses the current explicitly invoked Review Skill and current
+repository Runner. Its safety boundary is a fresh session, strict read-only
+behavior, locked PR base/head/effective diff, complete semantic inspection,
+independent validation, stability recheck, and maintainer manual Merge.
+
+A local execution profile cannot change reviewed SHAs, findings, severity,
+verdict, or the read-only boundary.
+
+## Reporting
+
+Record command identity, execution context, retries, failure classification,
+result path/digest, and limitations when abnormal. Never expose credentials or
+complete environment values.

--- a/.agents/policies/context-retrieval.md
+++ b/.agents/policies/context-retrieval.md
@@ -1,0 +1,32 @@
+# LCK context retrieval policy
+
+The current leaf Issue body is the default full-text business input. LCK may
+also acquire applicable repository instructions, relevant code and tests, the
+minimum Skill input, and current Git/GitHub object identities.
+
+Do not eagerly load complete Issue comments, Parent Feature or Epic bodies,
+sibling Issues, all linked documents, all ADRs, roadmap material, or historical
+workflow sessions. A link alone is not an instruction to read its full target.
+
+Expand context only when the leaf explicitly references another requirement,
+scope remains ambiguous, active sources conflict, a hard dependency affects
+eligibility, safety or architecture is at risk, or Acceptance Criteria name a
+fixture, protocol, report, or frozen artifact.
+
+Expansion is progressive: read the minimum relevant section, reassess, and
+expand only if still insufficient. Unbounded recursive expansion through
+parents, comments, and links is forbidden. Unresolved ambiguity fails closed at
+a Human Gate.
+
+Comments are decision history, not startup context. Parent and Epic bodies are
+upstream scope sources, not default execution inputs. Deterministic queries may
+verify labels, state, Parent, blockers, Project Status, PR identity, SHAs, and
+checks without injecting the corresponding full text into model context.
+
+`feature-completion-audit` is the bounded exception: it may retrieve the target
+Feature hierarchy and the state/evidence needed for that audit, but not
+unrelated history or repository documentation.
+
+Runtime token telemetry is outside this repository. Raw rollout logs and token
+reports must not be committed and never change permissions, gates, findings,
+verdicts, merge authorization, or completion evidence.

--- a/.agents/policies/workflow-evidence.md
+++ b/.agents/policies/workflow-evidence.md
@@ -1,0 +1,278 @@
+# Workflow evidence and compact validation policy
+
+## Responsibilities
+
+```text
+LCK         lifecycle control and current mechanical authority for migrated phases
+Skill       semantic procedure, judgment, findings, and human-facing report
+Evidence    deterministic compatibility/audit facts for non-migrated or historical paths
+Validation  deterministic command plans, exit codes, and bounded diagnostics
+Maintainer  explicit remediation start, manual Merge, and Feature closeout
+```
+
+Evidence and Validation never authorize repository or GitHub writes and never
+replace semantic correctness review. For migrated Delivery / Review / Remediation
+phases, LCK reacquires the current mechanical facts itself; persisted Evidence
+snapshots and cross-phase handoffs are not lifecycle authority.
+
+## Current front doors
+
+Migrated lifecycle phases enter through LCK:
+
+```text
+python -m tools.lck delivery prepare|complete
+python -m tools.lck review prepare|complete
+python -m tools.lck remediation prepare|no-change|complete
+```
+
+The Validation Runner remains current for bounded deterministic validation;
+historical Evidence output is audit material only and is not a Task lifecycle
+entry point:
+
+```text
+tools/lck/wsl2_validation_runner.py
+```
+
+Their implementation CLIs are Runner/LCK internals, not alternate Skill write routes:
+
+```text
+tools/lck/feature_audit.py
+tools/lck/validation_runner.py
+```
+
+| Workflow phase | Current mechanical front door | Validation |
+| --- | --- | --- |
+| Initial Delivery | `python -m tools.lck delivery prepare|complete` | LCK runs formal Delivery validation |
+| Independent Review | `python -m tools.lck review prepare|complete` | LCK runs formal Review validation on the live-resolved head |
+| Explicit Remediation | `python -m tools.lck remediation prepare|no-change|complete` | LCK reuses migrated Delivery validation/effects; no-change closes an unchanged prepared session |
+| Closeout | `python -m tools.lck closeout <TASK>` | LCK closeout gate and effects |
+
+Historical Evidence snapshots may locate audit material, but they must not
+select or authorize a current Task target. A targeted validation profile is not
+CI-equivalent.
+
+## Authority consumption
+
+For LCK-managed phases, consume the bounded LCK result for facts and validation
+owned by that operation instead of independently reproducing the same mechanical
+work. Additional checks or evidence expansion require a concrete diagnostic or
+audit trigger; precaution, Task importance, or a desire for a more complete
+report is not sufficient.
+
+This boundary applies in particular to three normal paths:
+
+- Delivery uses targeted development feedback until the candidate is
+  targeted-ready, then enters LCK Delivery Complete for authoritative Critical
+  Outcome and formal validation rather than pre-running an equivalent full suite.
+- Review Prepare runs and persists formal Review validation for the exact
+  reviewed head before sealing the clone. Semantic Review consumes that evidence
+  and inspects tests as source/coverage; the sealed `review_root` is evidence, not
+  a workspace for rerunning the validation suite.
+- A terminal successful Closeout reports from compact `lck-agent-view` and stops.
+  `receipt_reference` is an on-demand audit pointer, not a default dereference
+  instruction.
+
+When bounded evidence is genuinely insufficient, report the gap or expand only
+the referenced evidence needed for the current diagnosis. Such supplemental work
+is non-authoritative unless LCK itself defines it as part of the operation.
+
+## Execution identity
+
+Use the Skill and Runner explicitly invoked from the current repository. Do not
+load them from `main`, a PR base, audited main, or another commit. Do not create
+a detached worktree or bundle merely to obtain a different control-plane
+version.
+
+Every result artifact records, when applicable:
+
+- Skill name/path and content SHA-256;
+- Runner, profile specification, Rules, and implementation content SHA-256;
+- profile/schema/Runner versions;
+- repository head and clean/dirty state;
+- Task, PR, base/head/effective-diff, audited-main, or merge identities.
+
+Content identity is reproducibility evidence, not a source hierarchy. LCK binds
+formal Delivery / Review validation to the current invocation target. Review
+head/base applicability is invocation-local; it is not a reusable cross-phase
+freshness contract or persisted authorization token.
+
+When a PR changes Skills, Runners, Rules, profiles, or workflow governance, an
+independent Review directly evaluates those changes, tests, permissions, and
+failure behavior. Runner success is supporting evidence, never self-approval.
+
+## PR resolve/create
+
+`tools/lck/github_prs.py` is a shared deterministic helper used by
+LCK Delivery effects. It is not a Skill entry point and does not own lifecycle
+state. LCK supplies the live-resolved Task/base/branch context and rechecks the
+result before any dependent effect. Agents and Skills do not call this helper
+directly or supply PR identity as authority.
+
+Semantic implementation self-checking remains Agent-owned and ephemeral. The
+pre-LCK durable `self_review.py` binder/artifact gate was removed during LCK v1
+cleanup; no self-review artifact can authorize Delivery or Independent Review.
+
+## Local artifacts
+
+Mutable artifact roots have distinct owners and MUST NOT be treated as interchangeable
+fallback locations:
+
+```text
+.agents/evidence.local/            historical/non-LCK Evidence Runner output
+.agents/validation.local/          Validation Runner output in the workspace being validated
+.workflow.local/lck/               LCK runtime state and durable LCK Review evidence
+```
+
+All repository-local roots above must be Git ignored and MUST never be staged or
+committed. The ownership boundary for Independent Review is stricter: the source
+repository writes Review runtime state and preserved evidence only below
+`.workflow.local/lck/`. Formal Review validation runs inside the operation-owned
+standalone clone and may emit its ordinary `.agents/validation.local/` result **inside
+that clone**; before the clone is sealed/deleted, LCK copies only the bounded evidence
+that must survive to `.workflow.local/lck/review-validation/` in the source repository.
+Independent Review MUST NOT write source `.agents/evidence.local/` or source
+`.agents/validation.local/`.
+
+Stored output must be bounded and must exclude credentials, auth headers, cookies,
+private keys, complete environment dumps, private reasoning, transcripts, unbounded
+source/diffs, and machine-sensitive absolute paths.
+
+## Historical evidence contract
+
+The historical Evidence implementation may still be used for Feature audit
+evidence:
+
+```text
+feature-audit-snapshot
+feature-audit-recheck
+```
+
+These operations are read-only audit evidence. They are not a formal Task
+phase selector, do not authorize writes, and do not create a cross-phase
+freshness or handoff contract.
+
+Audit artifacts contain bounded normalized facts and explicit
+`pass`/`fail`/`unknown` gates. They are historical evidence, not lifecycle
+authority.
+
+The Agent still reads complete current specifications, diffs, source, tests,
+docs, and governance for semantic work. Snapshot metadata is not semantic
+review.
+
+## Validation contract
+
+Reusable profiles:
+
+```text
+current-ci-equivalent
+targeted
+targeted:tools-tests
+targeted:workflow-tests
+post-merge
+```
+
+Workflow profiles:
+
+```text
+workflow-delivery --base-sha <base>
+workflow-review --base-sha <base>
+workflow-closeout --base-sha <PR base>
+```
+
+Workflow profiles run the current CI-equivalent plan and all repository Skill
+validators. LCK invokes formal Review validation inside the isolated exact-head
+standalone Review clone before sealing the temporary repository read-only; the profile result
+is invocation evidence, not a cross-phase snapshot. `workflow-closeout` additionally
+requires clean local `main == origin/main`.
+
+Success stdout is a compact digest. Full redacted results and bounded failure
+diagnostics remain in the artifact root owned by that execution context: ordinary
+Validation Runner invocations use `.agents/validation.local/`, while formal Review
+results that must outlive the temporary clone are preserved under
+`.workflow.local/lck/review-validation/`.
+
+## LCK admission and Recovery boundary
+
+Delivery Preflight is a terminal admission gate, not a remediation phase.
+Recovery rules apply only after Invocation Preflight has passed and never
+authorize remediation of a Preflight result. A valid non-pass Preflight
+result (`fail`, `partial`, `unknown`, `blocked`, lifecycle conflict,
+identity conflict, incompatible entry state, or maintainer-decision-required)
+is a final disposition — not a recoverable state.
+
+LCK pass is required before a phase-owned effect may run. Any non-pass
+admission (`fail`, `partial`, `unknown`, `blocked`, lifecycle conflict,
+identity conflict, incompatible entry state, or maintainer-decision-required)
+forbids all write operations, auto-remediation, state modification, and
+re-invocation of the same operation to obtain `pass`.
+
+Historical Task evidence records may mention the old `worktree_state_compatible`
+gate and Delivery entry-point names. Those records are audit provenance only; the
+executable Task Evidence Runner, profiles, and approval Rules have been removed.
+
+Historical remediation evidence is not part of the LCK Review / Remediation
+lifecycle and MUST NOT authorize a current repair from an expected base/head
+or bounded handoff. Current remediation authority is `python -m tools.lck remediation
+prepare`, which reacquires the live Task/PR/head/base. A workspace-local failed
+Review record is the default semantic-findings source only. If a maintainer
+intentionally switches clone or Agent runtime and that ignored audit record is
+unavailable, `remediation prepare --findings-file <FILE>` may carry the completed
+Review findings across that boundary. This is a semantic-only handoff: it cannot
+supply or override PR/head/base/branch/check/check-policy authority, and the normal
+Codex/local-record path remains unchanged.
+
+A prepared Remediation session is operation-continuity state, not cross-phase
+authority, but it must still reach a formal terminal operation. If semantic
+inspection finds no implementation change is required, `remediation no-change`
+reacquires the current PR/base/head, requires the selected Task workspace to be
+clean and unchanged, writes a local no-change receipt, and releases the session.
+It does not commit, push, create a new head, set `fresh-review-required`, or
+satisfy deferred provider/cross-runtime Review acceptance. While a prepared
+Remediation session remains open, Review Prepare fails closed rather than
+interleaving a new Review with an unfinished implementation role.
+
+## Failure expansion
+
+`partial`, `unknown`, `fail`, drift, truncation, schema mismatch, or Runner
+unavailability never becomes `pass` through selective fallback.
+
+1. Preserve the original result and identity.
+2. Inspect only the named gate, fact, or failed-command log.
+3. Record the limitation or fallback.
+4. Do not rerun an equivalent complete command chain.
+5. Stop before a dependent write or verdict while the gate is unresolved.
+
+## Capability-limited cleanup
+
+Historical/read-only Evidence diagnostics may still observe a Required-Checks
+plan-limit `403`; in that evidence model the observation remains
+`required_checks_configuration = unknown` and keeps Evidence `partial`. It is
+never LCK lifecycle authority.
+
+LCK itself does **not** discover its required-check policy from the
+plan/permission-dependent branch-protection endpoint. The repository-controlled
+required-check policy is derived from the statically named jobs in the canonical
+`.github/workflows/ci.yml`, read from the operation's **exact trusted base commit**
+rather than from the caller's mutable checkout or candidate head. LCK v1 fails
+closed on dynamic job names or matrix jobs instead of guessing a check identity.
+Delivery Complete uses current authoritative `main`; Review / Remediation / Merge
+Preflight use the exact PR base. The snapshot records the policy source SHA and
+contract hash. Candidate-head policy edits are future policy only and cannot
+self-authorize the candidate. GitHub supplies only the live result for the
+base-required names on the exact PR head. Missing, malformed, unavailable, or
+base-mismatched policy fails closed before dependent lifecycle effects; there is
+no working-tree or GitHub-discovery fallback.
+
+Closeout may compute `eligible-under-capability-limited-policy` only for exact
+Task branch cleanup and only under the complete conditions defined by
+`task-closeout`. It never authorizes Merge, push, Issue/Project/label writes, or
+Review actions.
+
+## Reporting and external analysis
+
+Compact success reporting requires complete evidence, validation pass, stable
+identity, no unresolved finding, no fallback/conflict, and no pending maintainer
+decision. Abnormal paths use a detailed report.
+
+Repository Skills do not measure runtime Token use. Token analysis remains an
+external maintainer activity based on Codex rollout logs and Task metadata.

--- a/.agents/skills/feature-completion-audit/SKILL.md
+++ b/.agents/skills/feature-completion-audit/SKILL.md
@@ -1,0 +1,234 @@
+---
+name: feature-completion-audit
+description: Independently and strictly read-only audit one maintainer-specified open GitHub Feature against a locked current main. Inventory direct children, map acceptance criteria to current-main evidence, review integration and safety, validate, recheck stability, and output one fixed verdict. Do not implement, create Tasks, edit GitHub state, close the Feature, merge, perform Task closeout, or assess Epic completion.
+---
+
+# Feature completion audit
+
+Use this Skill for one existing open Feature before the maintainer manually
+closes it or sets Project Status to `Done`.
+
+Run in a new session that did not participate in direct-child splitting, key
+design decisions, implementation, fixes, review verdicts, or closeout.
+Otherwise stop with:
+
+```text
+本会话不能提供独立 Feature Completion Audit
+```
+
+A passing audit is evidence only and never authorizes Feature closeout.
+
+## Standard invocation
+
+```text
+请使用 feature-completion-audit，独立只读审计
+[Feature] <当前完整标题> #<Feature编号>。
+
+Expected main SHA: <当前 main SHA>
+```
+
+The Feature number is the primary key; the current Issue title is canonical.
+A request may limit execution to one named Phase. Verify prior Phase facts and
+stop at the requested boundary.
+
+## Context acquisition (hierarchy-aware exception)
+
+This audit is a hierarchy-aware flow, not a leaf-Issue-first default: its
+purpose requires the target Feature body, the relevant direct-child Issue
+hierarchy, completion state, and implementation / validation evidence. Read
+what the audit phases below require. Do not default to historical comments,
+unrelated docs/ADRs, the roadmap, sibling Feature history, or general
+workflow reports.
+
+## Policies and audit interface
+
+Read applicable `AGENTS.md` and:
+
+```text
+.agents/policies/command-execution.md
+.agents/policies/workflow-evidence.md
+```
+
+Shared lifecycle semantics are owned by `docs/workflows/lck/lifecycle.md`
+(§14 Feature Completion). Read the minimal needed section for the current
+phase; do not duplicate audit-semantic prose in this Skill.
+
+Audit the exact locked `origin/main` implementation and current Feature facts.
+Use the repository-defined operations:
+
+```text
+feature-audit-snapshot
+python -m tools.lck.validation_runner run --phase feature-audit --include-skill-validators --require-skill-validator
+feature-audit-recheck
+```
+
+Run validation against a worktree fixed at the audited main SHA. Record the
+actual Audit Skill, Evidence/Validation Runner, profile/schema, audited main,
+Feature snapshot, direct-child-set digest, and content hashes used. Historical
+Task/PR/delivery/review/closeout reports may locate evidence but are not
+completion proof.
+
+For `partial`, `unknown`, `fail`, truncation, schema mismatch, or drift, inspect
+only the named facts or failed commands and preserve the original status.
+
+## Permission boundary
+
+The audit is strictly read-only for Feature, child Issues, PRs, Project, labels,
+Relationships, reviews/threads, repository, branches, and code. It may fetch
+refs, use one isolated worktree at the audited main SHA, run validation, and
+write exact ignored local evidence artifacts.
+
+It does not authorize Feature or child edits/closure, Task creation, Project or
+label changes, body-checkbox edits, source/test/doc/config changes, commits,
+pushes, merge, GitHub Review submission, branch deletion, Task closeout, or Epic
+completion assessment. Gap recommendations are proposals only.
+
+## Phase 1: identify and lock
+
+Generate the Feature snapshot. Verify repository, open `type:feature`, canonical
+title, complete body/comments/fields, Parent, blockers, dependencies,
+Relationships, actual `origin/main`, and the direct-child collection.
+
+Lock and report:
+
+```text
+Audited branch: origin/main
+Audited main SHA
+Feature canonical identity
+Feature content / Relationship digest
+Direct-child set and digest
+Snapshot ID
+```
+
+Distinguish direct children from indirect descendants and related Issues. Use
+the evidence-insufficient path when identity, child-set, or main facts are
+unavailable or contradictory.
+
+## Phase 2: direct-child inventory
+
+For every direct child, record:
+
+- Issue number, title, type, state, labels, Parent, Project Status, blockers, and
+  Relationships;
+- whether it is necessary to Feature completion;
+- merged/closing PR, merge commit, checks, and correct linkage;
+- Task closeout/lifecycle facts when applicable;
+- approved no-PR/no-code exception and its current-main evidence;
+- current-main implementation, tests, docs, ADR, or approved-decision evidence.
+
+Do not infer completion from child closure counts. A closed child without merged
+or current-main evidence is not automatically satisfied. Report reopened,
+orphaned, blocked, or ambiguously parented work.
+
+## Phase 3: acceptance coverage
+
+Map every Feature acceptance criterion to one status:
+
+```text
+Satisfied
+Not satisfied
+Not applicable by approved decision
+Insufficient evidence
+```
+
+Cite current-main source, tests, docs, ADR, configuration, runtime/public
+behavior, merged PR, or an explicit approved decision. Child closure and prior
+reports are insufficient by themselves.
+
+Do not reinterpret ambiguous or contradictory criteria. Record the maintainer
+clarification required.
+
+## Phase 4: integration and safety
+
+Review the current-main result as a whole:
+
+- primary Feature goals and user/system value;
+- cross-Task interfaces and end-to-end behavior;
+- compatibility, configuration, documentation, and operations;
+- dead, isolated, placeholder, or unconnected implementation;
+- integrated tests, not only isolated unit tests;
+- credentials, permissions, UTC/data correctness, financial safety, live-mode
+  defaults, and repository-history safety where applicable;
+- required work not represented by a direct child.
+
+Inspect enough current code and evidence to establish Feature-level completion;
+a full historical re-review is not required by default.
+
+## Phase 5: validation and remote checks
+
+Run the Feature audit Validation profile against the locked audited-main
+worktree. Read actual remote-main checks and Required-Checks configuration.
+Preserve no-configured, plan-limit `403`, pending, failed, stale, cancelled,
+skipped, and unavailable states.
+
+A real validation failure is a completion gap. Missing or ambiguous evidence
+without a confirmed defect uses the evidence-insufficient verdict.
+
+## Phase 6: gaps and stability
+
+Classify each completion gap by severity and, when useful, propose the smallest
+candidate Task boundary without creating or editing a Task.
+
+Run `feature-audit-recheck`. Recollect Feature identity/content,
+Relationships, direct-child set, child lifecycle evidence, audited main, and
+checks. Any audited-main, material Feature, Relationship, or direct-child-set
+change invalidates the stable conclusion and requires a new independent audit.
+
+## Findings and verdicts
+
+Use exactly Blocking, High, Medium, Low, and Nit. Cite exact Feature clauses,
+child Issues, current-main files, validation, or GitHub state. Any unresolved
+Blocking/High/Medium finding prevents a passing verdict.
+
+Output exactly one:
+
+```text
+Feature 已完成，可以由维护者人工收尾
+```
+
+Only when all necessary direct work is complete, every criterion is
+`Satisfied` or approved `Not applicable`, current-main integration/tests/docs
+are complete, validation/checks pass, no blocker or Blocking/High/Medium finding
+remains, and the audited main, Feature, Relationships, and direct-child set are
+stable.
+
+```text
+Feature 尚未完成，需要补充或修复 Task
+```
+
+When a confirmed Blocking/High/Medium gap remains, necessary child work is
+incomplete, a criterion is not satisfied, current main lacks required
+implementation/integration/tests/docs, validation fails, or a blocker remains.
+
+```text
+证据不足，暂不能判定 Feature 完成
+```
+
+When no confirmed defect can be concluded but criteria, children, GitHub facts,
+current-main evidence, stability, or a maintainer decision are insufficient or
+contradictory.
+
+## Report and closeout gate
+
+On a clean path, report Feature identity/URL/Parent, audited main SHA, actual
+Skill/Runner identity, direct-child summary, acceptance matrix, integration and
+safety summary, findings, validation/checks, blockers and state conflicts,
+gap-to-Task recommendations, limitations, actions not performed, one fixed
+verdict, and:
+
+```text
+Audited main SHA: <actual SHA>
+```
+
+Use a detailed report for gaps, failed/pending evidence, drift, fallback,
+conflict, or maintainer decision.
+
+After a passing audit, the maintainer must re-verify current `origin/main`,
+Feature title/body, direct-child set, blockers, and checks immediately before
+manual closeout. This Skill performs none of those writes and never assesses
+Epic completion.
+
+Remove any temporary worktree by exact path without destructive broad cleanup.
+Re-run in a new independent session after any new merged Task, clarified
+Feature, resolved blocker, repaired validation, main change, child-set change,
+or reopened Feature. Never inherit an earlier verdict.

--- a/.agents/skills/task-closeout/SKILL.md
+++ b/.agents/skills/task-closeout/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: task-closeout
+description: Close out one maintainer-specified Task after maintainer manual Squash Merge through LCK live-state recovery. Never merge, manually close an Issue, repair code, clean unrelated branches, or assess Feature completion.
+---
+
+# Task closeout
+
+Use this Skill only after the maintainer states that a specific PR was
+manually Squash Merged and requests closeout for its exact Task. The statement
+authorizes verification; it is not proof of merge. This Skill never merges.
+
+## Standard invocation
+
+~~~text
+PR #<PR编号> 已由我人工 Squash Merge。
+
+请使用 task-closeout，完成
+[Task] <当前完整标题> #<Task编号> 的合并后核验与分支清理。
+~~~
+
+Task and PR numbers are primary keys; the current Issue title is canonical.
+The LCK resolver reacquires the PR from current Git/GitHub facts. Do not pass
+an old PR, branch, SHA, or snapshot as lifecycle authority.
+
+## Default context
+
+It does not default to re-reading the complete business Issue hierarchy
+(Parent/Epic bodies), business comments, or full implementation context. Read
+additional business context only when an explicit anomaly trigger requires it,
+such as an unresolved linkage, closure, or merge-identity conflict.
+
+## Policies and lifecycle owner
+
+Read the applicable AGENTS.md,
+.agents/policies/command-execution.md, and
+.agents/policies/workflow-evidence.md. Shared semantics are owned by
+docs/workflows/lck/lifecycle.md (§11 and §13).
+
+The lifecycle entry point is:
+
+~~~bash
+uv run --frozen python -m tools.lck closeout <TASK>
+~~~
+
+Before the maintainer merge, the deterministic merge gate is:
+
+~~~bash
+uv run --frozen python -m tools.lck merge preflight <TASK>
+~~~
+
+Merge Preflight verifies the unique current PR, head/base, required checks,
+current Review PASS, blockers, and mergeability. It returns
+READY_FOR_HUMAN_MERGE; it has no automatic merge path. The maintainer must
+perform the manual Squash Merge.
+
+LCK is the only Task lifecycle control authority. The historical Evidence
+snapshot and closeout interfaces are audit material only; they are not a
+substitute for LCK live-state resolution, phase eligibility, or write
+authority. The historical eligible-under-capability-limited-policy state
+remains a reported limitation, not permission to broaden cleanup.
+
+## Execution route contract
+
+`closeout` uses `elevated-first` because its already-authorized effects may
+write Git metadata and GitHub lifecycle state. `merge preflight` remains
+`sandbox-first` because it is a source-repository read-only gate and never
+merges. Select these routes from the exact LCK invocation before execution;
+never apply an elevated route to generic `uv`, `python`, `git`, or `gh`
+commands. The route changes execution context only and does not grant merge,
+Issue, Project, label, branch, or cleanup authority.
+
+## LCK closeout contract
+
+LCK resolves the current state on every invocation and fail-closes on
+ambiguous identity, multiple merged PRs, open PR conflicts, remote divergence,
+unknown merge identity, or unsafe worktree ownership. It does not require a
+previous Kernel process or authoritative snapshot lineage.
+
+The result separates:
+
+~~~text
+Business Delivery: COMPLETE | NOT_COMPLETE
+Cleanup: COMPLETE | PENDING
+~~~
+
+A verified merged PR makes Business Delivery COMPLETE. Cleanup may remain
+PENDING after an interrupted or failed idempotent effect and can be retried
+with the same LCK command. A GitHub-deleted remote branch is recognized as a
+normal post-merge state.
+
+The bounded effects may synchronize main by fast-forward, converge Project
+Status and lifecycle labels only when authoritative Issue closure is present,
+and clean only the verified Task branch after head/tree/worktree proof. LCK
+never manually closes the Issue, uses force push, resets, deletes unrelated
+branches, or assesses Feature completion.
+
+### Result-consumption boundary
+
+The final compact `lck-agent-view` is the normal reporting authority for the
+Closeout invocation. `receipt_reference` is a pointer, not an instruction to
+read. When the Agent View reports terminal success with Business Delivery
+`COMPLETE`, Cleanup `COMPLETE`, and `next_action` directing the Agent to stop,
+report from that compact result and stop. Do not follow `receipt_reference` or
+open the successful Audit Receipt merely to restate merge identity, exact
+branch/worktree actions, or make the report more complete.
+
+Expand the Audit Receipt only when the current result has a concrete need for
+diagnosis or audit: STOP, Cleanup `PENDING`, partial/unknown state, an effect
+anomaly, an Agent View that is insufficient to determine the current outcome,
+or an explicit maintainer request for audit details such as merge identity or
+exact cleanup proof. Read only the evidence needed for that question; the
+Receipt remains audit evidence and is not a second lifecycle result.
+
+## Recovery and reporting
+
+The same closeout command is the cleanup-only recovery entry when only the
+exact verified Task refs remain. Reacquire live facts; do not reconstruct state
+from an old report. Stop and surface facts when the unique safe action cannot
+be proved.
+
+For a normal terminal success, report the Task, Business Delivery, Cleanup,
+the bounded effect summary and limitations already present in the Agent View,
+plus the actions not performed. Exact merge/branch/worktree audit details are
+not required in the normal success report; provide them only when an allowed
+Audit Receipt trigger above applies. Explicitly state that no merge, manual
+Issue close, repair commit, unrelated cleanup, or Feature completion occurred.

--- a/.agents/skills/task-delivery-runner/SKILL.md
+++ b/.agents/skills/task-delivery-runner/SKILL.md
@@ -1,0 +1,421 @@
+---
+name: task-delivery-runner
+description: Deliver one maintainer-specified existing GitHub leaf Issue through LCK, including explicitly requested remediation after a failed Independent Review. LCK owns workspace preparation, live identity, profile-specific validation, commit, push, PR reuse/create as phase-appropriate, checks, and lifecycle boundaries. Review, merge, closeout, and Feature completion remain separate.
+---
+
+# Leaf delivery runner
+
+Use this shared Skill for one existing leaf Issue explicitly named by the maintainer.
+The canonical `type:*` label selects the semantic profile; this Skill does not
+maintain a second type allowlist or require the maintainer to name a provider-
+specific Skill.
+
+Initial Delivery is controlled by **LCK**. Codex / Claude owns semantic work;
+LCK owns deterministic lifecycle mechanics. A successful initial Delivery ends
+at `READY_FOR_REVIEW` and a Human boundary. It never starts Independent Review.
+
+Review remediation is also LCK-controlled after cutover, but starts only from an
+explicit Human request that identifies a failed LCK `review_id`.
+
+## Standard invocation
+
+```text
+请按 task-delivery-runner 完整处理
+[Task|Bug|Documentation|Research] <当前完整标题> #<Issue编号>，
+直到 PR 准备好接受独立审查。
+```
+
+For remediation after an Independent Review FAIL:
+
+```text
+请按 task-delivery-runner 对 leaf Issue #<Issue编号> 显式执行 remediation。
+Failed Review ID: <REVIEW_ID>
+```
+
+The failed `review_id` locates semantic findings only. LCK independently reacquires
+the current Task / PR / base / head / branch state; mechanical facts from the Review
+record are not write authorization. The originating workspace-local Review audit record
+is the default findings source. When intentionally switching clone or Agent runtime and
+that ignored local record is unavailable, the maintainer MAY provide the completed
+Review findings as an explicit semantic-only handoff:
+
+```bash
+uv run --frozen python -m tools.lck remediation prepare <TASK> \
+  --review-id <FAILED_REVIEW_ID> --findings-file <COMPLETED_REVIEW_FINDINGS>
+```
+
+`--findings-file` never supplies PR/head/base/branch/checks authority and MUST NOT be
+used to synthesize or rewrite findings merely to obtain admission. Existing Codex/local
+record behavior remains the primary path.
+
+The Issue number is the primary key; the current Issue title is canonical.
+
+Before the first LCK command, verify the project launcher:
+
+```bash
+command -v uv
+uv --version
+uv run --frozen python --version
+```
+
+If this preflight fails, report an environment/launcher failure. It is not a
+Delivery or Review verdict, and must not be converted into `STOP_REQUIRED`.
+
+## Policies and shared semantics
+
+Read applicable `AGENTS.md` and
+`.agents/policies/command-execution.md`, `.agents/policies/workflow-evidence.md`.
+Shared lifecycle semantics are owned by `docs/workflows/lck/lifecycle.md`.
+Read only the sections needed by the current invocation.
+
+The current Task body is the business specification for a Task; for Bug,
+Documentation, or Research, the current leaf Issue body is the business
+specification. Do not default to reading comments, complete Parent/Epic bodies,
+dependency bodies, templates, workflows, validation sources, or linked docs/ADRs.
+Expand only when the current leaf Issue explicitly references them, the
+specification is missing or ambiguous, a dependency affects implementation, a
+safety/architecture constraint applies, or verification requires it.
+Verifying these mechanical facts does not require reading the full text of any source into the model context. Read the minimum relevant source/section, evaluate sufficiency, and expand further only if still insufficient.
+
+## Execution route contract
+
+Select the route from the exact LCK invocation before running it. The known
+Git-metadata or GitHub-lifecycle write operations use `elevated-first`:
+`delivery prepare`, `delivery complete`, `remediation prepare`,
+`remediation complete`, and `closeout`. The source-repository read-only
+operations use `sandbox-first`: `status`, `review prepare`, `review complete`,
+`remediation no-change`, and `merge preflight` (including its compatibility
+alias `merge-preflight`).
+
+This route only selects the execution context for a command already authorized
+by this Skill and LCK; it does not grant branch, commit, push, PR, Project,
+merge, cleanup, or lifecycle authority. Do not intentionally run a known
+write operation in the sandbox to obtain a predictable `.git/index.lock` or
+equivalent failure before using its approved route. If a sandbox-first command
+fails, preserve the command-execution policy's classification and exact-context
+retry rules; a real command failure never justifies a broader-permission retry.
+
+It must contain the applicable profile contract. For a `type:task` Issue, that
+profile contract must include a valid `Critical Outcome` with:
+
+```text
+Caller: ...
+Capability: ...
+Observable result: ...
+Verification test: tests/.../test_*.py::test_*
+```
+
+The verification target is data, not an arbitrary command. LCK executes only
+the bounded pytest verifier defined by the repository runtime. Bug,
+Documentation, and Research Issues use their profile-specific contracts and do
+not receive a fabricated Critical Outcome.
+
+## Long-operation wait and progress contract
+
+For known heavyweight operations — `delivery complete`, `review prepare`, and
+formal workflow validation — use a fixed 30-second wait window for the first
+wait and every subsequent still-running poll (for example,
+`write_stdin`/`yield_time_ms=30000`). Do not use adaptive 1-second, 10-second,
+20-second, or 30-second polling. If the process exits earlier, return its
+output immediately; 30 seconds is the maximum wait window, not a minimum
+runtime.
+
+During these operations, structured progress may appear on stderr. It is
+bounded, non-authoritative observability only: use it to identify the current
+operation and stage, never as evidence for eligibility, freshness, verdicts,
+retry, Merge, Closeout, or any lifecycle result. The final stdout JSON remains
+the only machine-parseable lifecycle result.
+
+## Initial Delivery authority boundary
+
+For **initial Delivery**, the Agent / Skill MAY:
+
+- read the current leaf Issue and required scoped context;
+- understand, design, implement, diagnose, and explain the change;
+- edit files within approved Task scope;
+- run targeted validation while developing;
+- provide semantic completion metadata such as commit message, implementation
+  summary, risks, and limitations.
+
+For **initial Delivery**, the Agent / Skill MUST NOT directly:
+
+- choose or create the profile-owned Issue branch;
+- stage or commit the final candidate;
+- choose a remote/refspec or push;
+- choose a PR number or create/reuse/update the PR mechanically;
+- change Project lifecycle state;
+- invent or pass branch/SHA/base/PR identity as workflow authority;
+- start Independent Review, merge, close the Issue, or perform closeout.
+
+Those mechanics belong to LCK. If an LCK command returns STOP, do not fall back
+to direct Git/GitHub commands. Report the STOP reason and wait for the required
+maintainer or implementation action.
+
+## Initial Delivery procedure
+
+### 1. LCK Delivery Prepare
+
+The first lifecycle action for every supported leaf profile is:
+
+```bash
+uv run --frozen python -m tools.lck delivery prepare <TASK>
+```
+
+Proceed only when LCK returns a resolved Delivery context. LCK reacquires live
+Git/GitHub facts, resolves the canonical leaf profile, verifies readiness and
+blockers, creates, selects, or restores the one correct profile-owned workspace,
+verifies its postcondition, then performs and verifies the kernel-owned Project
+Status transition from `Ready` to `In Progress`. An already-`In Progress` safe
+recovery is idempotent and does not repeat the status write. LCK must not return
+`READY_FOR_DELIVERY` after an admission, workspace, status-write, or status-
+postcondition failure.
+
+Do not pass branch, expected SHA, base SHA, PR number, remote, or refspec.
+
+### 2. Semantic implementation
+
+Read the current leaf Issue body and implement the smallest complete change
+that satisfies its profile contract, Objective, Requirements, Acceptance
+Criteria, and explicit scope boundaries. Only a `type:task` candidate is
+required to satisfy a Critical Outcome; the other profiles use their typed
+policy gates.
+
+#### Development validation boundary
+
+Normal implementation validation is development feedback, not Delivery
+authorization. Before LCK Delivery Complete, choose the smallest check that
+matches the changed surface: a named targeted profile, a focused pytest node,
+or a scoped static check. Rerun the relevant target after a change when useful.
+
+For a normal leaf Issue, do not proactively run a full `current-ci-equivalent`, full
+`workflow-delivery`, or equivalent full-repository validation before LCK
+Delivery Complete merely as a precaution or to "confirm" the candidate. The
+formal full Delivery validation is intentionally reserved for LCK Delivery
+Complete.
+
+A broader or full validation run is allowed only when concrete evidence requires
+diagnostic expansion, such as a targeted failure indicating a cross-module
+regression, an unresolved concern tied to observed behavior, or an explicit
+maintainer request. Issue importance, broad scope, or a global-infrastructure
+classification alone is not a diagnostic trigger. Record and treat any broader
+run as diagnostic information only: it does not replace LCK's Critical Outcome
+verifier or formal validation, authorize commit/push/PR effects, or advance
+lifecycle state.
+
+During implementation, use a matching targeted Validation profile when useful:
+
+```bash
+uv run --frozen python -m tools.lck.wsl2_validation_runner targeted:tools-tests
+uv run --frozen python -m tools.lck.wsl2_validation_runner targeted:workflow-tests
+```
+
+Targeted validation is development feedback only. Do not treat it as final
+Delivery authorization and do not weaken tests to obtain a pass. Any full
+validation performed for diagnosis remains non-authoritative; LCK Delivery
+Complete must still run its own Critical Outcome and formal Delivery validation
+and bind the exact validated tree before commit.
+
+Once change-relevant validation passes, known profile contract gaps are closed,
+and no unresolved failure, finding, or concrete diagnostic concern remains,
+the candidate is **targeted-ready**. Proceed to LCK Delivery Complete. Do not
+insert precautionary repository-wide pytest/static validation, a second broad
+self-review, or status-only checking between targeted-ready and LCK merely to
+confirm the candidate. A newly observed failure/finding or an explicit
+maintainer request may reopen diagnostic work; that work remains
+non-authoritative.
+
+Before completion, inspect the complete workspace diff semantically. Remove or
+repair unrelated, generated, secret-bearing, or prohibited changes. The
+workspace presented to LCK is the candidate leaf-Issue tree.
+
+### 3. LCK Delivery Complete
+
+After semantic implementation is complete, invoke LCK with semantic metadata:
+
+```bash
+uv run --frozen python -m tools.lck delivery complete <TASK> \
+  --commit-message "<scoped commit message>" \
+  --summary "<implementation summary>" \
+  --risks "<risks or limitations>"
+```
+
+Do not supply branch, remote, SHA, base SHA, PR number, or refspec.
+
+Within one bounded invocation, LCK performs the deterministic sequence:
+
+```text
+reacquire live Task/Git/GitHub facts and the canonical leaf profile
+→ validate Delivery Complete eligibility
+→ require Project Status `In Progress` (or operation-owned partial `Review` recovery)
+→ parse the Task Critical Outcome only when the selected profile requires it
+→ stage current candidate tree
+→ run the selected profile's delivery gates
+→ run formal Delivery validation
+→ prove validated staged tree is unchanged
+→ commit_current_tree
+→ ensure_remote_branch
+→ ensure_open_pr
+→ observe current checks without making CI completion a Delivery gate
+→ set Project Status Review
+→ reacquire live facts
+→ prove local HEAD == remote HEAD == PR head
+→ READY_FOR_REVIEW
+→ STOP at Human boundary
+```
+
+If the invocation resumes after an earlier partial side effect, LCK does not
+trust a previous receipt as authority. It reacquires current facts and reruns
+the applicable Critical Outcome / formal validation gates before continuing.
+
+`Critical Outcome FAIL` when applicable, profile validation failure, remote divergence,
+ambiguous PR identity, stale lifecycle facts, or failed postconditions are
+terminal for that invocation. Pending, failed, missing, or otherwise unresolved
+PR checks may be reported as a non-authoritative observation, but do not veto
+Initial Delivery. Required-check success remains a Review Complete / Merge
+Preflight gate. LCK does not rebase, force push, guess an identity, or route
+itself into repair.
+
+### 4. Initial Delivery reporting
+
+On `READY_FOR_REVIEW`, report:
+
+- canonical Issue and PR URLs returned by current facts;
+- semantic changed-file summary;
+- Critical Outcome result;
+- formal Delivery validation result;
+- LCK effect receipts at summary level;
+- non-blocking checks observation and preserved limitations;
+- current lifecycle state;
+- remaining semantic risks or limitations;
+- exact fresh-session `task-pr-review-runner` prompt.
+
+Always state that Independent Review, Merge, Issue close, post-merge closeout,
+branch deletion, and Feature completion were not performed.
+
+## Review remediation
+
+This section applies only after the latest completed LCK Independent Review returned
+`FAIL` / `STOP_REQUIRED` and the maintainer explicitly requests repair. A successful
+remediation forces a fresh Review before any later remediation can start.
+
+The Agent / Skill MUST NOT accept a bounded mechanical handoff, expected SHA, base SHA,
+PR number, checks snapshot, validation snapshot, or old Evidence Runner snapshot as
+Remediation authority. The failed Review record supplies semantic findings; LCK resolves
+all actionable mechanical identity from current live Git / GitHub state.
+
+### 1. LCK Remediation Prepare
+
+```bash
+uv run --frozen python -m tools.lck remediation prepare <TASK> \
+  --review-id <FAILED_REVIEW_ID>
+```
+
+Proceed only on `READY_FOR_REMEDIATION`. With the normal local-record path, LCK
+verifies the failed Review audit record and reads its findings. For an explicit
+cross-workspace/runtime handoff where that ignored audit record does not exist,
+`--findings-file` supplies only the already-completed semantic findings. In both cases LCK
+reacquires the current OPEN non-Draft PR/head/base and profile-owned Issue branch and selects/restores
+the current implementation workspace.
+
+Do not pass expected head/base/PR identity. If current live identity is ambiguous,
+diverged, missing, or unsafe, STOP; do not use archived evidence snapshots or
+legacy command paths as a fallback.
+
+### 2. Semantic repair
+
+Read the returned findings, confirm them against the current implementation, implement
+the smallest complete repair, and add regression coverage. Classify each finding by the
+boundary at which its evidence can truthfully exist:
+
+- implementation/config/docs/test defects that can be repaired on the current workspace
+  are Remediation work and must be addressed before completion;
+- a requirement whose evidence can only be produced **after the repaired candidate head
+  exists**, or by a **separate provider / fresh Independent Review invocation**, is a
+  deferred Review-acceptance item. It remains unsatisfied, but it is **not** a Human Gate
+  and **not** a prerequisite for `remediation complete`;
+- genuine scope/architecture/product ambiguity still stops at Human Gate rather than being
+  silently expanded.
+
+Do not fabricate deferred evidence and do not ask the maintainer to provide future-head
+provider/cross-provider receipts before the repaired head exists. If actual repair changes
+are ready, continue to LCK Remediation Complete and report the deferred acceptance item as
+pending for the next fresh Review. If **no repair change exists** and the only remaining
+item is external/future Review evidence, do not manufacture a commit merely to advance the
+lifecycle. Close the prepared Remediation session through the formal no-change terminal
+operation below, then obtain the external evidence for the unchanged head.
+
+The Agent may edit and run targeted development validation. It MUST NOT directly stage
+the final tree, commit, push, create/replace the PR, mutate lifecycle state, or start a
+new Review.
+
+### 3. LCK Remediation No Change
+
+When the formal Remediation role was entered but semantic inspection confirms that no
+implementation/config/docs/test repair is required, close that prepared session without
+changing the candidate:
+
+```bash
+uv run --frozen python -m tools.lck remediation no-change <TASK> \
+  --review-id <FAILED_REVIEW_ID> \
+  --summary "<why no implementation change is required>"
+```
+
+Proceed only on `NO_IMPLEMENTATION_CHANGE`. LCK reacquires the current OPEN PR/head/base,
+requires the selected leaf-Issue workspace to be clean and still exactly match the prepared
+Remediation target, writes a formal no-change receipt under `.workflow.local/lck/`, and
+releases the prepared Remediation session. It does **not** commit, push, create a new head,
+set `fresh-review-required`, or claim that deferred provider/cross-runtime acceptance is
+satisfied. A retry for the same unchanged target is idempotent and replays the prior
+receipt.
+
+This operation is also the deterministic recovery path for an older prepared session that
+was left open because the Skill correctly refused to manufacture a no-op commit. Do not
+manually delete or edit the session marker.
+
+### 4. LCK Remediation Complete
+
+After an actual repair is ready:
+
+```bash
+uv run --frozen python -m tools.lck remediation complete <TASK> \
+  --review-id <FAILED_REVIEW_ID> \
+  --commit-message "<scoped repair commit message>" \
+  --summary "<repair summary>" \
+  --risks "<risks or limitations>"
+```
+
+LCK reuses the shared Delivery effects for profile-specific gates, formal validation, exact
+validated-tree commit, remote synchronization, non-blocking check observation, and final
+local/remote/PR head verification. Unlike Initial Delivery, Remediation must reuse existing OPEN PR
+state; it never creates a replacement PR.
+
+`remediation complete` gates the repaired implementation and the mechanics needed to create
+a stable new candidate head. It MUST NOT require provider-attributed implementation receipts,
+fresh cross-provider Review receipts, or other acceptance evidence that can only be
+truthfully produced by a separate session after that new head exists. Those requirements
+remain pending and MUST still block the later Independent Review PASS when the Task requires
+them. `READY_FOR_NEW_REVIEW` means only that the repaired head is ready to be reviewed.
+
+A successful result is:
+
+```text
+READY_FOR_NEW_REVIEW
+→ STOP
+```
+
+The new head invalidates the earlier semantic Review result. Remediation MUST NOT start
+Independent Review automatically. Report the repaired findings, new head,
+validation/check results, limitations, and tell the maintainer to start a new fresh
+`task-pr-review-runner` invocation.
+
+## Failure discipline
+
+Distinguish deterministic STOP from tool failure:
+
+- valid LCK / Runner STOP → stop; no alternate write route;
+- missing/unparseable tool result → at most one identical bounded retry;
+- semantic leaf-Issue ambiguity or requested scope expansion → Human Gate;
+- remote divergence or identity ambiguity → stop; never force push or guess;
+- `partial` / `unknown` evidence remains `partial` / `unknown` in reporting.
+
+The Skill is a semantic procedure. It is not the lifecycle state machine.

--- a/.agents/skills/task-pr-review-runner/SKILL.md
+++ b/.agents/skills/task-pr-review-runner/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: task-pr-review-runner
+description: Independently review the current live Task PR in a fresh, implementation-read-only LCK context. LCK resolves the PR/base/head/effective diff/Task Contract/validation from live state and guards verdict applicability. The Review Agent only Inspect/Reason/Judge/Report; it never fixes, writes GitHub state, merges, closes Issues, or starts remediation.
+---
+
+# Task PR review runner
+
+Use this Skill only in a fresh session that did not implement or remediate the head
+being reviewed. Shared semantics are owned by
+`docs/workflows/lck/review-and-remediation.md` and lifecycle placement by
+`docs/workflows/lck/lifecycle.md`.
+Read applicable `AGENTS.md` and `.agents/policies/command-execution.md`; Review has no direct Git/GitHub write authority.
+
+## Execution route contract
+
+`review prepare`, `review complete`, and `merge preflight` (including the
+`merge-preflight` compatibility alias) use `sandbox-first`. These operations
+keep the source repository read-only; Review's temporary clone and ignored LCK
+runtime state remain operation-owned exceptions defined by the policy. This
+classification is selected from the exact LCK invocation before it starts.
+
+The route only selects the execution context for a command already authorized
+by this Skill and LCK. It never grants GitHub, lifecycle, merge, or write
+authority, and Review must not be rerouted through a generic elevated `uv`,
+`python`, `git`, or `gh` rule. Preserve the policy's exact-context retry rules
+for a genuine `sandbox-denied` or `credential-isolated` result.
+
+## Invocation
+
+```text
+请使用 task-pr-review-runner，独立只读审查 Task #<TASK> 的当前 OPEN PR。
+```
+
+The Task number is the only mechanical key supplied to LCK. A maintainer may mention
+a PR number for human intent, but the Agent MUST NOT pass PR/base/head/checks/snapshot
+facts from Delivery as Review authority.
+
+Before the first LCK command, verify the project launcher:
+
+```bash
+command -v uv
+uv --version
+uv run --frozen python --version
+```
+
+If this preflight fails, report an environment/launcher failure. It is not a
+Review verdict, and must not be converted into `STOP_REQUIRED`.
+
+## Long-operation wait and progress contract
+
+For known heavyweight operations — `delivery complete`, `review prepare`, and
+formal workflow validation — use a fixed 30-second wait window for the first
+wait and every subsequent still-running poll (for example,
+`write_stdin`/`yield_time_ms=30000`). Do not use adaptive 1-second, 10-second,
+20-second, or 30-second polling. If the process exits earlier, return its
+output immediately; 30 seconds is the maximum wait window, not a minimum
+runtime.
+
+During these operations, structured progress may appear on stderr. It is
+bounded, non-authoritative observability only: use it to identify the current
+operation and stage, never as evidence for eligibility, freshness, verdicts,
+retry, Merge, Closeout, or any lifecycle result. The final stdout JSON remains
+the only machine-parseable lifecycle result.
+
+## 1. LCK Review Prepare
+
+```bash
+uv run --frozen python -m tools.lck review prepare <TASK>
+```
+
+Proceed only on `READY_FOR_SEMANTIC_REVIEW`. Use the returned `review_id`, current
+Task Contract, current review target, validation/check state, and `review_root`.
+The returned `structured_review_instructions` is the canonical Structured Review
+v2 semantic handoff. Use it to organize the review; do not replace it with an
+ad-hoc prompt or a Task-specific checklist.
+Before sealing, Review Prepare has already run and persisted the authoritative
+formal Review validation for the exact reviewed head. Consume that returned
+validation/check evidence; do not independently reproduce it. The `review_root`
+is a detached, clean, implementation-read-only standalone temporary clone for the
+live-resolved head and an immutable review evidence artifact, not an executable
+development workspace. The source tracked tree and source Git metadata remain
+read-only; only ignored LCK operation/evidence state may be written outside the clone.
+Review Prepare may begin while CI checks are pending or have failed; check success
+is revalidated as a fresh gate by Review Complete and Merge Preflight.
+
+If LCK returns STOP or stale, do not fall back to archived evidence snapshots,
+expected SHAs, direct `gh` selection, or a Delivery handoff.
+
+## 2. Semantic Review
+
+Inside the read-only review context, do exactly:
+
+```text
+Inspect
+Reason
+Judge
+Report
+```
+
+Complete all applicable obligations named by `structured_review_instructions`
+before the existing final verdict. A High or Medium blocker does not end the
+semantic review; continue the remaining applicable surfaces and perform the
+adversarial residual sweep before reporting. Use the existing canonical finding
+and report semantics, including concrete evidence and falsification reasoning
+when applicable. This handoff is semantic guidance only; it adds no receipt,
+completion gate, or new verdict.
+
+Read the complete effective diff and necessary related code. Build an independent AC
+coverage/evidence matrix. The current Task Contract, effective diff, and necessary related
+code are the default semantic context. Comments, Parent/Epic bodies, and other hierarchy
+or history are not default Review input; expand only when the current Task explicitly
+references them or a concrete ambiguity/dependency requires it. Inspect correctness,
+failure behavior, test source, coverage, and failure semantics, docs/config/public
+interfaces, and workflow/security boundaries when applicable. Inspecting tests means
+reading their source and judging semantic coverage; do not execute pytest, Ruff, mypy,
+lock checks, Skill validators, or an equivalent formal validation suite in the sealed
+`review_root`. Delivery conclusions, old Review verdicts, and old remediation rationale
+are not evidence.
+
+If the LCK-supplied validation/check evidence is insufficient to judge a Task
+requirement, report a specific **validation/evidence gap**. Do not create substitute
+validation authority by rerunning a suite in the sealed clone. The independence of
+Review is independent semantic judgement, not duplicate mechanical validation.
+
+Findings use Blocking, High, Medium, Low, Nit. Blocking/High/Medium defects or unmet
+Task requirements produce FAIL. When the unmet requirement is provider-attributed,
+cross-provider, or otherwise can only be truthfully evidenced by a separate/fresh Review of
+the candidate head, report it explicitly as a **Review-acceptance evidence gap**. Do not
+word such a finding as a requirement to block the earlier Delivery/Remediation completion
+that creates the head being reviewed, and never suggest fabricating the receipt.
+
+## 3. Complete Review with a fresh applicability snapshot
+
+`review complete` is a new LCK operation. Submit the semantic verdict for the sealed
+Review Prepare target:
+
+PASS:
+
+```bash
+uv run --frozen python -m tools.lck review complete <TASK> \
+  --review-id <REVIEW_ID> \
+  --verdict PASS
+```
+
+FAIL: write the complete blocking findings to an ignored or temporary file outside the
+read-only standalone Review clone, then:
+
+```bash
+uv run --frozen python -m tools.lck review complete <TASK> \
+  --review-id <REVIEW_ID> \
+  --verdict FAIL \
+  --findings-file <FINDINGS_FILE>
+```
+
+Review Complete acquires current authority exactly once and compares it with the sealed
+Review Prepare target before accepting either verdict. A changed target returns an
+explicit stale result such as `REVIEW_STALE_HEAD`, `REVIEW_STALE_BASE`,
+`REVIEW_STALE_TASK`, or `REVIEW_STALE_DIFF`. A stale semantic verdict is not accepted as
+the current Review result; start a fresh Review Prepare for the new target.
+
+For a PASS, current applicable PR checks must also still pass. For a FAIL, current
+checks are only observed so a semantic finding is not delayed by pending or failed
+CI. Review Complete itself performs no nested/full-state refresh after its operation
+snapshot is frozen.
+
+A valid PASS returns `READY_FOR_MERGE_PREFLIGHT`, not direct merge readiness. FAIL returns
+`STOP_REQUIRED` and stops; do not start Remediation automatically.
+
+## 4. PASS-only merge preflight
+
+Only after Review Complete returns `READY_FOR_MERGE_PREFLIGHT`, run the next read-only LCK
+operation:
+
+```bash
+uv run --frozen python -m tools.lck merge preflight <TASK>
+```
+
+Merge Preflight acquires a new fresh snapshot and independently verifies the accepted
+Review receipt against the current Task / PR / head / base, current required checks,
+blockers, and mergeability. It is intentionally a separate freshness boundary because
+state may change again after Review Complete.
+
+If Merge Preflight returns `READY_FOR_HUMAN_MERGE`, stop at the maintainer manual Squash
+Merge boundary. LCK and the Review Agent never merge.
+
+## 5. Report
+
+On PASS, report `通过，可以人工合并` only after Merge Preflight returns
+`READY_FOR_HUMAN_MERGE`. Include the reviewed head/base/diff, Review Complete
+applicability result, merge-preflight result, AC coverage, validation/checks, and any
+limitations.
+
+If Review Complete returns a stale result, report that the semantic verdict was not
+accepted for the current target and that a fresh Independent Review is required.
+
+On FAIL, report `不通过，需要修复`, the findings and evidence, the returned
+`STOP_REQUIRED`, and the failed `review_id` that the maintainer may explicitly use for
+Remediation while it remains the latest completed Review. Do not run Merge Preflight,
+Do not emit an automatic Delivery prompt, and do not start Remediation.
+
+Independent Review never modifies implementation, submits a GitHub Review, merges,
+closes the Task, performs Closeout, or assesses Feature completion.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,24 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(uv run --frozen python -m tools.lck.wsl2_validation_runner:*)",
+      "Bash(git status:*)",
+      "Bash(git log:*)",
+      "Bash(git diff:*)",
+      "Bash(git rev-parse:*)",
+      "Bash(git merge-base:*)",
+      "Bash(git check-ignore:*)",
+      "Bash(git branch --show-current)",
+      "Bash(git branch -vv)",
+      "Bash(git ls-remote origin:*)",
+      "Bash(git remote -v)",
+      "Bash(gh issue view:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh run list:*)"
+    ]
+  },
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  }
+}

--- a/.claude/skills/feature-completion-audit/SKILL.md
+++ b/.claude/skills/feature-completion-audit/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: feature-completion-audit
+description: Claude adapter for the canonical read-only LCK feature audit procedure.
+---
+
+# Claude adapter
+
+Follow `.agents/skills/feature-completion-audit/SKILL.md` as the canonical
+procedure. Claude-specific permissions do not grant lifecycle write authority.

--- a/.claude/skills/task-closeout/SKILL.md
+++ b/.claude/skills/task-closeout/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: task-closeout
+description: Claude adapter for the canonical LCK post-merge closeout procedure.
+---
+
+# Claude adapter
+
+Follow `.agents/skills/task-closeout/SKILL.md` as the canonical procedure.
+Claude-specific permissions do not grant merge authority or broaden cleanup.

--- a/.claude/skills/task-delivery-runner/SKILL.md
+++ b/.claude/skills/task-delivery-runner/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: task-delivery-runner
+description: Claude adapter for the canonical LCK leaf delivery procedure.
+---
+
+# Claude adapter
+
+Follow `.agents/skills/task-delivery-runner/SKILL.md` as the canonical
+procedure. Claude-specific command permissions come from `.claude/settings.json`;
+they do not change LCK lifecycle authority or fail-closed behavior.

--- a/.claude/skills/task-pr-review-runner/SKILL.md
+++ b/.claude/skills/task-pr-review-runner/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: task-pr-review-runner
+description: Claude adapter for the canonical LCK independent review procedure.
+---
+
+# Claude adapter
+
+Follow `.agents/skills/task-pr-review-runner/SKILL.md` as the canonical
+procedure. Claude-specific command permissions come from `.claude/settings.json`;
+they do not change review independence, authority, or freshness requirements.

--- a/.codex/rules/tracequant-wsl-validation.rules
+++ b/.codex/rules/tracequant-wsl-validation.rules
@@ -1,0 +1,50 @@
+# tracequant WSL2 Validation Runner rules
+#
+# Codex execpolicy uses prefix matching. These rules allow named fixed Runner
+# profile prefixes plus only the explicit non-writing Ruff format-check shape.
+# The Runner validates exact argv, cwd, repository, profile schema, canonical
+# commands, CI drift, preconditions, and output paths. Ambiguous validation
+# shapes remain unmatched or prompt. They do not allow generic Python, uv, shell wrappers,
+# GitHub writes, push, branch deletion, reset, clean, or arbitrary commands.
+
+prefix_rule(
+    pattern = ["uv", "run", "--frozen", "python", "-m", "tools.lck.wsl2_validation_runner", ["current-ci-equivalent", "targeted", "targeted:tools-tests", "targeted:workflow-tests", "post-merge"]],
+    decision = "allow",
+    justification = "Allow named fixed Validation Runner profiles; the Runner rejects trailing argv and non-canonical commands.",
+)
+
+prefix_rule(
+    pattern = ["uv", "run", "--frozen", "python", "-m", "tools.lck.wsl2_validation_runner", ["workflow-delivery", "workflow-review", "workflow-closeout"]],
+    decision = "allow",
+    justification = "Allow fixed workflow Validation profiles with exactly one full base SHA; the Runner enforces complete argv and phase preconditions.",
+)
+
+prefix_rule(
+    pattern = ["uv", "run", "--frozen", "python", "-m", "tools.lck.wsl2_validation_runner", ["current-ci-equivalent", "targeted", "targeted:tools-tests", "targeted:workflow-tests", "post-merge", "workflow-delivery", "workflow-review", "workflow-closeout"], ["--command", "--shell", "--exec", "--", "|", ">", "$(id)"]],
+    decision = "forbidden",
+    justification = "Block known command injection, shell, separator, pipe, redirection, and substitution forms.",
+)
+
+prefix_rule(
+    pattern = ["gh", "auth", "token"],
+    decision = "forbidden",
+    justification = "Do not print GitHub authentication tokens.",
+)
+
+prefix_rule(
+    pattern = ["uv", "run", "--frozen", "ruff", "format", "--check", "."],
+    decision = "allow",
+    justification = "Allow the current CI's explicit non-writing Ruff format-check shape; source formatting remains unmatched and approval-gated.",
+)
+
+prefix_rule(
+    pattern = ["git", ["push", "reset", "clean", "branch", "fetch"]],
+    decision = "prompt",
+    justification = "Git writes, ref refresh, dangerous local operations, and branch deletion require explicit workflow approval.",
+)
+
+prefix_rule(
+    pattern = ["gh", ["issue", "pr", "project", "api"]],
+    decision = "prompt",
+    justification = "GitHub mutations and direct API calls require explicit workflow approval.",
+)

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+* text=auto
+*.py text eol=lf
+*.toml text eol=lf
+*.lock text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.sh text eol=lf
+*.ps1 text eol=crlf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Validate lock file
         run: uv lock --check
 
-      - name: Run bootstrap acceptance tests
+      - name: Run repository boundary acceptance tests
         run: uv run --frozen pytest
 
       - name: Run Ruff lint
@@ -48,4 +48,4 @@ jobs:
         run: uv run --frozen ruff format --check .
 
       - name: Run mypy
-        run: uv run --frozen mypy src tests
+        run: uv run --frozen mypy src tools/lck tests

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ __pycache__/
 .env
 .env.*.local
 *.local.toml
+.agents/execution-profile.local.toml
+.agents/evidence.local/
+.agents/validation.local/
+.workflow.local/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,51 @@
+# TraceQuant agent instructions
+
+## Ownership boundary
+
+TraceQuant product code belongs under `src/tracequant/`. The Local Control Kernel
+(LCK) is repository tooling owned by `tools/lck/`; neither side may import the
+other. `nautilus_trader` remains confined to the product integration boundary
+documented in `docs/architecture/repository-structure.md`.
+
+## Issue-driven workflow
+
+Start from the maintainer-specified leaf Issue. Read its body and labels first;
+expand to parents, blockers, comments, or broad design documents only when the
+leaf contract is incomplete, ambiguous, safety-sensitive, or explicitly requires
+that context. Git and GitHub provide mechanical identity and lifecycle facts;
+conversation history and local receipts do not replace fresh LCK resolution.
+
+Natural-language entries route to the canonical procedures:
+
+- implementing an Issue: `.agents/skills/task-delivery-runner/SKILL.md`;
+- reviewing a PR: `.agents/skills/task-pr-review-runner/SKILL.md`;
+- closing out a manually merged PR: `.agents/skills/task-closeout/SKILL.md`;
+- auditing Feature completion: `.agents/skills/feature-completion-audit/SKILL.md`.
+
+The stable lifecycle entry is:
+
+```bash
+uv run --frozen python -m tools.lck --help
+```
+
+LCK owns deterministic branch, commit, push, PR, validation, receipt, freshness,
+and recovery mechanics. Agents own semantic implementation and review. A human
+maintainer alone authorizes merge and explicit remediation after Review FAIL.
+
+## Repository rules
+
+- Do not place LCK implementation or contracts in `src/tracequant/`.
+- Do not place product implementation or product configuration in `tools/lck/`.
+- Do not restore archived v1 business trees or import archived v1 modules.
+- Keep product documentation outside `docs/workflows/lck/` and
+  `docs/guides/lck/`; those two trees are LCK-only.
+- Keep local LCK state ignored and bounded. It is diagnostic evidence, not
+  lifecycle authority or a product persistence root.
+- Unknown identity, stale state, incomplete evidence, or conflicting authority
+  fails closed.
+- Run the repository's locked pytest, Ruff, formatting, and mypy checks before
+  delivery completion.
+
+Detailed lifecycle semantics live in `docs/workflows/lck/lifecycle.md` and
+`docs/workflows/lck/review-and-remediation.md`. Do not duplicate them here.
+Context acquisition is governed by `.agents/policies/context-retrieval.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# Claude adapter
+
+Follow `AGENTS.md` for repository invariants and workflow routing. Claude Skills
+under `.claude/skills/` are thin adapters to the canonical procedures under
+`.agents/skills/`. Claude-specific permissions in `.claude/settings.json` do not
+change LCK authority, review independence, fail-closed behavior, or the human-only
+merge boundary.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # TraceQuant
 
 TraceQuant v2 is an auditable quantitative research-to-live project for
-cryptocurrency perpetual futures. The current repository is deliberately only
-a clean bootstrap: it pins the approved NautilusTrader runtime, establishes
-package ownership, and provides mechanical guards for that boundary.
+cryptocurrency perpetual futures. Its product runtime remains a clean,
+non-production bootstrap: it pins the approved NautilusTrader runtime,
+establishes package ownership, and provides mechanical guards for that boundary.
+The repository also includes the approved Local Control Kernel (LCK) engineering
+tooling under `tools/lck/`; LCK is not part of the TraceQuant product runtime.
 
 There is no strategy, data ingestion, backtest workflow, exchange connectivity,
 order submission, Demo mode, or Live mode in this tree. Live trading is not
@@ -26,8 +28,153 @@ uv lock --check
 uv run --frozen pytest
 uv run --frozen ruff check .
 uv run --frozen ruff format --check .
-uv run --frozen mypy src tests
+uv run --frozen mypy src tools/lck tests
 ```
+
+## LCK: an engineering capability within TraceQuant
+
+While building and maintaining TraceQuant, the project is developing the Local
+Control Kernel (LCK): an engineering capability for making Codex-centered,
+AI-assisted development deterministic, auditable, and human-controlled. LCK
+separates semantic Agent work—understanding, designing, implementing, and
+reviewing—from deterministic lifecycle control such as resolving current
+repository and GitHub state, validating a candidate, and carrying out bounded
+delivery effects.
+
+LCK is part of TraceQuant's repository engineering system. It is not an
+independent product, general Agent platform, trading module, product-runtime
+dependency, or risk authority, and it does not make the current repository a
+trading system. LCK is provider-neutral by design: Codex is a primary use case,
+while other supported Agent providers can use the same lifecycle contract. The
+capability is intended to offer reusable engineering value to other open-source
+projects, but this repository does not claim drop-in installation, external
+adoption, or unsupported portability. See the
+[public LCK overview](docs/guides/lck/overview.md) for the lifecycle and
+boundaries.
+
+### Why TraceQuant developed LCK
+
+TraceQuant is intended to become a long-lived, auditable quantitative system.
+That kind of project needs more than an Agent that can produce a plausible
+patch: the current Issue, branch, commit, pull request, validation result, and
+recovery action must be resolved deterministically; semantic work must remain
+reviewable; and a human must retain authority over the irreversible merge. LCK
+was formed while building TraceQuant to provide those boundaries for
+Codex-assisted maintenance without turning the workflow controller into a
+trading or risk component.
+
+```mermaid
+flowchart LR
+    TQ["TraceQuant<br/>primary project identity<br/>auditable research-to-live goal"]
+    LCK["LCK<br/>engineering capability developed<br/>and used within TraceQuant"]
+    DELIVERY["Repository delivery and review<br/>deterministic, auditable,<br/>human-controlled"]
+    QUANT["Future quantitative capabilities<br/>research → live"]
+    REUSE["Other open-source projects<br/>intended manual study and adaptation"]
+    BOUNDARY["LCK does not provide<br/>trading decisions, exchange orders,<br/>or risk authority"]
+
+    TQ --> LCK
+    TQ --> QUANT
+    LCK --> DELIVERY
+    LCK -.->|reuse direction, not adoption claim| REUSE
+    LCK -.-> BOUNDARY
+```
+
+The diagram shows the relationship, not an implementation claim: the future
+quantitative system remains TraceQuant's product goal, while LCK governs the
+engineering workflow used to build and maintain it.
+
+### Current LCK capability surface
+
+The current capability is a repository workflow contract, not a separately
+released product. Its implemented surface includes:
+
+- an Issue-driven lifecycle with readiness, typed leaf contracts, and fresh
+  resolution of the current Git and GitHub state;
+- an explicit work-item contract, including the Task `Critical Outcome` gate
+  where that typed profile requires it, with Documentation, Bug, and Research
+  profiles using their own contracts;
+- a strict execution boundary: Agents perform semantic work, while LCK owns
+  bounded workspace preparation, lifecycle gates, formal validation, commit,
+  push, and pull-request effects;
+- exact-candidate validation and check observation before the lifecycle reaches
+  the human Review boundary;
+- a fresh, read-only Independent Review that independently judges the current
+  candidate rather than inheriting Delivery's correctness judgment;
+- human-controlled merge authority: Review PASS can make a change ready for
+  manual Squash Merge, but no Agent, Skill, or LCK operation merges it;
+- bounded Audit Receipts that explain lifecycle effects without becoming
+  permission tokens or a substitute for current live state; and
+- fail-closed recovery with explicit remediation after Review FAIL and a fresh
+  Review requirement for every repaired head.
+
+The [Issue lifecycle](docs/workflows/lck/lifecycle.md),
+[Independent Review and remediation](docs/workflows/lck/review-and-remediation.md),
+and [LCK overview](docs/guides/lck/overview.md) describe the current contract in
+more detail. The stable CLI entry is:
+
+```bash
+uv run --frozen python -m tools.lck --help
+```
+
+Implementation and configuration live only under `tools/lck/`, tests under
+`tests/tools/lck/`, workflow specifications under `docs/workflows/lck/`, and
+user guidance under `docs/guides/lck/`.
+
+### LCK lifecycle at a glance
+
+The human stops are intentional: Delivery does not start Review automatically,
+Review FAIL does not start repair automatically, and merge remains a manual
+maintainer action.
+
+```mermaid
+flowchart LR
+    ISSUE["Current Issue<br/>contract + readiness"]
+    PREPARE["LCK Delivery Prepare<br/>live state + workspace"]
+    IMPLEMENT["Implementation Agent<br/>scoped semantic change"]
+    COMPLETE["LCK Delivery Complete<br/>gates + formal validation + PR"]
+    HUMAN_REVIEW["HUMAN STOP<br/>start a fresh review"]
+    REVIEW["Fresh Independent Review<br/>read-only judgement"]
+    DECISION{"Review result"}
+    FAIL_STOP["HUMAN STOP<br/>findings; no auto-repair"]
+    REMEDIATE["Explicit remediation<br/>LCK reacquires state + Agent repairs"]
+    NEW_HEAD["LCK validates and updates<br/>the existing PR with a new head"]
+    PREFLIGHT["LCK Merge Preflight"]
+    MERGE["HUMAN SQUASH MERGE"]
+    CLOSEOUT["LCK Closeout<br/>state convergence + cleanup"]
+
+    ISSUE --> PREPARE --> IMPLEMENT --> COMPLETE --> HUMAN_REVIEW --> REVIEW
+    REVIEW --> DECISION
+    DECISION -->|FAIL| FAIL_STOP --> REMEDIATE --> NEW_HEAD --> REVIEW
+    DECISION -->|PASS| PREFLIGHT --> MERGE --> CLOSEOUT
+```
+
+### LCK releases and manual adoption
+
+The in-repository LCK restored by Task #333 is derived from the final
+pre-removal source commit
+`0d9d762238a3e837a864b5350bf16d1b885a73c3` and reorganized for the current v2
+ownership boundary. The [restoration manifest](docs/workflows/lck/restoration-manifest.md)
+records the old paths, blob identities, new paths, and adaptation decisions.
+
+The [GitHub Releases page](https://github.com/PhoenixSss/tracequant/releases) is
+the authority for named portable archives. The corrected historical preview is
+the published [`lck-v0.1.0-preview.2`
+Release](https://github.com/PhoenixSss/tracequant/releases/tag/lck-v0.1.0-preview.2),
+a pre-release fixed to source commit
+`850ce58c24646c69379d83d79c13d39b145280b5`. Its release record and named assets
+remain authoritative for that immutable preview; they do not float with the
+current repository implementation. The historical `preview.1` is superseded
+and remains immutable.
+
+For manual evaluation and repository-specific adaptation, see the
+[LCK adoption guide](docs/guides/lck/adoption.md). LCK is not a standalone
+product, one-click installation package, or universal portability promise:
+adopters must inspect the selected snapshot, adapt repository-specific
+contracts and integrations, and validate the result themselves.
+
+The initial v2 bootstrap restriction that excluded repository workflow-tooling
+roots is superseded for these exact LCK-owned paths. It remains in force for
+unapproved tooling trees and for any attempt to place LCK in the product package.
 
 ## Ownership and safety
 

--- a/docs/architecture/repository-structure.md
+++ b/docs/architecture/repository-structure.md
@@ -1,9 +1,10 @@
 # TraceQuant v2 repository structure
 
-This document is the current ownership contract for the clean TraceQuant v2
-bootstrap. The bootstrap proves source and dependency separation; it does not
-provide a strategy, data pipeline, backtester, exchange connection, or trading
-mode.
+This document is the current ownership contract for the TraceQuant v2 product
+bootstrap and its repository engineering tooling. The product bootstrap proves
+source and dependency separation; it does not provide a strategy, data pipeline,
+backtester, exchange connection, or trading mode. LCK is an approved repository
+capability outside that product runtime.
 
 ## Tracked layout
 
@@ -12,10 +13,17 @@ Every tracked top-level path has one purpose and owner:
 | Path | Purpose | Owner |
 | --- | --- | --- |
 | `.github/` | Repository-native CI and Issue metadata | Maintainers |
+| `.agents/` | Canonical Agent procedures and LCK execution/evidence policies | LCK maintainers |
+| `.claude/` | Thin Claude-specific adapters to canonical Agent procedures | LCK maintainers |
+| `.codex/` | Thin Codex execution-policy adapter | LCK maintainers |
 | `config/` | Safe configuration boundary documentation | TraceQuant configuration owner |
 | `docs/` | Current architecture, dependency policy, evidence, and release identity | Maintainers and named capability owners |
 | `src/` | The single production Python source root | TraceQuant engineering |
-| `tests/` | Product and architecture acceptance tests | TraceQuant engineering |
+| `tests/` | Product, architecture, and isolated repository-tooling tests | TraceQuant engineering and LCK maintainers |
+| `tools/lck/` | Repository-only Local Control Kernel implementation and configuration | LCK maintainers |
+| `AGENTS.md` | Agent entry routing and repository ownership boundaries | Maintainers |
+| `CLAUDE.md` | Thin Claude adapter to `AGENTS.md` and canonical Skills | Maintainers |
+| `.gitattributes` | Cross-platform tracked-text normalization | Maintainers |
 | `.env.example` | Safe statement of the currently empty environment surface | TraceQuant configuration owner |
 | `.gitignore` | Closed set of disposable checkout-local output and secret-shaped local files | Maintainers |
 | `.python-version` | Exact CPython 3.13 interpreter selection | Maintainers |
@@ -25,10 +33,34 @@ Every tracked top-level path has one purpose and owner:
 | `uv.toml` | Wheel-only installation policy for NautilusTrader | Maintainers |
 | `uv.lock` | Reproducible dependency resolution | Maintainers |
 
-There is no top-level `apps/`, `packages/`, `scripts/`, `tools/`, `deploy/`,
+There is no top-level `apps/`, `packages/`, `scripts/`, `deploy/`,
 `runtime/`, `data/`, `artifacts/`, or `vendor/` product root. A later scoped
 capability may add only a path already assigned below or amend this architecture
 through an explicit decision.
+
+`tools/` is not a product source root. Its only approved tracked subtree is
+`tools/lck/`. LCK tests are confined to `tests/tools/lck/`, its normative
+workflow documents to `docs/workflows/lck/`, and its user guides to
+`docs/guides/lck/`. Product implementation and product-specific configuration
+must not be placed in those LCK-owned paths.
+
+The initial bootstrap text that excluded `.agents/`, `.claude/`, `.codex/`,
+`tools/`, `tests/tools/`, and `docs/workflows/` as a class is superseded. The
+exact LCK-owned roots listed above are part of the approved tracked layout;
+unrelated trees under those broad names are not implicitly authorized.
+
+## Repository-tooling ownership
+
+LCK is an on-demand repository engineering tool, not part of the installed
+`tracequant` distribution. `tools.lck` must not import `tracequant` or
+`nautilus_trader`; product modules must not import `tools.lck`. Provider-neutral
+Review value contracts live in `tools/lck/review_models.py`, not in the product
+namespace. PyYAML is a development/tooling dependency and is not a TraceQuant
+runtime dependency.
+
+The stable entry is `uv run --frozen python -m tools.lck`. Detailed lifecycle
+semantics live under `docs/workflows/lck/`; this architecture document owns only
+the product/tooling boundary.
 
 ## Python and dependency ownership
 
@@ -135,7 +167,15 @@ __pycache__/
 .env
 .env.*.local
 *.local.toml
+.agents/execution-profile.local.toml
+.agents/evidence.local/
+.agents/validation.local/
+.workflow.local/
 ```
+
+The three LCK output roots are bounded, ignored repository-tooling state. They
+are not product persistence, do not satisfy an `evidence_root` or `run_root`, and
+never replace live Git/GitHub authority.
 
 The repository deliberately does not ignore local `data/`, `catalog/`,
 `cache/`, `runs/`, `artifacts/`, `evidence/`, `audit/`, `models/`, or `logs/`
@@ -143,10 +183,11 @@ fallbacks. Such names could hide a missing external-root configuration.
 
 ## Mechanical guards
 
-The bootstrap acceptance suite enforces the closed top-level tree, the single
-production namespace and source root, the exact wheel-only dependency and PyPI
-lock source, the Nautilus import boundary, the absence of retired workflow and
-v1 business paths, the generated-path allowlist, and import-time safety. The
+The acceptance suite enforces the approved product-and-LCK top-level layout, the
+single production namespace and source root, the exact wheel-only dependency
+and PyPI lock source, the Nautilus import boundary, the isolated LCK tooling allowlist,
+the absence of retired workflow and v1 business paths, the generated-path
+allowlist, and import-time safety. The
 Critical Outcome test additionally proves that TraceQuant resolves from this
 checkout while NautilusTrader resolves from the external environment.
 
@@ -154,5 +195,6 @@ Any later source/configuration expansion must extend tests at the boundary it
 introduces. Persistent-root creation must add absolute-path, environment, mode,
 schema, and runtime-identity failure tests. Strategy work must add public API,
 risk-veto, stale/unknown state, reconciliation, and no-exchange-client tests.
-Until then, the closed skeleton prevents those unimplemented capabilities from
-being implied by empty scaffolding.
+Until then, the product-runtime skeleton prevents those unimplemented product
+capabilities from being implied by empty scaffolding; it does not prohibit the
+approved repository-only LCK capability.

--- a/docs/architecture/technical-baseline.md
+++ b/docs/architecture/technical-baseline.md
@@ -1,8 +1,10 @@
 # TraceQuant v2 technical baseline
 
-The current implementation is a clean, non-production bootstrap. The runtime
-surface contains only the `tracequant` namespace and a minimal explicit identity
-seam for the installed NautilusTrader distribution.
+The current product implementation is a clean, non-production bootstrap. The
+runtime surface contains only the `tracequant` namespace and a minimal explicit
+identity seam for the installed NautilusTrader distribution. Repository-only LCK
+engineering tooling is approved outside this runtime and does not expand the
+product surface described here.
 
 ## Environment
 
@@ -51,7 +53,7 @@ uv lock --check
 uv run --frozen pytest
 uv run --frozen ruff check .
 uv run --frozen ruff format --check .
-uv run --frozen mypy src tests
+uv run --frozen mypy src tools/lck tests
 ```
 
 CI runs the clean no-cache wheel-only sync before these checks. The acceptance

--- a/docs/guides/lck/adoption.md
+++ b/docs/guides/lck/adoption.md
@@ -1,0 +1,361 @@
+# Manual LCK adoption and distribution boundaries
+
+This guide explains how an external open-source repository can manually study
+and adopt the Local Control Kernel (LCK) from TraceQuant during its current
+initial and actively evolving phase. It describes the boundaries of the
+available material; it is not an installation guide or a promise of
+portability.
+
+## What LCK is
+
+LCK is an engineering capability developed within TraceQuant to make
+Agent-assisted repository delivery auditable, deterministic, and human
+controlled. It separates semantic work from deterministic lifecycle mechanics:
+
+- a human maintainer owns intent, ambiguity decisions, and the final merge;
+- an Implementation Agent understands and changes the scoped work item;
+- a fresh Review Agent independently inspects and judges the candidate;
+- LCK resolves live Git/GitHub identity, applies lifecycle gates, runs formal
+  validation, performs bounded lifecycle effects, and records evidence;
+- Git and GitHub remain the current-state authority.
+
+LCK is invoked on demand. It is not a daemon, a standalone product, a general
+Agent platform, a trading module, or a risk authority. TraceQuant itself is
+still a Research MVP foundation: it does not currently provide exchange data
+ingestion, a backtester, strategies, model training, order execution, risk
+decisions, Demo, or Live trading.
+
+## Adoption paths and current availability
+
+There are two manual paths. They have different availability and maintenance
+implications:
+
+| Path | Current status | What it means |
+| --- | --- | --- |
+| Repository copy | Available for manual evaluation and adaptation | Inspect a chosen TraceQuant revision, copy the coherent LCK source and workflow material, then adapt every repository-specific integration point. |
+| Corrected versioned release archive | Available: [`lck-v0.1.0-preview.2`](https://github.com/PhoenixSss/tracequant/releases/tag/lck-v0.1.0-preview.2) | Use the named Release and its fixed assets as the supported `preview.2` source snapshot. The existing `preview.1` is historical and superseded. |
+
+The versioned path is a supported LCK source snapshot, not a generic GitHub
+source archive for an arbitrary commit or tag. The current
+[`lck-v0.1.0-preview.2` Release](https://github.com/PhoenixSss/tracequant/releases/tag/lck-v0.1.0-preview.2)
+is a GitHub pre-release, not a draft. It records source commit
+`850ce58c24646c69379d83d79c13d39b145280b5`, manifest digest
+`d5107429c1379bc608bb5f9ea7d5bae11f68abf48016b5fd4efb36735c32494e`, and
+archive digest
+`acb626d0e31073a9431dbd7a7d24a3fa9af8040e6cd10222e40c5564103d5d87` for
+`lck-v0.1.0-preview.2.tar.gz` (286,496 bytes). The [manifest.json
+asset](https://github.com/PhoenixSss/tracequant/releases/download/lck-v0.1.0-preview.2/manifest.json),
+[metadata.json
+asset](https://github.com/PhoenixSss/tracequant/releases/download/lck-v0.1.0-preview.2/metadata.json),
+and [SHA256SUMS
+asset](https://github.com/PhoenixSss/tracequant/releases/download/lck-v0.1.0-preview.2/SHA256SUMS)
+are part of the same Release record. Verify those live assets rather than
+copying values from a branch or stale snapshot.
+
+The historical
+[`lck-v0.1.0-preview.1`](https://github.com/PhoenixSss/tracequant/releases/tag/lck-v0.1.0-preview.1)
+release remains immutable historical evidence. Do not represent it as
+`preview.2`, replace its tag or assets, or treat its archive as the current
+supported snapshot. `preview.2` is fixed to its published source commit and
+does not follow current `main`; a later source change requires a new release
+identity.
+
+## Path A: repository-copy adoption
+
+This path starts by cloning or inspecting the
+[TraceQuant repository](https://github.com/PhoenixSss/tracequant) and selecting
+one coherent revision. Record the repository URL, commit SHA (or other
+immutable revision identity), and the date of inspection. The implementation
+is evolving, so do not combine files from unrelated revisions.
+
+At the current TraceQuant revision, the LCK implementation is a coherent
+source tree rather than a separately installable product package. The stable
+entry is `uv run --frozen python -m tools.lck`; the complete implementation,
+Review contracts, validation tools, and configuration are isolated under
+`tools/lck/`:
+
+```text
+tools/lck/
+  __main__.py
+  cli.py
+  bug_policy.py
+  critical_outcome.py
+  documentation_policy.py
+  issue_forms.py
+  markdown_sections.py
+  github_prs.py
+  github_projects.py
+  research_policy.py
+  review_models.py
+  common.py
+  validation_runner.py
+  wsl2_validation_runner.py
+  config/validation_profiles.json
+  ... responsibility-owned lifecycle modules ...
+.codex/rules/tracequant-wsl-validation.rules
+```
+
+Copy this set as a source snapshot and inspect its imports and validation
+identity paths before deleting or substituting anything. In particular,
+copying only `__main__.py` is insufficient. The
+[LCK implementation map](../../workflows/lck/implementation-map.md)
+is the starting point for understanding each responsibility-owned module.
+The current snapshot is built around Python 3.13 and uv 0.12.1, and its Issue
+form parser uses PyYAML; these are implementation dependencies to verify rather
+than universal LCK requirements.
+
+The source tree is only one part of the adoption. Copy and adapt the relevant
+workflow contract as a coherent set:
+
+```text
+AGENTS.md
+.github/ISSUE_TEMPLATE/documentation.yml
+.github/workflows/ci.yml
+.agents/policies/command-execution.md
+.agents/policies/workflow-evidence.md
+.agents/skills/task-delivery-runner/SKILL.md
+.agents/skills/task-pr-review-runner/SKILL.md
+.agents/skills/task-closeout/SKILL.md
+.agents/skills/feature-completion-audit/SKILL.md
+.claude/skills/task-delivery-runner/SKILL.md       # when Claude is supported
+.claude/skills/task-pr-review-runner/SKILL.md
+.claude/skills/task-closeout/SKILL.md
+.claude/skills/feature-completion-audit/SKILL.md
+docs/workflows/lck/lifecycle.md
+docs/workflows/lck/review-and-remediation.md
+docs/workflows/lck/agent-skills.md
+```
+
+The list above is an adoption starting point, not a frozen package manifest.
+The adopting repository must inspect transitive imports, active Skills, CI
+commands, templates, and the selected revision's release notes or source
+history. Historical Evidence Runner material is audit provenance, not an
+alternate LCK lifecycle entry point.
+
+## Path B: versioned release-archive adoption
+
+The corrected `preview.2` archive is available through its named [GitHub
+Release](https://github.com/PhoenixSss/tracequant/releases/tag/lck-v0.1.0-preview.2).
+It is a fixed source snapshot, not a floating view of `main`. Use the
+following manual sequence:
+
+1. Select the named `preview.2` Release rather than an unversioned branch,
+   arbitrary commit, or GitHub-generated archive.
+2. Download its named archive and metadata assets; verify and record the tag,
+   exact source commit, manifest digest, archive digest, asset identities, and
+   GitHub pre-release status.
+3. Extract the archive into a controlled location in the adopting repository.
+4. Read the archive's compatibility and upgrade guidance before replacing an
+   earlier snapshot.
+5. Adapt the repository integration points listed in the matrix below and run
+   non-destructive validation before any lifecycle write.
+
+The archive does not authorize automatic installation, and it does not turn
+TraceQuant's current source snapshot into a standalone product. A later
+correction or changed digest requires a new immutable release identity.
+
+## Reuse and adaptation matrix
+
+The following matrix distinguishes reusable ideas from material that needs
+adaptation and conventions that remain TraceQuant-specific.
+
+| Area | Directly reusable | Copyable but requires repository adaptation | TraceQuant-specific boundary |
+| --- | --- | --- | --- |
+| Responsibility split | Human intent/merge, Agent semantic work, fresh Review Agent, LCK deterministic control, Git/GitHub current facts | Map the roles to the adopting team's maintainers and supported providers | TraceQuant's maintainer roles and issue ownership are not transferred automatically |
+| LCK concepts | On-demand operations, fresh phase boundaries, operation snapshots, fail-closed ambiguity handling, bounded effects, audit-not-authority, manual merge | Preserve the invariants while matching the adopting repository's lifecycle and risk model | The concepts do not prove that an adopting repository has implemented them correctly |
+| LCK CLI and kernel | `tools/lck/` as a coherent source snapshot, invoked with `python -m tools.lck` | Repository root, default branch, GitHub identity, Issue/PR resolution, permissions, paths, and supported leaf profiles | `PhoenixSss/tracequant` identity and its current four-profile registry |
+| Profile policies and forms | Generic typed-profile pattern and shared Issue-form parsing | Canonical `type:*` labels, form fields, blocker rules, candidate paths, and any profile policy | TraceQuant's `type:task`, `type:bug`, `type:documentation`, `type:research` labels and policy semantics |
+| Workflow guidance | Shared lifecycle and Review principles in the current development docs | Rewrite examples, paths, maintainer instructions, and provider adapters for the adopting repository | TraceQuant's exact `AGENTS.md`, Project lifecycle, branch namespaces, and Issue relationships |
+| Agent Skills | Semantic Skill structure and the rule that Skills invoke LCK rather than own lifecycle state | Copy only the supported provider's current Skills, update discovery paths and prompts, and validate them | `.agents/skills/`, `.claude/skills/`, and their TraceQuant-specific provider/sandbox instructions |
+| Validation | Bounded validation, exact-head identity, static CI job policy, and redacted local evidence principles | Toolchain commands, language checks, CI job names, base-commit policy, permissions, and ignored output roots | `.github/workflows/ci.yml`, `tools/lck/config/validation_profiles.json`, and `.codex/rules/tracequant-wsl-validation.rules` as currently named |
+| GitHub lifecycle | Issue → Delivery → human stop → Independent Review → manual merge → Closeout model | Issue state labels, Project fields/statuses, PR policy, branch namespace, authentication, and repository permissions | TraceQuant's `codex:ready`, Project statuses, `documentation/<Issue>-<slug>` naming, and current GitHub metadata |
+| Local state and evidence | Keep runtime/evidence local, bounded, ignored, and separate from authority | Configure and verify equivalent ignored paths; never stage local state | `.workflow.local/lck/`, `.agents/validation.local/`, and `.agents/evidence.local/` ownership rules |
+| Product and architecture docs | The practice of separating current implementation from design intent and future work | Write an equivalent baseline for the adopting repository | TraceQuant's quantitative-trading roadmap, `src/tracequant/`, and future `apps/`, `packages/`, and `deploy/` boundaries |
+
+The matrix is deliberately not a portability claim. A copied file is not
+correctly adopted until its repository-specific assumptions are identified,
+adapted, and validated.
+
+## Minimum manual adoption sequence
+
+Use a disposable branch, test repository, or a small documentation Issue for
+the first exercise. Keep production repositories and credentials out of the
+first trial.
+
+### 1. Select and record the source
+
+Choose either a coherent TraceQuant commit for repository-copy adoption or a
+published supported release for archive adoption. Record the source identity,
+date, included LCK components, and any known compatibility limitations.
+
+### 2. Inspect the adopting repository
+
+Before copying files, decide which of the current LCK contracts the repository
+can actually support:
+
+- GitHub Issues, pull requests, labels, and the required Project lifecycle;
+- a deterministic default branch and one profile-owned Issue branch;
+- the GitHub CLI and Git permissions needed by the bounded effects;
+- the language/toolchain commands used by formal validation;
+- one or more supported semantic Agent providers;
+- ignored local directories for LCK runtime and validation evidence.
+
+If an assumption cannot be mapped safely, stop and adapt the contract before
+running lifecycle effects. Do not silently substitute a guessed branch, PR,
+SHA, check, or Project field.
+
+### 3. Copy and adapt the integration points
+
+Copy the coherent source and guidance sets described above. Then adapt, at
+minimum:
+
+- repository owner/name, default branch, and remote identity;
+- Issue form fields, canonical type labels, readiness/blocker semantics, and
+  Project status fields;
+- CI workflow and its statically named required jobs;
+- validation profiles, supported language checks, Python/uv or equivalent
+  launcher assumptions, and exact ignored output paths;
+- `AGENTS.md`, provider Skills, and links to the adopting repository's own
+  technical baseline and structure documentation.
+
+Keep the LCK source's fail-closed behavior and bounded effects while making
+these mappings explicit. Do not solve adaptation by adding an unbounded shell,
+arbitrary refspec, arbitrary GitHub write, or hidden lifecycle controller.
+
+### 4. Run non-destructive validation
+
+From the adopting repository root, first verify the launcher required by the
+selected snapshot:
+
+```bash
+command -v uv
+uv --version
+uv run --frozen python --version
+```
+
+Then run the adapted read-only status operation and the repository's ordinary
+static/documentation checks. In the current TraceQuant source shape, the LCK
+status entry is:
+
+```bash
+uv run --frozen python -m tools.lck status <ISSUE_NUMBER>
+```
+
+Confirm that the result resolves one unambiguous Issue/profile and that local
+runtime output remains under ignored paths. A status result is diagnostic
+information; it does not authorize a lifecycle write.
+
+### 5. Exercise one small lifecycle
+
+For a tiny documentation-only test Issue, invoke the current LCK entry points
+with only the Issue number. LCK must resolve the branch, SHA, PR, and lifecycle
+facts itself:
+
+```bash
+uv run --frozen python -m tools.lck delivery prepare <ISSUE_NUMBER>
+
+# In the prepared workspace, make one small documentation change and run the
+# adapted targeted checks.
+
+uv run --frozen python -m tools.lck delivery complete <ISSUE_NUMBER> \
+  --commit-message "docs: exercise manual LCK adoption" \
+  --summary "Exercise the adapted documentation delivery path." \
+  --risks "Disposable adoption exercise; no production behavior changed."
+```
+
+The expected initial terminal boundary is `READY_FOR_REVIEW`. Stop there for
+the first exercise unless a maintainer explicitly intends to continue. If the
+exercise continues, it must use a fresh Review invocation and retain the human
+merge boundary:
+
+```text
+delivery → HUMAN STOP → independent review → merge preflight →
+maintainer manual Squash Merge → closeout
+```
+
+Do not pass branch names, SHAs, PR numbers, remotes, or refspecs as authority
+to LCK. A failed Review stops and requires explicit maintainer-directed
+remediation; a changed head requires a fresh Review.
+
+## Roles and provider neutrality
+
+Codex is a primary use case for LCK, but LCK is provider-neutral by design.
+The current workflow documentation also supports Claude as an equivalent
+semantic provider. Provider differences may affect prompt format, tools, or
+sandbox setup; they must not decide the actionable branch, SHA, PR, push
+destination, lifecycle state, merge state, or recovery state.
+
+| Role | Responsibility in an adopting repository |
+| --- | --- |
+| Human maintainer | Define intent, resolve real ambiguity, approve remediation when needed, and perform the manual merge. |
+| Implementation Agent | Read the current Issue, implement only its scope, diagnose failures, and explain the change. |
+| Fresh Review Agent | Independently inspect the exact candidate, judge requirements and risks, and report PASS or FAIL without modifying it. |
+| Semantic Skill | Guide the provider's semantic work and invoke LCK; it is not a lifecycle state machine. |
+| LCK | Reacquire current mechanical facts at each operation boundary, validate, perform bounded authorized effects, and record evidence. |
+| Adopting repository | Own its Issue contract, labels, Project, CI, branch rules, ignored local state, documentation, and adaptation decisions. |
+
+## Current implementation, active evolution, and future portability
+
+Keep these statuses separate when describing LCK:
+
+### Current implementation
+
+In the current TraceQuant repository, LCK is an on-demand local CLI with a
+shared kernel and four typed leaf profiles. The live lifecycle has separate
+Delivery, Independent Review, Remediation, Merge Preflight, and Closeout
+operations. Documentation leaves use a repository-owned safe-change policy;
+they do not require a fabricated Critical Outcome.
+
+The [LCK Overview](overview.md),
+[current Issue workflow](../../workflows/lck/lifecycle.md),
+[Independent Review contract](../../workflows/lck/review-and-remediation.md),
+[Agent Skills registry](../../workflows/lck/agent-skills.md),
+[technical baseline](../../architecture/technical-baseline.md), and
+[repository structure](../../architecture/repository-structure.md) describe the
+current TraceQuant context. These documents are the sources to re-check when
+the copied snapshot and the current branch differ.
+
+### Active evolution and design baseline
+
+The [LCK v1 Design Charter](../../workflows/lck/design-charter-v1.md) is a design
+baseline, not proof that every future capability exists. Its durable principles
+include semantic/mechanical separation, live facts as authority, one
+phase-specific operation snapshot per LCK invocation, fail-closed ambiguity,
+bounded effects, no daemon, provider neutrality, Review FAIL → STOP, and human
+manual Squash Merge. The [typed leaf workflow map](../../workflows/lck/typed-profiles.md)
+records the current profile ownership boundary.
+
+Because LCK is actively evolving, future changes may alter source layout,
+profile contracts, validation, Skills, or lifecycle details. A repository-copy
+adopter must re-check the selected revision rather than assuming compatibility
+with future TraceQuant main.
+
+### Future portability work
+
+The `preview.2` archive is the current supported versioned path, but it remains
+a manually adopted source snapshot. A standalone LCK repository, package
+extraction, one-click installer, zero-configuration setup, universal
+compatibility, and automatic external adoption are not provided by this guide.
+They remain future portability or distribution work, not current implementation
+facts.
+
+Manual adoption also does not decouple LCK core from TraceQuant, change
+TraceQuant's product identity, or grant an adopting repository any of
+TraceQuant's quantitative, trading, exchange, or risk capabilities.
+
+## Distribution boundary checklist
+
+An adoption description is within scope only when it:
+
+- names the exact source revision or supported release;
+- states whether the selected distribution path is actually available;
+- separates direct reuse from repository adaptation;
+- identifies Issue, label, Project, CI, directory, Skill, and local-state
+  assumptions;
+- validates the adapted repository non-destructively before lifecycle writes;
+- preserves fresh review and maintainer merge boundaries; and
+- labels future packaging or portability work as future.
+
+It must not claim that TraceQuant has completed quantitative research,
+backtesting, Demo, Live trading, production execution, or general external
+adoption.

--- a/docs/guides/lck/overview.md
+++ b/docs/guides/lck/overview.md
@@ -1,0 +1,230 @@
+# LCK overview
+
+This page is a public orientation to the Local Control Kernel (LCK) as it is
+used within TraceQuant. It distinguishes current workflow behavior from design
+intentions. The [LCK v1 Design Charter](../../workflows/lck/design-charter-v1.md)
+is a design baseline; it is not proof that TraceQuant has completed its
+quantitative roadmap or that every future capability described there exists.
+
+## What LCK is
+
+TraceQuant is an actively developed open-source project whose long-term goal is
+an auditable research-to-live quantitative trading system for cryptocurrency
+perpetual futures. The current repository is a Research MVP foundation. It has
+no exchange client, research data pipeline, backtester, strategy, model,
+execution service, risk engine, or Live runtime. LCK does not change that
+boundary.
+
+LCK was developed within TraceQuant while constructing and maintaining it. It
+is an engineering capability for making AI-assisted software delivery deterministic,
+auditable, and human-controlled. It addresses a practical problem: an Agent
+can reason about a change, but conversational context alone should not decide
+which branch, commit, pull request, lifecycle state, or recovery action is
+currently safe.
+
+LCK is an on-demand local control layer, not a long-running daemon, standalone
+Agent platform, trading module, or risk authority. Its purpose is to control
+the deterministic parts of the repository workflow while leaving semantic
+judgment with people and Agents.
+
+## Why it was developed inside TraceQuant
+
+TraceQuant is being built as a long-lived, auditable quantitative project.
+Maintaining that kind of repository with Agents requires current state to be
+resolved from Git and GitHub rather than inferred from conversation: the
+active Issue, branch, commit, pull request, validation result, lifecycle state,
+and safe recovery action all matter. LCK was developed within TraceQuant to
+make those mechanics deterministic while keeping design and implementation
+judgment with people and Agents.
+
+This is an engineering capability formed and actively used during TraceQuant's
+construction. It is not a claim that TraceQuant already has its future data,
+research, backtesting, execution, risk, or Live capabilities.
+
+## Semantic work and deterministic control
+
+The responsibilities are deliberately separated:
+
+| Responsibility | Primary owner |
+| --- | --- |
+| Define intent, resolve genuine ambiguity, and manually approve the merge | Human maintainer |
+| Understand the change, design it, implement it, diagnose it, and explain it | Implementation Agent |
+| Independently inspect, reason about, judge, and report on a candidate | Fresh Review Agent |
+| Resolve current Git/GitHub identity, evaluate lifecycle gates, run formal validation, commit, push, resolve the PR, and record bounded lifecycle evidence | LCK |
+| Store current repository, Issue, PR, branch, commit, and check state | Git and GitHub |
+
+The authority boundary can be summarized as follows:
+
+```mermaid
+flowchart TB
+    subgraph HUMAN["Human maintainer"]
+        INTENT["Define intent<br/>resolve ambiguity"]
+        MERGE["Manual Squash Merge"]
+    end
+
+    subgraph AGENTS["Semantic Agent roles"]
+        IMPLEMENTER["Implementation Agent<br/>understand, design, implement"]
+        REVIEWER["Fresh Review Agent<br/>inspect, reason, judge, report"]
+    end
+
+    subgraph KERNEL["LCK deterministic control"]
+        RESOLVE["Resolve live Issue / Git / GitHub identity"]
+        GATES["Profile gates + formal validation"]
+        EFFECTS["Bounded branch, commit, push,<br/>PR, and lifecycle effects"]
+        REVIEW_COMPLETE["Review Complete<br/>accept applicable PASS"]
+        PREFLIGHT["Fresh merge preflight"]
+        RECEIPT["Bounded Audit Receipt<br/>evidence, not authority"]
+        RECOVERY["Fail-closed recovery<br/>explicit remediation boundary"]
+    end
+
+    STATE["Git / GitHub current state<br/>Issue, PR, Project, branch, commits, checks"]
+    CANDIDATE["Candidate change"]
+    VERDICT["Independent Review report"]
+
+    INTENT --> STATE
+    STATE --> IMPLEMENTER
+    IMPLEMENTER --> CANDIDATE
+    CANDIDATE --> RESOLVE --> GATES --> EFFECTS
+    EFFECTS --> STATE
+    GATES --> RECEIPT
+    STATE --> REVIEWER
+    CANDIDATE --> REVIEWER
+    REVIEWER --> VERDICT
+    VERDICT -->|PASS| REVIEW_COMPLETE --> PREFLIGHT --> MERGE
+    MERGE --> STATE
+    RECOVERY --> RESOLVE
+```
+
+LCK can control the deterministic path and record what happened, but it does
+not decide whether a design is good, replace the fresh Review Agent, or merge
+on a maintainer's behalf. Git and GitHub remain the current-state authority;
+an Audit Receipt is bounded evidence for explanation and recovery, not a
+permission token.
+
+## Current capability surface
+
+The current LCK workflow provides these repository-level capabilities:
+
+- Issue-driven delivery with readiness checks, typed contracts, and a
+  profile-specific policy boundary;
+- explicit work-item contracts, including a Task `Critical Outcome` verifier
+  where required and separate contracts for Documentation, Bug, and Research
+  leaves;
+- a semantic/deterministic execution boundary between Agents and LCK;
+- formal candidate validation and current-check observation at the Delivery
+  boundary;
+- fresh, read-only Independent Review with a stale-target guard;
+- human-only Squash Merge authority after Review and merge preflight;
+- bounded Audit Receipts that preserve lifecycle evidence without replacing
+  live-state resolution; and
+- fail-closed recovery, including explicit remediation after Review FAIL and a
+  fresh Review for every repaired head.
+
+Codex is a primary use case, and the workflow is provider-neutral by design.
+Codex and other supported providers, including Claude in the current workflow
+documentation, can perform the semantic Agent roles under the same LCK
+contract. Provider-specific prompts, tools, or sandbox details must not decide
+the actionable branch, SHA, PR, push destination, merge state, or recovery
+state.
+
+## The controlled lifecycle
+
+The normal path is:
+
+1. **Issue and Delivery.** A maintainer starts from the current Issue
+   contract. LCK resolves live readiness facts and prepares the correct
+   profile-owned workspace. The Implementation Agent performs the scoped
+   semantic work. LCK Delivery Complete runs the applicable gates and formal
+   validation, commits the validated tree, synchronizes the branch, resolves
+   or creates the open PR, and moves the lifecycle to Review.
+
+2. **Human stop and Independent Review.** Delivery stops at a human boundary.
+   A fresh Review invocation independently resolves the current open PR,
+   base, head, checks, and applicable contract. The Review Agent works
+   read-only and does not inherit the Delivery Agent's correctness judgment.
+
+3. **Review PASS and manual merge.** A passing Review is followed by a fresh
+   merge preflight. Only after that preflight is the change ready for the
+   maintainer's manual Squash Merge. No Agent, Skill, or LCK operation
+   automatically merges a PR.
+
+4. **Review FAIL and explicit remediation.** A failed Review stops with
+   findings. It does not automatically start repair. A maintainer must
+   explicitly start remediation using the failed Review identity. LCK then
+   reacquires live state, the Implementation Agent repairs the scoped defect,
+   and LCK validates and updates the existing PR. The repaired head must go
+   through a fresh Independent Review; the old Review result cannot authorize
+   the new head.
+
+5. **Closeout.** After the maintainer has merged the PR, a separate LCK
+   Closeout operation reacquires the merge identity and converges the Issue,
+   Project, canonical `main`, and exact leaf-Issue branch lifecycle. Closeout is
+   separate from the merge decision and does not turn a planned quantitative
+   capability into a completed one.
+
+```text
+Issue → Delivery → HUMAN STOP → Independent Review
+                                  ├─ FAIL → HUMAN STOP → explicit remediation → fresh Review
+                                  └─ PASS → merge preflight → HUMAN SQUASH MERGE → Closeout
+```
+
+The same lifecycle in an editable public diagram is:
+
+```mermaid
+flowchart LR
+    ISSUE["Issue contract + readiness"]
+    DELIVERY["LCK Delivery<br/>prepare → implement → validate → PR"]
+    STOP["HUMAN STOP"]
+    REVIEW["Fresh Independent Review<br/>read-only"]
+    RESULT{"Review result"}
+    FAIL["HUMAN STOP<br/>findings"]
+    REPAIR["Explicit remediation<br/>repair current PR"]
+    NEW_HEAD["New candidate head"]
+    PREFLIGHT["Merge preflight"]
+    MERGE["HUMAN SQUASH MERGE"]
+    CLOSEOUT["LCK Closeout"]
+
+    ISSUE --> DELIVERY --> STOP --> REVIEW --> RESULT
+    RESULT -->|FAIL| FAIL --> REPAIR --> NEW_HEAD --> REVIEW
+    RESULT -->|PASS| PREFLIGHT --> MERGE --> CLOSEOUT
+```
+
+## Fresh state, recovery, and auditability
+
+Each LCK lifecycle operation resolves a fresh phase-specific snapshot from
+current Git and GitHub facts. A previous Agent message, expected SHA, PR
+number, validation snapshot, or audit receipt is not authority for a later
+operation. LCK checks freshness at operation boundaries and fails closed when
+identity is ambiguous, state has diverged, or a required fact cannot be
+trusted. It does not guess, force-push, automatically repair a failed Review,
+or wait in a background polling loop for the world to change.
+
+LCK records bounded operation results, validation, effect receipts, and other
+diagnostic evidence so that a maintainer can understand what happened. That
+audit evidence is not a permission token: current live state is resolved again
+before a later lifecycle effect. This separation makes recovery from an
+interrupted or stale operation an explicit state-resolution problem rather
+than a request to trust conversational memory.
+
+## Relationship to TraceQuant and reuse
+
+LCK remains an engineering capability within TraceQuant, whose product identity
+and quantitative-system goal remain primary. LCK governs repository delivery
+and review mechanics; it does not make trading decisions, submit exchange
+orders, or replace a future risk authority. Its provider-neutral control ideas
+are intended to have reuse value for other open-source projects that need
+auditable, human-controlled Agent-assisted maintenance. That is an intended
+reuse direction, not a claim of drop-in installation, external adoption, or
+capabilities that this repository does not currently support.
+
+For the normative current workflow, see the [Issue workflow](../../workflows/lck/lifecycle.md)
+and [Independent PR Review](../../workflows/lck/review-and-remediation.md). The [Agent Workflow
+Skills registry](../../workflows/lck/agent-skills.md) is a navigation document, while
+the [technical baseline](../../architecture/technical-baseline.md) remains the
+authority for TraceQuant's current product capabilities.
+
+For manual study and adaptation by another open-source project, see the
+[LCK adoption guide](adoption.md). It describes reuse value and the
+repository-specific work that remains necessary; it is not a standalone
+installation path, universal portability claim, or evidence of external
+adoption.

--- a/docs/releases/tracequant-v2-bootstrap-2026-09-13.md
+++ b/docs/releases/tracequant-v2-bootstrap-2026-09-13.md
@@ -4,6 +4,14 @@ This record binds the initial clean v2 dependency boundary to the committed
 lock and the official NautilusTrader release. It is reproducibility evidence,
 not a trading-readiness claim.
 
+This is a historical record of the initial product bootstrap. Task #333 later
+approved repository-only LCK roots under `tools/lck/`, `tests/tools/lck/`,
+`docs/workflows/lck/`, `docs/guides/lck/`, `.agents/`, `.claude/`, and `.codex/`.
+Any wording from the initial bootstrap that excluded those workflow-tooling
+roots is superseded; the product runtime and NautilusTrader boundaries below are
+unchanged. The recorded lock digest is the initial bootstrap identity, not a
+claim about a later lock containing development-only LCK dependencies.
+
 | Field | Value |
 | --- | --- |
 | Distribution | `nautilus-trader==2.0.0rc4` |

--- a/docs/workflows/lck/agent-skills.md
+++ b/docs/workflows/lck/agent-skills.md
@@ -1,0 +1,130 @@
+# Agent Workflow Skills
+
+本文件是 Agent-neutral workflow Skills 的**注册表 / 导航 / 兼容性入口**：
+列出当前 Skills、共享语义 owner 与验证入口。共享生命周期语义由
+`docs/workflows/lck/lifecycle.md`（lifecycle 规范）与
+`docs/workflows/lck/review-and-remediation.md`（Independent Review 规范）权威定义；
+本文件不再复制生命周期语义或执行 procedure。
+
+## Skill 集合
+
+当前 Runner 工作流：
+
+```text
+.agents/skills/task-delivery-runner/SKILL.md
+.agents/skills/task-pr-review-runner/SKILL.md
+.agents/skills/task-closeout/SKILL.md
+.agents/skills/feature-completion-audit/SKILL.md
+```
+
+Claude Code 对应 Skill：
+
+```text
+.claude/skills/task-delivery-runner/SKILL.md
+.claude/skills/task-pr-review-runner/SKILL.md
+.claude/skills/task-closeout/SKILL.md
+.claude/skills/feature-completion-audit/SKILL.md
+```
+
+## 共享语义与导航
+
+- Agent-neutral lifecycle 规范：`docs/workflows/lck/lifecycle.md`
+  （readiness、Delivery、PR/CI、Independent Review 位置、Human Gate、
+  remediation、manual Squash Merge、Closeout、Feature Completion、
+  natural-language entry、source-of-truth 模型）。
+- Independent Review 规范：`docs/workflows/lck/review-and-remediation.md`
+  （fresh session、head lock、verdict semantics、remediation handoff）。
+- Issue specification authoring：`docs/workflows/lck/issue-contracts.md`。
+- Typed leaf routing / profile ownership：
+  `docs/workflows/lck/typed-profiles.md`。
+- 自然语言入口（无需维护者提供内部 Skill 名称）：
+
+```text
+实现 Issue #N
+审查 PR #N
+PR #N 已人工合并，请完成 closeout
+```
+
+- 每个 Skill 保留自足的 executable procedure；生命周期语义按需从上述 shared
+  docs 读取最小必要 section。
+
+## Runner 与证据
+
+规范见：
+
+```text
+.agents/policies/workflow-evidence.md
+.agents/policies/command-execution.md
+```
+
+本地 artifacts 按 ownership 分区：
+
+```text
+.agents/evidence.local/      # historical/Feature-audit Evidence output
+.agents/validation.local/    # ordinary Validation Runner workspace output
+.workflow.local/lck/         # LCK runtime state / preserved Review evidence
+```
+
+不得提交。Independent Review 在 source repository 仅写 `.workflow.local/lck/`；
+`.agents/validation.local/` 如被 formal Review validation 使用，只存在于 disposable
+standalone clone 内。
+
+## Skill identity 验证
+
+当前 Codex / Claude Skill 路径、共享语义引用、单一机械入口与每个文件的
+SHA-256 由以下只读审计统一验证：
+
+```bash
+tools/lck/skill_audit.py
+```
+
+审计输出只覆盖 `active_skills` 与 `claude_skills`。已退役 Legacy Skill 不再位于
+active discovery namespace，也不再作为 current routing、失败回退或 competing
+semantic owner；其历史内容仅通过 Git 历史恢复。
+
+## Final source-of-truth matrix
+
+| Artifact family | Classification | Durable responsibility |
+| --- | --- | --- |
+| `AGENTS.md` | ACTIVE | repository invariants、leaf-first retrieval 与 natural-language workflow entry |
+| `docs/workflows/lck/lifecycle.md` | ACTIVE | shared lifecycle、readiness、Delivery、Closeout 与 Feature audit semantics |
+| `docs/workflows/lck/review-and-remediation.md` | ACTIVE | Independent Review semantics 与 verdict/remediation contract |
+| `CLAUDE.md` | ACTIVE | Claude-specific thin adapter 与 Skill discovery |
+| `.agents/skills/*-runner/`、`.agents/skills/task-closeout/`、`.agents/skills/feature-completion-audit/` | ACTIVE | Codex executable procedures |
+| `.claude/skills/` current four Skills | ACTIVE | Claude executable procedures |
+| `tools/lck/shared_facts.py` | ACTIVE | authoritative profile-neutral Git/GitHub fact acquisition and normalization |
+| `tools/lck/wsl2_validation_runner.py`、`validation_runner.py`、validation profiles 与 current tests | ACTIVE | deterministic validation plans、exit codes 与 bounded diagnostics |
+| `tools/lck/feature_audit.py` | AUDIT-ONLY | Feature audit evidence and adapter over shared facts；不具备 Task lifecycle authority |
+| pre-LCK Task Evidence Runner、Task profiles、Codex Rules、dedicated Runner/Rules tests 与 `self_review.py` binder/test | REMOVED | 不属于当前 workflow entry point；需要时仅从 Git 历史恢复 |
+| retired `.agents/skills/task-delivery/`、`.agents/skills/task-pr-review/` | DEAD / ABSENT | Legacy executable Skills 已退役；历史内容由 Git 历史及 frozen evidence 保留 |
+| Claude current Skills 中的 Codex/Claude permission-boundary 说明 | COMPATIBILITY ONLY | cross-agent adapter guidance; retained intentionally while both agents are supported |
+| retired Skill-variant provenance JSON/doc/tool/test bundle | DEAD / ABSENT | replaced by `skill_path_audit.py`; all stale current references removed |
+| removed trusted-runner、runtime usage-measurement 与 runtime manifest machinery | DEAD / ABSENT | no current responsibility; absence is regression-tested |
+
+当前没有 `UNCERTAIN` artifact。`COMPATIBILITY ONLY` 项仍有明确的双 Agent
+文档用途，未满足删除条件，因此有意保留。Legacy executable Skills 已完成 caller /
+routing / validator 收敛后删除，不再作为 compatibility runtime artifact 保留。
+
+Current reference graph：
+
+```text
+Issue body (business specification)
+  -> AGENTS.md (repository invariants and entry resolution)
+  -> shared development docs (lifecycle / review semantics)
+  -> agent-specific current Skills (executable procedure)
+  -> LCK + Validation Runner (Task lifecycle control and deterministic validation)
+  -> tools/lck/shared_facts.py (authoritative profile-neutral Git/GitHub facts)
+  -> Git / GitHub Issues, relationships, Projects, PRs and CI (durable state)
+```
+
+Feature audit consumes `shared_facts.py` through the bounded
+`feature_audit.py` adapter; LCK core never imports the audit module.
+
+`.agents/evidence.local/`、`.agents/validation.local/` 与 `.workflow.local/lck/` 都是
+Git-ignored local artifacts，但 ownership 不同：前两者属于历史 Evidence / ordinary
+Validation Runner，后者属于 LCK runtime 与需要跨 temporary Review clone 生命周期保留的
+Review evidence。它们都不是 Git/GitHub authority 或新的 source of truth。
+
+## 仓库外 Token 消耗分析边界
+
+Codex rollout JSONL、Token 报告和会话级比较数据只在仓库外分析，且不得提交本仓库。外部分析不改变 Skill 权限、质量门禁、Review verdict、人工 Merge 或完成证据。

--- a/docs/workflows/lck/design-charter-v1.md
+++ b/docs/workflows/lck/design-charter-v1.md
@@ -1,0 +1,1677 @@
+# LCK v1 Design Charter
+
+> **Status:** Draft Design Baseline
+> **Architecture name:** Local Control Kernel Workflow v1
+> **Short name:** LCK v1
+> **Purpose:** Define the target control architecture, lifecycle responsibilities, design constraints, and migration guardrails for the next-generation local Codex / Claude Agentic SDLC workflow.
+> **Current revision:** Adds **Operation Snapshot Isolation** as the lifecycle-wide state model: one phase-specific authoritative snapshot per lifecycle operation, immutable within that operation; bounded postcondition queries verify only effects caused by that operation; the next lifecycle operation reacquires fresh authority.
+
+---
+
+## 1. Charter Purpose
+
+This document freezes the design baseline for **LCK v1 (Local Control Kernel Workflow v1)**.
+
+LCK v1 is not a new agent platform and not a parallel workflow runtime. It is the target evolution of the repository's existing Runner-based workflow architecture.
+
+Its purpose is to move deterministic lifecycle control out of Skills and semantic agents, while preserving the current interactive Codex / Claude workflow.
+
+The target architecture is:
+
+> **Human keeps intent and merge authority.
+> Codex / Claude keep semantic work.
+> Skills become semantic procedures and entry instructions.
+> LCK owns deterministic lifecycle control.
+> Git and GitHub remain the authoritative current-state systems.**
+
+LCK v1 MUST evolve from the current Runner infrastructure. It MUST NOT introduce a second long-lived workflow platform beside the existing system.
+
+---
+
+## 2. Core Architectural Decision
+
+The primary architectural change is:
+
+> **Lifecycle control moves out of Skill interpretation and into a deterministic local control layer.**
+
+The current workflow already contains strong deterministic infrastructure through Evidence Runner, Validation Runner, Git/GitHub helpers, and related workflow utilities.
+
+LCK v1 treats these components as the technical foundation of the future control plane.
+
+The intended evolution is conceptually:
+
+```text
+Current
+
+Human
+  ↓
+Codex / Claude
+  ↓
+Skill                       ← lifecycle controller
+  ├─ calls Runner
+  ├─ interprets Runner facts
+  ├─ decides phase actions
+  ├─ performs Git/GitHub writes
+  └─ advances lifecycle
+       ↓
+Runner                      ← deterministic assistant
+```
+
+Target:
+
+```text
+Human
+  ↓
+Codex / Claude
+  ↓
+Skill                       ← semantic procedure / entry instructions
+  ↓
+LCK                         ← lifecycle controller
+  ├─ acquires phase-specific authoritative snapshots
+  ├─ evaluates deterministic gates against frozen operation inputs
+  ├─ runs formal validation
+  ├─ executes bounded Git/GitHub effects
+  ├─ verifies only the postconditions of effects it caused
+  └─ returns deterministic results / receipts
+       ↓
+Git / GitHub                ← authoritative current state
+```
+
+The implementation MUST prefer restructuring and reusing current Runner code over creating a new parallel framework.
+
+---
+
+## 3. LCK v1 Goals
+
+LCK v1 MUST achieve the following goals.
+
+### 3.1 Preserve interactive Codex / Claude usage
+
+Codex and Claude windows remain the primary human interaction surface.
+
+A normal Task may still begin with a simple instruction such as:
+
+```text
+请严格遵循 LCK v1 实现 Issue #123
+```
+
+The user MUST NOT be forced to replace interactive work with a black-box background workflow.
+
+### 3.2 Separate semantic work from deterministic mechanics
+
+Codex / Claude remain responsible for semantic work:
+
+```text
+Understand
+Design
+Implement
+Diagnose
+Review
+Explain
+```
+
+LCK becomes responsible for deterministic mechanics:
+
+```text
+repository identity
+branch identity
+workspace preparation
+HEAD / SHA resolution
+remote identity
+PR identity
+checks state
+phase eligibility
+formal validation
+commit execution
+push execution
+PR creation/reuse/update
+merge preflight
+closeout mechanics
+recovery classification
+cleanup
+```
+
+### 3.3 Remove lifecycle authority from Skills
+
+Skills remain useful, but their responsibility changes.
+
+A Skill MAY:
+
+- explain the semantic role of the current phase;
+- tell the Agent which LCK entrypoint to invoke;
+- define semantic expectations;
+- define output structure;
+- define what semantic work is allowed or prohibited.
+
+A Skill MUST NOT:
+
+- implement a Git/GitHub state machine;
+- determine actionable branch / SHA / PR identity;
+- decide whether direct Git/GitHub writes are permitted;
+- perform lifecycle state transitions through interpreted procedural logic;
+- act as the primary recovery engine.
+
+### 3.4 Make workflow correctness independent of conversation continuity
+
+Workflow correctness MUST NOT depend on:
+
+- the Agent remembering an earlier SHA;
+- a Codex session remaining open;
+- a Claude session remaining open;
+- an earlier conversation retaining phase facts;
+- the same model continuing the Task;
+- a cross-phase handoff snapshot remaining fresh.
+
+A **new lifecycle operation** MUST be able to reconstruct its current workflow state from authoritative current facts.
+
+If one lifecycle operation intentionally spans more than one process invocation because semantic Agent work occurs between LCK entrypoints, LCK MAY persist a sealed operation-owned snapshot / guard solely to resume that same operation. Such state MUST NOT authorize a later lifecycle operation and MUST NOT become cross-phase authority.
+
+### 3.5 Reduce control-plane complexity
+
+LCK v1 is successful only if it improves correctness while reducing or containing control complexity.
+
+The final architecture MUST NOT become:
+
+```text
+Current Workflow
++ LCK
++ compatibility runtime
++ snapshot lineage
++ another state engine
+```
+
+The target is a net simplification.
+
+---
+
+## 4. Non-Goals
+
+LCK v1 MUST NOT become a general agent platform.
+
+The following are explicit non-goals unless future evidence justifies them through a separate architecture decision:
+
+- long-running workflow daemon;
+- background workflow server;
+- workflow database;
+- event-sourced lifecycle store;
+- durable provenance lineage system;
+- cross-phase authoritative snapshot cache;
+- a second bounded verified fact handoff system;
+- generic drift framework;
+- generic dynamic permission engine;
+- generic workflow DSL;
+- DAG compiler;
+- import graph;
+- workflow lockfile system;
+- local clone of GitHub Agentic Workflows Safe Outputs MCP Gateway;
+- plugin architecture for workflow control;
+- arbitrary shell execution API;
+- automatic Review → Remediation loop;
+- automatic merge;
+- background retry loop;
+- durable fact cache introduced only for token or latency optimization;
+- lazy or incremental acquisition of authoritative Git/GitHub facts after an operation snapshot has been frozen;
+- phase-internal full-state refresh loops used to keep an in-flight operation synchronized with external changes;
+- background polling loops that wait for GitHub checks or other asynchronous eligibility facts to change;
+- distributed control infrastructure built for hypothetical future needs.
+
+The default answer to such mechanisms in LCK v1 is **NO**.
+
+---
+
+## 5. Full Lifecycle Model
+
+LCK v1 uses the following full Task lifecycle:
+
+```text
+Task Contract
+      │
+      ▼
+Prepare
+      │
+      ▼
+Delivery
+      │
+      ▼
+HUMAN STOP
+      │
+      ▼
+Independent Review
+   │          │
+ FAIL        PASS
+   │          │
+   ▼          ▼
+HUMAN STOP   Merge Preflight
+   │          │
+explicit     ▼
+remediation HUMAN SQUASH MERGE
+   │          │
+   ▼          ▼
+Remediation Closeout
+   │
+   └────────────→ Independent Review again
+```
+
+Recovery is not a normal linear phase. It is a cross-cutting state resolution capability available at any invocation boundary.
+
+---
+
+## 6. Full-Lifecycle Responsibility Model
+
+The following responsibility model is the design baseline for LCK v1.
+
+| Lifecycle area | Human | Codex / Claude | Skill | LCK / Runner | Git / GitHub |
+|---|---|---|---|---|---|
+| **Task Contract** | Defines / approves business intent and resolves real ambiguity | May analyze Task, identify conflicts, propose clarification | Provides Task semantic rules | Validates contract requirements required by workflow | Stores Issue body and lifecycle metadata |
+| **Prepare** | Starts the Task | Reads Task and semantic context | Instructs Agent how to enter Delivery | **Resolves live facts, checks eligibility, prepares or resumes correct workspace** | Authoritative repository / Issue / PR state |
+| **Delivery** | Provides semantic steering when needed | **Understand / Design / Implement / Diagnose** | Provides Delivery semantic procedure | **Formal validation, lifecycle gates, commit, remote synchronization, PR resolution/creation/update, delivery result** | Stores commit / branch / PR / checks |
+| **Independent Review** | Starts a separate Review invocation | **Fresh semantic reviewer; Inspect / Reason / Judge / Report** | Provides Review semantic procedure | **Resolves current review target, prepares clean read-only context, runs deterministic validation, checks verdict applicability** | Authoritative PR head/base/checks/review state |
+| **Review FAIL** | **Decides remediation / redesign / abandon** | MUST NOT automatically continue into repair | MUST NOT automatically transition workflow | **Returns STOP_REQUIRED** | Stores findings / review state |
+| **Remediation** | Explicitly starts repair | **Understands findings, modifies implementation, diagnoses failures** | Provides remediation semantic procedure | **Re-resolves live state, validates, commits, synchronizes remote, updates existing PR** | Stores new PR head and checks |
+| **Review PASS** | Decides whether to merge | No merge authority | No merge authority | Performs deterministic merge preflight only | Authoritative mergeability and checks |
+| **Merge** | **Performs manual Squash Merge** | No authority | No authority | MUST NOT auto-merge in v1 | Executes and records merge |
+| **Closeout** | Usually no action; resolves true ambiguity if needed | Normally no semantic work | May provide minimal explanatory procedure if retained | **Reacquires merged state, determines Business Delivery status, synchronizes main, converges metadata, performs cleanup** | Authoritative merged / Issue / branch state |
+| **Recovery / State Resolution** | Resolves only genuine ambiguity | Used only when semantic judgment is genuinely required | MUST NOT own recovery state machine | **Reconstructs current state from live Git/GitHub facts and selects the unique safe deterministic action or STOP** | Authoritative current state |
+
+---
+
+## 7. Agent Roles
+
+LCK v1 distinguishes two semantic Agent roles.
+
+### 7.1 Implementation Agent
+
+Used in:
+
+```text
+Prepare
+Delivery
+Remediation
+```
+
+Primary responsibilities:
+
+```text
+Understand
+Design
+Implement
+Diagnose
+Explain
+```
+
+The Implementation Agent MAY:
+
+- read repository files;
+- inspect Git history and diffs;
+- modify permitted workspace files;
+- run local semantic/debugging tests;
+- explain implementation decisions;
+- respond to Human steering;
+- consume Review findings during explicitly started remediation.
+
+The Implementation Agent MUST NOT directly own:
+
+- branch identity;
+- remote identity;
+- actionable SHA;
+- PR identity;
+- push target;
+- lifecycle authorization;
+- phase transition;
+- merge;
+- closeout;
+- recovery classification.
+
+### 7.2 Independent Review Agent
+
+Used only in Independent Review.
+
+Responsibilities:
+
+```text
+Inspect
+Reason
+Judge
+Report
+```
+
+The Review Agent MUST:
+
+- operate from a fresh review context;
+- review the target resolved by LCK;
+- remain read-only with respect to implementation;
+- independently judge the Task and current PR;
+- report PASS / FAIL and findings.
+
+The Review Agent MUST NOT:
+
+- modify implementation;
+- inherit Delivery's semantic verdict as truth;
+- supply actionable target SHA as authority;
+- start remediation automatically;
+- merge.
+
+Implementation Agent and Review Agent are separate workflow roles even when both use Codex or both use Claude.
+
+---
+
+## 8. Skill Role
+
+Skills remain part of LCK v1, but only as Agent-side semantic guidance.
+
+Conceptually:
+
+```text
+Skill
+=
+semantic procedure
++ role instructions
++ allowed semantic behavior
++ LCK entrypoint guidance
+```
+
+Not:
+
+```text
+Skill
+=
+lifecycle state machine
++ Git/GitHub authorization engine
++ branch/PR/SHA resolver
++ recovery engine
+```
+
+A future Delivery Skill may state, for example:
+
+```text
+You are performing Task Delivery.
+
+Your responsibilities:
+- understand the Task;
+- design the implementation;
+- modify the workspace;
+- diagnose failures;
+- provide semantic delivery metadata.
+
+Use LCK for lifecycle operations.
+
+Do not directly:
+- create or select task branches;
+- commit;
+- push;
+- resolve or create PRs;
+- change lifecycle state;
+- merge.
+```
+
+---
+
+## 9. Invocation Model
+
+LCK v1 MUST use an **on-demand invocation model**.
+
+It MUST NOT require a resident daemon.
+
+The normal lifecycle unit is an **operation**. Each new lifecycle operation MUST begin with one bounded authoritative acquisition stage:
+
+```text
+start operation
+→ acquire every authoritative Git / GitHub fact required by this operation
+→ freeze one phase-specific Operation Snapshot
+→ evaluate eligibility against that immutable snapshot
+→ perform semantic/local work and/or bounded Safe Effects
+→ for effects caused by this operation, query only their targeted postconditions
+→ emit structured evidence / receipt
+→ end operation
+```
+
+The authoritative acquisition stage MAY require multiple local Git, remote Git, and GitHub API calls. "Acquire once" means:
+
+> **Each required authoritative fact is acquired during one bounded operation-start window and is not reacquired after the snapshot is frozen.**
+
+It does NOT require one physical shell command or one atomic GitHub API transaction.
+
+Typical interaction remains:
+
+```text
+Human
+  ↓
+Codex / Claude session
+  ↓
+LCK operation entry
+  ↓
+Operation Snapshot
+  ↓
+deterministic operation / semantic handoff
+  ↓
+LCK exits or seals operation-owned continuation state
+  ↓
+Codex / Claude continues semantic work
+```
+
+Every LCK invocation is an **operation boundary** and MUST acquire a fresh phase-specific snapshot. Examples:
+
+```text
+Delivery Prepare      → fresh DeliveryPrepareSnapshot
+Delivery Complete     → fresh DeliveryCompleteSnapshot
+Review Prepare        → fresh ReviewPrepareSnapshot
+Review Complete       → fresh ReviewCompleteSnapshot
+Remediation Prepare   → fresh RemediationPrepareSnapshot
+Remediation No Change → fresh RemediationNoChangeSnapshot
+Remediation Complete  → fresh RemediationCompleteSnapshot
+Merge Preflight       → fresh MergeSnapshot
+Closeout              → fresh CloseoutSnapshot
+Recovery invocation   → fresh RecoverySnapshot
+```
+
+When semantic Agent work occurs between two LCK entrypoints, the later entrypoint is a **new operation**, not a continuation of the earlier operation's authority. The earlier operation may persist an exact target identity, evidence, or owned-resource marker as historical input for comparison, but the later operation MUST acquire current authority once and decide whether that historical target is still applicable.
+
+Operation-owned interruption metadata may survive a crashed process only to identify resources and support deterministic cleanup/recovery. A retry is a new operation and MUST reacquire fresh authority; it MUST NOT resume the prior operation's snapshot as current authority.
+
+A prepared Remediation session MUST have an explicit terminal path even when semantic
+inspection determines that no tree change is required. `remediation no-change` reacquires
+current authority, verifies that the prepared PR/base/head still match and the selected
+workspace is clean and unchanged, writes a no-change receipt, and releases the session. It
+MUST NOT create a commit, push, advance the candidate, set a fresh-review boundary, or treat
+external/future Review acceptance evidence as satisfied. Manually deleting a prepared
+session is not a lifecycle operation.
+While a prepared Remediation session exists, Review Prepare MUST fail closed until that
+session reaches either the changed-candidate terminal (`remediation complete`) or the
+unchanged-candidate terminal (`remediation no-change`). This prevents overlapping semantic
+roles from turning ignored operation-continuity state into a stale cross-invocation lock.
+
+Example conceptual entrypoints remain:
+
+```text
+lck delivery prepare <issue>
+lck delivery complete <issue>
+lck review prepare <issue-or-pr>
+lck review complete <review-id>
+lck remediation prepare <issue>
+lck remediation no-change <issue>
+lck remediation complete <issue>
+lck merge preflight <issue-or-pr>
+lck closeout <issue>
+lck status <issue>
+```
+
+Exact CLI design is not frozen by this Charter.
+
+The architectural requirement is:
+
+> **LCK is invoked on demand. Each lifecycle operation derives one immutable input snapshot from current authority, and the next lifecycle operation reacquires fresh authority.**
+
+---
+
+## 10. Fact Authority Model
+
+### 10.1 Authoritative durable state
+
+The authoritative durable sources are:
+
+- Git commits and refs;
+- authoritative remote Git refs queried from the remote;
+- GitHub Issue state;
+- GitHub PR state;
+- GitHub current PR head/base;
+- GitHub check results for exact PR heads;
+- repository-controlled required-check policy;
+- GitHub review state;
+- GitHub merge state;
+- Task contract;
+- repository-controlled workflow definitions.
+
+Local remote-tracking refs such as `refs/remotes/origin/main` MAY be used as diagnostics or local materialization state, but MUST NOT silently replace an authoritative remote query when current remote identity is required.
+
+Observation of remote authority SHOULD be read-only when no local materialization is required. A resolver MUST NOT mutate local Git state merely to learn what the remote currently contains.
+
+The **set of checks required by LCK** is repository-controlled workflow policy, not a
+plan/permission-dependent GitHub discovery result. In v1 it is derived from the
+statically named jobs in canonical `.github/workflows/ci.yml`, read from an **exact
+trusted base commit**, never from the caller's current working tree or candidate head.
+LCK v1 MUST fail closed on dynamic job names or matrix jobs rather than guessing the
+GitHub check-run identity. Delivery Complete is governed by current authoritative
+`main`; Review / Remediation / Merge Preflight are governed by the exact PR base commit. A PR
+candidate therefore cannot weaken the checks that govern its own acceptance; a policy
+change in the candidate head becomes effective only after merge and governs later
+operations from the new `main`. GitHub remains the authority for whether those named
+checks are present/pending/successful on the exact PR head. The snapshot records the
+policy source SHA and contract hash. If the base-bound repository policy is missing,
+malformed, unavailable, or mismatched to the operation base, LCK MUST fail closed before
+dependent lifecycle effects rather than reinterpret the unknown policy as an empty
+required-check set or fall back to a mutable checkout.
+
+### 10.2 Operation Snapshot Isolation
+
+Every lifecycle operation MUST acquire a **phase-specific complete Operation Snapshot** before it makes a lifecycle decision or begins expensive / effectful work.
+
+The snapshot contains all authoritative Git / GitHub input facts that the operation is expected to need, for example:
+
+```text
+operation identity
+Task identity / contract / contract hash
+local repository identity and relevant local refs
+current authoritative remote refs
+current PR identity / head / base
+repository-controlled required-check policy bound to the exact trusted base commit
+current GitHub check results bound to the exact PR head
+phase-specific relationship / merge / project facts
+acquisition metadata and source diagnostics
+```
+
+The exact fact set is phase-specific. LCK MUST NOT query facts belonging only to hypothetical future phases.
+
+After the snapshot is frozen:
+
+- authoritative input facts are immutable for that operation;
+- downstream helpers MUST consume the snapshot rather than call the live-state resolver again;
+- the operation MUST NOT lazily fetch previously omitted authoritative facts later in the workflow;
+- external changes MUST NOT mutate the in-flight operation's target;
+- freshness is evaluated at the next lifecycle transition through a new snapshot.
+
+An Operation Snapshot is an input-consistency boundary, not a claim that Git and GitHub provide a single transactional read across all APIs.
+
+### 10.3 Diagnostic durable state
+
+LCK MAY persist diagnostic evidence such as:
+
+- run ID;
+- timestamps;
+- Kernel / Runner version;
+- workflow source/version/hash;
+- operation snapshot hash / acquisition metadata;
+- validation results;
+- effect receipts;
+- historical observed SHA;
+- historical PR identity;
+- Human action;
+- review result;
+- audit artifacts.
+
+Diagnostic state answers:
+
+> **What happened at that time?**
+
+It MUST NOT answer:
+
+> **What is currently authorized for a new lifecycle operation?**
+
+### 10.4 Operation-owned interruption and handoff evidence
+
+Within one bounded operation, LCK MAY persist operation-owned state required to explain or recover from interruption, such as:
+
+```text
+operation ID
+sealed target identity / Operation Snapshot evidence
+owned workspace / temporary-clone path
+in-flight guard / lease metadata
+formal-validation evidence path
+review handoff marker
+```
+
+This state MAY survive process termination so a later invocation can identify and clean owned resources, or compare a previously reviewed target with fresh current authority. It is historical evidence, not current authority.
+
+It MUST:
+
+- be scoped to the invocation / operation that created it;
+- have explicit ownership and cleanup rules;
+- be invalid as current authority for every later invocation;
+- require a fresh snapshot before any later lifecycle decision;
+- never require generalized snapshot lineage.
+
+### 10.5 Derived operation evidence
+
+Evidence produced by the operation MAY grow incrementally after the authoritative snapshot is frozen, for example:
+
+```text
+formal validation result
+Critical Outcome result
+Safe Effect receipt
+semantic Review findings
+Review verdict
+cleanup result
+```
+
+This derived evidence does not change the authoritative input snapshot.
+
+### 10.6 Forbidden state category
+
+LCK v1 MUST NOT create:
+
+> **durable derived authoritative state across lifecycle operations**
+
+Examples include:
+
+- durable "expected head SHA" used by a later phase as current authority;
+- authoritative cross-phase fact handoff;
+- durable freshness contract;
+- snapshot lineage required for recovery;
+- generic workflow drift state;
+- lazy authoritative fact caches that are incrementally filled during an operation and then reused as if they represented one consistent live state.
+
+---
+
+## 11. Core State Principles
+
+The following principles are mandatory.
+
+### P1 — Evolve, do not replace
+
+LCK MUST evolve from existing Runner infrastructure.
+
+It MUST NOT introduce a parallel long-term workflow runtime.
+
+### P2 — Interactive Agent stays
+
+Codex / Claude windows remain the primary human interaction surface.
+
+### P3 — Semantic / Mechanic separation
+
+Semantic work belongs to the Agent.
+
+Deterministic lifecycle mechanics belong to LCK.
+
+### P4 — Skill is not controller
+
+Skills may guide semantic work and invoke LCK, but MUST NOT own lifecycle control.
+
+### P5 — On-demand, no daemon
+
+LCK v1 uses on-demand operations and MUST NOT require a resident service.
+
+### P6 — Live facts are authority
+
+Current Git / GitHub state is authoritative for mechanical identity and lifecycle state at the start of a new lifecycle operation.
+
+### P7 — Freshness at operation boundaries
+
+Every new lifecycle operation MUST reacquire the authoritative facts required by that operation rather than trust a prior operation snapshot.
+
+Freshness belongs to lifecycle transition boundaries, not to repeated refresh inside an already-running operation.
+
+### P8 — Operation Snapshot Isolation
+
+Each lifecycle operation MUST acquire its required authoritative input facts once, freeze them as an immutable Operation Snapshot, and use that snapshot throughout the operation.
+
+Downstream helpers MUST NOT silently reacquire live authority after snapshot freeze.
+
+Operation-local identity guards are allowed inside the invocation. Persisted ownership/target evidence may survive interruption, but any later invocation MUST reacquire fresh authority before using that evidence for applicability or cleanup decisions.
+
+### P9 — Audit is not authority
+
+Historical evidence may be durable but MUST NOT authorize future lifecycle operations.
+
+### P10 — Static authority, dynamic eligibility
+
+A phase has statically declared capabilities.
+
+Whether a capability can execute now depends on the fresh Operation Snapshot acquired at that operation boundary. Static repository policy that governs a candidate MUST come from the trusted predecessor/base identity for that operation, not from mutable working-tree state or from the candidate being authorized.
+
+### P11 — Bounded Safe Effects
+
+LCK side effects MUST be narrow, typed, deterministic, auditable, and explicitly verified.
+
+Post-effect verification MUST query only the facts necessary to prove the postcondition of the effect LCK just caused. It MUST NOT trigger an unrelated full-state re-resolution.
+
+### P12 — Runtime owns actionable identity
+
+Agent-provided branch, remote, SHA, PR number, push refspec, or equivalent actionable identity MUST NOT be trusted as execution authority.
+
+### P13 — Critical Outcome is a first-class Task contract requirement
+
+The target workflow MUST support a Task-level Critical Outcome that proves the real supported caller reaches the intended capability and produces an observable result.
+
+Implementing Critical Outcome requires synchronized changes to both:
+
+- the Task / Issue body contract or template;
+- deterministic validation / gate execution.
+
+LCK design MUST NOT forget the Task-side contract change.
+
+### P14 — Fail closed on ambiguity
+
+If the deterministic resolver cannot construct one complete, unambiguous Operation Snapshot for the requested lifecycle operation, the workflow MUST STOP before expensive or effectful work begins.
+
+### P15 — Review FAIL means STOP
+
+Review FAIL MUST NOT automatically start remediation.
+
+A new remediation invocation requires explicit Human intent.
+
+### P16 — Human merge remains
+
+LCK v1 retains manual Squash Merge.
+
+### P17 — Business Delivery is separate from Cleanup
+
+Successful merge may complete business delivery even when cleanup is still pending.
+
+### P18 — Recovery from reality
+
+A new recovery operation derives current state from Git/GitHub authority, not old workflow lineage.
+
+An interrupted in-flight operation MAY resume from its own sealed operation snapshot and ownership guard, but that state cannot authorize a later operation.
+
+### P19 — Provider-neutral control
+
+Codex and Claude use the same LCK lifecycle contract.
+
+Provider differences remain in the semantic Agent layer.
+
+### P20 — Complexity must decrease
+
+The final LCK migration MUST reduce or contain control-plane complexity.
+
+Repeated nested resolution, hidden live queries, full-state refresh loops, and polling-based eligibility logic are control-plane complexity and SHOULD be removed.
+
+### P21 — Acceptance evidence is gated where it can truthfully exist
+
+A lifecycle operation MUST NOT require evidence that can only be produced by a later
+operation, by the candidate identity that the current operation is responsible for creating,
+or by a separate provider/fresh semantic invocation. Such evidence remains explicitly
+unsatisfied and gates the later acceptance boundary where it can truthfully be evaluated.
+
+In particular, Delivery/Remediation completion may create the stable candidate head needed
+for provider-attributed or cross-provider Review evidence. Those later Review requirements
+MUST NOT form a circular precondition that prevents the candidate head from being committed
+and pushed. Conversely, `READY_FOR_REVIEW` / `READY_FOR_NEW_REVIEW` MUST NOT imply that
+those later acceptance requirements are satisfied.
+
+---
+
+## 12. Capability Model
+
+LCK v1 uses:
+
+> **Static authority; dynamic eligibility.**
+
+A phase declares what kinds of effects it may perform.
+
+Example conceptual model:
+
+| Phase | Agent authority | LCK effect capability |
+|---|---|---|
+| Prepare | read / semantic inspection | prepare or restore Task workspace |
+| Delivery | workspace write | formal validation; commit; ensure remote; ensure open PR |
+| Independent Review | read-only | resolve review target; validation; publish review result |
+| Remediation | workspace write | validation; commit; ensure remote; update existing PR |
+| Merge | none | merge preflight only |
+| Closeout | none normally | main sync; metadata convergence; cleanup |
+| Recovery | none by default | deterministic state resolution and bounded recovery effects |
+
+LCK MUST NOT use a generalized global Boolean such as:
+
+```text
+write_actions_allowed = true
+```
+
+as the primary authorization model.
+
+Instead:
+
+```text
+phase capability
++
+current operation preconditions
+=
+operation eligibility
+```
+
+---
+
+## 13. Safe Effect Model
+
+Every LCK write operation begins from a frozen Operation Snapshot. Each Safe Effect MUST follow:
+
+```text
+Operation Snapshot already frozen
+        ↓
+validate effect-specific preconditions against that snapshot
+        ↓
+perform ONE bounded side effect
+        ↓
+query ONLY the authoritative fact(s) needed to prove this effect's postcondition
+        ↓
+verify exact postcondition
+        ↓
+return structured Effect Receipt
+```
+
+Examples:
+
+```text
+push exact commit H to remote Task ref
+        ↓
+git ls-remote exact Task ref
+        ↓
+verify remote ref == H
+```
+
+```text
+create or update PR P
+        ↓
+query PR P identity
+        ↓
+verify expected head/base/state
+```
+
+A Safe Effect postcondition query is not a new lifecycle snapshot and MUST NOT be used as an excuse to re-resolve unrelated Task / PR / branch / relationship facts.
+
+If the targeted postcondition reveals ambiguity, conflict, or an unexpected external change, the current operation MUST STOP. A subsequent lifecycle operation will acquire a fresh snapshot.
+
+Every Safe Effect MUST have:
+
+- a clear purpose;
+- a narrow input contract;
+- no Agent-controlled actionable identity;
+- explicit preconditions derived from the current Operation Snapshot;
+- explicit postconditions;
+- deterministic error states;
+- audit evidence;
+- bounded retries only where safe;
+- fail-closed behavior on ambiguity;
+- idempotent behavior where practical.
+
+Candidate effects may include:
+
+```text
+commit_current_tree
+ensure_remote_branch
+ensure_open_pr
+publish_review
+cleanup_task_refs
+```
+
+The exact final effect set is not frozen by this Charter.
+
+LCK v1 MUST NOT expose:
+
+```text
+run_arbitrary_shell
+push_arbitrary_refspec
+write_arbitrary_github_object
+```
+
+or equivalent generic escape hatches.
+
+---
+
+## 14. Validation and Critical Outcome
+
+### 14.1 Validation boundary
+
+LCK MUST provide a deterministic validation/gate boundary that can execute repository and Task acceptance requirements.
+
+### 14.2 Critical Outcome
+
+The target workflow MUST add a formal **Critical Outcome** to the Task contract.
+
+Conceptually:
+
+```text
+real supported caller
+        ↓
+new or changed capability
+        ↓
+observable expected result
+```
+
+Critical Outcome is intended to prove:
+
+> The Task's claimed user-facing or supported capability is actually connected end-to-end.
+
+It MUST NOT be silently replaced by:
+
+- private helper unit tests;
+- module existence;
+- local function return values;
+- mocked-away integration boundaries;
+- passing static checks.
+
+### 14.3 Task contract synchronization
+
+Critical Outcome implementation requires a corresponding change to Task Issue bodies/templates.
+
+The workflow implementation MUST include:
+
+1. Task contract format / authoring rules;
+2. deterministic reading of the contract;
+3. formal execution or verification;
+4. evidence output;
+5. Delivery veto when Critical Outcome fails.
+
+Critical Outcome MUST NOT be implemented only in Runner code while leaving Task bodies unable to express the required contract.
+
+### 14.4 Acceptance hierarchy
+
+Conceptually:
+
+```text
+Task Contract Valid
+        ↓
+Critical Outcome PASS
+        ↓
+Task-specific Acceptance Criteria
+        ↓
+Regression / integration / unit tests
+        ↓
+Static validation
+        ↓
+Delivery mechanics
+```
+
+Cheap checks MAY execute earlier for fail-fast efficiency.
+
+But in acceptance semantics:
+
+> **Critical Outcome FAIL = Delivery MUST NOT complete.**
+
+---
+
+## 15. Delivery Contract
+
+A successful Delivery follows the following ownership pattern.
+
+### Human
+
+Starts Delivery and provides semantic steering only when required.
+
+### LCK Delivery Prepare
+
+`Delivery Prepare` is one lifecycle operation.
+
+LCK:
+
+1. acquires one complete `DeliveryPrepareSnapshot` containing the Task, current local repository facts, authoritative remote main / Task refs, current PR facts, and other Prepare-specific eligibility inputs;
+2. freezes that snapshot;
+3. validates lifecycle eligibility;
+4. prepares or restores the correct Task workspace;
+5. verifies only the local postconditions of workspace preparation;
+6. returns a deterministic Delivery context / prepare receipt.
+
+LCK MUST NOT repeatedly resolve Git/GitHub state while preparing the workspace.
+
+### Implementation Agent
+
+Codex / Claude:
+
+- understands the Task;
+- designs the change;
+- modifies permitted files;
+- adds or updates tests;
+- diagnoses failures;
+- responds to Human semantic steering;
+- returns semantic completion metadata.
+
+The Agent does not directly commit, push, create PRs, or advance lifecycle state.
+
+LCK does not continuously refresh Git/GitHub while the Agent implements. External changes are evaluated when the next lifecycle operation begins.
+
+### LCK Delivery Completion
+
+`Delivery Complete` is a **new lifecycle operation** and therefore starts from a fresh `DeliveryCompleteSnapshot`.
+
+LCK:
+
+1. acquires and freezes all authoritative facts required for Delivery completion;
+2. compares the fresh operation inputs with the permitted Delivery context / Task contract as required;
+3. executes Critical Outcome;
+4. runs formal validation;
+5. verifies allowed scope / validated tree;
+6. commits the validated tree;
+7. verifies the commit effect locally;
+8. ensures the remote Task branch and verifies only that remote-ref postcondition;
+9. ensures the current OPEN PR and verifies only that PR effect's postcondition;
+10. emits a Delivery receipt built from the frozen snapshot, validation evidence, and Safe Effect receipts;
+11. returns `READY_FOR_REVIEW`;
+12. stops.
+
+Delivery Completion MUST NOT perform a final full Git/GitHub re-resolution merely to "refresh" facts it already acquired at operation start. Any unexpected targeted postcondition failure causes STOP; the next invocation will reacquire fresh authority.
+
+Delivery MUST end at a Human boundary before Independent Review.
+
+---
+
+## 16. Independent Review Contract
+
+Independent Review is a semantic workflow spanning **two distinct LCK operations** with a fresh semantic Review Agent between them:
+
+```text
+Review Prepare operation
+        ↓
+sealed Review target + isolated workspace
+        ↓
+fresh semantic Review Agent
+        ↓
+Review Complete operation
+```
+
+The two LCK invocations do not share current authority. Review Prepare records exactly what was reviewed; Review Complete reacquires current authority exactly once and determines whether the semantic verdict is still applicable.
+
+### Review Prepare operation
+
+Before running formal validation or starting semantic review, LCK MUST acquire one complete immutable `ReviewPrepareSnapshot` containing every authoritative live fact required to establish the review target. If an immutable Git object is not present locally, the standalone Review clone MAY be created/materialized as part of this bounded acquisition stage so deterministic commit-bound facts can be derived without mutating the source repository. The snapshot includes as applicable:
+
+- repository identity;
+- Task identity, state, labels, Task contract, and Task contract hash;
+- authoritative remote main and Task branch identity;
+- the unique current OPEN PR;
+- exact PR head / base / branch identities;
+- repository-controlled required-check policy bound to the exact PR base commit, including source SHA and contract hash;
+- current check results bound to the exact reviewed head;
+- Review-specific relationship / eligibility facts.
+
+If any required fact cannot be acquired unambiguously, Review Prepare MUST STOP **before** expensive validation or semantic review work begins.
+
+After the `ReviewPrepareSnapshot` is frozen:
+
+- no authoritative Git/GitHub fact is reacquired inside Review Prepare;
+- no downstream Review Prepare helper may call the full live-state resolver;
+- no checks polling or phase-internal refresh loop is allowed;
+- the exact Task contract, PR, base, and head remain immutable authoritative inputs.
+
+The effective diff is a **derived repository fact**, not an additional live authority query.
+Review Prepare MUST NOT require the source repository to contain the current PR head object
+in order to acquire the authoritative snapshot. After the exact base/head identities are
+frozen, LCK materializes those commits only inside the standalone Review clone and derives
+merge-base, effective-diff hash, and changed-file inventory there.
+
+LCK then:
+
+1. allocates an operation-owned path in the system temporary directory;
+2. creates a standalone local clone of the source repository without registering a source Git worktree;
+3. gives the clone independent Git object storage (no source-object hardlinks), restores `origin` to the real repository remote, and materializes only an exact required base/head commit if the local clone does not already contain it;
+4. derives merge-base, effective diff identity, and changed-file inventory inside the clone from the frozen base/head identities;
+5. checks out the exact snapshot head in detached mode and verifies a clean workspace;
+6. runs deterministic applicable validation against that immutable target;
+7. persists validation/check evidence and exact review identity;
+8. seals the entire temporary clone read-only for the semantic Review Agent;
+9. returns `READY_FOR_SEMANTIC_REVIEW`.
+
+The source tracked tree and source Git metadata MUST remain read-only throughout Independent Review; LCK MAY write only ignored operation/evidence state such as `.workflow.local/lck/`. Review Prepare and cleanup MUST NOT use `git worktree add/remove/prune` or require writes to the source repository's `.git/worktrees`. Formal Review validation runs inside the temporary clone and any evidence that must survive clone deletion is copied only into the ignored LCK local evidence root. The temporary clone exists only from successful Review Prepare workspace creation through Review Complete. After Review Complete durably records PASS, FAIL, or STALE, LCK deletes the owned clone directly. If Prepare fails after clone creation, it records failure evidence and removes the clone. If the process is interrupted, the operation marker identifies the exact owned temporary path for later cleanup; no source Git registration recovery is required.
+
+The Review Agent:
+
+- independently inspects the exact effective change bound to the sealed Review target;
+- evaluates Task requirements;
+- evaluates Critical Outcome evidence bound to that target / validation evidence;
+- returns PASS / FAIL with findings;
+- does not mutate implementation or current lifecycle state.
+
+### Review Complete operation
+
+`review complete` is a **new LCK operation**. Before accepting either PASS or FAIL as the current Independent Review result, LCK MUST acquire one fresh immutable `ReviewCompleteSnapshot` containing the current facts required to test verdict applicability.
+
+Review Complete then compares the fresh identity with the sealed Review Prepare target. At minimum:
+
+```text
+current PR != reviewed PR
+→ REVIEW_STALE_PR
+
+current PR head != reviewed head
+→ REVIEW_STALE_HEAD
+
+current relevant base != reviewed base
+→ REVIEW_STALE_BASE
+
+current Task Contract hash != reviewed Task Contract hash
+→ REVIEW_STALE_TASK
+
+current effective diff != reviewed effective diff
+→ REVIEW_STALE_DIFF
+```
+
+Current applicable checks MUST also still satisfy the Review completion gate. If PR/base/head/Task
+identity is unchanged, Review Complete MAY re-derive the effective diff from the still-owned sealed
+Review clone; it MUST NOT require the source repository to materialize the reviewed PR commits.
+
+If any stale condition exists, the semantic verdict MAY remain historical evidence for the old target, but it MUST NOT become the current accepted Review PASS/FAIL, MUST NOT clear the requirement for a fresh Review, and MUST NOT authorize Remediation or Merge. A new Review Prepare is required for the new target.
+
+Within Review Complete itself, authority is still acquired only once: downstream helpers consume the `ReviewCompleteSnapshot` and MUST NOT perform hidden full-state resolution.
+
+### PASS
+
+If the semantic verdict is PASS and the fresh Review Complete snapshot still matches the sealed target, LCK records an accepted Review receipt for that exact identity and returns:
+
+```text
+READY_FOR_MERGE_PREFLIGHT
+```
+
+This is **not** readiness for Human merge. Merge Preflight is a later lifecycle operation that must reacquire current authority again.
+
+### FAIL
+
+If the semantic verdict is FAIL and the fresh Review Complete snapshot still matches the sealed target, LCK records the failed Review and returns `STOP_REQUIRED`.
+
+No automatic remediation occurs. Human intent is required to start Remediation.
+
+### Why both Review Complete and Merge Preflight recheck freshness
+
+Review Complete protects the correctness of the lifecycle statement being published: it must not accept a PASS/FAIL for target `A` as the current Review result after the PR or Task has already moved to `B`.
+
+Merge Preflight independently protects the later merge transition because state may change again after Review Complete. These are separate operation boundaries, not redundant refreshes inside one operation.
+
+## 17. Remediation Contract
+
+Remediation starts only through explicit Human intent after Review FAIL.
+
+### Remediation Prepare
+
+`Remediation Prepare` is a new lifecycle operation and acquires one fresh `RemediationPrepareSnapshot` containing:
+
+- Task;
+- current OPEN PR;
+- current PR head/base;
+- current workspace state;
+- the relevant failed Review findings as historical semantic evidence. The normal source is the
+  originating workspace-local Review audit record. When a maintainer intentionally switches clone
+  or Agent runtime and that ignored record is unavailable, the completed findings may be supplied
+  explicitly as a portable semantic-only file.
+
+The fresh snapshot determines all mechanical eligibility and current target identity. Neither the
+local Review record nor a portable findings file may authorize PR/head/base/branch/check facts. Once
+frozen, Remediation Prepare does not repeatedly refresh live authority.
+
+The Implementation Agent:
+
+- understands the findings;
+- changes the implementation;
+- diagnoses issues;
+- completes semantic repair.
+
+### Remediation Complete
+
+`Remediation Complete` is another new lifecycle operation and therefore acquires a fresh `RemediationCompleteSnapshot`.
+
+LCK then:
+
+- evaluates current Task / PR / workspace identity from that snapshot;
+- executes Critical Outcome;
+- runs formal validation;
+- commits the validated repair;
+- verifies the commit effect;
+- ensures the remote branch and verifies only the remote-ref postcondition;
+- updates or reuses the current OPEN PR and verifies only the PR postcondition;
+- emits a Remediation receipt;
+- stops at the next Independent Review boundary.
+
+LCK MUST NOT perform a final full-state refresh after these effects. Unexpected effect postconditions cause STOP; the next invocation reacquires current authority.
+
+Remediation Complete gates only facts and evidence that can truthfully exist at the
+Remediation Complete boundary. Requirements that depend on the newly created repaired head,
+a separate provider, or a fresh Independent Review remain pending Review-acceptance
+requirements and MUST NOT block creation of that head. They MUST still be enforced by the
+subsequent Review/merge acceptance path when the Task requires them.
+
+Remediation MUST NOT automatically trigger Review.
+
+---
+
+## 18. Merge Contract
+
+LCK v1 retains:
+
+> **Manual Squash Merge**
+
+Merge Preflight is a **new lifecycle operation** and MUST acquire a fresh `MergeSnapshot`.
+
+The snapshot MAY include:
+
+- correct current PR;
+- current Task contract / relevant Task state;
+- current head;
+- current base;
+- repository-controlled required-check policy bound to the exact current PR base commit, plus current exact-head check results;
+- mergeability;
+- the applicable Review receipt / verdict as historical evidence;
+- unresolved blocking conditions.
+
+Merge Preflight compares the fresh current identity with the exact identity recorded in the Review receipt.
+
+Examples:
+
+```text
+current PR head != reviewed head
+→ REVIEW_STALE_HEAD
+→ STOP and require fresh Review
+
+current Task contract hash != reviewed Task contract hash
+→ REVIEW_STALE_TASK
+→ STOP and require fresh Review
+
+current relevant base != reviewed base
+→ REVIEW_STALE_BASE
+→ STOP and require fresh Review
+```
+
+This is the correct freshness boundary for Review applicability.
+
+LCK MUST NOT execute the merge automatically in v1.
+
+The Human performs the Squash Merge.
+
+---
+
+## 19. Closeout Contract
+
+Closeout MUST distinguish:
+
+```text
+Business Delivery
+```
+
+from:
+
+```text
+Cleanup
+```
+
+`Closeout` is a new lifecycle operation and MUST acquire one fresh `CloseoutSnapshot` before deciding business delivery or cleanup actions.
+
+The snapshot may include:
+
+- current Task state;
+- authoritative merged PR identity;
+- merge commit / merged head identity;
+- authoritative main identity;
+- project / metadata state;
+- relevant local / remote cleanup facts.
+
+### Business Delivery
+
+If the frozen `CloseoutSnapshot` proves the intended PR has been successfully merged and the Task delivery contract is satisfied:
+
+```text
+Business Delivery = COMPLETE
+```
+
+### Cleanup
+
+Cleanup may independently be:
+
+```text
+COMPLETE
+PENDING
+```
+
+Cleanup includes items such as:
+
+- local branch cleanup;
+- worktree cleanup;
+- remote branch cleanup if applicable;
+- main synchronization;
+- metadata convergence.
+
+Each cleanup Safe Effect verifies only its own targeted postcondition. Closeout MUST NOT run the full live-state resolver again after each cleanup action.
+
+A cleanup failure MUST NOT retroactively convert a successfully merged business delivery into business failure.
+
+Cleanup operations SHOULD be idempotent and retryable. A later Closeout / cleanup retry begins as a new operation with a fresh snapshot.
+
+---
+
+## 20. Recovery / State Resolution Model
+
+Recovery is a cross-cutting deterministic capability, not a semantic lifecycle phase.
+
+Each **new recovery operation** begins by asking:
+
+> **What is true now?**
+
+Not:
+
+> **How does current state differ from an old cross-phase workflow snapshot?**
+
+The Recovery resolver acquires one fresh `RecoverySnapshot`, freezes it, and selects the unique safe deterministic action or STOP. It MUST NOT repeatedly re-resolve the entire world during that same recovery operation.
+
+An interrupted in-flight operation is a special case. If LCK has an operation-owned sealed snapshot / guard and the operation can be mechanically proven resumable, LCK MAY resume the **same** operation from that sealed input contract. This is not cross-phase authority. If ownership or resumability is ambiguous, abandon / clean up safely where possible and start a new lifecycle operation from fresh authority.
+
+Examples:
+
+| Current facts at a new operation boundary | LCK behavior |
+|---|---|
+| local Task branch exists, remote absent | validate current operation eligibility and run `ensure_remote_branch` if permitted |
+| remote branch exists, OPEN PR absent | `ensure_open_pr` |
+| historical CLOSED PR exists | ignore it for active PR resolution |
+| exactly one matching OPEN PR exists | use it |
+| multiple active matching PRs | STOP |
+| remote branch diverged | STOP |
+| PR already merged | Business Delivery becomes COMPLETE |
+| merge removed remote branch | treat missing remote branch as normal post-merge state |
+| cleanup incomplete | Cleanup = PENDING |
+| current MergeSnapshot head differs from reviewed head | Review receipt is stale; STOP |
+| Review operation was interrupted after snapshot/workspace seal | resume the same owned Review target if resumability is mechanically proven; otherwise STOP / abandon safely |
+| facts do not produce one safe deterministic action | STOP and surface exact unavailable / ambiguous facts to Human |
+
+Recovery MUST NOT depend on:
+
+- restoring a previous Kernel process;
+- cross-phase snapshot lineage;
+- provenance chains used as current authority;
+- generalized drift graphs;
+- repeatedly refreshing live state inside one recovery operation.
+
+---
+
+## 21. Retry Policy
+
+Retries MUST be classified and MUST preserve Operation Snapshot Isolation.
+
+| Failure type | Default LCK behavior |
+|---|---|
+| transient HTTP/network failure during authoritative snapshot acquisition | bounded retry of the same idempotent fact query is allowed **before snapshot freeze** |
+| required authoritative fact still unavailable after bounded acquisition retry | STOP before expensive/effectful work |
+| exact-base canonical-CI required-check policy is missing / malformed / unavailable / dynamic / mismatched | STOP before dependent lifecycle effects; do not use the mutable checkout, candidate head, or GitHub plan limitations as an implicit fallback |
+| required check result is missing or CI / required checks are pending at snapshot acquisition | STOP / WAIT boundary; start a fresh operation later; no in-operation polling loop |
+| targeted Safe Effect postcondition query has a transient HTTP/network failure | bounded retry of that exact postcondition query allowed |
+| targeted Safe Effect postcondition reveals state conflict / unexpected external change | STOP; do not full re-resolve; next lifecycle operation reacquires fresh authority |
+| deterministic validation failure | persist diagnostic evidence and return failure to semantic implementation/remediation flow |
+| Critical Outcome failure | Delivery blocked until semantic repair |
+| Review FAIL | zero automatic remediation |
+| identity ambiguity | zero Agent retry; STOP |
+| remote divergence | STOP |
+| merge conflict requiring semantic resolution | STOP / explicit remediation |
+| cleanup failure | bounded idempotent retry; Business Delivery remains COMPLETE if already merged |
+
+A retry MUST NOT turn into a hidden second full `LiveStateResolver` pass after an Operation Snapshot has been frozen.
+
+---
+
+## 22. Observability and Audit
+
+LCK MUST retain enough evidence to explain what happened without turning evidence into workflow authority.
+
+Audit records MAY include:
+
+- Task;
+- operation / invocation IDs;
+- phase;
+- LCK / Runner version;
+- workflow version/hash;
+- semantic engine identity/version;
+- start and end timestamps;
+- Operation Snapshot hash / identity;
+- snapshot acquisition start/end timestamps;
+- authoritative source / command identifiers used during acquisition;
+- observed input facts;
+- operation-owned workspace / guard identity;
+- validation results;
+- Critical Outcome results;
+- Safe Effect requests and targeted postcondition receipts;
+- review verdict;
+- Human boundary actions;
+- failure classification and bounded diagnostics.
+
+Rule:
+
+> **Audit log and historical Operation Snapshots explain what happened. They do not authorize a new lifecycle operation.**
+
+A later operation MUST reacquire current authority even when a prior snapshot or receipt is available for comparison.
+
+---
+
+## 23. Complexity Budget
+
+Complexity control is an acceptance criterion for LCK itself.
+
+### Hard v1 constraints
+
+LCK v1 target:
+
+```text
+0 new workflow databases
+0 daemons
+0 generic workflow DSLs
+0 generic dynamic permission engines
+0 cross-phase authoritative caches
+0 snapshot lineage systems
+0 automatic Review→Remediation loops
+0 automatic merges
+0 phase-internal full-state refresh loops
+0 hidden downstream live-state resolver calls after snapshot freeze
+0 lazy incremental authoritative fact caches inside an operation
+0 background polling loops for checks eligibility
+```
+
+### Design rule
+
+For every lifecycle operation, first ask:
+
+> **What authoritative facts does this operation actually require?**
+
+Acquire that phase-specific fact set once at operation start, freeze it, and pass the resulting snapshot downward.
+
+For every proposed post-effect query, ask:
+
+> **What exact authoritative fact proves the effect I just caused?**
+
+Query only that postcondition. Do not use a full live-state refresh as a generic verification mechanism.
+
+### Change discipline
+
+A small workflow bug fix SHOULD default to:
+
+```text
+0 new durable cross-operation control-state fields
+0 new provenance concepts
+0 new hidden Resolver entrypoints
+```
+
+New write capability SHOULD normally be introduced as one explicit bounded Safe Effect at a time.
+
+The migration SHOULD aim for net deletion or simplification of:
+
+- repeated nested `resolver.resolve()` calls;
+- snapshot authority across lifecycle operations;
+- expected-SHA plumbing used as current authority;
+- handoff freshness logic;
+- generic drift categories;
+- phase-internal check polling;
+- full-state post-effect refreshes;
+- Skill-owned Git/GitHub mechanics;
+- direct Agent lifecycle writes;
+- duplicate lifecycle state logic.
+
+---
+
+## 24. Provider Neutrality
+
+LCK lifecycle correctness MUST be independent of whether semantic work is performed by Codex or Claude.
+
+The same lifecycle architecture MUST support:
+
+```text
+Codex implementation
+→ Claude remediation
+→ fresh Codex review
+```
+
+or any equivalent combination.
+
+Provider-specific differences may exist in:
+
+- prompt/Skill formatting;
+- sandbox configuration;
+- semantic tool availability;
+- output-schema integration.
+
+They MUST NOT determine:
+
+- current branch;
+- actionable SHA;
+- current PR;
+- phase eligibility;
+- push destination;
+- merge state;
+- recovery state.
+
+---
+
+## 25. Migration Principles
+
+LCK v1 migration MUST proceed by responsibility transfer, not by duplicating the whole workflow.
+
+Preferred pattern:
+
+```text
+existing Runner capability
+→ extract / normalize deterministic responsibility
+→ make operation entry acquire one phase-specific snapshot
+→ pass immutable snapshot to downstream deterministic helpers
+→ move bounded lifecycle effects into LCK
+→ verify each effect with targeted postconditions
+→ simplify Skill
+→ delete obsolete repeated-resolution / snapshot-handoff / control logic
+```
+
+Not:
+
+```text
+build complete LCK platform
+→ keep old workflow
+→ maintain compatibility forever
+```
+
+The migration plan MUST identify existing mechanisms as one of:
+
+```text
+KEEP
+MOVE
+SIMPLIFY
+REMOVE
+```
+
+Examples of intended direction:
+
+| Existing mechanism | Direction |
+|---|---|
+| repository-local semantic Skills | KEEP + SIMPLIFY |
+| Validation Runner | KEEP + STRENGTHEN |
+| Evidence / Fact Runner | KEEP + REORGANIZE into operation-start snapshot acquisition |
+| Git/GitHub write mechanics in Skills | MOVE to LCK Safe Effects |
+| repeated / nested `resolver.resolve()` inside helpers | REMOVE; helpers consume Operation Snapshot |
+| live remote observation implemented through broad local `git fetch --prune` | REMOVE where observation-only; prefer read-only authoritative remote query |
+| full-state re-resolution after a bounded effect | REPLACE with targeted postcondition verification |
+| phase-internal CI/check polling | REMOVE; STOP and use a fresh later invocation |
+| cross-phase trusted snapshot authority | REMOVE |
+| bounded verified fact handoff as workflow authority | REMOVE |
+| generic freshness / drift framework | REMOVE or sharply narrow to operation boundary receipt-staleness checks |
+| dynamic global write authorization | REPLACE with static phase capability + operation snapshot precondition |
+| automatic review/repair loop | REMOVE |
+| manual Squash Merge | KEEP |
+| monolithic closeout success state | REPLACE with Business Delivery + Cleanup |
+
+Migration tests SHOULD verify snapshot acquisition boundaries and absence of hidden live queries without requiring a large workflow simulator.
+
+---
+
+## 26. Architecture Acceptance Criteria
+
+Before LCK v1 implementation is considered architecturally complete, the design and implementation MUST demonstrate all of the following:
+
+1. The user can still start work through a simple Codex / Claude window instruction.
+2. Codex and Claude can use the same lifecycle contract.
+3. Agent sessions may change without invalidating workflow correctness.
+4. Skills no longer implement lifecycle mechanics as interpreted state machines.
+5. LCK can reconstruct current workflow state from live Git/GitHub authority at each new lifecycle operation boundary.
+6. Cross-phase authoritative snapshots are not required.
+7. Branch / SHA / PR actionable identity is resolved by LCK.
+8. Agent cannot directly own commit / push / PR mutation / lifecycle transition.
+9. Delivery ends at a Human boundary before Independent Review.
+10. Independent Review uses a fresh review role; Review Prepare and Review Complete each use one immutable operation snapshot, and Complete rejects stale reviewed targets before accepting the verdict.
+11. Review FAIL always stops.
+12. Remediation requires explicit Human intent.
+13. Human Squash Merge remains mandatory in v1.
+14. Closeout distinguishes Business Delivery from Cleanup.
+15. Recovery does not require an old Kernel process or cross-phase snapshot lineage.
+16. Historical CLOSED PRs do not incorrectly block current active PR resolution.
+17. Normal lifecycle evolution is not generalized into "drift".
+18. Critical Outcome is part of the target Task contract and is enforced as a Delivery gate.
+19. Task Issue/template changes required for Critical Outcome are implemented together with the corresponding deterministic validation support.
+20. LCK does not require a workflow database or daemon.
+21. Control-plane complexity is demonstrably reduced or contained versus the current baseline.
+22. Current Runner infrastructure is reused rather than duplicated by a parallel runtime.
+23. Every new lifecycle operation has one explicit authoritative snapshot-acquisition boundary before expensive or effectful work.
+24. After snapshot freeze, downstream helpers do not reacquire authoritative Git/GitHub state or invoke hidden full-state resolution.
+25. Operation Snapshot facts are phase-specific and complete for that operation; authoritative facts are not lazily added later.
+26. Review Prepare performs no authoritative Git/GitHub refresh after its snapshot freeze; Review Complete is a separate operation that acquires one fresh snapshot and rejects stale PR / head / base / Task Contract / effective-diff identity before accepting the verdict.
+27. Merge Preflight independently acquires fresh authority and rejects an accepted Review receipt whose Task contract / PR / head / relevant base identity is stale.
+28. Safe Effects verify their own targeted postconditions and do not trigger unrelated full-state re-resolution.
+29. Pending asynchronous eligibility such as CI checks causes a STOP / WAIT boundary and a later fresh invocation rather than an in-operation polling loop.
+30. Operation-owned snapshots / guards may identify an interrupted operation and its resources, but any retry or later invocation must acquire fresh authority and cannot reuse the prior snapshot as current authority.
+31. Observation-only remote fact acquisition does not require broad mutation of local Git metadata when a read-only authoritative remote query is sufficient.
+32. Failure reports preserve the exact unavailable / ambiguous fact or failed query instead of collapsing unrelated failures into a generic unresolved-state message.
+33. Required-check policy is read from the exact trusted base commit, records its source SHA and contract hash, and cannot be weakened by the candidate head or by uncommitted/local-checkout changes.
+
+---
+
+## 27. Design Freeze Summary
+
+The following decisions are considered the current LCK v1 design baseline.
+
+### Frozen
+
+- Name: **Local Control Kernel Workflow v1 (LCK v1)**.
+- Full-lifecycle responsibility model is the authoritative responsibility model.
+- Codex / Claude remain the interactive semantic engines.
+- Skills remain but cease to be lifecycle controllers.
+- LCK evolves from existing Runner infrastructure.
+- LCK uses on-demand operations, not a daemon.
+- Git/GitHub live state is authoritative for mechanical facts at new lifecycle operation boundaries.
+- **Operation Snapshot Isolation** is the lifecycle-wide state model.
+- Each new lifecycle operation acquires one phase-specific complete authoritative snapshot and freezes it before expensive/effectful work.
+- Authoritative input facts are not reacquired or lazily added after snapshot freeze.
+- Downstream helpers consume the Operation Snapshot and do not own hidden live-state resolution.
+- Freshness is checked once at every LCK invocation / lifecycle operation boundary, not by repeatedly refreshing inside an invocation.
+- Review Prepare seals the reviewed target; Review Complete is a new operation that reacquires current authority once and rejects stale verdict applicability before publishing the current Review result.
+- Merge Preflight is another new operation and independently rejects stale accepted Review receipts before Human merge.
+- Operation-owned snapshots / guards are historical target/ownership evidence only; retries and later invocations reacquire authority and do not resume old snapshot authority.
+- Audit evidence is not workflow authority.
+- Phase authority is static; operation eligibility is dynamic from the fresh operation snapshot.
+- LCK uses bounded Safe Effects.
+- Safe Effects use targeted postcondition verification rather than full-state refresh.
+- Observation-only remote state resolution should be read-only and should not mutate local Git merely to learn current remote facts.
+- Pending asynchronous eligibility stops the current operation; LCK does not poll inside the operation waiting for the world to change.
+- Review FAIL stops.
+- Remediation requires explicit Human intent.
+- Manual Squash Merge remains.
+- Business Delivery and Cleanup are separate.
+- Recovery derives new-operation state from current reality.
+- Critical Outcome is part of the target workflow and requires synchronized Task-contract changes.
+- LCK success requires correctness improvement and control-complexity reduction.
+
+### Not yet frozen
+
+The following remain implementation design questions:
+
+- exact CLI command names;
+- exact module/file layout;
+- exact structured output schemas;
+- exact Operation Snapshot dataclass / schema layout;
+- exact Safe Effect inventory;
+- exact Task Critical Outcome syntax;
+- exact Task template migration strategy;
+- exact Runner refactor sequence;
+- exact lifecycle metadata naming;
+- exact audit artifact format;
+- exact implementation mechanism for same-operation interruption guards / leases.
+
+These MUST be decided later without violating the frozen architectural principles above.
+
+---
+
+## 28. Guiding Principle
+
+The design can be summarized as:
+
+> **Keep intelligence in the Agent.
+> Keep authority in deterministic control.
+> Keep truth in Git and GitHub.
+> Acquire that truth once per lifecycle operation.
+> Freeze authoritative inputs while the operation runs.
+> Verify only the effects the operation itself caused.
+> Refresh truth at the next lifecycle boundary.
+> Keep the Human at irreversible boundaries.
+> Keep the control plane small.**
+
+---

--- a/docs/workflows/lck/implementation-map.md
+++ b/docs/workflows/lck/implementation-map.md
@@ -1,0 +1,78 @@
+# LCK implementation map
+
+`uv run --frozen python -m tools.lck` is the stable CLI entry. Lifecycle
+implementation lives under `tools/lck/` so a
+maintainer or reviewer can start with the responsibility that owns the behavior.
+
+| Concern | Start here | Typical companion modules |
+| --- | --- | --- |
+| leaf Issue type/profile contract and routing | `issue_profiles.py`, `profile_policies.py` | `models.py`, `eligibility.py`, `bug_policy.py`, `documentation_policy.py`, `research_policy.py` |
+| profile-neutral authoritative Git/GitHub facts | `shared_facts.py` | `models.py`, `feature_audit.py` adapter |
+| contracts, immutable state/result models | `models.py` | `issue_profiles.py` |
+| live Git/GitHub facts, Fact Profiles, operation snapshots | `state.py` | `models.py` |
+| lifecycle admission / eligibility | `eligibility.py` | `state.py` |
+| formal validation and required-check gates | `validation_gates.py` | `state.py`, `documentation_policy.py` |
+| bounded Git/GitHub write effects and profile effect executors | `effects.py` | `delivery.py`, `remediation.py`, or `closeout.py` |
+| Delivery prepare/complete | `delivery.py` | `eligibility.py`, `validation_gates.py`, `effects.py` |
+| isolated Review workspace and review records | `review_workspace.py` | `review.py` |
+| Independent Review and Merge Preflight | `review.py` | `review_workspace.py`, `validation_gates.py` |
+| remediation and owned-candidate recovery | `remediation.py` | `eligibility.py`, `delivery.py`, `effects.py` |
+| post-merge Closeout | `closeout.py` | `eligibility.py`, `profile_policies.py` |
+| Agent View, Audit Receipt, failure evidence/replay | `receipts.py` | affected phase module |
+| CLI dispatch only | `cli.py` | phase modules |
+
+## Dependency rule
+
+Shared layers (`models`, `shared_facts`, `state`, `eligibility`, `validation_gates`,
+`profile_policies`) must not import phase orchestration modules. `shared_facts`
+must remain profile-neutral; `feature_audit.py` consumes it through an
+audit adapter and is never an LCK core dependency. Effects depend only on
+shared layers. Phase modules compose shared layers/effects. `receipts.py`
+projects completed phase results, and `cli.py` is the outermost dispatcher.
+Avoid runtime import tricks, service locators, or module mutation to bypass
+this direction.
+
+`issue_profiles.py` owns canonical label resolution and profile metadata.
+`profile_policies.py` owns the one dispatch boundary from that metadata to the
+generic contract/candidate/review/completion capabilities. Lifecycle phase
+modules must not add another type-driven dispatch table. Profile policies may
+return validated, data-only effect descriptors; `effects.py` executes only
+registered effect kinds and proves their postconditions.
+
+The same module owns the immutable production `ProfilePolicyRegistry`, the
+injectable `LeafIssuePolicy` seam, and the frozen four-stage
+`ProfileEvidenceEnvelope` (`contract`, `candidate`, `review`, `completion`).
+Policy blockers and stage payloads are validated by the selected policy before
+the shared kernel transports or records them; the canonical leaf contract is
+referenced by identity/digest rather than copied into the envelope. Review
+workspace isolation, path containment, and review identity freshness remain
+kernel responsibilities; profile policies only supply bounded artifact
+semantics/evidence.
+
+`LiveState` and `OperationSnapshot` store Issue-neutral identity, branch, and
+`leaf_contract` fields. The historical `task_*` names remain read-only or
+serialized projections for compatibility; they are never a second canonical
+source. `leaf_contract` is the acquired Issue contract input, while
+`ProfileEvidenceEnvelope` remains lifecycle-stage evidence.
+
+When diagnosing a lifecycle issue, read this map first and inspect the owner module
+plus at most its direct companion modules before broad repository searches.
+
+## Test map
+
+The former mixed `tests/tools/` suite is now isolated under `tests/tools/lck/`:
+
+- `test_state.py` — live-state, Fact Profiles, resolver query contracts.
+- `test_issue_profiles.py` — canonical leaf Issue type/profile resolution.
+- `test_lck_bug.py` — Bug defect contract and shared lifecycle boundaries.
+- `test_lck_prepare.py` — prepare/admission and eligibility behavior.
+- `test_lck_review.py` — Review workspace, Review Complete, Merge Preflight.
+- `test_lck_remediation.py` — remediation sessions and partial-effect recovery.
+- `test_lck_receipts.py` — Agent View / Audit Receipt and failure evidence.
+- `test_lck_closeout.py` plus `test_lck_closeout_additional.py` — Closeout.
+- `test_lck_delivery.py` — Delivery completion and bounded effects.
+- `test_lck_profile_architecture.py` — injectable policy and evidence envelope.
+- `test_lck_structure.py` — facade/module dependency guardrails.
+
+`tests/tools/lck/test_acceptance.py` owns the current repository-layout Critical
+Outcome verification node.

--- a/docs/workflows/lck/issue-contracts.md
+++ b/docs/workflows/lck/issue-contracts.md
@@ -1,0 +1,382 @@
+# Issue Authoring (Issue Specification v2)
+
+本文件定义 TraceQuant 的 Issue Specification v2：六类 Issue（Epic / Feature / Task /
+Bug / Documentation / Research）的职责、正文结构、authoring 规则和信息所有权。它与
+`.github/ISSUE_TEMPLATE/*.yml` 保持一致，是创建和迁移 Issue 的唯一 authoring 参考。
+
+> **核心原则：Minimum sufficient specification。**
+> 让 fresh Codex / Claude session 获得正确完成当前工作所需的最少但充分的信息。
+> 不设固定字符数或 Token 上限；正文中每段文字至少承担一个作用：change scope、
+> change expected behavior、change acceptance、impose a real constraint、
+> point to necessary source of truth。否则 **remove or link instead of copy**。
+
+## 1. 统一语义模型
+
+```text
+Epic
+→ program / product outcome and boundaries
+
+Feature
+→ coherent behavioral capability (WHAT)
+
+Leaf work item
+├── Task      → implementation contract
+├── Bug       → defect contract
+├── Documentation → documentation fact contract
+└── Research  → evidence / decision contract
+```
+
+- Task、Bug、Documentation、Research 是不同 work kind，但处于相同 leaf-work 层级，可作为
+  Feature 的 Sub-issue。
+- 少数情况下 Bug / Documentation / Research 可直接挂在 Epic 下，但不是默认结构。
+- **不得**把六种类型理解为六个互斥层级。
+- 普通实现工作默认保持 `1 Task ≈ 1 PR ≈ 1 main squash commit`。
+
+## 2. 信息所有权
+
+一条事实只能有一个 canonical owner，其他位置只引用、不复制（除非当前工作在缺少该
+信息时无法正确理解）。
+
+| 信息 | Canonical owner |
+|---|---|
+| Repository hard safety / agent routing | `AGENTS.md` |
+| Claude-specific guidance | `CLAUDE.md` |
+| LCK workflow contracts | `docs/workflows/lck/*` |
+| Stable architecture invariants | `docs/architecture/*` |
+| Durable architecture decisions | ADR |
+| Program / product outcome | Epic |
+| Behavioral capability | Feature |
+| Implementation contract | Task |
+| Defect contract | Bug |
+| Documentation fact contract | Documentation |
+| Evidence / decision investigation | Research |
+| Current Issue specification | Issue body |
+| Discussion / change history | Issue comments |
+| Parent hierarchy | GitHub Parent / Sub-issues |
+| Blocking dependency | GitHub blocked-by / blocking |
+| Status / Priority / Size | Private GitHub Project |
+| Classification / lifecycle | Labels |
+| Implementation evidence | PR |
+| Standard automated validation | CI |
+| Merge enforcement | Ruleset |
+
+Issue body 中不得复制 repository-wide rules、标准验证、Git/PR workflow、Project
+metadata 或完整 Parent specification。
+
+## 3. 六类 Issue 的职责与正文结构
+
+### Epic — outcome + boundaries
+
+> 为什么做，以及完成后整个系统达到什么状态。Epic 不是普通 coding-agent
+> implementation unit。
+
+REQUIRED：`Outcome`、`Why`、`Scope`、`Non-goals`、`Success / Exit Criteria`
+OPTIONAL：`Constraints / Decisions`、`Risks`、`References`
+
+- Outcome 描述最终状态，不是 Feature/Task 清单。
+- Success / Exit Criteria 描述 Epic-level result。
+- Scope 引用已批准的产品/阶段基线，区分本次核心交付与未纳入的条件式扩展；
+  阶段出口描述可观察结果，不因后续扩展尚未实施而追加当前完成义务。
+- 软件成果完成、研究候选准入和具体运行/资金授权分别判断，不能相互替代。
+- 不复制各 Feature 的完整 specification；不维护 child task checklist。
+- 不包含标准 pytest / Ruff / mypy / CI、Git workflow、Priority / Size / Status、
+  Parent / Dependency 文本字段。
+- Constraints / Decisions 只保存真正跨 Feature 且已批准的约束，优先引用 ADR。
+- Agent 收到“实现 Epic #N”时不应直接编码：若没有可执行 leaf work item，应报告需要
+  拆分或指定 Task/Bug。
+
+### Feature — behavioral capability (WHAT)
+
+> 系统需要具备什么行为或能力。明显偏 WHAT，不偏 HOW。
+
+REQUIRED：`Capability`、`Scope`、`Non-goals`、`Acceptance Criteria`
+OPTIONAL：`Context`、`Key Scenarios / Edge Cases`、`Constraints / Decisions`、
+`References`
+
+- Scope 必须说明批准的需求来源、主责模块、完整有限成果及必要行为合同；跨模块时
+  明确协同职责，不把跨模块协作本身当作拆 Feature 的理由或改变领域所有权。
+- 已有 REQ / DP 编号时引用其批准版本/章节及本 Feature 承担的部分；尚未编号的
+  批准要求可引用明确来源，不为填模板发明编号、创建包或扩建规划系统。
+- AC 覆盖各项成果、必要失败边界及最终集成结果；满足当前 AC 后停止新增开发义务，
+  进入既有 completion audit。子项全部关闭不能代替行为证据或正式完成判断。
+- 实施前将所有计划成果分解为有限工作清单；具体叶项、输入和先后安排只在一份
+  明确引用的规划记录中维护。Feature 保留完整行为边界，不复制子项规格或状态。
+- 不写文件名、class、function、implementation sequence、逐文件修改方案；只有实现
+  方式本身已是 approved architecture / compatibility contract 时才进入
+  Constraints / Decisions。
+- 只有一个主要实现目标、一个 PR 即可完成、无需多个独立 leaf work item、没有长期
+  独立 behavioral specification 价值的“Feature”应直接创建 Task。
+
+### Task — implementation contract（主要 coding-agent execution contract）
+
+REQUIRED：`Objective`、`Requirements`、`Critical Outcome`、`Acceptance Criteria`
+OPTIONAL：`Context`、`Scope Boundary / Non-goals`、`Constraints / Decisions`、
+`References`、`Task-specific Verification`
+
+Task 必须满足：one primary objective、bounded scope、independently verifiable、
+normally one PR、minimal unrelated context、observable acceptance。
+
+Requirements 必须明确本项承接的批准成果/要求、必要输入合同及可复用实现。
+来源可简短引用到批准规格的版本/章节和适用 REQ / DP；正文仍须足以理解本项行为，
+不能只列编号让实现者递归读取上游。存在相邻能力混淆或 scope-creep 风险时，
+必须在 Requirements 或 `Scope Boundary / Non-goals` 说明排除项。
+每个 Task 只承担有限清单中的明确部分，不要求复制整个 Feature 的剩余工作。
+
+`Critical Outcome` 是 Task-level end-to-end acceptance contract，必须使用固定四行格式：
+
+```text
+Caller: <真实受支持入口或调用方>
+Capability: <本 Task 新增或改变的能力>
+Observable result: <从 Caller 可观察到的结果>
+Verification test: tests/.../test_*.py::test_*
+```
+
+`Verification test` 只能绑定仓库 `tests/` 下一个明确 pytest node id。它不是任意
+shell command，也不能用 private helper/file-exists/grep 代替真实 supported path。LCK
+在 Delivery Complete 中运行该 verifier；FAIL 是 Delivery veto。Independent Review 仍需
+判断该测试是否真实覆盖 `Caller → Capability → Observable result`，不能仅因 pytest
+退出码为 0 就继承语义 verdict。
+
+Task 不得复制：parent Feature / Epic 完整正文、repository architecture summary、
+Git workflow、branch/commit/PR/merge instruction、标准 pytest / Ruff / mypy、
+Project metadata、historical discussion。
+
+`Task-specific Verification` 只用于标准 CI 之外确有必要的特殊验证。
+
+### Bug — defect contract（独立 Form，本身就是 leaf work item）
+
+REQUIRED：`Observed`、`Expected`、`Reproduction / Evidence`、`Acceptance Criteria`
+OPTIONAL：`Impact`、`Environment`、`Logs / Screenshots`、
+`Scope Boundary / Non-goals`、`Regression Evidence`
+
+- Reproduction / Evidence 可以是复现步骤、失败测试、日志或其他足以定位问题的证据。
+- Environment / Logs 非普适字段，均为 optional，不强迫填写 `N/A`。
+- Acceptance Criteria 描述恢复后的 contract，而不是简单“错误消失”。
+
+### Documentation — documentation fact contract（独立 Form，本身就是 leaf work item）
+
+> 用于新增、修正或收敛文档事实，完成后不改变系统运行行为。
+
+REQUIRED：`Documentation Goal`、`Requirements`、`Acceptance Criteria`
+OPTIONAL：`Additional documentation context`
+
+- Documentation Form 只收集完成本次文档变化所必需的最小信息；Sources / References、
+  Scope Boundary / Non-goals、Constraints / Decisions 和 documentation-specific
+  verification 仅在确有必要时通过 optional context 补充，不要求填写 `N/A`。
+- 如果工作需要修改 runtime、业务源码、测试、CI、Agent control behavior 或其它系统
+  行为，应重新分类为 Task / Bug，或拆分新的 implementation leaf，不得扩大 Documentation
+  范围。
+- 行为型 `.md`、policy、Agent instruction 或其它文件不会仅因文件扩展名而成为
+  Documentation；类型由工作是否改变文档事实与系统行为决定。
+
+### Research — evidence / decision contract
+
+> 适用于 technical selection、exchange/API investigation、architecture spike、
+> benchmark、performance investigation、quantitative hypothesis、dependency /
+> security / feasibility / data-quality investigation。
+
+REQUIRED：`Question / Decision Needed`、`Context`、`Scope`、`Non-goals`、
+`Evidence / Evaluation Criteria`、`Expected Outcome / Artifact`
+OPTIONAL：`Hypotheses`、`Data Requirements`、`Method`、`Constraints`、`References`
+
+边界：已经决定实施 → Task；是否应该实施仍需证据 → Research。
+
+Research 有效结果可以是 `IMPLEMENT` / `DO NOT IMPLEMENT` / `NEEDS MORE EVIDENCE` /
+`ARCHITECTURE DECISION`。“决定不做”属于有效完成结果。不强制所有调查填写
+Hypotheses / Data Requirements / Method。
+
+- Context 说明结论的具体消费者/待决事项；已有需求或验证项时简短引用来源。
+- Scope 固定适用系统/版本、数据/方案/时间边界，以及与问题有关的有限样本、请求、
+  试验或资源预算；不要求填全部维度，也不统一规定时长。
+- Evidence / Evaluation Criteria 事先定义证据充分性、预算耗尽/来源不可得时的停止
+  条件，并区分 fixture、实际来源与适用运行环境的证据。
+- Expected Outcome / Artifact 定义有限产物；`NEEDS MORE EVIDENCE` 应交付已知事实、
+  限制和有界 follow-up 建议。是否满足本次 Research AC 仍按原合同判断，不能仅用
+  “证据不足”自动宣告完成，也不能自动延长研究或创建实施 Task。
+
+### 批准基线、有限工作分解与变更
+
+以下是 authoring 语义，适用于 UI、API 和 Agent 编写的 Issue；不新增表单必填章节、
+机器解析字段、Project 状态或 LCK gate。填写提示本身不代替当前 Issue 规格。
+
+**基线引用。** 产品需求、总体设计和阶段计划须经批准并有可访问的明确版本/章节，
+才能作为工作分解依据。草稿、示例 REQ/DP、阶段编号或本地评审文件的存在不自动
+改变当前 Issue、架构权威或运行授权。引用只提供必要语义，不复制设计全文，
+也不将设计中的阶段编号写成第二份 Project metadata。Bug 的明确缺陷证据和
+Documentation 的事实来源仍是各自合同，不强迫它们绑定产品 DP。
+
+**一份有限分解。** 在 Feature 实施前，确定全部交付义务和一份规范的工作分解记录；
+可放在获准的规划文档或明确的规划正文位置，通过 Feature 引用。已有记录应复用，
+不得新建竞争清单。该记录逐项说明：
+
+| 内容 | 必须明确 |
+|---|---|
+| 来源与成果 | 对应的批准要求、Feature AC、适用 DP/部分及可观察交付物 |
+| 已有与剩余 | 当前实现证据、复用部分和全部剩余成果；已完成工作不重新分配 |
+| 输入 | 必要合同、消费者及影响实施的未知项；正式 blocker 仍以原生关系表达 |
+| 验收与边界 | 适用行为/失败/集成结果、证据类型、排除项和停止条件 |
+| 叶项分解 | 有限候选叶项及其承担部分；创建时间可后移，交付义务不因此开放增长 |
+
+有限成果说明 WHAT；代码结构、实现步骤和实际叶项合同仍在相应执行位置定义。
+叶项引用用于定位，不复制 Parent、blocked-by、Project Status 或关闭状态的真相。
+部分成果可提前提供合同/代码，整体集成验收可后置，但必须分别说明边界；不能把
+提前可消费的部分当作整个 Feature 已完成，也不能绕过当前原生 blocker。
+
+**变化处理。** 创建或扩展叶项前，将变化归入下表；未解决的范围冲突只阻止依赖它的
+工作，其他已获准且独立的工作可以继续。
+
+| 变化 | 处理 |
+|---|---|
+| 原义务纯拆细 | 保持输入/输出、AC、排除项与总义务不变，更新唯一分解记录；不将其包装为新能力 |
+| 既有要求未满足 | 记录具体合同、复现和修复验收，按既有 Bug/remediation 路径处理；不因没有 DP 编号拒绝必要修复 |
+| 必要合同/安全前置遗漏 | 说明来源、最小修订、消费者与剩余工作影响；经明确决定后更新基线，不静默塞入下一批 |
+| 新能力或新增完成标准 | 先提出范围变更及取舍/依赖影响，经维护者批准再纳入；“技术上有用”不足以成为范围依据 |
+| 迁移、后置或取消既有义务 | 明确旧义务、承接位置或处置、理由及影响；批准后同步规格与必要原生关系，不能伪造完成 |
+
+不以固定 Task 个数压住必要正确性/安全修复，也不以一个宽泛 REQ 容纳无限新义务。
+连续发现新前置时，停止受影响部分的滚动创建并复核完整分解。范围变更只记录一次
+清楚的决定及必要引用，不新增审批平台、完整历史台账或逐 Task 的通用流程副本。
+仍须遵守已有实施、独立 Review、显式 remediation、人工 merge、closeout 和
+Feature completion 边界；获准创建/修改规格不自动授予其中其他操作权限。
+
+## 4. Acceptance Criteria authoring
+
+AC 必须描述**可以观察、测试或明确判断的完成事实**。允许简洁 checklist、
+Given/When/Then 或等价 behavioral statements；不强制 Gherkin。
+
+禁止：
+
+- generic Definition of Done（`pytest passes`、`Ruff passes`、`mypy passes`、
+  `CI green`、`PR created`）——由 repository workflow / CI 负责；
+- 把 implementation plan 当 AC（除非具体结构本身就是 contract）。
+
+优先描述：externally observable behavior、invariant、failure behavior、
+state transition、regression condition。
+
+Task 的 Critical Outcome 只验证指定 supported path，不替代其余 AC。
+Feature 的最终集成结果不能由独立子项各自 PASS 推断；适用证据达到当前完成标准后，
+停止追加无来源开发工作并使用既有完成审计，不引入第二套 Outcome Check 完成状态。
+
+## 5. Non-goals 规则
+
+| Type | Non-goals |
+|---|---|
+| Epic | REQUIRED |
+| Feature | REQUIRED |
+| Task | OPTIONAL（存在明显 scope-creep 风险时填写） |
+| Bug | OPTIONAL |
+| Documentation | OPTIONAL（仅在确有必要时通过 Additional documentation context 说明） |
+| Research | REQUIRED |
+
+不得为了模板完整强迫填写 `None` / `N/A` / `无`。
+
+## 6. Metadata 从正文移除
+
+正文不包含：Parent、Dependency、Priority、Size、Status、Ready checklist、
+standard validation、branch/PR workflow。目标 ownership：
+
+```text
+Parent                  → GitHub Parent/Sub-issues
+hard dependency         → GitHub blocked-by/blocking
+Status / Priority / Size → Private GitHub Project
+classification / lifecycle → labels
+standard validation     → CI / repository rules
+branch / PR / Squash workflow → development docs / Ruleset
+```
+
+标题前缀 `[Epic] / [Feature] / [Task] / [Bug] / [Documentation] / [Research]` 和 `type:*` labels
+保留（personal account 下 native Issue Types 不可用，前缀对 notification、PR
+reference 和 plain-text Agent input 有辨识价值）。
+
+## 7. Issue body 与 comments
+
+- Issue body = current specification；comments = discussion / decision history。
+- 讨论导致 requirement 变化时：更新 body 使其表达最新 canonical specification，
+  并添加一条简短 comment 说明 changed what / why。
+- Comment 不得长期作为 silent specification override。
+
+## 8. Requirement precedence
+
+```text
+1. Platform / maintainer / security hard boundaries
+2. Repository hard invariants and active durable decisions
+   (applicable AGENTS.md, active architecture contracts, accepted ADRs)
+3. Current leaf Issue body (Task / Bug / Documentation / Research)
+4. Parent Feature current specification
+5. Parent Epic current outcome / constraints
+6. General conventions / background docs
+7. Historical discussion / comments
+```
+
+- specific Task 不得静默违反 safety invariant / active ADR。
+- current canonical source 优先于复制到下级 Issue 的旧文本。
+- comment 改 requirement 后必须 canonicalize 回 body。
+- 同级 source 冲突且无法确定权威时触发 Human Gate。
+
+## 9. Research closeout
+
+Research body 表达 pre-research specification；不把完整过程日志堆入正文。
+
+- 小型调查：Issue final comment 记录 Conclusion / Evidence / Recommendation /
+  Follow-up。
+- 有长期复用价值：提交 versioned repository research report，由 PR review；
+  Issue 只保留简短结果和报告链接。
+- Architecture decision：`Research → evidence → ADR`，Issue 链接 ADR。
+- 如需实现：`Research → new Task(s)`。
+
+## 10. Semantic information budget（Token 效率）
+
+不设字符数 / Token 上限。优先消除：
+
+- **Very high**：Epic 中复制 child Feature specs；Task 中复制 repository-wide
+  rules；permanent body 中保存大段 workflow boilerplate。
+- **High**：standard validation；Git workflow；Parent / Dependency duplication；
+  Project metadata duplication。
+- **Medium**：Ready checklist；required `N/A` 字段；over-structured Research
+  fields。
+
+不得为了节省 Token 删除：safety constraints、task-specific requirements、
+observable behavior、meaningful edge cases、acceptance、important scope boundary。
+
+## 11. 迁移规则（历史 Issue 改写时适用）
+
+本节规定保持原义务不变的结构迁移。采用新的产品/设计基线并改变范围、AC 或依赖，
+属于前述显式范围变更，不能伪装成格式规范化；模板更新不授权批量改写既有 Issue。
+对已有实施历史的 Feature，必须明确批准受影响的剩余规格调整及历史证据保留方式，
+不能通过自动迁移重写已完成工作的原合同。
+
+- 只迁移**明确尚未开始实施**的 Issue（OPEN + Project/lifecycle state 尚未开始 +
+  无 active/merged implementation PR + 无 implementation-in-progress evidence）。
+- Closed / Done / In Progress / Review / 已完成但 metadata 漂移 / 已产生正式
+  implementation history 的 Issue 一律不改写。
+- Epic / Feature 不能只看自身 Status：如果任何 descendant 已进入 implementation、
+  已完成或已产生实际 PR，默认 `DO NOT AUTO-MIGRATE`，除非维护者明确批准。
+- **Normalize structure, preserve meaning**：允许调整章节、合并重复、删除
+  repository-wide boilerplate、删除已由 native GitHub/Project 正确表达的 metadata、
+  修复明显 active stale naming；禁止改变产品目标、新增 requirement、删除 safety
+  constraint / observable behavior / Non-goal / 重要 edge case、改变 AC 语义、
+  根据当前代码重新设计旧 specification、把实现建议升级为 requirement。
+- **Form `type: markdown` guidance 不得进入 Issue body**：Form 顶部的 authoring
+  guidance 只用于创建 Issue 时向作者显示辅助说明（`type: markdown` 不会作为用户
+  输入提交），迁移/shadow conversion 只生成由可提交 form fields 对应的
+  specification 内容；migrated Issue body 必须直接从第一个实际 specification
+  section（`### Outcome` / `### Capability` / `### Objective` 等）开始。
+- 缺失信息（Non-goals、AC、Evidence criteria 等）只能从原正文、current canonical
+  parent、明确引用且仍 active 的 ADR / architecture contract 恢复；无法确定时标记
+  `NEEDS MAINTAINER REVIEW`，不自动创造 requirement。
+- 正文中的 Parent/Dependency 只有已被 native GitHub relationships 正确表达时才可
+  移除；否则标记 `NEEDS MAINTAINER REVIEW`，不得静默删除。
+- 迁移默认只修改 Issue body；title、state、labels、assignee、milestone、Parent、
+  Sub-issues、blocked-by/blocking、Project fields、comments、linked PR 一律不动。
+- 批量改写前必须经过 Human Gate；正式迁移逐个进行：重新读取最新 body → 与
+  snapshot hash 比较（已变化则 SKIP 并报告）→ 转换 → 更新 → 重新读取做 semantic
+  comparison。
+
+## 12. 相关文档
+
+- `AGENTS.md` — repository hard safety、agent routing、issue-driven workflow。
+- `CLAUDE.md` — Claude Code 开发命令与架构上下文。
+- `.github/ISSUE_TEMPLATE/*.yml` — 六类 Issue Form 的字段定义（本文档的机器可执行
+  对应物）。
+- `docs/architecture/*` — 稳定架构不变量。
+- `docs/workflows/lck/*` — LCK 工作流契约（本文件即其一）。

--- a/docs/workflows/lck/lifecycle.md
+++ b/docs/workflows/lck/lifecycle.md
@@ -1,0 +1,402 @@
+# Issue Workflow（Agent-neutral Lifecycle Specification）
+
+本文件是 TraceQuant Agent-neutral Issue lifecycle 的 **shared semantic owner**：
+Issue 从建立到完成的所有 shared lifecycle semantics（readiness、Delivery、
+PR/CI、Independent Review 引用、Human Gate、Closeout、Feature completion、
+natural-language entry resolution、source-of-truth 模型、failure/ambiguity
+handling）由本文件权威定义。
+
+Codex 与 Claude Code 的 workflow Skills 引用本文件作为生命周期语义来源，
+各自保留 agent-specific executable procedure。本文件不复制 Retrieval v2 规则
+（其 authoritative owner 是根目录 `AGENTS.md`）。
+
+> **共享文档读取纪律**：shared document 的存在 ≠ 每次全文加载。
+> Skill / Agent 应按 current intent / phase 读取本文件最小必要 section，
+> 评估充分性后再按需扩展。Delivery 不应因本文件存在而默认加载
+> Review / Closeout / Feature Completion 全部章节。
+
+## 1. Lifecycle overview
+
+```text
+Issue (Specifying)
+  → Ready（codex:ready + Project Ready + 无 blocker）
+  → Delivery Prepare（workspace postcondition → Project In Progress）
+  → Delivery（implementation/tests → commit/push → PR → Project Review）
+  → Independent Review（fresh session，read-only；可与 CI 并行）
+  → maintainer manual Squash Merge
+  → Closeout（merge identity / state convergence / branch cleanup）
+  → Feature completion（hierarchy-aware audit）
+```
+
+GitHub Issue、Parent/Sub-issues、blocked-by/blocking、Pull Request、Project
+Status 与 labels 是 durable workflow state 的载体；本文件定义其语义，
+GitHub native metadata 是其机械事实。
+
+## 2. Issue specification ownership
+
+- Issue 正文的 authoring 规则与信息所有权由 `docs/workflows/lck/issue-contracts.md`
+  （Issue Specification v2）权威定义。
+- 本文件不重复 authoring 规则；specification 编写 / 修订时按需引用
+  `issue-authoring.md`。
+- 当前 leaf Issue body 是 current work-item business specification
+  （见 §15 Source-of-truth authority model）。
+
+## 3. Lifecycle metadata ownership
+
+| Metadata | Owner | 说明 |
+|---|---|---|
+| Issue body | issue-authoring.md（authoring 规则）+ maintainer | body 是 canonical specification |
+| type/area labels | maintainer / issue-authoring | issue type 语义 |
+| `codex:ready` / `codex:blocked` / `codex:needs-spec` | lifecycle 状态标签，本文件定义语义 | ready = 可实施；blocked = 不得实施；needs-spec = 规格不完整 |
+| Project Status（Inbox/Specifying/Ready/In Progress/Review/Blocked/Done） | lifecycle 状态，与 labels 配合 | 本文件定义含义；Runner 提供机械事实 |
+| Parent / Sub-issues / blocked-by / blocking | GitHub native metadata | 不在正文重复机械 metadata |
+| PR / merge identity | GitHub native（Squash Merge） | closeout 验证对象 |
+
+不得在 Issue 正文重复维护与 native relationship 等价的机械 metadata。
+
+## 4. Readiness
+
+一个 Task 满足以下条件才可开始 Delivery：
+
+- `codex:ready` label 存在且无 `codex:blocked`；
+- Project Status = Ready（或等效 lifecycle 状态）；
+- 无未解决的 blocked-by；
+- body 具有完整 Objective / Requirements / Acceptance Criteria / Non-goals；
+- 无 Human Gate 未决事项。
+
+readiness 由 deterministic Runner 快照验证（机械事实），
+不由模型对全文的解读决定。
+
+## 5. Natural-language entry resolution
+
+维护者可使用以下 Agent-neutral 自然语言入口，无需知道内部 Skill 名称。
+详细解析契约：
+
+### `实现 Issue #N`
+
+- intent = **Delivery**
+- 解析：target Issue → readiness 验证 → shared Delivery lifecycle semantics
+  （§6）→ 正确 Delivery Skill（Codex: `.agents/skills/task-delivery-runner/`；
+  Claude: `.claude/skills/task-delivery-runner/`）→ 需要时 deterministic Runner。
+- 不要求维护者提供内部 Skill 名称。
+- Delivery Skill 先读取唯一 canonical `type:*` label，并选择对应的
+  semantic profile；上述 Codex / Claude 路径是同一个 leaf-aware shared
+  Delivery entry，不为 Bug、Documentation、Research 复制 controller。
+- 只有 `type:task` 选择 Task Critical Outcome gate；Bug、Documentation、Research
+  使用各自 profile contract，不要求也不生成假的 Critical Outcome。
+
+### `审查 PR #N`
+
+- intent = **Independent Review**
+- 解析：target PR → fresh-session expectation → read-only independent review
+  → head lock → 当前 Task specification + effective diff →
+  no Delivery verdict inheritance。shared semantics 见
+  `docs/workflows/lck/review-and-remediation.md`；执行 Skill：`task-pr-review-runner`
+  （Codex: `.agents/skills/task-pr-review-runner/`；
+  Claude: `.claude/skills/task-pr-review-runner/`）。
+
+### `PR #N 已人工合并，请完成 closeout`
+
+- intent = **Closeout**
+- 解析：merge identity 验证 → reviewed head == merged head →
+  Issue / Project lifecycle convergence → canonical main 同步 →
+  branch lifecycle → post-merge validation。执行 Skill：`task-closeout`
+  （Codex: `.agents/skills/task-closeout/`；Claude: `.claude/skills/task-closeout/`）。
+
+### Feature completion
+
+维护者请求对指定 open Feature 执行独立只读 completion audit 时：
+intent = **Feature Completion Audit**，执行 Skill：`feature-completion-audit`
+（Codex: `.agents/skills/feature-completion-audit/`；
+Claude: `.claude/skills/feature-completion-audit/`；
+hierarchy-aware exception，见 `AGENTS.md`）。
+
+### 解析失败 / 歧义
+
+intent 无法可靠解析时：**不要猜**。回退到 explicit Skill-name fallback，
+或进入 Human Gate（§12）。
+
+## 6. Delivery semantics
+
+四类 leaf Issue 的 routing / profile owner / shared-kernel 边界见
+[`docs/workflows/lck/typed-profiles.md`](typed-profiles.md)。
+该导航图是 profile ownership delta，不复制本文件的 lifecycle procedure。
+
+The project-level `uv.toml` directs canonical `uv` commands to
+`.workflow.local/uv-cache`. This is local runtime state and the directory is
+Git-ignored; an explicit `UV_CACHE_DIR` override remains supported. Workflow
+subprocesses continue to receive the same path through `build_workflow_env()`.
+
+- Task `Critical Outcome` 是正式 Delivery gate：LCK 从当前 Task body 读取结构化
+  contract，使用固定 pytest verifier 执行真实 supported path。缺失、malformed、unsafe
+  target 或 verifier failure 均 fail closed；不得用普通 unit/static check 替代。
+- Bug leaf 使用 `.github/ISSUE_TEMPLATE/bug.yml` 定义的 Observed / Expected /
+  Reproduction-or-Evidence / Acceptance Criteria defect contract；Bug 不要求 Critical
+  Outcome，但缺失、重复、占位或不足以识别缺陷的证据必须在 shared lifecycle admission
+  前 fail closed。Bug 的回归判断绑定当前 candidate head。
+- Documentation leaf 使用 `.github/ISSUE_TEMPLATE/documentation.yml` 定义的
+  documentation fact contract，不要求 Critical Outcome，也不生成假的 Critical Outcome
+  evidence。它由 repository-owned typed safe-change policy 限制在 README.md 与安全的
+  `docs/**` 范围；Agent/policy/workflow 控制文件和 runtime、tests、CI、LCK 文件一旦进入
+  candidate diff，LCK 必须返回 reclassification / split required。
+- 每个 authoritative operation 在入口绑定一个稳定的 fact profile，并在 operation snapshot
+  中记录 profile 与 acquired facts。Delivery Prepare 直接返回同一次 fresh acquisition 绑定的
+  完整 Task Contract；semantic caller 不应为同一 operation 再查询 Task body。
+- LCK 最终 stdout 是紧凑的 `lck-agent-view`，只保留当前调用方判断状态与下一动作所需的
+  authoritative identity、result summary 和 `receipt_reference`。完整 operation snapshot、fact
+  acquisition、validation/effect/postcondition evidence 与诊断日志保存在
+  `.workflow.local/lck/audit-receipts/` 下的 operation-owned Audit Receipt；STOP、FAIL、stale
+  等结果同样使用结构化 Agent View 和 Receipt，不以 progress stderr 代替 lifecycle result。
+- 对 LCK-owned mechanical facts / validation / lifecycle result，后续 Agent 默认消费当前
+  operation 的 bounded result，而不是为了 precaution、再次确认或报告完整性重新执行、重新
+  推导或展开完整审计证据。额外 diagnostic / audit expansion 必须有具体 failure、finding、
+  unresolved concern、anomaly、信息缺口或 maintainer 显式请求作为 trigger；补充结果仍不得
+  替代 LCK authority。
+- Initial Delivery 的 lifecycle mechanics（workspace prepare、commit validated tree、
+  remote synchronization、OPEN PR resolve/create、Project Status → Review）由 LCK
+  deterministic control 执行；Agent/Skill 不提供 branch/SHA/PR/refspec authority。
+- Delivery Prepare 只有在 workspace 创建、选择或恢复及其 postcondition 成功后，
+  才通过 kernel-owned bounded effect 执行 Project Status `Ready → In Progress`，
+  并在返回 `READY_FOR_DELIVERY` 前验证 live status。already-`In Progress` 的安全
+  恢复路径幂等成功且不重复写入；admission、workspace、status write 或 status
+  postcondition 失败均不得声称 Prepare 成功。
+- Documentation 使用独立的 `documentation/<Issue>-<slug>` branch namespace；Task 的
+  `task/`、历史 Task aliases 与其匹配规则保持不变。
+- Bug 使用独立的 `bug/<Issue>-<slug>` branch namespace；不会创建 wrapper Task，且与
+  Task、Documentation、Research 的 branch identity 相互隔离。
+- Research leaf 使用独立的 `research/<Issue>-<slug>` branch namespace；v1 只接受
+  `docs/research/**` 下可版本化的仓库产物。Research 不要求 Critical Outcome，Delivery
+  只执行 Research artifact policy 与正式 validation；产物必须在 Review 中绑定当前
+  Issue、PR、base/head、effective diff 与 artifact digest。
+- Research Review PASS 必须携带四个精确值之一：`IMPLEMENT`、`DO NOT IMPLEMENT`、
+  `NEEDS MORE EVIDENCE`、`ARCHITECTURE DECISION`。后两者是成功的 Research 结果，不能
+  被误报为 lifecycle failure；Closeout 在合并后写入并确认 Project 的 `Research Outcome`。
+- 一次 Initial Delivery 覆盖：LCK Delivery Prepare → Project Status `In Progress` →
+  semantic implementation / targeted
+  development validation → LCK Delivery Complete → Critical Outcome → formal validation →
+  commit validated tree → ensure remote branch → ensure OPEN PR → observe current CI checks
+  （non-blocking）→ Project Status `Review` → final live verification → `READY_FOR_REVIEW`。
+- 正常 Delivery Complete 只接受 `In Progress`；若 live status 仍为 `Ready`，必须
+  fail closed 并要求重新执行 Delivery Prepare。仅保留 operation-owned partial
+  `Review` 的 completion recovery 语义。
+- 一个 Task 通常产生一个 PR（base = `main`）。
+- Initial Task branch bootstrap is LCK-owned. An existing branch is reusable only when
+  Task identity, ownership, base, and the required worktree state are mechanically proven.
+  A missing branch is creatable only when current/local/remote `main` identities are
+  aligned, no local/remote/worktree conflict exists, and the target uses canonical
+  `task/<Issue number>-<slug>` naming. The Skill does not create the branch and has no
+  fallback write route.
+- Noncanonical names such as `task-<Issue number>` are never new-branch creation targets.
+  Historical numeric forms may be reused only for an existing branch whose ownership is
+  proven. Ambiguous identity or inconsistent live state fails closed.
+- 实现只处理当前 leaf Task；不进行无关重构。Targeted validation during implementation is
+  development feedback only. Final Delivery authorization is owned by LCK, which runs the
+  Critical Outcome and formal validation before committing the exact validated tree.
+- 当 change-relevant targeted validation 已通过、已知 Task Contract gap 已关闭且不存在新的
+  failure / finding / concrete diagnostic concern 时，candidate 进入 targeted-ready，应直接
+  调用 LCK Delivery Complete。Task scope 广、重要或属于 infrastructure 本身不足以触发一次
+  precautionary repository-wide validation。
+- Within one `delivery complete` invocation, the observed Task body, `origin/main`, Task
+  branch and committed head are ephemeral preconditions. If they change before a later
+  side effect, LCK stops and the next invocation reacquires/revalidates current facts; no
+  cross-phase snapshot becomes authority.
+- Human Gate 事项未决时不得继续 Delivery（§9）。
+- Delivery 不执行 Independent Review、不 merge、不 close Issue、不 closeout。
+
+## 7. PR / CI lifecycle
+
+- PR base = `main`，Squash-only merge policy 由 GitHub Ruleset 定义
+  （本文件不重定义）。
+- CI（`.github/workflows/ci.yml`）运行 pytest / ruff / mypy。LCK 所要求的
+  check 名称由 canonical CI workflow 中的静态 job 定义，并从 **exact trusted
+  base commit** 读取；不能读取调用者当前 checkout、未提交修改或 candidate
+  head 上的未来 workflow policy。LCK v1 对 dynamic job name / matrix job
+  fail closed。Initial Delivery / Remediation 只观察当前 PR checks，不以 required
+  check success 作为完成条件；Review Complete / Merge Preflight 由 exact PR base
+  policy 约束。候选 head 对该配置的修改只在 merge 后成为后续 operation 的新
+  policy，不能降低它自身的验收门禁。GitHub
+  `statusCheckRollup` 只提供 exact PR head 上这些 check 的 live result。
+  GitHub Ruleset 可继续作为平台侧独立强制层，但 plan/permission-dependent
+  Required-Checks discovery API 不作为 LCK lifecycle authority。
+- PR 关联 `Closes #N` 仅当 maintainer 预期 merge 后 close。
+- merge 决策：passing Independent Review for current PR head
+  + maintainer manual Squash Merge。
+- merge 前由 LCK 执行 deterministic preflight：
+  uv run --frozen python -m tools.lck merge preflight <TASK>；
+  LCK 只返回人工合并就绪，不执行 merge。
+
+## 8. Independent Review
+
+shared semantics 由 `docs/workflows/lck/review-and-remediation.md` 权威定义：
+fresh session、strict read-only、head lock、independent judgement、
+no Delivery mechanical authority inheritance、LCK live target resolution、
+Review Prepare/Complete operation-boundary stale guard、PASS / FAIL、new head → fresh re-review。
+
+Review Prepare 在 sealed handoff 前已经对 exact reviewed head 执行并持久化 formal Review
+validation。Independent Review 的独立性是 semantic judgement；Reviewer 消费该 validation/check
+evidence 并审阅 test source / coverage / failure semantics，不在 sealed review artifact 中重跑
+等价正式 validation。证据不足时报告 validation/evidence gap，而不是创建替代 authority。
+
+本文件只声明其在 lifecycle 中的位置：Review 可在 CI checks 运行期间与其并行，
+但 Review Complete 的 PASS 与 maintainer merge 前的 Merge Preflight 都必须
+  基于各自 fresh authority 验证 checks 通过；Review FAIL 必须先 STOP，只有
+  Human 显式发起后才进入 remediation（§10）。
+
+对于 Research leaf，Review identity 还必须包含当前仓库产物的路径、digest、decision
+candidate 与 effective diff 绑定；Review Complete PASS 缺少 typed outcome 时 fail closed。
+
+## 9. Human Gate
+
+以下情形必须 STOP 并进入显式 Human Gate（维护者批准前不得 repository
+write 或继续）：
+
+- Task body / Audit 揭示 target architecture 与当前 contract 重大冲突；
+- 实现必须扩大到 Non-goal（Runner 大改、Context Compiler、Ruleset 等）；
+- 规格歧义在 expansion trigger 顺序内无法解决；
+- fail-closed 条件触发且无法安全定位冲突源；
+- 维护者显式要求。
+
+Human Gate 批准默认在同一执行会话记录；跨会话恢复时维护者必须显式提供
+或指向已批准的 gate evidence。**不得**为寻找批准记录而默认读取全部
+Issue comments（Retrieval v2 comments default-off 仍适用）。
+
+## 10. Remediation after failed Review
+
+- Review FAIL → LCK 返回 `STOP_REQUIRED`，不得自动启动修复。
+- Human 显式提供当前 Task completed FAIL 的 `review_id` 启动 remediation；
+  workspace-local Review record 中只有 findings 可作为 semantic input，current PR/head/base
+  必须由 LCK live reacquire。跨 clone / Agent runtime 切换导致该 ignored local record 不可用时，
+  Human 可额外提供该 completed Review 的 `--findings-file`；它仍然只是 semantic input，
+  不能提供任何机械 identity/authorization。
+- Implementation Agent 修复后由 LCK 完成 validation / commit / push / existing
+  PR reuse，产生 new head，并在 `READY_FOR_NEW_REVIEW` 再次 STOP。
+- 如果正式进入 Remediation 后确认不存在 implementation repair，且只剩 external/future
+  Review evidence，必须调用 `remediation no-change` 形成 `NO_IMPLEMENTATION_CHANGE`
+  receipt 并释放 prepared session；不得制造空提交，也不得手工删除 session marker。该
+  operation 会 fresh reacquire 当前 PR/base/head，要求工作树 clean 且 candidate 未变化；
+  不 commit/push、不设置 `fresh-review-required`，也不声称 deferred evidence 已满足。
+- 只能在 repaired head 形成后、独立 provider 会话或 fresh Review 中真实产生的验收
+  evidence（例如 Task 显式要求的 provider-attributed / cross-provider receipts）不得作为
+  `remediation complete` 的循环前置条件；它们保持 pending，并在后续 Independent Review
+  acceptance 中继续 fail-closed。`READY_FOR_NEW_REVIEW` 不表示这些 evidence 已满足。
+- prepared Remediation session 未经 `remediation complete` 或 `remediation no-change`
+  正式终结时，新的 Review Prepare 必须 fail closed；不得让 Review 与未终结的
+  implementation session 交错，避免遗留 session 锁死后续 invocation。
+- successful remediation 设置 `fresh-review-required` negative boundary；在新的 Review
+  verdict 被接受前不得再次 remediation。该 boundary 不携带 target authorization。
+- 任何新 commit 都需要 **fresh independent re-review**；不得复用旧 verdict。
+
+## 11. Manual Squash Merge boundary
+
+- 只有 maintainer 可以执行 Squash Merge。
+- 任何 workflow Skill / Agent 都不得 merge（包括自动 merge）。
+- merge 前必须存在当前 PR head 的 passing Independent Review。
+
+## 12. Failure / Ambiguity handling
+
+| 场景 | 行为 |
+|---|---|
+| Specification ambiguity | 按 expansion trigger 顺序展开 → 仍不 resolve → **Human Gate**，绝不猜测 |
+| Conflict（body / parent / ADR / 实现） | **fail closed**；无法安全定位 → Human Gate |
+| Missing dependency | native relationship / 最小相关源 → unresolved → Human Gate |
+| Review failure | `STOP_REQUIRED` → Human explicit remediation → new head → fresh re-review |
+| Head changed during Review | `REVIEW_STALE_HEAD`，本次 verdict 无效并重新 Review |
+| Relevant base changed during Review | `REVIEW_STALE_BASE`，本次 verdict 无效并重新 Review |
+| Merge head ≠ reviewed head | **block closeout**，人工介入 |
+| NL entry 无法解析 | explicit Skill-name fallback / Human Gate |
+
+## 13. Closeout semantics
+
+Closeout 仅在 maintainer 已人工 Squash Merge 后执行：
+
+1. 由
+   uv run --frozen python -m tools.lck closeout <TASK>
+   从当前 Git / GitHub facts 重新求解 merge identity（reviewed head == 实际 merged head）；
+2. 将 Business Delivery 与 Cleanup 分离：merged PR 可立即得到
+   Business Delivery = COMPLETE，cleanup 失败只产生 Cleanup = PENDING。Research 的
+   `Research Outcome` 写入与 postcondition 也必须完成；DO NOT IMPLEMENT 与
+   NEEDS MORE EVIDENCE 仍然是 Business Delivery 的成功结果。该值由 LCK 在验证
+   current Task contract、merged PR/base/head 与最新 Review PASS 的 exact artifact
+   binding 后，通过受约束 completion effect 自动写入 canonical Project；人工预设
+   不是正常步骤，也不是 fallback；
+3. 收敛 Issue / Project lifecycle（state、Status、labels）并同步 canonical
+   `main`；
+4. 仅在 head/tree/worktree proof 完整时删除已验证的 Task branch，识别
+   GitHub 已删除的 remote branch，并允许安全重试；
+5. 不依赖旧 Kernel session 或 authoritative snapshot lineage。
+
+Closeout 不 repair 代码、不手动 close Issue、不清理无关 branch、
+不评估 Feature completion。
+
+正常 terminal success（Business Delivery = COMPLETE、Cleanup = COMPLETE、`next_action`
+要求 stop）直接以 compact `lck-agent-view` 作为报告来源并停止。`receipt_reference` 是按需
+Audit pointer，不是默认读取指令；只有 STOP、PENDING/partial/unknown、effect anomaly、Agent
+View 信息不足或 maintainer 明确要求 merge identity / exact cleanup proof 等审计细节时才展开。
+
+## 14. Feature Completion
+
+Feature Completion Audit 是 hierarchy-aware exception（普通 leaf-Issue-first
+不适用于它）：读取 target Feature + 相关 child hierarchy + completion state +
+implementation/validation evidence，但保持有界（不读无关 comments / docs /
+roadmap）。verdict 供 maintainer closeout 决策使用。
+
+## 15. Source-of-truth authority model
+
+Normative / semantic authority 与 Mechanical / factual authority 是两层，
+不做单一线性排序：
+
+### Normative / semantic authority（自上而下）
+
+1. system / platform constraints（`.codex/rules`、`.claude/settings.json`、CI、Ruleset）
+2. maintainer explicit current instruction / approved Human Gate
+3. repository hard rules + active durable architecture decisions / ADR
+   （`AGENTS.md` hard sections、`docs/architecture/*`）
+4. current leaf Issue body —— **current work-item business specification**
+5. Agent-neutral workflow specification（本文件、`pr-review.md`）
+6. agent-specific executable Skill
+7. historical Issue comments / reports（默认不可见，显式 trigger 才读，
+   永不 override 4）
+
+current leaf Issue body 不得覆盖：system/platform、maintainer constraint、
+safety、repository hard invariant、active durable architecture decision。
+
+### Mechanical / factual authority
+
+current GitHub / Git / CI / deterministic Runner facts 对其事实域具有
+authority：Issue state、labels、Project Status、Parent、blocked-by/blocking、
+PR identity、base/head SHA、review head、merge identity、CI/check status、
+branch/main state。
+
+mechanical facts 可以使 stale textual assumption 失效，并触发
+fail-closed / Human Gate；但 **不得成为 business specification**，
+不得覆盖 current Issue requirement。
+
+### Workflow identity locking
+
+与当前 phase 相关的 workflow object identity 必须锁定并验证：Task / Issue
+identity、PR base、PR head、effective diff、reviewed head、audited main、
+merge SHA 等。这些 identity 在要求稳定的 phase 中发生变化时，必须
+invalidation / fail closed / Human Gate，不得静默继续。
+
+### Skill / Runner version is not itself a workflow gate
+
+除非 current Task、repository hard rule 或 approved workflow policy 明确
+要求，否则不要求为了执行 workflow 将 Skill / Runner 强制从 `main`、PR base
+或特定 trusted commit 重新加载。当前 worktree 中适用的 active Skill / Runner
+可以作为执行工具；workflow correctness 由 locked workflow object
+identities + current canonical specification + deterministic evidence 保证。
+不重新引入 trusted Skill、main-only Skill、Skill hash as workflow state 等
+已明确不采用的旧设计。
+
+`AGENTS.md` 只保留 fresh Agent 必须知道的简洁原则；本文件承载完整模型。
+
+## 16. 与其它 instruction 的关系
+
+- `AGENTS.md`：always-loaded control plane（hard rules、Retrieval v2、
+  routing 原则）。本文件是 AGENTS 中 lifecycle 细节的 on-demand 展开层。
+- `docs/workflows/lck/review-and-remediation.md`：Independent Review shared semantics。
+- `docs/workflows/lck/issue-contracts.md`：Issue specification authoring。
+- `.agents/policies/*`：deterministic mechanics / evidence policy
+  （Runner 与证据的权威规则）。
+- Codex / Claude workflow Skills：各自 agent-specific executable procedure，
+  引用本文件相应 section（按需，非全文）。

--- a/docs/workflows/lck/restoration-manifest.md
+++ b/docs/workflows/lck/restoration-manifest.md
@@ -1,0 +1,138 @@
+# LCK restoration manifest
+
+This is the auditable old-path to new-path inventory for Task #333.
+
+- Authoritative source commit: `0d9d762238a3e837a864b5350bf16d1b885a73c3`
+- Source tree: `2e8b5d641bd2b9f230cfe4e114932d9bb9b6fc96`
+- Removal commit: `8fd67a7d7ad0f012e52680d3572c9614169bd8d6`
+- Equivalent archive tag: `tracequant-v1-archive-2026-09-12`
+- Recovery method: Git object/path reads only; no revert, cherry-pick, or v1 tree overlay.
+
+The blob column records the historical object when the old path is a complete file.
+Rows marked omitted or responsibility replaced document why no old file is silently lost.
+
+| Old path | Historical blob | New path | Status | Responsibility/rationale |
+| --- | --- | --- | --- | --- |
+| `tools/agent_workflow/bug_policy.py` | `59778f868989abd7441e20f79d01d240b6f319f0` | `tools/lck/bug_policy.py` | restored/adapted | Moved into the isolated LCK tooling root; imports and identity paths adapted. |
+| `tools/agent_workflow/critical_outcome.py` | `d1de9c72d010bea17e9ab94fe918cee503e1e603` | `tools/lck/critical_outcome.py` | restored/adapted | Moved into the isolated LCK tooling root; imports and identity paths adapted. |
+| `tools/agent_workflow/documentation_policy.py` | `22187c105166e1cf2d787e283bc3ba42a9c7208f` | `tools/lck/documentation_policy.py` | restored/adapted | Moved into the isolated LCK tooling root; imports and identity paths adapted. |
+| `tools/agent_workflow/issue_form_contract.py` | `b019a121390126b5be681fad92f82c837c423125` | `tools/lck/issue_forms.py` | restored/adapted | Moved into the isolated LCK tooling root; imports and identity paths adapted. |
+| `tools/agent_workflow/lck.py` | `6487b03b3817bd0c1414a9f5fddeed497313990a` | `tools/lck/__main__.py` | restored/adapted | Moved into the isolated LCK tooling root; imports and identity paths adapted. |
+| `tools/agent_workflow/lck_core/README.md` | `70fd67f473beea7e61746efc42cfa329d3142355` | `docs/workflows/lck/implementation-map.md` | restored/adapted | Moved into the isolated LCK tooling root; imports and identity paths adapted. |
+| `tools/agent_workflow/lck_core/__init__.py` | `451928f507d2ac41cfaa7d5e1b2df3058c6aeb34` | `tools/lck/__init__.py` | restored/adapted | Moved into the isolated LCK tooling root; imports and identity paths adapted. |
+| `tools/agent_workflow/lck_core/cli.py` | `46485552dc9e04b4f0393f4fe0b81594a89520e2` | `tools/lck/cli.py` | restored/adapted | Moved into the isolated LCK tooling root; imports and identity paths adapted. |
+| `tools/agent_workflow/lck_core/closeout.py` | `d4d67fed8f3e101051d0c77bcbbda3e61f615025` | `tools/lck/closeout.py` | restored/adapted | Moved into the isolated LCK tooling root; imports and identity paths adapted. |
+| `tools/agent_workflow/lck_core/delivery.py` | `82ef5979f7f804b255293412f8a6f533fec9697d` | `tools/lck/delivery.py` | restored/adapted | Moved into the isolated LCK tooling root; imports and identity paths adapted. |
+| `tools/agent_workflow/lck_core/effective_diff.py` | `dacffd950ff8e30bebc8bb06fe464d70f91a95cd` | `tools/lck/effective_diff.py` | restored/adapted | Moved into the isolated LCK tooling root; imports and identity paths adapted. |
+| `tools/agent_workflow/lck_core/effects.py` | `744f4bc729f18f071410779a3df18ef7891008e9` | `tools/lck/effects.py` | restored/adapted | Moved into the isolated LCK tooling root; imports and identity paths adapted. |
+| `tools/agent_workflow/lck_core/eligibility.py` | `0eefd4b2e9af18b7dfde9e35af59ee347cebe018` | `tools/lck/eligibility.py` | restored/adapted | Moved into the isolated LCK tooling root; imports and identity paths adapted. |
+| `tools/agent_workflow/lck_core/issue_profiles.py` | `b46b752ede9acccb20900ec34f5b956865fbed61` | `tools/lck/issue_profiles.py` | restored/adapted | Moved into the isolated LCK tooling root; imports and identity paths adapted. |
+| `tools/agent_workflow/lck_core/models.py` | `a75373d814946e8b039d884c5aca5f955a54eae9` | `tools/lck/models.py` | restored/adapted | Moved into the isolated LCK tooling root; imports and identity paths adapted. |
+| `tools/agent_workflow/lck_core/profile_policies.py` | `ee94ac9560748bfc68eb686d4417bcacc4c233a1` | `tools/lck/profile_policies.py` | restored/adapted | Moved into the isolated LCK tooling root; imports and identity paths adapted. |
+| `tools/agent_workflow/lck_core/receipts.py` | `52b7f720770e90e92dea951fb3aba97ed93a51e2` | `tools/lck/receipts.py` | restored/adapted | Moved into the isolated LCK tooling root; imports and identity paths adapted. |
+| `tools/agent_workflow/lck_core/remediation.py` | `0f71b50afa4c2f1315bc16741bb3926d33830b21` | `tools/lck/remediation.py` | restored/adapted | Moved into the isolated LCK tooling root; imports and identity paths adapted. |
+| `tools/agent_workflow/lck_core/review.py` | `8e08c371b18d22a5201b74871bdf13660c5620cf` | `tools/lck/review.py` | restored/adapted | Moved into the isolated LCK tooling root; imports and identity paths adapted. |
+| `tools/agent_workflow/lck_core/review_authority.py` | `19678c2e9b747e47611e3073ccae8c350dad3910` | `tools/lck/review_authority.py` | restored/adapted | Moved into the isolated LCK tooling root; imports and identity paths adapted. |
+| `tools/agent_workflow/lck_core/review_workspace.py` | `7e1380ba40941eb4ec6881e0e3ec3d9c7a42c1df` | `tools/lck/review_workspace.py` | restored/adapted | Moved into the isolated LCK tooling root; imports and identity paths adapted. |
+| `tools/agent_workflow/lck_core/shared_facts.py` | `441e35889227b92082c60e054b94a4621a30029e` | `tools/lck/shared_facts.py` | restored/adapted | Moved into the isolated LCK tooling root; imports and identity paths adapted. |
+| `tools/agent_workflow/lck_core/state.py` | `d3487855807a332a3d91828de8c81566f099b94e` | `tools/lck/state.py` | restored/adapted | Moved into the isolated LCK tooling root; imports and identity paths adapted. |
+| `tools/agent_workflow/lck_core/structured_review_instructions.py` | `286ee82612623e89a9c67ebec8427196a36298b5` | `tools/lck/structured_review_instructions.py` | restored/adapted | Moved into the isolated LCK tooling root; imports and identity paths adapted. |
+| `tools/agent_workflow/lck_core/validation.py` | `d95bceb4a6c82df208f3e1ba673dc224625ea2d4` | `tools/lck/validation_gates.py` | restored/adapted | Moved into the isolated LCK tooling root; imports and identity paths adapted. |
+| `tools/agent_workflow/markdown_sections.py` | `565f224b77e5b43d20c4d126e7ed0bf158bffa07` | `tools/lck/markdown_sections.py` | restored/adapted | Moved into the isolated LCK tooling root; imports and identity paths adapted. |
+| `tools/agent_workflow/pr_resolve.py` | `49e18571f92403bdad5476d203171ae79cc857cb` | `tools/lck/github_prs.py` | restored/adapted | Moved into the isolated LCK tooling root; imports and identity paths adapted. |
+| `tools/agent_workflow/project_status.py` | `d74274dbfb05629c3987c7c9cea7040b034b47dc` | `tools/lck/github_projects.py` | restored/adapted | Moved into the isolated LCK tooling root; imports and identity paths adapted. |
+| `tools/agent_workflow/research_policy.py` | `ed7ff0666612d604b581686e30c71cb7f5832982` | `tools/lck/research_policy.py` | restored/adapted | Moved into the isolated LCK tooling root; imports and identity paths adapted. |
+| `tools/agent_workflow/skill_path_audit.py` | `c9465df1fd2550ddb4a6c6e427daa6683a30dd31` | `tools/lck/skill_audit.py` | restored/adapted | Reworked to audit one canonical `.agents` Skill source plus thin provider adapters instead of duplicated Skill bodies. |
+| `tools/agent_workflow/workflow_common.py` | `840a78713ed02561e4be4558fb9ac4f9bfc38fb5` | `tools/lck/common.py` | restored/adapted | Moved into the isolated LCK tooling root; imports and identity paths adapted. |
+| `tools/agent_workflow/workflow_evidence.py` | `4ba719efc2cb58bce59a2a3cccbf303fbed54ff0` | `tools/lck/feature_audit.py` | restored/adapted | Moved into the isolated LCK tooling root; imports and identity paths adapted. |
+| `tools/agent_workflow/workflow_validation.py` | `3282d8c21e6a09e199443cbd9ddc8f52104c72bd` | `tools/lck/validation_runner.py` | restored/adapted | Moved into the isolated LCK tooling root; imports and identity paths adapted. |
+| `tools/agent_workflow/wsl2_validation_profiles.json` | `3fea9933126f11fc009cc57187049442fc2e1e22` | `tools/lck/config/validation_profiles.json` | restored/adapted | Moved into the isolated LCK tooling root; imports and identity paths adapted. |
+| `tools/agent_workflow/wsl2_validation_runner.py` | `65934b3270518da123eba0f702b68253b4844644` | `tools/lck/wsl2_validation_runner.py` | restored/adapted | Moved into the isolated LCK tooling root; imports and identity paths adapted. |
+| `src/tracequant/contracts/review.py` | `72c2ba279e05a1b2e75b1c1071b81a927f273e76` | `tools/lck/review_models.py` | restored/adapted | Workflow Review contracts moved out of the product namespace. |
+| `src/tracequant/contracts/__init__.py` | `2570dbda2b3b4db25c56ed7ebea246db774f662b` | — | omitted | Product-package re-export is no longer applicable; callers import tools.lck.review_models. |
+| `src/tracequant/domain/models.py (DomainValidationError only)` | `see named source file` | `tools/lck/review_models.py (ValueError base)` | responsibility replaced | Avoids restoring the archived v1 domain model tree. |
+| `src/tracequant/domain/__init__.py` | `9211195ddfd0d14449e946d7323fcdea8a5e5283` | — | omitted | Archived business-domain export is outside LCK scope. |
+| `tests/tools/lck_test_support.py` | `668bbc6a895016512fe1f4db22514e4569fa8488` | `tests/tools/lck/support.py` | restored/adapted | Moved under the isolated LCK test root and updated for package imports/current v2 contracts. |
+| `tests/tools/test_agent_neutral_workflow.py` | `2aba6101ebac23a9ef674edc6216dfd18ebf0ab2` | `tests/tools/lck/test_agent_neutral_workflow.py` | restored/adapted | Replaced duplicate-provider equality checks with canonical-source, thin-adapter, routing, and LCK-only documentation checks. |
+| `tests/tools/test_critical_outcome.py` | `e799fc2c3da7aa463f19ea8aee11b9aa87bb23b5` | `tests/tools/lck/test_critical_outcome.py` | restored/adapted | Moved under the isolated LCK test root and updated for package imports/current v2 contracts. |
+| `tests/tools/test_issue_form_contract.py` | `de9f5d1fd7700f27d5bf1ea1c898a18f47fd5001` | `tests/tools/lck/test_issue_form_contract.py` | restored/adapted | Moved under the isolated LCK test root and updated for package imports/current v2 contracts. |
+| `tests/tools/test_issue_templates.py` | `ecb4f99b07577de734843520cfc4f79a6a7643ec` | `tests/tools/lck/test_issue_templates.py` | restored/adapted | Moved under the isolated LCK test root and updated for package imports/current v2 contracts. |
+| `tests/tools/test_lck.py` | `b1442e793a1fd9dc91792e4dd7dee661ffb654be` | `tests/tools/lck/test_branch_naming.py` | restored/adapted | Moved under the isolated LCK test root and updated for package imports/current v2 contracts. |
+| `tests/tools/test_lck_acceptance.py` | `aafd4f2ac637ddc42215d5474e0796a682b03023` | `tests/tools/lck/test_acceptance.py` | restored/adapted | Rewritten around the stable module CLI, required Task #333 Critical Outcome, new import boundary, typed profiles, adapters, and manifest. Detailed lifecycle behavior remains covered by the migrated phase tests. |
+| `tests/tools/test_lck_bug.py` | `d5bc9c2df7ed8d404c2aaee849aebf085d19615d` | `tests/tools/lck/test_bug.py` | restored/adapted | Moved under the isolated LCK test root and updated for package imports/current v2 contracts. |
+| `tests/tools/test_lck_closeout.py` | `0faa0c5ca3e4bbd4ba81e2463f2bf51e16826ebe` | `tests/tools/lck/test_closeout.py` | restored/adapted | Moved under the isolated LCK test root and updated for package imports/current v2 contracts. |
+| `tests/tools/test_lck_closeout_additional.py` | `87cb0f25f40f339bff0edcca3b8b4b628a7fa2f3` | `tests/tools/lck/test_closeout_additional.py` | restored/adapted | Moved under the isolated LCK test root and updated for package imports/current v2 contracts. |
+| `tests/tools/test_lck_delivery.py` | `2c721084ecef508fff6414ea8473b3855b59bb6a` | `tests/tools/lck/test_delivery.py` | restored/adapted | Moved under the isolated LCK test root and updated for package imports/current v2 contracts. |
+| `tests/tools/test_lck_documentation.py` | `563c3a8664e3963a47dab13e36788b5fa35291b6` | `tests/tools/lck/test_documentation.py` | restored/adapted | Moved under the isolated LCK test root and updated for package imports/current v2 contracts. |
+| `tests/tools/test_lck_issue_profiles.py` | `33ebda42cc6428d001c4209f77293ae5ec4220a2` | `tests/tools/lck/test_issue_profiles.py` | restored/adapted | Moved under the isolated LCK test root and updated for package imports/current v2 contracts. |
+| `tests/tools/test_lck_prepare.py` | `8e4f9c1a47cdb778cde161603f2d12d078c727a9` | `tests/tools/lck/test_prepare.py` | restored/adapted | Moved under the isolated LCK test root and updated for package imports/current v2 contracts. |
+| `tests/tools/test_lck_profile_architecture.py` | `bb112893d726e7196216404b4ba9506ddbbdcfdb` | `tests/tools/lck/test_profile_architecture.py` | restored/adapted | Moved under the isolated LCK test root and updated for package imports/current v2 contracts. |
+| `tests/tools/test_lck_receipts.py` | `1b0396ff440cf40fe2eb6e101cde910afde9e7ed` | `tests/tools/lck/test_receipts.py` | restored/adapted | Moved under the isolated LCK test root and updated for package imports/current v2 contracts. |
+| `tests/tools/test_lck_remediation.py` | `1693da725c4aeefa827c3b9bdc8ebb973bacc3a9` | `tests/tools/lck/test_remediation.py` | restored/adapted | Moved under the isolated LCK test root and updated for package imports/current v2 contracts. |
+| `tests/tools/test_lck_research.py` | `65a1e8ea16251e6ffd99dfea93e1ea540074cc56` | `tests/tools/lck/test_research.py` | restored/adapted | Moved under the isolated LCK test root and updated for package imports/current v2 contracts. |
+| `tests/tools/test_lck_review.py` | `039759394f7194dcb0f747580fe9e5e135eb4a89` | `tests/tools/lck/test_review.py` | restored/adapted | Moved under the isolated LCK test root and updated for package imports/current v2 contracts. |
+| `tests/tools/test_lck_review_models.py` | `9c3bf632faec9b001e6d527968bd59d8ca6e11f3` | `tests/tools/lck/test_review_models.py` | restored/adapted | Moved under the isolated LCK test root and updated for package imports/current v2 contracts. |
+| `tests/tools/test_lck_state.py` | `7e8c083f83ae60953cb1bbd53967b96eda432358` | `tests/tools/lck/test_state.py` | restored/adapted | Moved under the isolated LCK test root and updated for package imports/current v2 contracts. |
+| `tests/tools/test_lck_structure.py` | `432f0a366faf4226b9177d90f1927ae03c879696` | `tests/tools/lck/test_structure.py` | restored/adapted | Updated from the historical facade plus nested `lck_core` shape to the single flat `tools/lck` package while preserving responsibility and dependency guards. |
+| `tests/tools/test_lck_typed_dependency_contracts.py` | `9d3246e2b41aa8716b45b0ef0d3c918c6ca4c84e` | `tests/tools/lck/test_typed_dependency_contracts.py` | restored/adapted | Moved under the isolated LCK test root and updated for package imports/current v2 contracts. |
+| `tests/tools/test_markdown_sections.py` | `2bfdb0df36945e11a5c89d6356cc0e26c0e37a45` | `tests/tools/lck/test_markdown_sections.py` | restored/adapted | Moved under the isolated LCK test root and updated for package imports/current v2 contracts. |
+| `tests/tools/test_pr_resolve.py` | `279b8fb5353c02b7f80c251f597e3c8b6e3698ed` | `tests/tools/lck/test_pr_resolve.py` | restored/adapted | Moved under the isolated LCK test root and updated for package imports/current v2 contracts. |
+| `tests/tools/test_retrieval_v2_policy.py` | `d80eed775a0f22b32b225f7aac4339ebf187649a` | `tests/tools/lck/test_retrieval_v2_policy.py` | restored/adapted | Retrieval semantics moved out of mixed product instructions into `.agents/policies/context-retrieval.md`; tests now guard that isolated owner. |
+| `tests/tools/test_runtime_telemetry_removed.py` | `a7fbf857f3530f2469609ed9ec0544a74cc88fba` | `tests/tools/lck/test_runtime_telemetry_removed.py` | restored/adapted | Reduced historical path allowlists to direct guards against a runtime telemetry module/command and a check of the isolated external-analysis policy. |
+| `tests/tools/test_workflow_common.py` | `161b0031afc517b38f7496a003b5b6a76c96f21a` | `tests/tools/lck/test_workflow_common.py` | restored/adapted | Moved under the isolated LCK test root and updated for package imports/current v2 contracts. |
+| `tests/tools/test_workflow_evidence.py` | `cccdebb06afaa66bca463d2fa4f1f455b17c1fab` | `tests/tools/lck/test_feature_audit.py` | restored/adapted | Moved under the isolated LCK test root and updated for package imports/current v2 contracts. |
+| `tests/tools/test_workflow_skills.py` | `a3000a8f7348aa8fa07a2c5c1e8f0d4336f1525c` | `tests/tools/lck/test_workflow_skills.py` | restored/adapted | Updated for the module CLI and one-canonical-source design; lifecycle authority, read-only Review, manual merge, and adapter routing remain covered. |
+| `tests/tools/test_workflow_validation.py` | `1998975563ab92d7a7a43aad95ccb66a7725bd5c` | `tests/tools/lck/test_validation_runner.py` | restored/adapted | Moved under the isolated LCK test root and updated for package imports/current v2 contracts. |
+| `tests/tools/test_wsl2_validation_rules.py` | `ab72dbd7f6466a811209545c3d6c9bb34a595164` | `tests/tools/lck/test_wsl2_validation_rules.py` | restored/adapted | Moved under the isolated LCK test root and updated for package imports/current v2 contracts. |
+| `tests/tools/test_wsl2_validation_runner.py` | `4a3beaf77f170c67c263befe2c8498e3d51eace6` | `tests/tools/lck/test_wsl2_validation_runner.py` | restored/adapted | Moved under the isolated LCK test root and updated for package imports/current v2 contracts. |
+| `.agents/execution-profile.example.toml` | `3540fda7da639a24b5aeb5d6c203fa1f5024c3a4` | `.agents/execution-profile.example.toml` | restored/adapted | Paths and module entry commands adapted. |
+| `.agents/policies/command-execution.md` | `f0d891214027fbbc8a561d8e070a0f9c0bc7cc1a` | `.agents/policies/command-execution.md` | restored/adapted | Paths and module entry commands adapted. |
+| `.agents/policies/workflow-evidence.md` | `02cc896af843aaec5060619b278bd78e2eb351d1` | `.agents/policies/workflow-evidence.md` | restored/adapted | Paths and module entry commands adapted. |
+| `.agents/skills/feature-completion-audit/SKILL.md` | `9bf78f0c57e71f046b9c47c2abe2b94eb15b8175` | `.agents/skills/feature-completion-audit/SKILL.md` | restored/adapted | Paths and module entry commands adapted. |
+| `.agents/skills/task-closeout/SKILL.md` | `5409c28b8d9f8fc20631b91f3c66e0e2e4a674c5` | `.agents/skills/task-closeout/SKILL.md` | restored/adapted | Paths and module entry commands adapted. |
+| `.agents/skills/task-delivery-runner/SKILL.md` | `ac93fef57b7971d4fd8fed2945a8eb632d0e46f8` | `.agents/skills/task-delivery-runner/SKILL.md` | restored/adapted | Paths and module entry commands adapted. |
+| `.agents/skills/task-pr-review-runner/SKILL.md` | `a590cb43408bef7af28b4fdc3b4255279b20706a` | `.agents/skills/task-pr-review-runner/SKILL.md` | restored/adapted | Paths and module entry commands adapted. |
+| `.claude/settings.json` | `1b3f170fa76ff791bede19f43b64d7cf54dcc2ab` | `.claude/settings.json` | restored/adapted | Paths and module entry commands adapted. |
+| `.claude/skills/feature-completion-audit/SKILL.md` | `534321b46cd4e3da8445c9c5d2e258da42594339` | `.claude/skills/feature-completion-audit/SKILL.md` | replaced by thin adapter | Canonical procedure is .agents/skills; provider copy is intentionally not duplicated. |
+| `.claude/skills/task-closeout/SKILL.md` | `082e681e1e5e655c8e979599cfe29882b755d764` | `.claude/skills/task-closeout/SKILL.md` | replaced by thin adapter | Canonical procedure is .agents/skills; provider copy is intentionally not duplicated. |
+| `.claude/skills/task-delivery-runner/SKILL.md` | `1e7d95550fcc41cb69147a6a09140d515891c7ff` | `.claude/skills/task-delivery-runner/SKILL.md` | replaced by thin adapter | Canonical procedure is .agents/skills; provider copy is intentionally not duplicated. |
+| `.claude/skills/task-pr-review-runner/SKILL.md` | `2dbf4473b0bfcb77057df9da5a7fea4e6b7ca0e4` | `.claude/skills/task-pr-review-runner/SKILL.md` | replaced by thin adapter | Canonical procedure is .agents/skills; provider copy is intentionally not duplicated. |
+| `.codex/rules/tracequant-wsl-validation.rules` | `e0dfd5e852687870fd23e2d39b55d9c330194440` | `.codex/rules/tracequant-wsl-validation.rules` | restored/adapted | Paths and module entry commands adapted. |
+| `docs/guides/LCK-overview.md` | `787acf1aeeb55cb18ceacb4c77789255f427aaec` | `docs/guides/lck/overview.md` | restored/adapted | Moved into an LCK-only documentation subtree and updated for current paths. |
+| `docs/guides/LCK-adoption.md` | `899c3ad89016db499801de17606dac44de384828` | `docs/guides/lck/adoption.md` | restored/adapted | Moved into an LCK-only documentation subtree and updated for current paths. |
+| `docs/workflows/LCK-v1-Design-Charter.md` | `ef1f23d95d13b44b22ba821977613c5f2f26e6f4` | `docs/workflows/lck/design-charter-v1.md` | restored/adapted | Moved into an LCK-only documentation subtree and updated for current paths. |
+| `docs/workflows/agent-skills.md` | `155549b4b2d317f0b616f75fe4811446438af305` | `docs/workflows/lck/agent-skills.md` | restored/adapted | Moved into an LCK-only documentation subtree and updated for current paths. |
+| `docs/workflows/wsl2-validation-runner/README.md` | `672a5c35559d6ec69c678bb8ccfcedc7402805e0` | `docs/workflows/lck/validation/README.md` | restored/adapted | Moved into an LCK-only documentation subtree and updated for current paths. |
+| `docs/workflows/wsl2-validation-runner/maintenance-and-adoption.md` | `ca7ad760f25205dbc4e170d29d9fd51c327f2d62` | `docs/workflows/lck/validation/maintenance-and-adoption.md` | restored/adapted | Moved into an LCK-only documentation subtree and updated for current paths. |
+| `docs/workflows/wsl2-validation-runner/security-hardening-cases.md` | `2ae2b88608eeb0e1ebd1a9bbad27a30c141e7088` | `docs/workflows/lck/validation/security-hardening-cases.md` | restored/adapted | Moved into an LCK-only documentation subtree and updated for current paths. |
+| `docs/development/issue-authoring.md` | `0869f8e57fc4138b2fcbb3c0ad1428da47e0eab4` | `docs/workflows/lck/issue-contracts.md` | restored/adapted | Moved into an LCK-only documentation subtree and updated for current paths. |
+| `docs/development/issue-workflow.md` | `18161bdfd081dbec8f16e83078ce635fa31ea792` | `docs/workflows/lck/lifecycle.md` | restored/adapted | Moved into an LCK-only documentation subtree and updated for current paths. |
+| `docs/development/pr-review.md` | `424aa29fe7dee740766ab4a5ef8908c879c1bcc9` | `docs/workflows/lck/review-and-remediation.md` | restored/adapted | Moved into an LCK-only documentation subtree and updated for current paths. |
+| `docs/architecture/typed-leaf-workflows.md` | `b114439330ad53e368f8249d0016b03c7bec7fea` | `docs/workflows/lck/typed-profiles.md` | restored/adapted | Moved into an LCK-only documentation subtree and updated for current paths. |
+| `AGENTS.md` | `3ef45f8e74f1d4b5c25acae810bfa69d49d6c2c7` | `AGENTS.md` | current v2 file adapted | Historical mixed product/workflow instructions were not overlaid; LCK routing stays concise at root. |
+| `AGENTS.md (LCK context-retrieval sections)` | `3ef45f8e74f1d4b5c25acae810bfa69d49d6c2c7` | `.agents/policies/context-retrieval.md` | responsibility extracted | Leaf-first, progressive retrieval and external telemetry boundaries moved into an LCK-only policy owner. |
+| `CLAUDE.md` | `7c1efae9ce826356ee4d5ce3e937fe7cd0af1447` | `CLAUDE.md` | current v2 file adapted | Historical file was not overlaid; only its still-applicable LCK responsibility was merged. |
+| `.gitattributes` | `aad11276a1a2152bf9feca13cd0537c9a9f7f62d` | `.gitattributes` | current v2 file adapted | Historical file was not overlaid; only its still-applicable LCK responsibility was merged. |
+| `.gitignore` | `a625b693be15d9d387678af02fb0194f4d4ec399` | `.gitignore` | current v2 file adapted | Historical file was not overlaid; only its still-applicable LCK responsibility was merged. |
+| `.github/workflows/ci.yml` | `2a19a3721dd45b7ec1d2dcf4d22e8ae0b46b45b3` | `.github/workflows/ci.yml` | current v2 file adapted | Historical file was not overlaid; only its still-applicable LCK responsibility was merged. |
+| `README.md` | `21eb4e755667e2cd6ae9350230c2c3557c7d841f` | `README.md` | restored/adapted | Restored the complete historical LCK introduction, motivation, capability, lifecycle, and adoption section; updated paths and distinguished the Task #333 source from immutable preview releases. |
+| `pyproject.toml` | `d9f954bfce4cc4ffa038c9e25445e7336921f8b1` | `pyproject.toml` | current v2 file adapted | Historical file was not overlaid; only its still-applicable LCK responsibility was merged. |
+| `uv.toml` | `90c772803bfaf728c71656d065260ffcf951e4f6` | `uv.toml` | current v2 file adapted | Historical file was not overlaid; only its still-applicable LCK responsibility was merged. |
+| `docs/architecture/repository-structure.md` | `47868bda04b51328173369b31f48876e08fcc182` | `docs/architecture/repository-structure.md` | current v2 file adapted | Historical file was not overlaid; only its still-applicable LCK responsibility was merged. |
+
+## Deliberately excluded v1 trees
+
+The archived product implementations under `src/tracequant/data/`,
+`src/tracequant/config.py`, `src/tracequant/logging.py`,
+`src/tracequant/core/`, and the old `apps/`, `packages/`, and `deploy/`
+trees do not provide an LCK responsibility and are not restored. Product,
+research-data, release-history, and planning artifacts that merely mention LCK
+also remain archived; current product documentation links to the isolated LCK
+documentation instead.
+
+## Canonical-source rule
+
+Normative workflow documents live only under `docs/workflows/lck/`; public
+usage guidance lives only under `docs/guides/lck/`; executable canonical
+Skills live only under `.agents/skills/`. Claude Skill files are thin
+provider adapters and contain no second lifecycle procedure.

--- a/docs/workflows/lck/review-and-remediation.md
+++ b/docs/workflows/lck/review-and-remediation.md
@@ -1,0 +1,349 @@
+# PR Independent Review（LCK Review / Remediation Semantics）
+
+本文件是 TraceQuant Independent Review 与 Remediation 的 shared semantic owner。
+Review / Remediation 的机械生命周期控制属于 LCK；Codex / Claude 只承担语义角色。
+Git / GitHub current state 是机械事实权威，Delivery 输出、旧 snapshot、expected SHA、
+PR identity handoff 或 validation snapshot 都不能授权后续 Review / Remediation。
+
+## 1. Purpose / independence
+
+Independent Review 是一个单独、fresh 的只读 invocation。Review Agent 不得参与
+被审查 head 的 implementation 或 remediation，也不得继承 Delivery 的正确性、
+风险、AC 覆盖或推荐结论。
+
+Review Agent 只负责：
+
+```text
+Inspect
+Reason
+Judge
+Report
+```
+
+Review 不修复实现、不提交 GitHub Review、不改 Issue / PR / Project、不 merge。
+
+## 2. LCK launcher preflight
+
+在第一次调用 LCK 前，先确认项目解释器入口可用：
+
+```bash
+command -v uv
+uv --version
+uv run --frozen python --version
+```
+
+该检查失败属于 environment/launcher failure，不是 Review verdict，也不得转换为
+`STOP_REQUIRED`。裸 `python` 不是本仓库的环境依赖；不要通过全局 alias 或软链接规避。
+
+## 3. LCK live target resolution
+
+Review 必须从以下入口开始：
+
+```bash
+uv run --frozen python -m tools.lck review prepare <TASK>
+```
+
+调用方只提供 Task number。不得向 Review LCK 传入 Delivery 提供的 base SHA、head
+SHA、PR number、checks snapshot、validation snapshot 或 snapshot id 作为 authority。
+
+LCK 在本次 invocation 开始时从 live Git / GitHub 重新解析 authoritative inputs：
+
+- current OPEN non-Draft PR；
+- current PR base / head；
+- current Task Contract；
+- current applicable checks；
+- Review eligibility 所需的其他 live facts。
+
+`merge base`、`effective diff` 与 `changed-file inventory` 不是额外的 live authority
+query；它们在 base/head identity 冻结、standalone clone 创建并按需 materialize exact
+commit 后，**只在 temporary clone 内机械推导**。因此 source repository 即使尚未拥有
+current PR head object，也不得在 clone 创建前因本地 `git merge-base/diff` 失败而阻止
+fresh Review。
+
+`review prepare` 在开始 live resolution、temporary clone 和 formal validation 前建立一个
+Task-local operation marker；它只用于阻止同一 Task 的重复 in-flight Prepare，不是
+`review_id` 或跨阶段 authority。成功时才返回 `review_id`、live review target、Task
+Contract、validation、checks 和 isolated `review_root`。Formal validation FAIL 会先
+把 command-level result、validated base/head 和 evidence path 持久化，再 fail closed，
+不产生 semantic Review `review_id`。Marker 在 standalone clone path 被预留之前
+只记录 operation ownership；创建后、validation、异常退出和成功 handoff 都更新
+同一个 marker。成功 handoff 会一直保留到 Review completion，以便 command result
+丢失时仍能从 marker + guard 判断 ownership；后续 Prepare 只有在 owner 已退出且
+handoff 的 clone/guard 不完整时才回收其 LCK-owned state。
+
+LCK 的最终 stdout 是紧凑的 `lck-agent-view`，并提供 `receipt_reference`；Review Prepare
+仍直接提供完整 Task Contract 与 sealed review target 所需的最小输入。完整 operation
+snapshot、guard、validation/check evidence 和诊断信息保存在 ignored
+`.workflow.local/lck/audit-receipts/` Receipt 中，progress heartbeat 仍只写 stderr，不能
+成为第二个 lifecycle result。
+
+Review Prepare 的 formal validation 是 exact reviewed head 的 authoritative mechanical
+validation。Semantic Reviewer 应消费 Prepare 返回的 validation/check evidence，不默认重跑
+pytest、Ruff、mypy、lock 或 Skill validator 等等价 suite。这里的 independent 指
+**independent semantic judgement**，不是 duplicate mechanical validation。
+
+## 4. Fresh semantic context and read-only workspace
+
+LCK 在系统临时目录创建 reviewed head 的 detached standalone clone；它通过本地 clone
+读取 source repository，但不注册 source worktree、不修改 source `.git/worktrees`。Clone
+使用独立 Git metadata/object storage，origin 恢复为真实 remote；LCK 先在 exact head 上运行
+正式 Review validation；需要跨 clone 生命周期保留的 validation evidence 复制到 ignored
+`.workflow.local/lck/`，再将整个 temporary Review clone 封为 read-only。Review Complete
+成功持久化 PASS / FAIL，或以需要重新 Prepare 的 stale terminal outcome 结束后，才直接删除该
+clone；如果 Review Complete 在 terminal result 持久化前因 transient/infrastructure failure
+退出，必须保留 guard、clone 和 prepare marker，使同一 `review_id` 可安全重试。异常中断只需
+按 operation-owned path 回收临时目录，不需要 `git worktree remove/prune`。
+
+Reviewer 只从 `review_root`、当前 Task Contract 和必要的 current GitHub context
+建立新的 semantic context。不得把 Delivery self-review、旧 Review verdict、旧
+remediation rationale 或 persuasive framing 当作 evidence。
+
+Review Agent 可以读取完整 effective diff、相关 unchanged code、tests、docs、config
+和 public interfaces；必须逐项判断 Acceptance Criteria、正确性、failure paths、
+安全边界与回归风险。
+对 tests 的检查是读取 test source、判断 coverage 与 failure semantics。sealed `review_root`
+是 immutable review evidence artifact，不是 executable development workspace。若 LCK 已提供的
+validation/check evidence 无法支持某项 requirement 判断，Reviewer 必须报告明确的
+validation/evidence gap，而不是在 sealed clone 中自行执行 suite 创建替代 validation authority。
+Review Prepare 不等待 CI checks 进入终态；semantic Review 可以与 CI 并行。Checks
+success 只在 Review Complete 与后续 Merge Preflight 的 fresh gate 中决定是否可进入
+人工合并边界。
+
+## 4.1 Structured Review v2 semantic instructions
+
+Structured Review v2 的唯一 reviewer-facing owner 是
+`tools/lck/structured_review_instructions.py`。Review Prepare
+通过 `structured_review_instructions` 将该 owner 返回的 instruction data 放入
+standard semantic handoff；因此正常 `task-pr-review-runner` invocation 不需要
+maintainer 追加实验性提示词。该 handoff 要求 Reviewer 完成其列出的全部适用
+semantic surfaces，在 blocker 后继续审查，并在现有 verdict 前执行 residual sweep。
+
+这是 semantic guidance，不是新的 completion state、receipt gate 或 verdict
+authority。Review Complete、现有 finding/report semantics、Merge Preflight、freshness
+与 maintainer manual merge boundary 保持不变。
+
+## 5. Review Complete：fresh applicability snapshot
+
+语义审查结束后，调用 `review complete`。它是一个**新的 LCK operation**，不是
+Review Prepare authority 的延续：
+
+PASS：
+
+```bash
+uv run --frozen python -m tools.lck review complete <TASK> \
+  --review-id <REVIEW_ID> \
+  --verdict PASS
+```
+
+FAIL：先把 blocking findings 写入 review workspace 之外的临时/ignored 文本文件，
+再调用：
+
+```bash
+uv run --frozen python -m tools.lck review complete <TASK> \
+  --review-id <REVIEW_ID> \
+  --verdict FAIL \
+  --findings-file <FINDINGS_FILE>
+```
+
+`review_id` 定位 Review Prepare 封存的 reviewed target、validation evidence 和
+workspace ownership；这些是“审查了什么”的历史证据，不是 Review Complete 的当前
+机械 authority。
+
+Review Complete 在 operation 入口只获取一次 fresh `ReviewCompleteSnapshot`，并与
+Prepare 时封存的 target 比较：
+
+该 snapshot 使用 review-complete fact profile：读取当前 Task Contract、关系/阻塞、
+OPEN PR identity 与当前 checks，但不读取 Issue comments、closure timeline、source
+Delivery workspace staged/changed/worktree inventory 或完整 PR history。PASS 所需的
+exact-base required-check policy 绑定在同一个 bounded operation-start window 内，不触发
+第二次 full live-state resolve。
+
+```text
+PR changed            → REVIEW_STALE_PR
+PR head changed       → REVIEW_STALE_HEAD
+PR base changed       → REVIEW_STALE_BASE
+Task Contract changed → REVIEW_STALE_TASK
+effective diff changed→ REVIEW_STALE_DIFF
+```
+
+PASS 的 current applicable checks 也必须仍然满足 completion gate；FAIL 只观察 current
+checks，从而不会因 pending 或 failed CI 延迟 semantic finding。若 PR/base/head/Task
+identity 仍一致，effective diff applicability 从仍受 LCK ownership 保护的 sealed Review
+clone 重新机械推导；Review Complete 不要求 source repository materialize reviewed commits。
+
+任何 stale result 都不会把 semantic verdict 发布成当前有效 Review PASS/FAIL，也不会
+解除 fresh-review requirement；必须重新执行新的 Review Prepare。Review Complete
+snapshot 冻结后不得再 nested/full Resolve。
+
+## 6. Verdict semantics and Merge Preflight
+
+正式 Review 只有两种 semantic verdict：PASS / FAIL，但 PASS 还必须经过独立的
+Merge Preflight operation 才能进入人工合并边界。
+
+### PASS
+
+要求：semantic Review 无 blocking finding，Prepare 时 formal Review validation 通过，
+Review Complete fresh identity 与 sealed reviewed target 一致，current applicable checks
+仍通过。
+
+对于 Documentation leaf，semantic Review 还必须依据当前 Documentation contract 检查
+事实准确性、范围、一致性与 artifact correctness；LCK 已在 Delivery / Review 边界执行
+repository-owned typed safe-change policy，禁止把 runtime、tests、CI、Agent control 或
+workflow-policy 修改伪装成文档变化，也不要求不存在的 Critical Outcome evidence。
+
+对于 Bug leaf，semantic Review 还必须依据当前 Observed / Expected /
+Reproduction-or-Evidence / Acceptance Criteria defect contract 判断修复目标和回归证据；
+回归正确性必须针对当前 candidate head，head 变化后旧 Review 自动失效并要求 fresh Review。
+
+Review Complete 返回：
+
+```text
+READY_FOR_MERGE_PREFLIGHT
+```
+
+随后执行新的只读 operation：
+
+```bash
+uv run --frozen python -m tools.lck merge preflight <TASK>
+```
+
+Merge Preflight 再获取一次 fresh `MergeSnapshot`，独立确认 current Task / PR / head /
+base、accepted Review receipt、**exact PR base commit** 中的 required-check policy 与
+当前 exact-head check results、blockers 和 mergeability。当前 checkout 或 PR head
+不能重定义本次 merge 的 required-check authority。只有它返回：
+
+```text
+READY_FOR_HUMAN_MERGE
+```
+
+才可报告 `通过，可以人工合并`，并立即停在 Human manual Squash Merge boundary。
+Agent / Skill / LCK v1 都不自动 merge。
+
+Review Complete 与 Merge Preflight 都做 freshness 检查并不重复：二者是两个独立
+operation，中间 current state 仍可能变化。
+
+### FAIL / `不通过，需要修复`
+
+当当前 reviewed object 存在 Blocking / High / Medium semantic finding，或 Task 要求
+未满足时使用。FAIL 必须提供可供后续修复理解的 findings。
+
+如果 Review Complete 证明该 reviewed target 仍适用，LCK 返回：
+
+```text
+STOP_REQUIRED
+```
+
+并且：
+
+```text
+Review FAIL
+→ STOP
+→ Human decides what to do
+```
+
+绝不自动进入 Remediation，也不存在 Review → Delivery → Review 自动循环。Low / Nit
+可以报告，但不应伪装成 blocking finding。
+
+formal validation / checks 自身无法产生可接受结果时，LCK 在 objective gate 处 STOP；
+不要通过 `CONDITIONAL`、fallback snapshot 或旧 Delivery evidence 绕过 gate。
+
+## 7. Review record boundary
+
+`review complete` 可以把 accepted Review 结果写到 ignored
+`.workflow.local/lck/reviews/` 作为 audit / diagnostic record。它可记录 sealed reviewed
+identity、Prepare validation/checks、fresh completion snapshot/checks 和 semantic findings，
+用于回答“当时审查了什么、在接受 verdict 时它是否仍适用”。
+
+该 record **不是当前机械授权**。Merge Preflight、Remediation、Closeout 都必须在自己的
+operation boundary 获取 fresh Git / GitHub facts。尤其不得把 record 中的旧 head、base、
+checks 或 validation 当作后续写操作的 current identity。
+
+## 8. Explicit Remediation
+
+Remediation 只能由 Human 明确发起，并且必须引用当前 Task **最新已完成且为 FAIL**
+的 LCK `review_id`：
+
+```bash
+uv run --frozen python -m tools.lck remediation prepare <TASK> \
+  --review-id <FAILED_REVIEW_ID>
+```
+
+LCK 默认从 workspace-local failed Review audit record 读取 **semantic findings only**。
+如果 Human 明确切换 clone / Agent runtime，而该 ignored local record 不存在，可以通过
+`--findings-file <COMPLETED_REVIEW_FINDINGS>` 携带已经完成的 Review findings。该文件不是
+Review authority，也不能携带机械 target；LCK 在两种路径下都独立从 live Git / GitHub
+重新解析：
+
+- current Task；
+- current OPEN PR；
+- current PR head/base；
+- current local/remote Task branch；
+- current workspace state。
+
+旧 Review record 或 portable findings file 里的任何 SHA / base / PR identity 都不具有
+admission authority；即使当前 head 已变化，机械 target 也以 live state 为准，findings
+仅作为待理解的语义输入。Local record 存在时继续走原有严格校验路径；portable findings
+只在该 local audit record 缺失时启用，不改变正常 Codex 路径。
+
+Implementation Agent 在 LCK 准备的 current Task workspace 上：
+
+```text
+Understand findings
+→ Repair
+→ Diagnose
+→ add regression coverage
+```
+
+不得直接 commit / push / create PR / change lifecycle state。
+
+## 9. Remediation completion
+
+语义修复完成后：
+
+```bash
+uv run --frozen python -m tools.lck remediation complete <TASK> \
+  --review-id <FAILED_REVIEW_ID> \
+  --commit-message "<repair commit message>" \
+  --summary "<repair summary>" \
+  --risks "<risks or limitations>"
+```
+
+LCK 复用 Initial Delivery 已迁移的 bounded effects：
+
+```text
+reacquire live facts
+→ Bug defect contract (Bug) / Documentation policy (Documentation) / Critical Outcome (Task)
+→ formal Delivery validation
+→ commit exact validated repair tree
+→ ensure remote Task branch
+→ reuse existing OPEN PR
+→ current checks
+→ verify final local/remote/PR head alignment
+→ READY_FOR_NEW_REVIEW
+→ STOP
+```
+
+Remediation 不允许创建替代 PR；current existing OPEN PR 若不存在或身份不再唯一，
+必须 STOP。Remediation complete 也不会自动启动 Review。成功 completion 会写入一个本地
+`fresh-review-required` **negative lifecycle boundary**：它只阻止再次 remediation，
+不选择或授权 PR/head/base；机械 target 仍完全由下一阶段 live state 解析。
+
+任何 repair commit 产生 new head 后，都必须由 Human 在新的 fresh invocation 中
+重新启动 Independent Review。只有新的 Review verdict 被 LCK 正式接受后，该 boundary
+才解除；因此旧 FAIL `review_id` 不能连续驱动第二次 remediation。
+
+## 10. Provider neutrality
+
+Codex 与 Claude 使用同一个 LCK mechanical contract。二者都可以作为
+Implementation Agent 或 fresh Review Agent；provider 选择不改变 lifecycle
+correctness、live-state authority、read-only Review、stale guard、Human boundary
+或 no-auto-remediation 规则。
+
+## 11. Merge / Closeout interaction
+
+PASS 只表示当前 Review invocation 对当时 live-resolved reviewed object 可进入
+Human merge decision。实际 merge 前仍必须由 deterministic merge preflight / Human
+确认 current PR 状态；LCK v1 不自动 merge。
+
+Closeout redesign 不属于本 cutover。任何 Closeout consumer 都不得因为存在旧
+snapshot / handoff 就跳过 current merged identity 的重新确认。

--- a/docs/workflows/lck/typed-profiles.md
+++ b/docs/workflows/lck/typed-profiles.md
@@ -1,0 +1,85 @@
+# Typed leaf workflow architecture
+
+This is the short navigation map for the four supported leaf Issue profiles.
+The complete lifecycle contract remains in
+[`lifecycle.md`](lifecycle.md) and
+the Independent Review contract remains in
+[`review-and-remediation.md`](review-and-remediation.md).
+
+## Routing and ownership
+
+```text
+canonical type:* label
+        ↓
+tools/lck/issue_profiles.py         # one resolver and profile registry
+        ↓
+tools/lck/profile_policies.py       # one profile-policy dispatch layer
+        ↓
+shared LCK phase controllers        # one Delivery / Review / Remediation / Closeout kernel
+        ↓
+Git/GitHub effects, receipts, and lifecycle state
+```
+
+The resolver accepts exactly one canonical leaf label. Missing, conflicting,
+unknown, `type:feature`, and `type:epic` labels stop before effects. Codex and
+Claude select equivalent semantic contracts; neither provider owns a second
+lifecycle controller.
+
+| Type label | Semantic contract owner | Profile-specific policy | Branch namespace | Critical Outcome |
+| --- | --- | --- | --- | --- |
+| `type:task` | Task Issue body | `critical_outcome.py` | `task/` (legacy aliases remain compatible) | required |
+| `type:bug` | Bug Issue form | `bug_policy.py` | `bug/` | not required |
+| `type:documentation` | Documentation Issue form | `documentation_policy.py` | `documentation/` | not required |
+| `type:research` | Research Issue form | `research_policy.py` | `research/` | not required |
+
+The `ProfilePolicyRegistry` stores the policy selectors and candidate
+capabilities.
+`profile_policies.py` is the only adapter that dispatches those selectors to
+the typed policy modules. Phase controllers do not maintain a type allowlist;
+they call the shared adapter and retain one mechanical owner for live-state
+resolution, identity/freshness, validation, effects, receipts, and recovery.
+
+## Ordinary profile extension contract
+
+Adding an ordinary leaf profile is a registration change. The implementation
+may add a profile policy, one registration entry to the existing generic
+registry, profile-owned contract/evidence/blocker schema and codecs, and
+profile-specific tests. It must use the existing generic Issue Form parser,
+policy blocker contract, evidence envelope, effect descriptor/executor,
+phase controllers, and receipt infrastructure.
+
+The shared Delivery, Review, Remediation, and Closeout kernel must not gain a
+profile-specific branch, concrete policy import, fixed result/model/receipt
+field, or new profile semantics in shared facts. Eligibility must aggregate
+the generic shared blocker gate and registered policy blockers; it must not
+contain a special case for a profile or blocker. A profile cannot use an
+arbitrary callable or hidden side effect to bypass the registry, policy
+validation, bounded effect executor, postcondition, or receipt authority.
+For Closeout, the generic policy context distinguishes the target being
+completed from a closed dependency: a target completion postcondition is not
+an admission prerequisite. Research derives its Project outcome only from the
+exact reviewed artifact binding and asks the bounded effect executor to set and
+verify it; maintainers do not pre-populate that field.
+
+The generic registry injection seam is independently testable: an isolated
+registry may register an additional policy and resolve it through the same
+profile metadata contract. The production canonical registry and its four
+supported profiles remain unchanged. Extension tests must exercise only the
+existing generic registration and dispatch boundary; they must not add a
+second lifecycle controller or a profile-specific branch to production code.
+
+Extending a generic protocol or adding a previously absent generic blocker,
+evidence, effect, parser, or Kernel capability is an architecture exception.
+It requires a separately designed and reviewed architecture change; it is not
+part of an ordinary profile registration. The acceptance suite in
+`tests/tools/lck/test_profile_architecture.py` mechanically checks both sets
+of boundaries and the shared Kernel invariants, including immutable snapshots,
+fresh Review identity, maintainer-only merge, bounded effects, postconditions,
+and audit receipt authority.
+
+## Activation evidence
+
+Historical activation identities remain recoverable from Git history and are
+not copied into current product or research documentation. Current live LCK
+receipts, PR identities, fresh Review, and post-merge Closeout are authoritative
+for each execution.

--- a/docs/workflows/lck/validation/README.md
+++ b/docs/workflows/lck/validation/README.md
@@ -1,0 +1,97 @@
+# WSL2 Task Workflow Validation Runner
+
+## Purpose
+
+`wsl2_validation_runner.py` is the single mechanical entry for named local
+validation contracts. It validates complete argv, repository identity, profile
+schema, canonical commands, phase preconditions, CI drift, output location, and
+process cleanup before or while running any subcommand.
+
+It compresses successful evidence; it does not authorize workflow lifecycle
+writes, Review, Merge, or Closeout.
+
+## Entry points
+
+```bash
+uv run --frozen python -m tools.lck.wsl2_validation_runner current-ci-equivalent
+uv run --frozen python -m tools.lck.wsl2_validation_runner targeted
+uv run --frozen python -m tools.lck.wsl2_validation_runner targeted:tools-tests
+uv run --frozen python -m tools.lck.wsl2_validation_runner targeted:workflow-tests
+uv run --frozen python -m tools.lck.wsl2_validation_runner post-merge
+uv run --frozen python -m tools.lck.wsl2_validation_runner workflow-delivery --base-sha <SHA>
+uv run --frozen python -m tools.lck.wsl2_validation_runner workflow-review --base-sha <SHA>
+uv run --frozen python -m tools.lck.wsl2_validation_runner workflow-closeout --base-sha <SHA>
+```
+
+The fixed profiles are defined in
+`tools/lck/config/validation_profiles.json`. Workflow profiles invoke
+`validation_runner.py` once with the corresponding phase contract.
+
+`targeted` profiles are development evidence only. They are not complete
+CI-equivalent validation.
+
+## Current CI contract
+
+The canonical CI command set is:
+
+```bash
+uv lock --check
+uv run --frozen pytest
+uv run --frozen ruff check .
+uv run --frozen ruff format --check .
+uv run --frozen mypy src tools/lck tests
+```
+
+CI-equivalent local profiles also run `git diff --check`. The Runner compares the
+workflow file, profile specification, and in-code canonical allowlist so drift
+fails before evidence is accepted.
+
+## Execution identity
+
+The Runner uses the current repository files. Each result records:
+
+- repository head SHA and clean/dirty state;
+- active Skill path and SHA-256 when the profile belongs to a workflow Skill;
+- Runner, profile specification, Rules, and workflow validation paths and
+  SHA-256 values;
+- profile/schema and exact command results.
+
+These values provide reproducibility. They do not create a main/base control
+plane and do not require cross-commit extraction.
+
+Final `workflow-delivery`, `workflow-review`, and `workflow-closeout` validation
+requires a clean worktree. Development profiles may run while the current files
+are being changed.
+
+## Safety boundary
+
+The Runner:
+
+- starts only from the repository root under the Linux filesystem, not `/mnt`;
+- rejects symlink entry, wrong repository identity, invalid/trailing argv, and
+  non-canonical profile commands;
+- accepts no shell string, arbitrary command, arbitrary pytest argument, or
+  output path;
+- writes only below ignored `.agents/validation.local/wsl2-runs/`;
+- starts each child in a dedicated process group and terminates the complete
+  group on timeout or interruption;
+- stores complete redacted logs locally and prints a compact digest;
+- propagates validation, timeout, interruption, and artifact-write failures as
+  non-zero exits.
+
+The Rules file authorizes fixed Runner profile prefixes and the current CI's
+explicit `uv run --frozen ruff format --check .` shape. Other direct validation
+commands remain fail-closed where prefix matching cannot prove their complete
+argv safe. Prefix routing is not semantic acceptance: the Runner validates the
+complete argv.
+
+## Result contract
+
+Success stdout is one compact JSON object containing profile, status, command
+counts, duration, result path, result SHA-256, and no failed command. Detailed
+per-command argv, exit code, duration, output, truncation, and hashes remain in
+the ignored result directory.
+
+On failure, inspect only the reported failed command and its bounded artifact.
+Do not replay the complete validation chain unless the profile contract itself
+requires a new full run after repair.

--- a/docs/workflows/lck/validation/maintenance-and-adoption.md
+++ b/docs/workflows/lck/validation/maintenance-and-adoption.md
@@ -1,0 +1,58 @@
+# Validation Runner maintenance and adoption
+
+## Synchronized contract
+
+A validation-command change may require coordinated updates to:
+
+1. `.github/workflows/ci.yml`;
+2. `tools/lck/config/validation_profiles.json`;
+3. the Runner canonical command allowlist;
+4. CI/profile drift tests;
+5. exact-argv and failure-path tests;
+6. execpolicy routing tests;
+7. Skill and operational documentation.
+
+Incomplete updates must fail rather than silently execute a different command
+set.
+
+## Development and final validation
+
+During Runner, profile, Rules, or Skill development, use an appropriate targeted
+profile or explicit authorized development checks. Final workflow validation is
+run from the current clean committed head and records actual content hashes.
+There is no separate control-plane checkout or cross-commit bundle.
+
+Rules changes require a fresh Codex session for live verification. Static
+`codex execpolicy check` proves matching behavior but does not prove a running
+session reloaded the changed project Rules.
+
+## Profile design
+
+Add a profile only for a stable named contract. Profiles must not expose
+arbitrary commands, paths, shell expressions, or free-form pytest arguments.
+The readable JSON specification and the independent in-code allowlist are both
+required: the specification describes the plan; the allowlist prevents the plan
+from becoming an arbitrary-command channel.
+
+## Adoption criteria
+
+The Runner is suitable when commands are stable, repeated, and verbose; success
+can be represented by a compact digest; and failure still has command-level
+artifacts. It is not a replacement for interactive implementation commands or
+semantic review.
+
+Maintain these invariants:
+
+- Rules authorize a small entry; the Runner validates complete argv.
+- Targeted evidence is never reported as CI-equivalent evidence.
+- Workflow profiles bind results to the current repository head and active
+  Skill/Runner hashes.
+- Full logs remain ignored and local.
+- Failures, truncation, timeout, and partial evidence remain visible.
+- Post-merge validation requires synchronized clean main identity.
+
+## Rollback
+
+Rollback must revert consuming Skills, Runner/profile contracts, Rules, tests,
+and documentation together. The result must have exactly one complete
+validation path; validation must not be skipped or duplicated.

--- a/docs/workflows/lck/validation/security-hardening-cases.md
+++ b/docs/workflows/lck/validation/security-hardening-cases.md
@@ -1,0 +1,45 @@
+# Validation Runner security cases
+
+## Complete argv
+
+Execpolicy uses prefix matching. A routed prefix may still contain an invalid
+tail. The Runner therefore rejects unexpected argument count, option, value,
+separator, shell form, and non-canonical command before creating success
+evidence.
+
+## Repository and output identity
+
+The entry must be the current repository Runner, invoked from that repository
+root under the Linux filesystem. Symlinks, wrong roots, `/mnt` repositories,
+and output paths outside ignored `.agents/validation.local/wsl2-runs/` fail
+closed.
+
+Result artifacts bind repository head/clean state and current Skill, Runner,
+profile, Rules, and workflow-validation content hashes.
+
+## Writable profile protection
+
+The profile JSON is not an arbitrary command source. Every command ID and argv
+must match an in-code canonical allowlist; workflow profiles have fixed phase,
+base-SHA, validator, and precondition contracts. Modified non-canonical content
+fails before subprocess execution.
+
+## Process tree cleanup
+
+Every child starts in a new POSIX session. Timeout and interruption signal the
+complete process group, wait for a bounded grace period, and escalate when
+necessary. Result-write failure is a Runner failure, not a pass.
+
+## Sensitive output
+
+Complete stdout/stderr stays in ignored local artifacts and is redacted for
+common credentials, authorization headers, cookies, private keys, and secrets.
+The terminal receives only a bounded digest on success and bounded diagnostics
+on failure.
+
+## Governance changes
+
+When a PR modifies a Skill, Runner, Rules, profile, or workflow, independent
+Review directly inspects the changed behavior, tests, permission routing, and
+failure paths. Runner success is evidence, not proof of semantic correctness or
+permission to merge.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,10 @@ dependencies = [
 [dependency-groups]
 dev = [
     "mypy",
+    "pyyaml",
     "pytest",
     "ruff",
+    "types-pyyaml",
 ]
 
 [tool.uv.build-backend]
@@ -30,6 +32,7 @@ addopts = [
     "--strict-config",
     "--strict-markers",
 ]
+pythonpath = ["."]
 testpaths = ["tests"]
 
 [tool.ruff]
@@ -44,6 +47,9 @@ quote-style = "double"
 select = ["E4", "E7", "E9", "F", "I", "UP"]
 
 [tool.mypy]
-files = ["src", "tests"]
+explicit_package_bases = true
+exclude = ["^tests/tools/lck/"]
+files = ["src", "tools/lck", "tests"]
+mypy_path = "src"
 python_version = "3.13"
 strict = true

--- a/tests/acceptance/test_v2_bootstrap.py
+++ b/tests/acceptance/test_v2_bootstrap.py
@@ -9,15 +9,21 @@ from pathlib import Path
 from typing import Any, cast
 
 import tracequant
-from tracequant.integrations import nautilus
+import tracequant.integrations.nautilus as nautilus
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 EXPECTED_NAUTILUS_VERSION = "2.0.0rc4"
 EXPECTED_TOP_LEVEL = {
+    ".agents",
+    ".claude",
+    ".codex",
     ".env.example",
+    ".gitattributes",
     ".github",
     ".gitignore",
     ".python-version",
+    "AGENTS.md",
+    "CLAUDE.md",
     "LICENSE",
     "README.md",
     "config",
@@ -25,6 +31,7 @@ EXPECTED_TOP_LEVEL = {
     "pyproject.toml",
     "src",
     "tests",
+    "tools",
     "uv.lock",
     "uv.toml",
 }
@@ -104,14 +111,11 @@ def test_clean_bootstrap_uses_pinned_external_nautilus() -> None:
     assert nautilus.import_package().__name__ == "nautilus_trader"
 
 
-def test_candidate_tree_matches_the_closed_v2_skeleton() -> None:
+def test_candidate_tree_matches_the_approved_product_and_lck_layout() -> None:
     paths = _candidate_paths()
     assert {path.parts[0] for path in paths} == EXPECTED_TOP_LEVEL
 
     forbidden_roots = {
-        ".agents",
-        ".claude",
-        ".codex",
         ".workflow.local",
         "apps",
         "artifacts",
@@ -120,12 +124,29 @@ def test_candidate_tree_matches_the_closed_v2_skeleton() -> None:
         "packages",
         "runtime",
         "scripts",
-        "tools",
         "vendor",
     }
     assert not ({path.parts[0] for path in paths} & forbidden_roots)
-    assert not any(path.is_relative_to(Path("docs/workflows")) for path in paths)
-    assert not any(path.is_relative_to(Path("tests/tools")) for path in paths)
+    assert all(
+        path.is_relative_to(Path("tools/lck"))
+        for path in paths
+        if path.is_relative_to(Path("tools"))
+    )
+    assert all(
+        path.is_relative_to(Path("tests/tools/lck"))
+        for path in paths
+        if path.is_relative_to(Path("tests/tools"))
+    )
+    assert all(
+        path.is_relative_to(Path("docs/workflows/lck"))
+        for path in paths
+        if path.is_relative_to(Path("docs/workflows"))
+    )
+    assert all(
+        path.is_relative_to(Path("docs/guides/lck"))
+        for path in paths
+        if path.is_relative_to(Path("docs/guides/lck"))
+    )
 
     production_python = {
         path
@@ -140,6 +161,7 @@ def test_candidate_tree_matches_the_closed_v2_skeleton() -> None:
     assert all(
         path.is_relative_to(Path("src/tracequant"))
         or path.is_relative_to(Path("tests"))
+        or path.is_relative_to(Path("tools/lck"))
         for path in paths
         if path.suffix == ".py"
     )
@@ -198,6 +220,10 @@ def test_import_and_generated_path_guards_fail_closed() -> None:
         ".env",
         ".env.*.local",
         "*.local.toml",
+        ".agents/execution-profile.local.toml",
+        ".agents/evidence.local/",
+        ".agents/validation.local/",
+        ".workflow.local/",
     } == ignore_entries
     assert (
         not {
@@ -226,3 +252,58 @@ def test_import_boundary_guard_rejects_direct_and_dynamic_references() -> None:
 
     for source in prohibited_sources:
         assert _contains_forbidden_nautilus_reference(ast.parse(source))
+
+
+def test_lck_and_product_import_boundaries_are_one_way() -> None:
+    for relative_path in _candidate_paths():
+        if relative_path.suffix != ".py":
+            continue
+        if not (
+            relative_path.is_relative_to(Path("src"))
+            or relative_path.is_relative_to(Path("tools/lck"))
+        ):
+            continue
+        tree = ast.parse((REPOSITORY_ROOT / relative_path).read_text(encoding="utf-8"))
+        imported: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported.update(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported.add(node.module)
+        if relative_path.is_relative_to(Path("src")):
+            assert not any(
+                name == "tools.lck" or name.startswith("tools.lck.")
+                for name in imported
+            )
+        else:
+            assert not any(
+                name == "tracequant"
+                or name.startswith("tracequant.")
+                or name == "nautilus_trader"
+                or name.startswith("nautilus_trader.")
+                for name in imported
+            )
+
+
+def test_distribution_excludes_lck_tooling() -> None:
+    build = _toml(REPOSITORY_ROOT / "pyproject.toml")["tool"]["uv"]["build-backend"]
+    assert build == {"module-name": "tracequant", "module-root": "src"}
+
+
+def test_repository_text_approves_lck_without_expanding_product_runtime() -> None:
+    readme = (REPOSITORY_ROOT / "README.md").read_text(encoding="utf-8")
+    structure = (
+        REPOSITORY_ROOT / "docs/architecture/repository-structure.md"
+    ).read_text(encoding="utf-8")
+    baseline = (REPOSITORY_ROOT / "docs/architecture/technical-baseline.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "approved Local Control Kernel (LCK)" in readme
+    assert "tooling under `tools/lck/`" in readme
+    assert "initial v2 bootstrap restriction" in readme
+    assert "initial bootstrap text" in structure
+    assert "exact LCK-owned roots" in structure
+    assert "Repository-only LCK" in baseline
+    assert "engineering tooling is approved outside this runtime" in baseline
+    assert "LCK is not part of the TraceQuant product runtime" in readme

--- a/tests/tools/lck/__init__.py
+++ b/tests/tools/lck/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the repository-owned Local Control Kernel."""

--- a/tests/tools/lck/support.py
+++ b/tests/tools/lck/support.py
@@ -1,0 +1,629 @@
+# ruff: noqa: E402, I001
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+AGENT_WORKFLOW = str(Path(__file__).parents[3] / "tools" / "agent_workflow")
+if AGENT_WORKFLOW not in sys.path:
+    sys.path.insert(0, AGENT_WORKFLOW)
+
+from tools.lck import (  # type: ignore[import-not-found]  # noqa: E402
+    models as lck_models,
+    review_workspace as lck_review_workspace,
+    state as lck_state,
+)
+
+from tools.lck.common import (  # type: ignore[import-not-found]  # noqa: E402
+    CommandResult,
+    sha256_json,
+)
+
+
+SHA = "a" * 40
+
+
+REQUIRED_CHECKS_WORKFLOW_TEXT = """name: CI
+on:
+  pull_request:
+    branches: [main]
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+"""
+
+
+def _write_required_checks_workflow(root: Path) -> None:
+    path = root / ".github" / "workflows" / "ci.yml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(REQUIRED_CHECKS_WORKFLOW_TEXT, encoding="utf-8")
+
+
+@pytest.fixture(autouse=True)
+def _repository_required_checks_contract(tmp_path: Path) -> None:
+    _write_required_checks_workflow(tmp_path)
+
+
+def _required_policy(*names: str, source_sha: str = SHA) -> dict[str, Any]:
+    items = list(names)
+    return {
+        "configuration": "repository-base-ci",
+        "source": f"git:{source_sha}:.github/workflows/ci.yml:jobs",
+        "source_sha": source_sha,
+        "workflow_path": ".github/workflows/ci.yml",
+        "contract_sha256": sha256_json(
+            {"workflow": ".github/workflows/ci.yml", "required-checks": items}
+        ),
+        "contexts": {"items": items, "count": len(items), "truncated": False},
+    }
+
+
+class FakeRunner:
+    def __init__(
+        self,
+        *,
+        branch: str = "main",
+        local_branches: set[str] | None = None,
+        remote_branches: dict[str, str] | None = None,
+        clean: bool = True,
+        head_sha: str = SHA,
+        local_main_sha: str = SHA,
+        remote_main_sha: str = SHA,
+        open_pr: dict[str, Any] | None = None,
+    ) -> None:
+        self.branch = branch
+        self.local_branches = local_branches or set()
+        self.remote_branches = remote_branches or {}
+        self.clean = clean
+        self.head_sha = head_sha
+        self.local_main_sha = local_main_sha
+        self.remote_main_sha = remote_main_sha
+        self.open_pr = open_pr
+        self.commands: list[tuple[str, ...]] = []
+
+    def run(
+        self,
+        argv: list[str] | tuple[str, ...],
+        *,
+        command_id: str,
+        **_: Any,
+    ) -> CommandResult:
+        command = tuple(str(item) for item in argv)
+        self.commands.append(command)
+        args = list(command[1:]) if command and command[0] == "git" else list(command)
+        stdout = ""
+        returncode = 0
+        if args[:2] == ["for-each-ref", "--format=%(refname:short)"]:
+            stdout = "\n".join(sorted(self.local_branches))
+        elif args[:3] == ["ls-remote", "--heads", "origin"]:
+            stdout = "\n".join(
+                f"{oid}\trefs/heads/{branch}"
+                for branch, oid in sorted(self.remote_branches.items())
+            )
+        elif args == ["branch", "--show-current"]:
+            stdout = self.branch
+        elif args == ["rev-parse", "HEAD"]:
+            stdout = self.head_sha
+        elif args[:2] == ["rev-parse", "refs/heads/main"]:
+            stdout = self.local_main_sha
+        elif args[:1] == ["rev-parse"] and len(args) == 2:
+            branch = args[1].removeprefix("refs/heads/")
+            if branch not in self.local_branches:
+                returncode = 1
+            else:
+                stdout = SHA
+        elif args[:3] == ["gh", "pr", "list"]:
+            if self.open_pr is not None:
+                stdout = json.dumps([self.open_pr])
+            else:
+                stdout = "[]"
+        elif args[:3] == ["gh", "pr", "view"]:
+            if self.open_pr is None:
+                returncode = 1
+            else:
+                stdout = json.dumps(self.open_pr)
+        elif (
+            args[:1] == ["show"]
+            and len(args) == 2
+            and args[1].endswith(":.github/workflows/ci.yml")
+        ):
+            stdout = REQUIRED_CHECKS_WORKFLOW_TEXT
+        elif args[:2] == ["gh", "api"] and "required_status_checks" in args[2]:
+            stdout = json.dumps({"contexts": ["quality"]})
+        elif args[:2] == ["switch", "-c"]:
+            branch = args[2]
+            self.local_branches.add(branch)
+            self.branch = branch
+            if len(args) >= 5 and args[3] == "--track":
+                remote = args[4].removeprefix("origin/")
+                self.head_sha = self.remote_branches.get(remote, self.head_sha)
+        elif args[:2] == ["switch", "--track"]:
+            branch = args[3]
+            self.local_branches.add(branch)
+            self.branch = branch
+            remote = args[2].removeprefix("origin/")
+            self.head_sha = self.remote_branches.get(remote, self.head_sha)
+        elif args[:1] == ["switch"]:
+            branch = args[1]
+            if branch not in self.local_branches:
+                returncode = 1
+            else:
+                self.branch = branch
+        else:
+            returncode = 1
+        return CommandResult(
+            command_id=command_id,
+            argv=command,
+            returncode=returncode,
+            stdout=f"{stdout}\n" if stdout else "",
+            stderr="" if returncode == 0 else "unsupported fake command",
+        )
+
+
+def _issue() -> dict[str, Any]:
+    body = "Task Contract"
+    return {
+        "number": 159,
+        "title": "[Task] 建立 LCK Core 与 Live State Resolution",
+        "body_sha256": sha256_json({"body": body}),
+        "state": "OPEN",
+        "labels": {"items": ["type:task", "codex:ready"]},
+        "project_status": "Ready",
+        "critical_outcome": {
+            "status": "valid",
+            "contract": {
+                "caller": "task-delivery-runner initial Delivery",
+                "capability": "LCK Delivery",
+                "observable_result": "READY_FOR_REVIEW",
+                "verification_test": "tests/tools/lck/test_branch_naming.py::test_canonical_branch_is_derived_from_current_issue_title",
+            },
+        },
+    }
+
+
+def _task_contract(issue: dict[str, Any] | None = None) -> dict[str, Any]:
+    value = issue or _issue()
+    body = "Task Contract"
+    return {
+        "number": value.get("number", 159),
+        "title": value.get("title"),
+        "url": value.get("url"),
+        "body": body,
+        "body_sha256": value.get("body_sha256") or sha256_json({"body": body}),
+        "critical_outcome": value.get("critical_outcome"),
+        "bug_contract": value.get("bug_contract"),
+    }
+
+
+def _relationships(
+    *,
+    blocked_by: dict[str, Any] | None = None,
+    issue_type: str | None = "Task",
+) -> dict[str, Any]:
+    return {
+        "available": True,
+        "issue_type": issue_type,
+        "blocked_by": blocked_by
+        if blocked_by is not None
+        else {"items": [], "count": 0, "truncated": False},
+    }
+
+
+def _git_snapshot(fake: FakeRunner) -> dict[str, Any]:
+    return {
+        "branch": fake.branch,
+        "head_sha": fake.head_sha,
+        "local_main_sha": fake.local_main_sha,
+        "tracking_main_sha": fake.remote_main_sha,
+        "remote_main_sha": fake.remote_main_sha,
+        "remote_main_query": "pass",
+        "clean": fake.clean,
+        "status_entries": 0 if fake.clean else 1,
+        "worktree_branches": {"items": [fake.branch], "count": 1, "truncated": False},
+    }
+
+
+def _install_facts(
+    monkeypatch: pytest.MonkeyPatch,
+    fake: FakeRunner,
+    *,
+    issue: dict[str, Any] | None = None,
+    relationships: dict[str, Any] | None = None,
+    open_pr: dict[str, Any] | None = None,
+    history: list[dict[str, Any]] | None = None,
+) -> None:
+    monkeypatch.setattr(lck_state, "_repository_slug", lambda *_args: "owner/repo")
+    issue_value = issue or _issue()
+    monkeypatch.setattr(
+        lck_state,
+        "_issue_view_with_contract",
+        lambda *_args: (issue_value, _task_contract(issue_value)),
+    )
+    monkeypatch.setattr(
+        lck_state,
+        "_relationship_snapshot",
+        lambda *_args: relationships if relationships is not None else _relationships(),
+    )
+    monkeypatch.setattr(
+        lck_state,
+        "_git_snapshot",
+        lambda *_args, **_kwargs: _git_snapshot(fake),
+    )
+    monkeypatch.setattr(lck_state, "resolve_open_pr", lambda *_args: open_pr)
+    monkeypatch.setattr(
+        lck_state, "list_matching_prs", lambda *_args, **_kwargs: history or []
+    )
+
+
+def _resolver(fake: FakeRunner) -> lck_state.LiveStateResolver:
+    return lck_state.LiveStateResolver(Path.cwd(), runner=cast(Any, fake))
+
+
+def _open_pr(
+    branch: str,
+    *,
+    is_draft: bool = False,
+) -> dict[str, Any]:
+    return {
+        "number": 200,
+        "state": "OPEN",
+        "isDraft": is_draft,
+        "baseRefName": "main",
+        "baseRefOid": SHA,
+        "headRefName": branch,
+        "headRefOid": SHA,
+        "url": "https://github.com/owner/repo/pull/200",
+        "statusCheckRollup": [],
+    }
+
+
+def _review_state(
+    *,
+    head: str = SHA,
+    base: str = SHA,
+    clean: bool = True,
+) -> lck_models.LiveState:
+    branch = "task/159-lck-core-live-state-resolution"
+    issue = _issue()
+    issue.update(
+        {
+            "project_status": "Review",
+            "body_sha256": "d" * 64,
+        }
+    )
+    pr = _open_pr(branch)
+    pr.update({"headRefOid": head, "baseRefOid": base})
+    return lck_models.LiveState(
+        task_number=159,
+        repository="owner/repo",
+        issue=issue,
+        relationships=_relationships(),
+        git={
+            "branch": branch,
+            "head_sha": head,
+            "local_main_sha": base,
+            "remote_main_sha": base,
+            "origin_fetch": "pass",
+            "clean": clean,
+        },
+        target_branch=branch,
+        local_task_branch=branch,
+        local_task_head=head,
+        remote_task_branch=branch,
+        remote_task_oid=head,
+        open_pr=pr,
+        merged_pr_numbers=(),
+        merged=False,
+        checks={
+            "count": 1,
+            "failed": 0,
+            "pending": 0,
+            "skipped_or_unknown": 0,
+            "all_success": True,
+        },
+        cleanup={},
+        task_contract={
+            "number": 159,
+            "title": issue["title"],
+            "url": issue.get("url"),
+            "body": "Task Contract",
+            "body_sha256": "d" * 64,
+            "critical_outcome": issue.get("critical_outcome"),
+        },
+    )
+
+
+def _review_identity_value(
+    *, head: str = SHA, base: str = SHA
+) -> lck_review_workspace.ReviewIdentity:
+    return lck_review_workspace.ReviewIdentity(
+        task_number=159,
+        pr_number=200,
+        base_sha=base,
+        head_sha=head,
+        task_body_sha256="d" * 64,
+        merge_base_sha=base,
+        effective_diff_sha256="e" * 64,
+        changed_files=("tools/lck/__main__.py",),
+    )
+
+
+class StaticResolver:
+    def __init__(self, repo_root: Path, state: lck_models.LiveState) -> None:
+        self.repo_root = repo_root
+        self.state = state
+        branch = str(state.git.get("branch") or "main")
+        head_sha = str(state.git.get("head_sha") or state.local_task_head or SHA)
+        local_branches = {state.local_task_branch} if state.local_task_branch else set()
+        remote_branches = (
+            {state.remote_task_branch: str(state.remote_task_oid)}
+            if state.remote_task_branch and state.remote_task_oid
+            else {}
+        )
+        self.runner = cast(
+            Any,
+            FakeRunner(
+                branch=branch,
+                local_branches=local_branches,
+                remote_branches=remote_branches,
+                clean=state.git.get("clean") is True,
+                head_sha=head_sha,
+                local_main_sha=str(state.git.get("local_main_sha") or SHA),
+                remote_main_sha=str(state.git.get("remote_main_sha") or SHA),
+                open_pr=dict(state.open_pr)
+                if isinstance(state.open_pr, dict)
+                else None,
+            ),
+        )
+        self.calls = 0
+
+    def resolve(self, _task_number: int) -> lck_models.LiveState:
+        self.calls += 1
+        return self.state
+
+
+class FakeWorkspaceRunner:
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.status_output = ""
+        self.commands: list[tuple[str, ...]] = []
+
+    def run(
+        self,
+        argv: list[str] | tuple[str, ...],
+        *,
+        command_id: str,
+        **_: Any,
+    ) -> CommandResult:
+        command = tuple(str(item) for item in argv)
+        self.commands.append(command)
+        args = list(command[1:]) if command and command[0] == "git" else list(command)
+        stdout = ""
+        if args == ["worktree", "list", "--porcelain"]:
+            stdout = f"worktree {self.root}\n"
+        elif args == ["status", "--porcelain=v1", "--untracked-files=all"]:
+            stdout = self.status_output
+        elif args == ["rev-parse", "HEAD"]:
+            stdout = f"{SHA}\n"
+        else:
+            return CommandResult(
+                command_id=command_id,
+                argv=command,
+                returncode=1,
+                stdout="",
+                stderr=f"unsupported fake command: {args}",
+            )
+        return CommandResult(
+            command_id=command_id,
+            argv=command,
+            returncode=0,
+            stdout=stdout,
+            stderr="",
+        )
+
+
+class FakeReviewWorkspace:
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.sealed: list[Path] = []
+        self.ready_checked: list[Path] = []
+        self.removed: list[Path] = []
+
+    def path_for(self, _task: int, _operation_id: str) -> Path:
+        return self.root
+
+    def create(
+        self,
+        _task: int,
+        _base: str,
+        _head: str,
+        path: Path | None = None,
+    ) -> Path:
+        root = path or self.root
+        root.mkdir(parents=True, exist_ok=True)
+        return root
+
+    def seal_read_only(self, path: Path) -> None:
+        self.sealed.append(path)
+
+    def seal_for_review(self, path: Path, _head: str) -> None:
+        self.seal_read_only(path)
+
+    def assert_ready_for_completion(self, path: Path, _head: str) -> None:
+        self.ready_checked.append(path)
+
+    def remove(self, path: Path) -> None:
+        self.removed.append(path)
+
+    def remove_recovered(self, path: Path) -> None:
+        self.remove(path)
+
+
+class FakeReviewChecks:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def evaluate(self, snapshot: lck_models.OperationSnapshot) -> dict[str, Any]:
+        self.calls += 1
+        pr = snapshot.state.open_pr or {}
+        return {
+            "status": "pass",
+            "pr": {
+                "number": pr.get("number", 200),
+                "head_sha": pr.get("headRefOid", SHA),
+                "base_sha": pr.get("baseRefOid", SHA),
+            },
+            "checks": snapshot.state.checks,
+        }
+
+    def observe(self, snapshot: lck_models.OperationSnapshot) -> dict[str, Any]:
+        self.calls += 1
+        pr = snapshot.state.open_pr or {}
+        return {
+            "status": "observed",
+            "gate": "non-blocking",
+            "check_state": "pending",
+            "pr": {
+                "number": pr.get("number", 200),
+                "head_sha": pr.get("headRefOid", SHA),
+                "base_sha": pr.get("baseRefOid", SHA),
+            },
+            "checks": snapshot.state.checks,
+        }
+
+
+class FakeReviewValidation:
+    def run(self, _root: Path, _base: str, _head: str) -> dict[str, Any]:
+        return {"status": "pass", "phase": "review"}
+
+
+def _review_guard(
+    identity: lck_review_workspace.ReviewIdentity,
+    *,
+    review_root: Path | str = "review-root",
+) -> dict[str, Any]:
+    return {
+        "task_number": 159,
+        "identity": identity.to_dict(),
+        "review_root": str(review_root),
+        "checks": {
+            "status": "pass",
+            "pr": {
+                "number": identity.pr_number,
+                "head_sha": identity.head_sha,
+                "base_sha": identity.base_sha,
+            },
+        },
+        "validation": {"status": "pass"},
+        "snapshot": {
+            "schema_version": lck_models.LCK_SCHEMA_VERSION,
+            "operation": "review-prepare",
+            "state": {"task_number": identity.task_number},
+        },
+    }
+
+
+def _write_owned_candidate_session(
+    store: lck_review_workspace.ReviewInvocationStore,
+    review_id: str,
+    *,
+    start_head: str = SHA,
+    candidate_head: str = "b" * 40,
+    candidate_tree: str = "c" * 40,
+) -> None:
+    operation_id = store.new_id()
+    store.write_remediation_session(
+        159,
+        {
+            "schema_version": lck_models.LCK_SCHEMA_VERSION,
+            "kind": "remediation-session",
+            "task_number": 159,
+            "review_id": review_id,
+            "operation_id": operation_id,
+            "start_head_sha": start_head,
+            "pr_number": 200,
+            "base_sha": SHA,
+            "findings_sha256": "f" * 64,
+            "findings_source": "local-review-record",
+            "candidate": {
+                "operation_id": operation_id,
+                "start_head_sha": start_head,
+                "head_sha": candidate_head,
+                "tree_oid": candidate_tree,
+            },
+            "authority": "test",
+        },
+    )
+
+
+class OwnedCandidateRunner(FakeRunner):
+    def __init__(self, *, head_sha: str, tree_oid: str) -> None:
+        branch = "task/159-lck-core-live-state-resolution"
+        open_pr = _open_pr(branch)
+        super().__init__(
+            branch=branch,
+            local_branches={branch},
+            remote_branches={branch: SHA},
+            clean=True,
+            head_sha=head_sha,
+            open_pr=open_pr,
+        )
+        self.tree_oid = tree_oid
+
+    def run(
+        self,
+        argv: list[str] | tuple[str, ...],
+        *,
+        command_id: str,
+        **kwargs: Any,
+    ) -> CommandResult:
+        command = tuple(str(item) for item in argv)
+        if command == ("git", "rev-parse", "HEAD^{tree}"):
+            self.commands.append(command)
+            return CommandResult(command_id, command, 0, f"{self.tree_oid}\n", "")
+        if command == ("git", "diff", "--quiet"):
+            self.commands.append(command)
+            return CommandResult(command_id, command, 0, "", "")
+        if command[:3] == ("git", "diff", "--quiet"):
+            self.commands.append(command)
+            return CommandResult(command_id, command, 1, "", "")
+        if command == (
+            "git",
+            "status",
+            "--porcelain=v1",
+            "--untracked-files=all",
+        ):
+            self.commands.append(command)
+            return CommandResult(command_id, command, 0, "", "")
+        if command == ("git", "write-tree"):
+            self.commands.append(command)
+            return CommandResult(command_id, command, 0, f"{self.tree_oid}\n", "")
+        if command[:3] == ("git", "cat-file", "-e"):
+            self.commands.append(command)
+            return CommandResult(command_id, command, 0, "", "")
+        if command[:3] == ("git", "merge-base", "--is-ancestor"):
+            self.commands.append(command)
+            return CommandResult(command_id, command, 0, "", "")
+        if command[:3] == ("git", "push", "-u"):
+            self.commands.append(command)
+            self.remote_branches[self.branch] = self.head_sha
+            assert self.open_pr is not None
+            self.open_pr["headRefOid"] = self.head_sha
+            return CommandResult(command_id, command, 0, "", "")
+        if command == (
+            "git",
+            "rev-parse",
+            "--abbrev-ref",
+            "--symbolic-full-name",
+            "@{upstream}",
+        ):
+            self.commands.append(command)
+            return CommandResult(command_id, command, 0, f"origin/{self.branch}\n", "")
+        return super().run(argv, command_id=command_id, **kwargs)

--- a/tests/tools/lck/test_acceptance.py
+++ b/tests/tools/lck/test_acceptance.py
@@ -1,0 +1,135 @@
+"""Repository-level acceptance tests for the restored LCK capability."""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+from pathlib import Path
+
+from tools.lck import cli, issue_profiles
+
+ROOT = Path(__file__).resolve().parents[3]
+LCK_ROOT = ROOT / "tools" / "lck"
+SKILLS = (
+    "task-delivery-runner",
+    "task-pr-review-runner",
+    "task-closeout",
+    "feature-completion-audit",
+)
+
+
+def _imports(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    result: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            result.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            result.add(node.module)
+    return result
+
+
+def test_restored_lck_runs_from_current_repository_layout() -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "tools.lck", "--help"],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    for command in ("delivery", "review", "remediation", "merge", "closeout"):
+        assert command in result.stdout
+
+    assert Path(cli.__file__).resolve().is_relative_to(LCK_ROOT)
+    assert not (ROOT / "tools" / "agent_workflow").exists()
+    assert not (ROOT / "src" / "tracequant" / "contracts" / "review.py").exists()
+
+
+def test_restored_lck_is_separate_from_product_code_and_distribution() -> None:
+    for path in LCK_ROOT.glob("*.py"):
+        imported = _imports(path)
+        assert not any(
+            name == "tracequant"
+            or name.startswith("tracequant.")
+            or name == "nautilus_trader"
+            or name.startswith("nautilus_trader.")
+            for name in imported
+        ), path
+
+    product_source = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in (ROOT / "src" / "tracequant").rglob("*.py")
+    )
+    assert "tools.lck" not in product_source
+    pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    assert 'module-root = "src"' in pyproject
+    assert 'module-name = "tracequant"' in pyproject
+
+
+def test_lck_exposes_the_complete_lifecycle_parser() -> None:
+    parser = cli._build_parser()
+    commands = (
+        ("delivery", "prepare", "333"),
+        (
+            "delivery",
+            "complete",
+            "333",
+            "--commit-message",
+            "m",
+            "--summary",
+            "s",
+        ),
+        ("review", "prepare", "333"),
+        (
+            "review",
+            "complete",
+            "333",
+            "--review-id",
+            "r",
+            "--verdict",
+            "PASS",
+        ),
+        ("remediation", "prepare", "333", "--review-id", "r"),
+        ("merge", "preflight", "333"),
+        ("closeout", "333"),
+    )
+    for argv in commands:
+        assert parser.parse_args(argv).command == argv[0]
+
+
+def test_typed_leaf_profiles_share_the_restored_kernel() -> None:
+    profiles = issue_profiles.PROFILES_BY_TYPE_LABEL
+    assert set(profiles) == {
+        "type:task",
+        "type:bug",
+        "type:documentation",
+        "type:research",
+    }
+    assert all(profile.lifecycle_enabled for profile in profiles.values())
+    assert len({profile.profile_id for profile in profiles.values()}) == 4
+
+
+def test_agent_assets_have_one_canonical_source_and_thin_adapters() -> None:
+    for skill in SKILLS:
+        canonical = ROOT / ".agents" / "skills" / skill / "SKILL.md"
+        adapter = ROOT / ".claude" / "skills" / skill / "SKILL.md"
+        assert canonical.is_file()
+        adapter_text = adapter.read_text(encoding="utf-8")
+        assert canonical.relative_to(ROOT).as_posix() in adapter_text
+        assert len(adapter_text.splitlines()) < 15
+        assert "python -m tools.lck" in canonical.read_text(encoding="utf-8")
+
+
+def test_restoration_manifest_records_source_objects_and_decisions() -> None:
+    manifest = (ROOT / "docs/workflows/lck/restoration-manifest.md").read_text(
+        encoding="utf-8"
+    )
+    assert "0d9d762238a3e837a864b5350bf16d1b885a73c3" in manifest
+    assert "tools/lck/" in manifest
+    assert "tests/tools/lck/" in manifest
+    assert "docs/workflows/lck/" in manifest
+    assert "restored/adapted" in manifest
+    assert "omitted" in manifest

--- a/tests/tools/lck/test_agent_neutral_workflow.py
+++ b/tests/tools/lck/test_agent_neutral_workflow.py
@@ -1,0 +1,59 @@
+"""Tests for agent-neutral LCK routing and source ownership."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools.lck.skill_audit import SKILLS, audit
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_shared_semantic_owner_docs_are_lck_only() -> None:
+    for relative in (
+        "docs/workflows/lck/lifecycle.md",
+        "docs/workflows/lck/review-and-remediation.md",
+        "docs/workflows/lck/issue-contracts.md",
+        "docs/workflows/lck/typed-profiles.md",
+        "docs/guides/lck/overview.md",
+    ):
+        assert (ROOT / relative).is_file()
+    assert not (ROOT / "docs/development").exists()
+
+
+def test_natural_language_routes_to_canonical_skills() -> None:
+    agents = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
+    for skill in SKILLS:
+        assert f".agents/skills/{skill}/SKILL.md" in agents
+    assert "uv run --frozen python -m tools.lck --help" in agents
+
+
+def test_claude_is_a_thin_agent_adapter() -> None:
+    claude = (ROOT / "CLAUDE.md").read_text(encoding="utf-8")
+    assert "AGENTS.md" in claude
+    assert ".claude/settings.json" in claude
+    assert len(claude.splitlines()) < 20
+
+
+def test_each_claude_skill_points_to_one_canonical_source() -> None:
+    for skill in SKILLS:
+        adapter = (ROOT / ".claude" / "skills" / skill / "SKILL.md").read_text(
+            encoding="utf-8"
+        )
+        assert f".agents/skills/{skill}/SKILL.md" in adapter
+        assert len(adapter.splitlines()) < 15
+
+
+def test_skill_audit_accepts_the_current_layout() -> None:
+    result, returncode = audit(ROOT)
+    assert returncode == 0, result["violations"]
+    assert result["status"] == "pass"
+    assert set(result["canonical_skills"]) == set(SKILLS)
+    assert set(result["adapters"]) == set(SKILLS)
+
+
+def test_agent_skills_guide_is_navigation_not_product_documentation() -> None:
+    guide = (ROOT / "docs/workflows/lck/agent-skills.md").read_text(encoding="utf-8")
+    assert ".agents/skills/" in guide
+    assert "tools/lck/" in guide
+    assert "src/tracequant" not in guide

--- a/tests/tools/lck/test_branch_naming.py
+++ b/tests/tools/lck/test_branch_naming.py
@@ -1,0 +1,23 @@
+# ruff: noqa: E402, I001
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+AGENT_WORKFLOW = str(Path(__file__).parents[3] / "tools" / "agent_workflow")
+if AGENT_WORKFLOW not in sys.path:
+    sys.path.insert(0, AGENT_WORKFLOW)
+
+from tools.lck import (  # type: ignore[import-not-found]  # noqa: E402
+    models as lck_models,
+)
+
+
+def test_canonical_branch_is_derived_from_current_issue_title() -> None:
+    assert (
+        lck_models.canonical_task_branch(
+            159, "[Task] 建立 LCK Core 与 Live State Resolution"
+        )
+        == "task/159-lck-core-live-state-resolution"
+    )

--- a/tests/tools/lck/test_bug.py
+++ b/tests/tools/lck/test_bug.py
@@ -1,0 +1,427 @@
+# ruff: noqa: E402, I001
+
+"""Acceptance tests for the implementation-bearing Bug LCK profile."""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import replace
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+ROOT = Path(__file__).parents[3]
+AGENT_WORKFLOW = str(ROOT / "tools" / "agent_workflow")
+if AGENT_WORKFLOW not in sys.path:
+    sys.path.insert(0, AGENT_WORKFLOW)
+
+from tools.lck.bug_policy import (  # type: ignore[import-not-found]  # noqa: E402
+    BugPolicyStatus,
+    bug_contract_snapshot,
+    bug_template_contract,
+    is_valid_bug_contract,
+)
+from tools.lck import (  # type: ignore[import-not-found]  # noqa: E402
+    closeout as lck_closeout,
+    eligibility as lck_eligibility,
+    issue_profiles as lck_profiles,
+    models as lck_models,
+    review_workspace as lck_review_workspace,
+)
+from .support import (  # noqa: E402
+    FakeRunner,
+    StaticResolver,
+    _install_facts,
+    _issue,
+    _relationships,
+    _resolver,
+    _review_identity_value,
+    _review_state,
+)
+from tools.lck.common import CommandResult  # type: ignore[import-not-found]  # noqa: E402
+from tools.lck.feature_audit import (  # type: ignore[import-not-found]  # noqa: E402
+    _issue_view_with_contract,
+)
+
+
+BUG_BODY = """### Observed
+
+The Bug profile is rejected before an implementation workspace can be prepared.
+
+### Expected
+
+An implementation-bearing Bug uses the shared lifecycle without a wrapper Task.
+
+### Reproduction / Evidence
+
+The profile resolver reports the canonical type:bug profile as disabled.
+
+### Acceptance Criteria
+
+- A valid Bug reaches shared Delivery admission without a fabricated Critical Outcome.
+- A regression test or equivalent evidence is reviewed against the candidate head.
+"""
+
+
+def _bug_issue() -> dict[str, Any]:
+    issue = _issue()
+    issue.update(
+        {
+            "number": 159,
+            "title": "[Bug] enable implementation-bearing Bug workflow",
+            "body": BUG_BODY,
+            "body_sha256": "d" * 64,
+            "labels": {"items": ["type:bug", "codex:ready"]},
+            "critical_outcome": None,
+            "bug_contract": bug_contract_snapshot(BUG_BODY),
+        }
+    )
+    return issue
+
+
+def test_live_issue_view_carries_the_bug_form_contract() -> None:
+    class Runner:
+        repo_root = ROOT
+
+        def run(self, argv: Any, *, command_id: str, **_: Any) -> CommandResult:
+            value: dict[str, Any]
+            if command_id == "gh-issue-project-items-159":
+                value = {
+                    "data": {
+                        "repository": {
+                            "issue": {
+                                "number": 159,
+                                "projectItems": {
+                                    "nodes": [
+                                        {
+                                            "project": {
+                                                "number": 1,
+                                                "title": "Quant System Development",
+                                                "owner": {"login": "owner"},
+                                            },
+                                            "content": {
+                                                "number": 159,
+                                                "repository": {
+                                                    "nameWithOwner": "owner/repo"
+                                                },
+                                            },
+                                            "fieldValues": {
+                                                "nodes": [],
+                                                "pageInfo": {"hasNextPage": False},
+                                            },
+                                        }
+                                    ],
+                                    "pageInfo": {"hasNextPage": False},
+                                },
+                            }
+                        }
+                    }
+                }
+            else:
+                value = {
+                    "number": 159,
+                    "title": "[Bug] enable implementation-bearing Bug workflow",
+                    "state": "OPEN",
+                    "labels": [{"name": "type:bug"}],
+                    "body": BUG_BODY,
+                }
+            return CommandResult(
+                command_id,
+                tuple(str(item) for item in argv),
+                0,
+                json.dumps(value),
+                "",
+            )
+
+    warnings: list[dict[str, Any]] = []
+    issue, contract = _issue_view_with_contract(
+        Runner(),
+        "owner/repo",
+        159,
+        warnings,
+        include_comments=False,
+        include_closure=False,
+    )
+
+    assert warnings == []
+    assert issue is not None
+    assert contract is not None
+    assert issue["bug_contract"]["status"] == BugPolicyStatus.PASS.value
+    assert contract["bug_contract"] == issue["bug_contract"]
+    assert "critical_outcome" not in contract or contract["critical_outcome"] is None
+
+
+def test_bug_profile_uses_defect_contract_without_task_critical_outcome(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The supported Bug entrypoint is shared LCK admission, not Task wrapping."""
+
+    issue = _bug_issue()
+    fake = FakeRunner(branch="main")
+    _install_facts(
+        monkeypatch,
+        fake,
+        issue=issue,
+        relationships=_relationships(issue_type="Bug"),
+    )
+
+    resolution = lck_profiles.resolve_leaf_issue_profile(issue)
+    assert resolution.resolved
+    assert resolution.profile is lck_profiles.BUG_PROFILE
+    assert resolution.profile.lifecycle_enabled
+    assert not resolution.profile.requires_critical_outcome
+    assert resolution.profile.branch_namespace == "bug/"
+
+    state = _resolver(fake).resolve(159)
+    decision = lck_eligibility.PhaseEligibilityResolver().resolve(
+        state, lck_models.Phase.DELIVERY_PREPARE
+    )
+
+    assert decision.eligible
+    assert decision.capabilities == ("prepare_task_workspace",)
+    assert state.target_branch == "bug/159-enable-implementation-bearing-bug-workflow"
+    assert state.issue is not None
+    assert is_valid_bug_contract(cast(Any, state.issue["bug_contract"]))
+    assert state.issue["critical_outcome"] is None
+
+
+def test_bug_contract_is_bound_to_form_and_fails_closed_on_ambiguous_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    assert bug_template_contract().field_ids == (
+        "observed",
+        "expected",
+        "reproduction_evidence",
+        "acceptance_criteria",
+    )
+
+    ambiguous = BUG_BODY.replace(
+        "### Reproduction / Evidence",
+        "### Expected\n\nA second conflicting expected behavior.\n\n"
+        "### Reproduction / Evidence",
+    )
+    contract = bug_contract_snapshot(ambiguous)
+    assert contract["status"] == BugPolicyStatus.RECLASSIFICATION_REQUIRED.value
+    assert contract["duplicate_sections"] == ["Expected"]
+    assert not is_valid_bug_contract(contract)
+
+    issue = _bug_issue()
+    issue["body"] = ambiguous
+    issue["bug_contract"] = contract
+    fake = FakeRunner(branch="main")
+    _install_facts(
+        monkeypatch,
+        fake,
+        issue=issue,
+        relationships=_relationships(issue_type="Bug"),
+    )
+    decision = lck_eligibility.PhaseEligibilityResolver().resolve(
+        _resolver(fake).resolve(159), lck_models.Phase.DELIVERY_PREPARE
+    )
+    assert not decision.eligible
+    assert any("Bug defect contract invalid" in reason for reason in decision.reasons)
+    assert any("duplicate sections: Expected" in reason for reason in decision.reasons)
+
+
+def _body_with_section_content(body: str, section: str, content: str) -> str:
+    marker = f"### {section}\n\n"
+    start = body.index(marker) + len(marker)
+    end = body.find("\n### ", start)
+    if end < 0:
+        end = len(body)
+    return body[:start] + content.strip() + "\n\n" + body[end + 1 :]
+
+
+@pytest.mark.parametrize(
+    ("section", "placeholder"),
+    [
+        ("Observed", "实际发生：\n..."),
+        ("Expected", "正确行为应为：\n..."),
+        ("Reproduction / Evidence", "复现步骤或证据：\n无法在当前环境复现"),
+        ("Acceptance Criteria", "- [ ] ..."),
+    ],
+)
+def test_bug_form_placeholders_stop_before_delivery_admission(
+    monkeypatch: pytest.MonkeyPatch,
+    section: str,
+    placeholder: str,
+) -> None:
+    body = _body_with_section_content(BUG_BODY, section, placeholder)
+    contract = bug_contract_snapshot(body)
+
+    assert contract["status"] == BugPolicyStatus.RECLASSIFICATION_REQUIRED.value
+    assert section in contract["insufficient_sections"]
+
+    issue = _bug_issue()
+    issue.update({"body": body, "bug_contract": contract})
+    fake = FakeRunner(branch="main")
+    _install_facts(
+        monkeypatch,
+        fake,
+        issue=issue,
+        relationships=_relationships(issue_type="Bug"),
+    )
+    decision = lck_eligibility.PhaseEligibilityResolver().resolve(
+        _resolver(fake).resolve(159), lck_models.Phase.DELIVERY_PREPARE
+    )
+
+    assert not decision.eligible
+    assert any("Bug defect contract invalid" in reason for reason in decision.reasons)
+
+
+def test_bug_review_stales_when_candidate_head_changes() -> None:
+    reviewed = _review_identity_value()
+    state = _review_state()
+    bug_contract = bug_contract_snapshot(BUG_BODY)
+    issue = dict(state.issue)
+    issue.update(
+        {
+            "labels": {"items": ["type:bug", "codex:ready"]},
+            "body": BUG_BODY,
+            "bug_contract": bug_contract,
+            "critical_outcome": None,
+        }
+    )
+    assert state.task_contract is not None
+    task_contract = dict(state.task_contract)
+    task_contract.update(
+        {
+            "body": BUG_BODY,
+            "body_sha256": reviewed.task_body_sha256,
+            "bug_contract": bug_contract,
+        }
+    )
+    pr = dict(state.open_pr or {})
+    pr.update(
+        {
+            "headRefName": "bug/159-enable-implementation-bearing-bug-workflow",
+            "headRefOid": "b" * 40,
+        }
+    )
+    bug_state = replace(
+        state,
+        issue=issue,
+        task_contract=task_contract,
+        target_branch="bug/159-enable-implementation-bearing-bug-workflow",
+        open_pr=pr,
+    )
+
+    with pytest.raises(lck_models.ReviewStaleError, match="REVIEW_STALE_HEAD"):
+        lck_review_workspace._assert_review_target_facts_applicable(
+            reviewed, bug_state, task_contract
+        )
+
+
+def test_bug_branch_namespace_isolated_from_task_aliases() -> None:
+    assert lck_models.branch_matches_profile(
+        "bug/159-enable-implementation-bearing-bug-workflow",
+        159,
+        lck_profiles.BUG_PROFILE,
+    )
+    assert not lck_models.branch_matches_profile(
+        "task/159-enable-implementation-bearing-bug-workflow",
+        159,
+        lck_profiles.BUG_PROFILE,
+    )
+    assert not lck_models.branch_matches_profile(
+        "bug/159-enable-implementation-bearing-bug-workflow",
+        159,
+        lck_profiles.TASK_PROFILE,
+    )
+
+
+def test_bug_closeout_uses_shared_path_for_merged_bug_branch() -> None:
+    state = _review_state()
+    bug_branch = "bug/159-enable-implementation-bearing-bug-workflow"
+    bug_contract = bug_contract_snapshot(BUG_BODY)
+    issue = dict(state.issue)
+    issue.update(
+        {
+            "state": "CLOSED",
+            "labels": {"items": ["type:bug"]},
+            "project_status": "Done",
+            "body": BUG_BODY,
+            "bug_contract": bug_contract,
+            "critical_outcome": None,
+            "issue_closure": {
+                "evidence_status": "complete",
+                "status": "closed-by-pr",
+                "closer_repository": "owner/repo",
+                "closer_number": 200,
+            },
+        }
+    )
+    merged_pr = {
+        "number": 200,
+        "state": "MERGED",
+        "baseRefName": "main",
+        "baseRefOid": "a" * 40,
+        "headRefName": bug_branch,
+        "headRefOid": "a" * 40,
+        "mergeCommit": {"oid": "b" * 40},
+        "mergedAt": "2026-08-23T00:00:00Z",
+        "closingIssuesReferences": [{"number": 159}],
+    }
+    task_contract = dict(cast(dict[str, Any], state.task_contract))
+    task_contract.update(
+        {"body": BUG_BODY, "bug_contract": bug_contract, "critical_outcome": None}
+    )
+    bug_state = replace(
+        state,
+        issue=issue,
+        relationships=_relationships(issue_type="Bug"),
+        target_branch=bug_branch,
+        local_task_branch=bug_branch,
+        local_task_head="a" * 40,
+        remote_task_branch=bug_branch,
+        remote_task_oid="a" * 40,
+        open_pr=None,
+        merged_pr_numbers=(200,),
+        merged=True,
+        merged_pr=merged_pr,
+        task_contract=task_contract,
+    )
+
+    class FixedEffect:
+        def __init__(self, effect: str, action: str) -> None:
+            self.receipt = lck_models.EffectReceipt(
+                effect=effect, action=action, details={}
+            )
+
+        def execute(self, *_args: Any, **_kwargs: Any) -> lck_models.EffectReceipt:
+            return self.receipt
+
+    class ReviewStore:
+        def read_latest_review(self, _task_number: int) -> dict[str, Any]:
+            return {"task_number": 159, "review_id": "bug-review", "verdict": "PASS"}
+
+        def read_record(self, _task_number: int, _review_id: str) -> dict[str, Any]:
+            return {
+                "task_number": 159,
+                "review_id": "bug-review",
+                "verdict": "PASS",
+                "status": "READY_FOR_MERGE_PREFLIGHT",
+                "identity": {
+                    "task_number": 159,
+                    "pr_number": 200,
+                    "base_sha": "a" * 40,
+                    "head_sha": "a" * 40,
+                    "task_body_sha256": issue["body_sha256"],
+                    "merge_base_sha": "a" * 40,
+                    "effective_diff_sha256": "e" * 64,
+                    "changed_files": [],
+                },
+            }
+
+    result = lck_closeout.CloseoutCompleter(
+        StaticResolver(Path.cwd(), bug_state),
+        main_effect=FixedEffect("synchronize_main", "synchronized"),
+        metadata_effect=FixedEffect("converge_task_metadata", "already-converged"),
+        cleanup_effect=FixedEffect("cleanup_task_refs", "already-clean"),
+        review_store=ReviewStore(),
+    ).complete(159)
+
+    assert result.business_delivery == "COMPLETE"
+    assert result.cleanup == "COMPLETE"

--- a/tests/tools/lck/test_closeout.py
+++ b/tests/tools/lck/test_closeout.py
@@ -1,0 +1,673 @@
+# ruff: noqa: E402, I001
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+AGENT_WORKFLOW = str(Path(__file__).parents[3] / "tools" / "agent_workflow")
+if AGENT_WORKFLOW not in sys.path:
+    sys.path.insert(0, AGENT_WORKFLOW)
+
+from tools.lck import (  # type: ignore[import-not-found]  # noqa: E402
+    closeout as lck_closeout,
+    models as lck_models,
+    review as lck_review,
+    state as lck_state,
+)
+
+
+SHA = "a" * 40
+MERGE_SHA = "b" * 40
+BRANCH = "task/162-closeout"
+
+
+def _state(
+    *,
+    local_branch: str | None = None,
+    remote_branch: str | None = None,
+    remote_oid: str | None = None,
+    merged_head: str = SHA,
+    issue_state: str = "CLOSED",
+) -> lck_models.LiveState:
+    issue = {
+        "number": 162,
+        "title": "[Task] closeout",
+        "state": issue_state,
+        "labels": {"items": ["type:task", "codex:ready"]},
+        "body_sha256": "d" * 64,
+        "project_status": "Done",
+        "issue_closure": {
+            "evidence_status": "complete",
+            "status": "closed-by-pr",
+            "closer_repository": "owner/repo",
+            "closer_number": 262,
+        },
+    }
+    merged_pr = {
+        "number": 262,
+        "state": "MERGED",
+        "baseRefName": "main",
+        "baseRefOid": SHA,
+        "headRefName": BRANCH,
+        "headRefOid": merged_head,
+        "mergeCommit": {"oid": MERGE_SHA},
+        "mergedAt": "2026-08-23T00:00:00Z",
+        "closingIssuesReferences": [{"number": 162}],
+    }
+    return lck_models.LiveState(
+        task_number=162,
+        repository="owner/repo",
+        issue=issue,
+        relationships={
+            "available": True,
+            "blocked_by": {"items": [], "count": 0, "truncated": False},
+        },
+        git={
+            "branch": "main",
+            "head_sha": MERGE_SHA,
+            "local_main_sha": MERGE_SHA,
+            "remote_main_sha": MERGE_SHA,
+            "origin_fetch": "pass",
+            "clean": True,
+            "worktree_branches": {"items": ["main"], "count": 1},
+        },
+        target_branch=BRANCH,
+        local_task_branch=local_branch,
+        local_task_head=merged_head if local_branch else None,
+        remote_task_branch=remote_branch,
+        remote_task_oid=remote_oid,
+        open_pr=None,
+        merged_pr_numbers=(262,),
+        merged=True,
+        merged_pr=merged_pr,
+        checks={
+            "count": 0,
+            "failed": 0,
+            "pending": 0,
+            "skipped_or_unknown": 0,
+            "all_success": True,
+        },
+        cleanup={
+            "business_delivery": "complete",
+            "cleanup": "pending",
+        },
+        task_contract={
+            "number": 162,
+            "title": "[Task] closeout",
+            "body": "Task Contract",
+            "body_sha256": "d" * 64,
+        },
+    )
+
+
+class RequiredChecksRunner:
+    def run(
+        self, argv: list[str] | tuple[str, ...], *, command_id: str, **_kwargs: Any
+    ) -> Any:
+        command = tuple(str(item) for item in argv)
+        if command[:2] == ("git", "show") and command[2].endswith(
+            ":.github/workflows/ci.yml"
+        ):
+            return SimpleNamespace(
+                returncode=0,
+                stdout="name: CI\njobs:\n  quality:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo ok\n",
+                stderr="",
+                command_id=command_id,
+                argv=command,
+            )
+        if command[:2] == ("gh", "api") and "required_status_checks" in command[2]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps({"contexts": []}),
+                stderr="",
+                command_id=command_id,
+                argv=command,
+            )
+        return SimpleNamespace(
+            returncode=1,
+            stdout="",
+            stderr="unsupported",
+            command_id=command_id,
+            argv=command,
+        )
+
+
+class StaticResolver:
+    def __init__(self, state: lck_models.LiveState) -> None:
+        self.repo_root = Path.cwd()
+        self.state = state
+        self.runner = cast(Any, RequiredChecksRunner())
+        self.calls = 0
+
+    def resolve(self, _task_number: int) -> lck_models.LiveState:
+        self.calls += 1
+        return self.state
+
+
+class SequenceResolver:
+    def __init__(self, *states: lck_models.LiveState) -> None:
+        self.repo_root = Path.cwd()
+        self.states = states
+        self.index = 0
+        self.runner = cast(Any, RequiredChecksRunner())
+
+    def resolve(self, _task_number: int) -> lck_models.LiveState:
+        state = self.states[min(self.index, len(self.states) - 1)]
+        self.index += 1
+        return state
+
+
+class StaticReviewStore:
+    def __init__(self, *, head_sha: str = SHA) -> None:
+        self.latest = {"task_number": 162, "review_id": "review", "verdict": "PASS"}
+        self.record = {
+            "task_number": 162,
+            "review_id": "review",
+            "verdict": "PASS",
+            "status": "READY_FOR_MERGE_PREFLIGHT",
+            "identity": {
+                "task_number": 162,
+                "pr_number": 262,
+                "base_sha": SHA,
+                "head_sha": head_sha,
+                "task_body_sha256": "d" * 64,
+                "merge_base_sha": SHA,
+                "effective_diff_sha256": "e" * 64,
+                "changed_files": [],
+            },
+        }
+
+    def read_latest_review(self, _task_number: int) -> dict[str, Any]:
+        return self.latest
+
+    def read_record(self, _task_number: int, _review_id: str) -> dict[str, Any]:
+        return self.record
+
+
+class RecordingRunner:
+    def __init__(
+        self,
+        returncode: int = 0,
+        *,
+        pr_view: str = "",
+        remote_outputs: list[str] | None = None,
+    ) -> None:
+        self.returncode = returncode
+        self.pr_view = pr_view
+        self.remote_outputs = list(remote_outputs or [])
+        self.calls: list[tuple[str, ...]] = []
+
+    def run(self, argv: list[str], **_kwargs: Any) -> Any:
+        self.calls.append(tuple(argv))
+        if argv[:3] == ["gh", "pr", "view"]:
+            stdout = self.pr_view
+        elif argv[:3] == ["git", "ls-remote", "--heads"] and self.remote_outputs:
+            stdout = self.remote_outputs.pop(0)
+        else:
+            stdout = ""
+        return SimpleNamespace(returncode=self.returncode, stdout=stdout, stderr="")
+
+
+class FixedEffect:
+    def __init__(self, receipt: lck_models.EffectReceipt) -> None:
+        self.receipt = receipt
+
+    def execute(self, *_args: Any, **_kwargs: Any) -> lck_models.EffectReceipt:
+        return self.receipt
+
+
+def _receipt(effect: str, action: str) -> lck_models.EffectReceipt:
+    return lck_models.EffectReceipt(effect=effect, action=action, details={})
+
+
+def test_closeout_resolves_business_delivery_and_cleanup_from_live_state() -> None:
+    resolver = StaticResolver(_state())
+    result = lck_closeout.CloseoutCompleter(
+        cast(Any, resolver),
+        main_effect=cast(
+            Any, FixedEffect(_receipt("synchronize_main", "synchronized"))
+        ),
+        metadata_effect=cast(
+            Any,
+            FixedEffect(_receipt("converge_task_metadata", "already-converged")),
+        ),
+        cleanup_effect=cast(
+            Any,
+            FixedEffect(_receipt("cleanup_task_refs", "already-clean")),
+        ),
+        review_store=cast(Any, StaticReviewStore()),
+    ).complete(162)
+
+    assert result.business_delivery == "COMPLETE"
+    assert result.cleanup == "COMPLETE"
+    assert result.status == "BUSINESS_DELIVERY_COMPLETE"
+
+
+def test_closeout_keeps_business_complete_when_cleanup_is_pending() -> None:
+    resolver = StaticResolver(_state())
+    result = lck_closeout.CloseoutCompleter(
+        cast(Any, resolver),
+        main_effect=cast(Any, FixedEffect(_receipt("synchronize_main", "pending"))),
+        metadata_effect=cast(
+            Any,
+            FixedEffect(_receipt("converge_task_metadata", "pending")),
+        ),
+        cleanup_effect=cast(
+            Any,
+            FixedEffect(_receipt("cleanup_task_refs", "pending")),
+        ),
+        review_store=cast(Any, StaticReviewStore()),
+    ).complete(162)
+
+    assert result.business_delivery == "COMPLETE"
+    assert result.cleanup == "PENDING"
+
+
+def test_closeout_stops_on_remote_divergence() -> None:
+    state = _state(
+        remote_branch=BRANCH,
+        remote_oid="c" * 40,
+    )
+    with pytest.raises(lck_models.LckStopError, match="remote Task branch diverges"):
+        lck_closeout.CloseoutCompleter(
+            cast(Any, StaticResolver(state)),
+            main_effect=cast(
+                Any,
+                FixedEffect(_receipt("synchronize_main", "synchronized")),
+            ),
+            metadata_effect=cast(
+                Any,
+                FixedEffect(_receipt("converge_task_metadata", "already-converged")),
+            ),
+            cleanup_effect=cast(
+                Any,
+                FixedEffect(_receipt("cleanup_task_refs", "already-clean")),
+            ),
+            review_store=cast(Any, StaticReviewStore()),
+        ).complete(162)
+
+
+def test_merge_preflight_has_manual_merge_boundary() -> None:
+    pr = {
+        "number": 262,
+        "state": "OPEN",
+        "isDraft": False,
+        "baseRefName": "main",
+        "baseRefOid": SHA,
+        "headRefName": BRANCH,
+        "headRefOid": SHA,
+        "mergeable": "MERGEABLE",
+    }
+    issue = {
+        "number": 162,
+        "title": "[Task] closeout",
+        "state": "OPEN",
+        "labels": {"items": ["type:task", "codex:ready"]},
+        "project_status": "Review",
+        "body_sha256": "d" * 64,
+    }
+    state = lck_models.LiveState(
+        task_number=162,
+        repository="owner/repo",
+        issue=issue,
+        relationships={
+            "available": True,
+            "blocked_by": {"items": [], "count": 0, "truncated": False},
+        },
+        git={
+            "branch": BRANCH,
+            "head_sha": SHA,
+            "local_main_sha": SHA,
+            "remote_main_sha": SHA,
+            "origin_fetch": "pass",
+            "clean": True,
+        },
+        target_branch=BRANCH,
+        local_task_branch=BRANCH,
+        local_task_head=SHA,
+        remote_task_branch=BRANCH,
+        remote_task_oid=SHA,
+        open_pr=pr,
+        merged_pr_numbers=(),
+        merged=False,
+        checks={
+            "count": 0,
+            "failed": 0,
+            "pending": 0,
+            "skipped_or_unknown": 0,
+            "all_success": True,
+        },
+        cleanup={},
+    )
+
+    class Review:
+        def run(self, _task: int, _state: lck_models.LiveState) -> dict[str, Any]:
+            return {"status": "pass", "review_id": "review"}
+
+    class Checks:
+        def evaluate(self, _snapshot: lck_models.OperationSnapshot) -> dict[str, Any]:
+            return {
+                "status": "pass",
+                "configuration": "not-configured",
+                "required": [],
+                "observed": {},
+                "pr": {"number": 262, "head_sha": SHA, "base_sha": SHA},
+            }
+
+    result = lck_review.MergePreflight(
+        cast(Any, StaticResolver(state)),
+        review_gate=cast(Any, Review()),
+        checks_gate=cast(Any, Checks()),
+    ).run(162)
+
+    assert result.status == "READY_FOR_HUMAN_MERGE"
+    assert result.to_dict()["automatic_merge"] is False
+
+
+def test_merge_preflight_uses_one_fresh_transition_snapshot() -> None:
+    pr = {
+        "number": 262,
+        "state": "OPEN",
+        "isDraft": False,
+        "baseRefName": "main",
+        "baseRefOid": SHA,
+        "headRefName": BRANCH,
+        "headRefOid": SHA,
+        "mergeable": "MERGEABLE",
+    }
+    issue = {
+        "number": 162,
+        "title": "[Task] closeout",
+        "state": "OPEN",
+        "labels": {"items": ["type:task", "codex:ready"]},
+        "project_status": "Review",
+        "body_sha256": "d" * 64,
+    }
+    state = lck_models.LiveState(
+        task_number=162,
+        repository="owner/repo",
+        issue=issue,
+        relationships={
+            "available": True,
+            "blocked_by": {"items": [], "count": 0, "truncated": False},
+        },
+        git={"branch": BRANCH, "clean": True},
+        target_branch=BRANCH,
+        local_task_branch=BRANCH,
+        local_task_head=SHA,
+        remote_task_branch=BRANCH,
+        remote_task_oid=SHA,
+        open_pr=pr,
+        merged_pr_numbers=(),
+        merged=False,
+        checks={
+            "count": 0,
+            "failed": 0,
+            "pending": 0,
+            "skipped_or_unknown": 0,
+            "all_success": True,
+        },
+        cleanup={},
+    )
+    changed = replace(state, issue={**issue, "project_status": "In Progress"})
+
+    class Review:
+        def run(self, _task: int, _state: lck_models.LiveState) -> dict[str, Any]:
+            return {"status": "pass", "review_id": "review"}
+
+    class Checks:
+        def evaluate(self, _snapshot: lck_models.OperationSnapshot) -> dict[str, Any]:
+            return {
+                "status": "pass",
+                "configuration": "not-configured",
+                "required": [],
+                "observed": {},
+                "pr": {"number": 262, "head_sha": SHA, "base_sha": SHA},
+            }
+
+    resolver = SequenceResolver(state, changed)
+    result = lck_review.MergePreflight(
+        cast(Any, resolver),
+        review_gate=cast(Any, Review()),
+        checks_gate=cast(Any, Checks()),
+    ).run(162)
+
+    assert result.status == "READY_FOR_HUMAN_MERGE"
+    assert resolver.index == 1
+
+
+def test_closeout_requires_reviewed_head_identity() -> None:
+    state = _state()
+    with pytest.raises(
+        lck_models.LckStopError, match="does not match the latest Review PASS"
+    ):
+        lck_closeout.CloseoutCompleter(
+            cast(Any, StaticResolver(state)),
+            review_store=cast(Any, StaticReviewStore(head_sha="c" * 40)),
+        ).complete(162)
+
+
+def test_closeout_rejects_stale_task_contract_identity() -> None:
+    state = _state()
+    stale = replace(
+        state,
+        task_contract={
+            **cast(dict[str, Any], state.task_contract),
+            "body_sha256": "f" * 64,
+        },
+    )
+    with pytest.raises(
+        lck_models.LckStopError,
+        match="Review PASS is stale: Task Contract changed",
+    ):
+        lck_closeout.CloseoutCompleter(
+            cast(Any, StaticResolver(stale)),
+            review_store=cast(Any, StaticReviewStore()),
+        ).complete(162)
+
+
+def test_closeout_stops_on_incomplete_merge_identity() -> None:
+    state = _state()
+    incomplete = dict(cast(dict[str, Any], state.merged_pr))
+    incomplete.pop("mergeCommit")
+    with pytest.raises(lck_models.LckStopError, match="identity is incomplete"):
+        lck_closeout.CloseoutCompleter(
+            cast(Any, StaticResolver(replace(state, merged_pr=incomplete))),
+            review_store=cast(Any, StaticReviewStore()),
+        ).complete(162)
+
+
+def test_cleanup_proves_squash_tree_when_refs_are_already_deleted() -> None:
+    runner = RecordingRunner()
+    resolver = StaticResolver(_state())
+    resolver.runner = cast(Any, runner)
+    result = lck_closeout.CleanupTaskRefsEffect(cast(Any, resolver)).execute(
+        _state(),
+        expected_head_sha=SHA,
+        merge_sha=MERGE_SHA,
+    )
+
+    assert result.action == "already-clean"
+    assert ("git", "diff", "--quiet", SHA, MERGE_SHA) in runner.calls
+
+
+def test_cleanup_rechecks_tip_before_non_force_remote_deletion() -> None:
+    runner = RecordingRunner(
+        remote_outputs=[f"{SHA}\trefs/heads/{BRANCH}\n", ""],
+    )
+    resolver = StaticResolver(_state(remote_branch=BRANCH, remote_oid=SHA))
+    resolver.runner = cast(Any, runner)
+
+    result = lck_closeout.CleanupTaskRefsEffect(cast(Any, resolver)).execute(
+        _state(remote_branch=BRANCH, remote_oid=SHA),
+        expected_head_sha=SHA,
+        merge_sha=MERGE_SHA,
+    )
+
+    assert result.action == "cleaned"
+    delete_call = next(call for call in runner.calls if "--delete" in call)
+    assert delete_call == ("git", "push", "origin", "--delete", BRANCH)
+    assert all("force" not in item for item in delete_call)
+
+
+def test_closeout_does_not_full_resolve_after_effects() -> None:
+    state = _state()
+    unresolved = replace(
+        state,
+        status=lck_models.ResolutionStatus.STOP,
+        stop_reasons=("ambiguous recovery",),
+    )
+    resolver = SequenceResolver(state, unresolved)
+
+    result = lck_closeout.CloseoutCompleter(
+        cast(Any, resolver),
+        main_effect=cast(
+            Any,
+            FixedEffect(_receipt("synchronize_main", "synchronized")),
+        ),
+        metadata_effect=cast(
+            Any,
+            FixedEffect(_receipt("converge_task_metadata", "already-converged")),
+        ),
+        cleanup_effect=cast(
+            Any,
+            FixedEffect(_receipt("cleanup_task_refs", "already-clean")),
+        ),
+        review_store=cast(Any, StaticReviewStore()),
+    ).complete(162)
+
+    assert result.business_delivery == "COMPLETE"
+    assert resolver.index == 1
+
+
+def test_resolver_recovers_deleted_noncanonical_branch_from_closing_pr(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = "PhoenixSss/tracequant"
+    branch = "task/162-merge-preflightcloseout-recovery-lck"
+    pr = {
+        "number": 167,
+        "url": f"https://github.com/{repository}/pull/167",
+        "state": "MERGED",
+        "isDraft": False,
+        "baseRefName": "main",
+        "baseRefOid": SHA,
+        "headRefName": branch,
+        "headRefOid": SHA,
+        "mergeCommit": {"oid": MERGE_SHA},
+        "mergedAt": "2026-08-23T00:00:00Z",
+        "headRepository": {"nameWithOwner": repository},
+        "closingIssuesReferences": [{"number": 162}],
+    }
+    issue = {
+        "number": 162,
+        "title": "[Task] 将 Merge Preflight、Closeout 与 Recovery 迁移至 LCK",
+        "state": "CLOSED",
+        "labels": {"items": ["type:task"]},
+        "issue_closure": {
+            "evidence_status": "complete",
+            "closed_by_pull_requests": {
+                "items": [
+                    {
+                        "number": 167,
+                        "state": "MERGED",
+                        "merged": True,
+                        "url": pr["url"],
+                        "repository": repository,
+                    }
+                ],
+                "count": 1,
+                "truncated": False,
+            },
+        },
+    }
+    runner = RecordingRunner(pr_view=json.dumps(pr))
+    resolver = lck_state.LiveStateResolver(
+        Path.cwd(), runner=cast(Any, runner), repository=repository
+    )
+
+    monkeypatch.setattr(
+        lck_state,
+        "_issue_view_with_contract",
+        lambda *_args: (
+            issue,
+            {
+                "number": 162,
+                "title": issue.get("title"),
+                "url": issue.get("url"),
+                "body": "Task Contract",
+                "body_sha256": issue.get("body_sha256", "d" * 64),
+                "critical_outcome": issue.get("critical_outcome"),
+            },
+        ),
+    )
+    monkeypatch.setattr(
+        lck_state,
+        "_relationship_snapshot",
+        lambda *_args: {
+            "available": True,
+            "blocked_by": {"items": [], "count": 0, "truncated": False},
+        },
+    )
+    monkeypatch.setattr(
+        lck_state,
+        "_git_snapshot",
+        lambda *_args, **_kwargs: {
+            "origin_fetch": "pass",
+            "branch": "main",
+            "head_sha": MERGE_SHA,
+            "local_main_sha": MERGE_SHA,
+            "remote_main_sha": MERGE_SHA,
+            "clean": True,
+            "worktree_branches": {"items": ["main"], "count": 1},
+        },
+    )
+    monkeypatch.setattr(
+        resolver,
+        "_task_branches",
+        lambda *_args: (set(), {}, True),
+    )
+    open_pr_branches: list[str] = []
+    history_branches: list[str] = []
+
+    def resolve_open(
+        _runner: Any,
+        _repository: str,
+        current_branch: str,
+        _base_branch: str,
+        _warnings: list[dict[str, Any]],
+    ) -> None:
+        open_pr_branches.append(current_branch)
+        return None
+
+    def list_history(
+        _runner: Any,
+        _repository: str,
+        current_branch: str,
+        _base_branch: str,
+        _warnings: list[dict[str, Any]],
+        *,
+        include_history_details: bool,
+    ) -> list[dict[str, Any]]:
+        assert include_history_details is True
+        history_branches.append(current_branch)
+        return [pr]
+
+    monkeypatch.setattr(lck_state, "resolve_open_pr", resolve_open)
+    monkeypatch.setattr(lck_state, "list_matching_prs", list_history)
+
+    state = resolver.resolve(162)
+
+    assert state.status is lck_models.ResolutionStatus.RESOLVED
+    assert state.target_branch == branch
+    assert state.merged is True
+    assert state.merged_pr == pr
+    assert open_pr_branches == [branch]
+    assert history_branches == [branch]

--- a/tests/tools/lck/test_closeout_additional.py
+++ b/tests/tools/lck/test_closeout_additional.py
@@ -1,0 +1,211 @@
+# ruff: noqa: E402, I001
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import (
+    Any,
+    cast,
+)
+
+import pytest
+
+AGENT_WORKFLOW = str(Path(__file__).parents[3] / "tools" / "agent_workflow")
+if AGENT_WORKFLOW not in sys.path:
+    sys.path.insert(0, AGENT_WORKFLOW)
+
+from tools.lck import (  # type: ignore[import-not-found]  # noqa: E402
+    closeout as lck_closeout,
+    eligibility as lck_eligibility,
+    models as lck_models,
+)
+from tools.lck.github_prs import list_matching_prs  # type: ignore[import-not-found]  # noqa: E402
+from tools.lck.common import (  # type: ignore[import-not-found]  # noqa: E402
+    CommandResult,
+)
+from .support import (  # noqa: E402
+    FakeRunner,
+    StaticResolver,
+    SHA,
+    _install_facts,
+    _issue,
+    _open_pr,
+    _relationships,
+    _resolver,
+    _review_state,
+)
+
+
+@pytest.mark.parametrize(
+    ("phase", "project_status", "open_pr"),
+    [
+        (lck_models.Phase.DELIVERY_PREPARE, "Ready", None),
+        (lck_models.Phase.REVIEW_PREPARE, "Review", "review"),
+        (lck_models.Phase.REMEDIATION_PREPARE, "Review", "remediation"),
+    ],
+)
+def test_all_non_closeout_phases_require_task_type(
+    monkeypatch: pytest.MonkeyPatch,
+    phase: lck_models.Phase,
+    project_status: str,
+    open_pr: str | None,
+) -> None:
+    branch = "task/159-lck-core-live-state-resolution"
+    fake = FakeRunner(
+        branch=branch, local_branches={branch}, remote_branches={branch: SHA}
+    )
+    issue = _issue()
+    issue["project_status"] = project_status
+    issue["labels"] = {"items": ["type:feature", "codex:ready"]}
+    phase_pr = _open_pr(branch) if open_pr is not None else None
+    _install_facts(
+        monkeypatch,
+        fake,
+        issue=issue,
+        relationships=_relationships(issue_type="Feature"),
+        open_pr=phase_pr,
+    )
+
+    state = _resolver(fake).resolve(159)
+    decision = lck_eligibility.PhaseEligibilityResolver().resolve(state, phase)
+
+    assert not decision.eligible
+    assert any("type:task" in reason for reason in decision.reasons)
+
+
+@pytest.mark.parametrize(
+    ("phase", "project_status", "open_pr"),
+    [
+        (lck_models.Phase.DELIVERY_PREPARE, "Ready", None),
+        (lck_models.Phase.REVIEW_PREPARE, "Review", "review"),
+        (lck_models.Phase.REMEDIATION_PREPARE, "Review", "remediation"),
+    ],
+)
+def test_all_non_closeout_phases_reject_lifecycle_label_conflict(
+    monkeypatch: pytest.MonkeyPatch,
+    phase: lck_models.Phase,
+    project_status: str,
+    open_pr: str | None,
+) -> None:
+    branch = "task/159-lck-core-live-state-resolution"
+    fake = FakeRunner(
+        branch=branch, local_branches={branch}, remote_branches={branch: SHA}
+    )
+    issue = _issue()
+    issue["project_status"] = project_status
+    issue["labels"] = {"items": ["type:task", "codex:ready", "codex:needs-spec"]}
+    phase_pr = _open_pr(branch) if open_pr is not None else None
+    _install_facts(
+        monkeypatch,
+        fake,
+        issue=issue,
+        open_pr=phase_pr,
+    )
+
+    state = _resolver(fake).resolve(159)
+    decision = lck_eligibility.PhaseEligibilityResolver().resolve(state, phase)
+
+    assert not decision.eligible
+    assert any("lifecycle labels" in reason for reason in decision.reasons)
+
+
+def test_closeout_eligibility_uses_merged_live_pr_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    branch = "task/159-lck-core-live-state-resolution"
+    fake = FakeRunner(branch=branch, local_branches={branch})
+    closed_issue = _issue()
+    closed_issue.update({"state": "CLOSED", "project_status": "Done"})
+    _install_facts(
+        monkeypatch,
+        fake,
+        issue=closed_issue,
+        history=[{"number": 200, "state": "MERGED"}],
+    )
+
+    state = _resolver(fake).resolve(159)
+    decision = lck_eligibility.PhaseEligibilityResolver().resolve(
+        state, lck_models.Phase.CLOSEOUT
+    )
+
+    assert state.merged is True
+    assert decision.eligible
+
+
+def test_closeout_cleanup_keeps_exact_worktree_safety_precondition(
+    tmp_path: Path,
+) -> None:
+    state = _review_state()
+
+    class WorktreeInUseRunner:
+        def __init__(self) -> None:
+            self.commands: list[tuple[str, ...]] = []
+
+        def run(
+            self,
+            argv: list[str] | tuple[str, ...],
+            *,
+            command_id: str,
+            **_: Any,
+        ) -> CommandResult:
+            command = tuple(str(item) for item in argv)
+            self.commands.append(command)
+            assert command_id == "lck-closeout-worktree-precondition"
+            assert command == ("git", "worktree", "list", "--porcelain")
+            return CommandResult(
+                command_id,
+                command,
+                0,
+                f"worktree /tmp/task\nbranch refs/heads/{state.target_branch}\n",
+                "",
+            )
+
+    resolver = cast(Any, StaticResolver(tmp_path, state))
+    runner = WorktreeInUseRunner()
+    resolver.runner = runner
+
+    receipt = lck_closeout.CleanupTaskRefsEffect(resolver).execute(
+        state,
+        expected_head_sha=SHA,
+        merge_sha="b" * 40,
+    )
+
+    assert receipt.action == "pending"
+    assert (
+        receipt.details["reason"] == "verified Task branch is still used by a worktree"
+    )
+    assert runner.commands == [("git", "worktree", "list", "--porcelain")]
+
+
+def test_closeout_history_query_retains_required_identity_details() -> None:
+    fake = FakeRunner()
+
+    assert (
+        list_matching_prs(
+            cast(Any, fake),
+            "owner/repo",
+            "task/159-lck-core-live-state-resolution",
+            "main",
+            [],
+            include_checks=False,
+            include_mergeability=False,
+            include_history_details=True,
+        )
+        == []
+    )
+
+    command = fake.commands[-1]
+    fields = set(command[command.index("--json") + 1].split(","))
+    assert {
+        "number",
+        "state",
+        "baseRefName",
+        "baseRefOid",
+        "headRefName",
+        "headRefOid",
+        "mergeCommit",
+        "mergedAt",
+        "closingIssuesReferences",
+    } <= fields
+    assert {"statusCheckRollup", "mergeable"}.isdisjoint(fields)

--- a/tests/tools/lck/test_critical_outcome.py
+++ b/tests/tools/lck/test_critical_outcome.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+AGENT_WORKFLOW = str(Path(__file__).parents[3] / "tools" / "agent_workflow")
+if AGENT_WORKFLOW not in sys.path:
+    sys.path.insert(0, AGENT_WORKFLOW)
+
+from tools.lck.critical_outcome import (  # type: ignore[import-not-found]  # noqa: E402
+    CriticalOutcomeError,
+    critical_outcome_snapshot,
+    parse_critical_outcome,
+)
+
+
+def _body(
+    verification: str = "tests/tools/lck/test_branch_naming.py::test_canonical_branch_is_derived_from_current_issue_title",
+) -> str:
+    return f"""### Objective
+Do one thing.
+
+### Critical Outcome
+Caller: task-delivery-runner initial Delivery
+Capability: LCK owns deterministic Delivery completion
+Observable result: validated Task head is committed, pushed and attached to one OPEN PR
+Verification test: {verification}
+
+### Acceptance Criteria
+- [ ] works
+"""
+
+
+def test_parse_critical_outcome_contract() -> None:
+    contract = parse_critical_outcome(_body())
+
+    assert contract.caller == "task-delivery-runner initial Delivery"
+    assert contract.capability == "LCK owns deterministic Delivery completion"
+    assert contract.observable_result.startswith("validated Task head")
+    assert contract.verification_test.startswith(
+        "tests/tools/lck/test_branch_naming.py::"
+    )
+
+
+@pytest.mark.parametrize("heading_level", range(1, 7))
+def test_parser_accepts_all_standard_markdown_heading_levels(
+    heading_level: int,
+) -> None:
+    body = _body().replace(
+        "### Critical Outcome",
+        f"{'#' * heading_level} Critical Outcome",
+    )
+
+    assert parse_critical_outcome(body).capability == (
+        "LCK owns deterministic Delivery completion"
+    )
+
+
+def test_parser_rejects_plain_text_critical_outcome_marker() -> None:
+    body = _body().replace("### Critical Outcome", "Critical Outcome")
+
+    with pytest.raises(CriticalOutcomeError, match="exactly one"):
+        parse_critical_outcome(body)
+
+
+def test_parser_rejects_duplicate_critical_outcome_headings_across_levels() -> None:
+    body = _body().replace(
+        "### Acceptance Criteria",
+        "## Critical Outcome\n\n### Acceptance Criteria",
+    )
+
+    with pytest.raises(CriticalOutcomeError, match="exactly one"):
+        parse_critical_outcome(body)
+
+
+def test_parser_does_not_absorb_fields_from_a_later_issue_section() -> None:
+    body = """### Critical Outcome
+Caller: task-delivery-runner initial Delivery
+Capability: LCK owns deterministic Delivery completion
+Observable result: validated Task head is committed, pushed and attached to one OPEN PR
+
+### Acceptance Criteria
+Verification test: tests/tools/lck/test_branch_naming.py::test_canonical_branch_is_derived_from_current_issue_title
+"""
+
+    with pytest.raises(CriticalOutcomeError, match="missing required fields"):
+        parse_critical_outcome(body)
+
+
+def test_parser_ignores_fenced_critical_outcome_heading() -> None:
+    body = """### Objective
+Do one thing.
+
+```markdown
+## Critical Outcome
+Caller: fake
+Capability: fake
+Observable result: fake
+Verification test: tests/tools/lck/test_branch_naming.py::test_fake
+```
+
+### Critical Outcome
+Caller: real
+Capability: bounded effect
+Observable result: observable result
+Verification test: tests/tools/lck/test_branch_naming.py::test_canonical_branch_is_derived_from_current_issue_title
+"""
+
+    assert parse_critical_outcome(body).caller == "real"
+
+
+def test_parser_accepts_markdown_bullet_and_bold_labels() -> None:
+    body = """### Critical Outcome
+- **Caller:** CLI
+- **Capability:** bounded effect
+- **Observable result:** observable result
+- **Verification test:** `tests/tools/lck/test_branch_naming.py::test_canonical_branch_is_derived_from_current_issue_title`
+"""
+    assert parse_critical_outcome(body).caller == "CLI"
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "### Objective\nmissing",
+        "### Critical Outcome\nCaller: x\nCapability: y\nObservable result: z",
+        _body("pytest tests/tools/lck/test_branch_naming.py"),
+        _body("../../tmp/test_bad.py::test_bad"),
+        _body("tests/tools/lck/test_branch_naming.py::test_x && rm -rf /"),
+    ],
+)
+def test_invalid_or_unsafe_contract_fails_closed(body: str) -> None:
+    with pytest.raises(CriticalOutcomeError):
+        parse_critical_outcome(body)
+
+
+def test_snapshot_is_compact_and_does_not_copy_issue_body() -> None:
+    snapshot = critical_outcome_snapshot(_body())
+
+    assert snapshot["status"] == "valid"
+    assert "body" not in snapshot
+    assert snapshot["contract"]["verification_test"].startswith("tests/")
+
+
+def test_task_issue_template_requires_critical_outcome() -> None:
+    root = Path(__file__).parents[3]
+    text = (root / ".github/ISSUE_TEMPLATE/task.yml").read_text(encoding="utf-8")
+    marker = "id: critical_outcome"
+    assert marker in text
+    section = text.split(marker, 1)[1].split("  - type:", 1)[0]
+    assert "label: Critical Outcome" in section
+    assert "required: true" in section
+    assert "Verification test: tests/.../test_*.py::test_*" in section

--- a/tests/tools/lck/test_delivery.py
+++ b/tests/tools/lck/test_delivery.py
@@ -1,0 +1,2245 @@
+# ruff: noqa: E402
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from dataclasses import replace
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+AGENT_WORKFLOW = str(Path(__file__).parents[3] / "tools" / "agent_workflow")
+if AGENT_WORKFLOW not in sys.path:
+    sys.path.insert(0, AGENT_WORKFLOW)
+
+from tools.lck import (  # type: ignore[import-not-found]  # noqa: E402
+    cli as lck_cli,
+)
+from tools.lck import (
+    delivery as lck_delivery,
+)
+from tools.lck import (
+    effects as lck_effects,
+)
+from tools.lck import (
+    models as lck_models,
+)
+from tools.lck import (
+    receipts as lck_receipts,
+)
+from tools.lck import (
+    review_workspace as lck_review_workspace,
+)
+from tools.lck import (
+    state as lck_state,
+)
+from tools.lck import validation_gates as lck_validation
+from tools.lck.common import (  # type: ignore[import-not-found]  # noqa: E402
+    CommandResult,
+    CommandRunner,
+    sha256_json,
+)
+
+SHA = "a" * 40
+
+
+def _without_route_contract(text: str) -> str:
+    """Remove the Codex-only `## Execution route contract` section.
+
+    The sandbox route (sandbox-first / elevated-first) is a Codex
+    execution-profile concept; Claude Code permissions come from
+    `.claude/settings.json`, so the Claude Skills deliberately omit it.
+    """
+    marker = "## Execution route contract"
+    start = text.find(marker)
+    assert start != -1
+    ends = [
+        index
+        for probe in ("\n## ", "\nIt must contain")
+        if (index := text.find(probe, start)) != -1
+    ]
+    assert ends
+    return text[:start] + text[min(ends) + 1 :]
+
+
+REQUIRED_CHECKS_WORKFLOW_TEXT = """name: CI
+on:
+  pull_request:
+    branches: [main]
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+"""
+
+
+def _write_required_checks_workflow(root: Path) -> None:
+    path = root / ".github" / "workflows" / "ci.yml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(REQUIRED_CHECKS_WORKFLOW_TEXT, encoding="utf-8")
+
+
+@pytest.fixture(autouse=True)
+def _repository_required_checks_contract(tmp_path: Path) -> None:
+    _write_required_checks_workflow(tmp_path)
+
+
+def _required_policy(*names: str, source_sha: str = SHA) -> dict[str, Any]:
+    items = list(names)
+    return {
+        "configuration": "repository-base-ci",
+        "source": f"git:{source_sha}:.github/workflows/ci.yml:jobs",
+        "source_sha": source_sha,
+        "workflow_path": ".github/workflows/ci.yml",
+        "contract_sha256": sha256_json(
+            {"workflow": ".github/workflows/ci.yml", "required-checks": items}
+        ),
+        "contexts": {"items": items, "count": len(items), "truncated": False},
+    }
+
+
+def _git(cwd: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=cwd, capture_output=True, text=True, check=True
+    )
+    return result.stdout.strip()
+
+
+def _repo(tmp_path: Path) -> tuple[Path, Path]:
+    repo = tmp_path / "repo"
+    origin = tmp_path / "origin.git"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.name", "Test")
+    _git(repo, "config", "user.email", "test@example.invalid")
+    (repo / "seed.txt").write_text("seed\n", encoding="utf-8")
+    _write_required_checks_workflow(repo)
+    _git(repo, "add", "seed.txt", ".github/workflows/ci.yml")
+    _git(repo, "commit", "-m", "seed")
+    subprocess.run(
+        ["git", "init", "--bare", str(origin)], check=True, capture_output=True
+    )
+    _git(repo, "remote", "add", "origin", str(origin))
+    _git(repo, "push", "-u", "origin", "main")
+    return repo, origin
+
+
+def _resolver_for_repo(repo: Path) -> lck_state.LiveStateResolver:
+    return lck_state.LiveStateResolver(
+        repo, runner=CommandRunner(repo), repository="owner/repo"
+    )
+
+
+def test_commit_current_tree_binds_validated_tree_to_commit(tmp_path: Path) -> None:
+    repo, _ = _repo(tmp_path)
+    _git(repo, "switch", "-c", "task/160-delivery")
+    (repo / "seed.txt").write_text("changed\n", encoding="utf-8")
+    effect = lck_effects.CommitCurrentTreeEffect(_resolver_for_repo(repo))
+
+    tree = effect.stage_candidate_tree()
+    effect.verify_tree_unchanged(tree)
+    receipt = effect.execute(tree, "Implement delivery cutover")
+
+    assert receipt.action == "committed"
+    assert _git(repo, "rev-parse", "HEAD^{tree}") == tree
+    assert _git(repo, "status", "--porcelain") == ""
+
+
+def test_commit_current_tree_rejects_tree_change_after_validation(
+    tmp_path: Path,
+) -> None:
+    repo, _ = _repo(tmp_path)
+    _git(repo, "switch", "-c", "task/160-delivery")
+    (repo / "seed.txt").write_text("candidate\n", encoding="utf-8")
+    effect = lck_effects.CommitCurrentTreeEffect(_resolver_for_repo(repo))
+    tree = effect.stage_candidate_tree()
+    (repo / "seed.txt").write_text("changed-after-validation\n", encoding="utf-8")
+
+    with pytest.raises(
+        lck_models.LckStopError, match="changed during formal validation"
+    ):
+        effect.verify_tree_unchanged(tree)
+
+
+def test_commit_current_tree_rejects_head_change_after_validation(
+    tmp_path: Path,
+) -> None:
+    repo, _ = _repo(tmp_path)
+    _git(repo, "switch", "-c", "task/160-delivery")
+    (repo / "seed.txt").write_text("candidate\n", encoding="utf-8")
+    effect = lck_effects.CommitCurrentTreeEffect(_resolver_for_repo(repo))
+    original_head = _git(repo, "rev-parse", "HEAD")
+    tree = effect.stage_candidate_tree()
+    _git(repo, "commit", "-m", "concurrent")
+
+    with pytest.raises(
+        lck_models.LckStopError, match="HEAD changed during formal validation"
+    ):
+        effect.verify_tree_unchanged(tree, expected_head_sha=original_head)
+
+
+def test_ensure_remote_branch_create_then_idempotent(tmp_path: Path) -> None:
+    repo, _ = _repo(tmp_path)
+    _git(repo, "switch", "-c", "task/160-delivery")
+    (repo / "task.txt").write_text("task\n", encoding="utf-8")
+    _git(repo, "add", "task.txt")
+    _git(repo, "commit", "-m", "task")
+    effect = lck_effects.EnsureRemoteBranchEffect(_resolver_for_repo(repo))
+
+    created = effect.execute("task/160-delivery")
+    repeated = effect.execute("task/160-delivery")
+
+    assert created.action == "created"
+    assert repeated.action == "already-synced"
+    assert created.details["head_sha"] == repeated.details["remote_oid"]
+
+
+def test_ensure_remote_branch_repairs_missing_upstream_when_already_synced(
+    tmp_path: Path,
+) -> None:
+    repo, _ = _repo(tmp_path)
+    branch = "task/160-delivery"
+    _git(repo, "switch", "-c", branch)
+    (repo / "task.txt").write_text("task\n", encoding="utf-8")
+    _git(repo, "add", "task.txt")
+    _git(repo, "commit", "-m", "task")
+    effect = lck_effects.EnsureRemoteBranchEffect(_resolver_for_repo(repo))
+    effect.execute(branch)
+    _git(repo, "branch", "--unset-upstream")
+
+    repaired = effect.execute(branch)
+
+    assert repaired.action == "already-synced"
+    assert repaired.details["upstream"] == f"origin/{branch}"
+    assert (
+        _git(
+            repo,
+            "rev-parse",
+            "--abbrev-ref",
+            "--symbolic-full-name",
+            "@{upstream}",
+        )
+        == f"origin/{branch}"
+    )
+
+
+def test_ensure_remote_branch_rejects_unvalidated_local_head(
+    tmp_path: Path,
+) -> None:
+    repo, _ = _repo(tmp_path)
+    _git(repo, "switch", "-c", "task/160-delivery")
+    (repo / "task.txt").write_text("task\n", encoding="utf-8")
+    _git(repo, "add", "task.txt")
+    _git(repo, "commit", "-m", "task")
+    effect = lck_effects.EnsureRemoteBranchEffect(_resolver_for_repo(repo))
+
+    with pytest.raises(
+        lck_models.LckStopError, match="validated local Task HEAD changed"
+    ):
+        effect.execute("task/160-delivery", expected_head_sha="b" * 40)
+
+    assert _git(repo, "ls-remote", "--heads", "origin", "task/160-delivery") == ""
+
+
+def test_ensure_remote_branch_fast_forwards_only_when_remote_is_ancestor(
+    tmp_path: Path,
+) -> None:
+    repo, _ = _repo(tmp_path)
+    _git(repo, "switch", "-c", "task/160-delivery")
+    (repo / "task.txt").write_text("one\n", encoding="utf-8")
+    _git(repo, "add", "task.txt")
+    _git(repo, "commit", "-m", "one")
+    effect = lck_effects.EnsureRemoteBranchEffect(_resolver_for_repo(repo))
+    effect.execute("task/160-delivery")
+
+    (repo / "task.txt").write_text("two\n", encoding="utf-8")
+    _git(repo, "commit", "-am", "two")
+    advanced = effect.execute("task/160-delivery")
+
+    assert advanced.action == "fast-forwarded"
+
+
+def test_ensure_remote_branch_stops_on_divergence(tmp_path: Path) -> None:
+    repo, origin = _repo(tmp_path)
+    _git(repo, "switch", "-c", "task/160-delivery")
+    (repo / "task.txt").write_text("one\n", encoding="utf-8")
+    _git(repo, "add", "task.txt")
+    _git(repo, "commit", "-m", "one")
+    effect = lck_effects.EnsureRemoteBranchEffect(_resolver_for_repo(repo))
+    effect.execute("task/160-delivery")
+    shared = _git(repo, "rev-parse", "HEAD")
+
+    other = tmp_path / "other"
+    subprocess.run(
+        ["git", "clone", str(origin), str(other)], check=True, capture_output=True
+    )
+    _git(other, "config", "user.name", "Other")
+    _git(other, "config", "user.email", "other@example.invalid")
+    _git(other, "switch", "task/160-delivery")
+    (other / "remote.txt").write_text("remote\n", encoding="utf-8")
+    _git(other, "add", "remote.txt")
+    _git(other, "commit", "-m", "remote")
+    _git(other, "push", "origin", "task/160-delivery")
+
+    _git(repo, "reset", "--hard", shared)
+    (repo / "local.txt").write_text("local\n", encoding="utf-8")
+    _git(repo, "add", "local.txt")
+    _git(repo, "commit", "-m", "local")
+
+    with pytest.raises(lck_models.LckStopError, match="REMOTE_BRANCH_DIVERGED"):
+        effect.execute("task/160-delivery")
+
+
+class RecordingGitRunner:
+    def __init__(
+        self,
+        repo: Path,
+        *,
+        fail_fetch: bool = False,
+        force_missing_object: bool = False,
+    ) -> None:
+        self.delegate = CommandRunner(repo)
+        self.commands: list[tuple[str, ...]] = []
+        self.fail_fetch = fail_fetch
+        self.force_missing_object = force_missing_object
+
+    def run(
+        self,
+        argv: list[str] | tuple[str, ...],
+        *,
+        command_id: str,
+        **kwargs: Any,
+    ) -> CommandResult:
+        command = tuple(str(item) for item in argv)
+        self.commands.append(command)
+        if self.force_missing_object and command[:3] == ("git", "cat-file", "-e"):
+            return CommandResult(
+                command_id=command_id,
+                argv=command,
+                returncode=1,
+                stdout="",
+                stderr="object unavailable",
+            )
+        if self.fail_fetch and command[:3] == ("git", "fetch", "--no-tags"):
+            return CommandResult(
+                command_id=command_id,
+                argv=command,
+                returncode=23,
+                stdout="",
+                stderr="fetch failed\n" + ("x" * 4000),
+            )
+        return self.delegate.run(argv, command_id=command_id, **kwargs)
+
+
+def test_ensure_remote_branch_uses_local_exact_remote_oid_without_fetch(
+    tmp_path: Path,
+) -> None:
+    repo, _ = _repo(tmp_path)
+    branch = "task/160-delivery"
+    _git(repo, "switch", "-c", branch)
+    (repo / "task.txt").write_text("one\n", encoding="utf-8")
+    _git(repo, "add", "task.txt")
+    _git(repo, "commit", "-m", "one")
+    _git(repo, "push", "-u", "origin", branch)
+    (repo / "task.txt").write_text("two\n", encoding="utf-8")
+    _git(repo, "commit", "-am", "two")
+    runner = RecordingGitRunner(repo)
+    resolver = lck_state.LiveStateResolver(repo, runner=runner, repository="owner/repo")
+
+    receipt = lck_effects.EnsureRemoteBranchEffect(resolver).execute(branch)
+
+    assert receipt.action == "fast-forwarded"
+    assert not any(command[:2] == ("git", "fetch") for command in runner.commands)
+
+
+def test_ensure_remote_branch_fetches_only_when_exact_remote_oid_is_missing(
+    tmp_path: Path,
+) -> None:
+    repo, origin = _repo(tmp_path)
+    branch = "task/160-delivery"
+    _git(repo, "switch", "-c", branch)
+    (repo / "task.txt").write_text("candidate\n", encoding="utf-8")
+    _git(repo, "add", "task.txt")
+    _git(repo, "commit", "-m", "candidate")
+
+    other = tmp_path / "other-missing-object"
+    subprocess.run(
+        ["git", "clone", str(origin), str(other)], check=True, capture_output=True
+    )
+    _git(other, "config", "user.name", "Other")
+    _git(other, "config", "user.email", "other@example.invalid")
+    _git(other, "switch", "-c", branch, "origin/main")
+    _git(other, "push", "-u", "origin", branch)
+
+    runner = RecordingGitRunner(repo, force_missing_object=True)
+    resolver = lck_state.LiveStateResolver(repo, runner=runner, repository="owner/repo")
+    receipt = lck_effects.EnsureRemoteBranchEffect(resolver).execute(branch)
+
+    assert receipt.action == "fast-forwarded"
+    assert any(command[:2] == ("git", "fetch") for command in runner.commands)
+
+
+def test_ensure_remote_branch_fetch_failure_has_bounded_classified_diagnostic(
+    tmp_path: Path,
+) -> None:
+    repo, origin = _repo(tmp_path)
+    branch = "task/160-delivery"
+    _git(repo, "switch", "-c", branch)
+    (repo / "task.txt").write_text("candidate\n", encoding="utf-8")
+    _git(repo, "add", "task.txt")
+    _git(repo, "commit", "-m", "candidate")
+
+    other = tmp_path / "other-fetch-failure"
+    subprocess.run(
+        ["git", "clone", str(origin), str(other)], check=True, capture_output=True
+    )
+    _git(other, "config", "user.name", "Other")
+    _git(other, "config", "user.email", "other@example.invalid")
+    _git(other, "switch", "-c", branch, "origin/main")
+    _git(other, "push", "-u", "origin", branch)
+
+    runner = RecordingGitRunner(repo, fail_fetch=True, force_missing_object=True)
+    resolver = lck_state.LiveStateResolver(repo, runner=runner, repository="owner/repo")
+    with pytest.raises(
+        lck_models.LckStopError, match="REMOTE_HEAD_FETCH_FAILED"
+    ) as error:
+        lck_effects.EnsureRemoteBranchEffect(resolver).execute(branch)
+
+    diagnostic = str(error.value)
+    assert "local_object_available=false" in diagnostic
+    assert "git_exit_code=23" in diagnostic
+    assert len(diagnostic) < 1800
+    assert not any(command[:2] == ("git", "push") for command in runner.commands)
+
+
+class ValidationRunner:
+    def __init__(self, *, status: str = "pass", returncode: int = 0) -> None:
+        self.status = status
+        self.returncode = returncode
+        self.commands: list[tuple[str, ...]] = []
+
+    def run(
+        self,
+        argv: list[str] | tuple[str, ...],
+        *,
+        command_id: str,
+        **_: Any,
+    ) -> CommandResult:
+        command = tuple(str(item) for item in argv)
+        self.commands.append(command)
+        return CommandResult(
+            command_id=command_id,
+            argv=command,
+            returncode=self.returncode,
+            stdout=json.dumps({"status": self.status}),
+            stderr="",
+        )
+
+
+def test_formal_validation_gate_requires_structured_pass(tmp_path: Path) -> None:
+    runner = ValidationRunner()
+    resolver = lck_state.LiveStateResolver(
+        tmp_path, runner=cast(Any, runner), repository="owner/repo"
+    )
+
+    payload = lck_validation.FormalValidationGate(resolver).run(SHA)
+
+    assert payload["status"] == "pass"
+    assert "--phase" in runner.commands[0]
+    assert "delivery" in runner.commands[0]
+
+
+@pytest.mark.parametrize(("status", "returncode"), [("fail", 1), ("pass", 1)])
+def test_formal_validation_gate_fails_closed(
+    tmp_path: Path, status: str, returncode: int
+) -> None:
+    runner = ValidationRunner(status=status, returncode=returncode)
+    resolver = lck_state.LiveStateResolver(
+        tmp_path, runner=cast(Any, runner), repository="owner/repo"
+    )
+    gate = lck_validation.FormalValidationGate(resolver)
+
+    with pytest.raises(
+        lck_models.LckStopError, match="formal Delivery validation failed"
+    ):
+        gate.run(SHA)
+
+    assert gate.last_payload == {"status": status}
+
+
+@pytest.mark.parametrize("mutation", ["merged", "invalid-target"])
+def test_ensure_open_pr_uses_operation_snapshot_preconditions(
+    tmp_path: Path,
+    mutation: str,
+) -> None:
+    head = "b" * 40
+    state = _live_state(
+        head=head,
+        clean=True,
+        project_status="In Progress",
+        open_pr=None,
+        remote_oid=head,
+    )
+    if mutation == "merged":
+        state = lck_models.LiveState(**{**state.__dict__, "merged": True})
+        expected = "already merged"
+    else:
+        state = lck_models.LiveState(**{**state.__dict__, "target_branch": "main"})
+        expected = "Task branch is invalid"
+    runner = CompletionRunner()
+    resolver = SequenceResolver(tmp_path, runner, [state])
+
+    with pytest.raises(lck_models.LckStopError, match=expected):
+        lck_effects.EnsureOpenPrEffect(cast(Any, resolver)).execute(
+            state,
+            head_sha=head,
+            summary="Move initial Delivery mechanics into LCK.",
+            risks="None.",
+            critical_outcome=_critical_snapshot(),
+            validation={"status": "pass"},
+            expected_base_sha=SHA,
+            expected_body_sha256="e" * 64,
+        )
+
+    assert resolver.calls == 0
+    assert runner.commands == []
+
+
+def _critical_snapshot() -> dict[str, Any]:
+    return {
+        "status": "valid",
+        "contract": {
+            "caller": "Delivery Skill",
+            "capability": "LCK Delivery complete",
+            "observable_result": "READY_FOR_REVIEW",
+            "verification_test": "tests/test_critical_path.py::test_critical_path",
+        },
+    }
+
+
+def _live_state(
+    *,
+    head: str,
+    clean: bool,
+    project_status: str,
+    open_pr: dict[str, Any] | None,
+    remote_oid: str | None,
+) -> lck_models.LiveState:
+    branch = "task/160-delivery-cutover"
+    return lck_models.LiveState(
+        task_number=160,
+        repository="owner/repo",
+        issue={
+            "number": 160,
+            "title": "[Task] 将 Delivery lifecycle control 迁移至 LCK",
+            "state": "OPEN",
+            "labels": {"items": ["type:task", "codex:ready"]},
+            "project_status": project_status,
+            "body_sha256": "e" * 64,
+            "critical_outcome": _critical_snapshot(),
+        },
+        relationships={
+            "available": True,
+            "issue_type": "Task",
+            "blocked_by": {"items": [], "count": 0, "truncated": False},
+        },
+        git={
+            "branch": branch,
+            "head_sha": head,
+            "local_main_sha": SHA,
+            "remote_main_sha": SHA,
+            "remote_main_query": "pass",
+            "clean": clean,
+        },
+        target_branch=branch,
+        local_task_branch=branch,
+        local_task_head=head,
+        remote_task_branch=branch if remote_oid else None,
+        remote_task_oid=remote_oid,
+        open_pr=open_pr,
+        merged_pr_numbers=(),
+        merged=False,
+        checks={"count": 0, "all_success": None},
+        cleanup={},
+        task_contract={
+            "number": 160,
+            "title": "[Task] 将 Delivery lifecycle control 迁移至 LCK",
+            "url": "https://github.com/owner/repo/issues/160",
+            "body": "Task Contract",
+            "body_sha256": "e" * 64,
+            "critical_outcome": _critical_snapshot(),
+        },
+    )
+
+
+def _snapshot(
+    state: lck_models.LiveState,
+    *,
+    operation: str = lck_models.Phase.DELIVERY_COMPLETE.value,
+    required: dict[str, Any] | None = None,
+) -> lck_models.OperationSnapshot:
+    return lck_models.OperationSnapshot(
+        operation=operation,
+        state=state,
+        required_checks=required or _required_policy("quality"),
+    )
+
+
+class CompletionRunner:
+    def __init__(self, *, critical_returncode: int = 0) -> None:
+        self.commands: list[tuple[str, ...]] = []
+        self.critical_returncode = critical_returncode
+
+    def run(
+        self,
+        argv: list[str] | tuple[str, ...],
+        *,
+        command_id: str,
+        **_: Any,
+    ) -> CommandResult:
+        command = tuple(str(item) for item in argv)
+        self.commands.append(command)
+        if command[:3] == ("git", "diff", "--quiet"):
+            returncode = 1
+            stdout = ""
+        elif command[:2] == ("git", "branch") and command[2:] == ("--show-current",):
+            returncode = 0
+            stdout = "task/160-delivery-cutover\n"
+        elif command[:3] == ("git", "rev-parse", "HEAD"):
+            returncode = 0
+            stdout = "b" * 40 + "\n"
+        elif command[:2] == ("git", "status"):
+            returncode = 0
+            stdout = ""
+        elif command[:2] == ("git", "show") and command[2].endswith(
+            ":.github/workflows/ci.yml"
+        ):
+            returncode = 0
+            stdout = REQUIRED_CHECKS_WORKFLOW_TEXT
+        elif command[:2] == ("gh", "api") and "required_status_checks" in command[2]:
+            returncode = 0
+            stdout = json.dumps({"contexts": []})
+        elif command and Path(command[0]).name == "uv":
+            returncode = self.critical_returncode
+            stdout = "1 passed\n" if returncode == 0 else "1 failed\n"
+        else:
+            returncode = 0
+            stdout = ""
+        return CommandResult(command_id, command, returncode, stdout, "")
+
+
+class SequenceResolver:
+    def __init__(
+        self,
+        repo_root: Path,
+        runner: CompletionRunner,
+        states: list[lck_models.LiveState],
+    ) -> None:
+        self.repo_root = repo_root
+        self.runner = cast(Any, runner)
+        self._states = states
+        self.calls = 0
+
+    def resolve(self, _task: int) -> lck_models.LiveState:
+        index = min(self.calls, len(self._states) - 1)
+        self.calls += 1
+        return self._states[index]
+
+
+class StubValidation:
+    def run(self, _base_sha: str) -> dict[str, Any]:
+        return {"status": "pass", "command_count": 6}
+
+
+class StubChecks:
+    def __init__(self, *, fail: str | None = None) -> None:
+        self.fail = fail
+        self.calls = 0
+        self.last_result: dict[str, Any] | None = None
+
+    def _result(self, number: int, head: str, base: str) -> dict[str, Any]:
+        if self.fail:
+            raise lck_models.LckStopError(self.fail)
+        result = {
+            "status": "pass",
+            "configuration": "repository",
+            "required": ["quality"],
+            "checks": {
+                "count": 0,
+                "failed": 0,
+                "pending": 0,
+                "skipped_or_unknown": 0,
+                "all_success": True,
+            },
+            "pr": {"number": number, "head_sha": head, "base_sha": base},
+        }
+        self.last_result = dict(result)
+        return result
+
+    def evaluate(self, snapshot: lck_models.OperationSnapshot) -> dict[str, Any]:
+        self.calls += 1
+        pr = snapshot.state.open_pr or {}
+        return self._result(
+            int(pr.get("number", 10)),
+            str(pr.get("headRefOid", "b" * 40)),
+            str(pr.get("baseRefOid", SHA)),
+        )
+
+    def observe(self, snapshot: lck_models.OperationSnapshot) -> dict[str, Any]:
+        self.calls += 1
+        pr = snapshot.state.open_pr or {}
+        result = self._result(
+            int(pr.get("number", 10)),
+            str(pr.get("headRefOid", "b" * 40)),
+            str(pr.get("baseRefOid", SHA)),
+        )
+        result["status"] = "observed"
+        result["gate"] = "non-blocking"
+        result["check_state"] = "pass"
+        self.last_result = dict(result)
+        return result
+
+    def observe_exact_pr(
+        self,
+        _repository: str,
+        pr_number: int,
+        *,
+        expected_head_sha: str,
+        expected_base_sha: str,
+    ) -> dict[str, Any]:
+        self.calls += 1
+        result = self._result(pr_number, expected_head_sha, expected_base_sha)
+        result["status"] = "observed"
+        result["gate"] = "non-blocking"
+        result["check_state"] = "pass"
+        self.last_result = dict(result)
+        return result
+
+    def query_exact_pr(
+        self,
+        _repository: str,
+        pr_number: int,
+        *,
+        expected_head_sha: str,
+        expected_base_sha: str,
+        required_checks: dict[str, Any],
+    ) -> dict[str, Any]:
+        del required_checks
+        self.calls += 1
+        return self._result(pr_number, expected_head_sha, expected_base_sha)
+
+
+class StubCommit:
+    def __init__(self, *, dirty: bool) -> None:
+        self.dirty = dirty
+        self.calls: list[str] = []
+
+    def current_head_tree(self) -> str:
+        self.calls.append("current_head_tree")
+        return "c" * 40
+
+    def stage_candidate_tree(self) -> str:
+        self.calls.append("stage_candidate_tree")
+        return "c" * 40
+
+    def verify_tree_unchanged(
+        self, _tree: str, *, expected_head_sha: str | None = None
+    ) -> None:
+        self.calls.append("verify_tree_unchanged")
+
+    def execute(
+        self,
+        tree: str,
+        _message: str,
+        *,
+        expected_parent_sha: str | None = None,
+    ) -> lck_models.EffectReceipt:
+        self.calls.append("execute")
+        return lck_models.EffectReceipt(
+            "commit_current_tree",
+            "committed",
+            {"head_sha": "b" * 40, "tree_oid": tree},
+        )
+
+
+class StubEffect:
+    def __init__(self, name: str, action: str) -> None:
+        self.name = name
+        self.action = action
+        self.calls = 0
+
+    def execute(self, *_args: Any, **kwargs: Any) -> lck_models.EffectReceipt:
+        self.calls += 1
+        details: dict[str, Any] = {}
+        if self.name == "ensure_remote_branch":
+            details["remote_oid"] = kwargs.get("expected_head_sha")
+        elif self.name in {"ensure_open_pr", "reuse_open_pr"}:
+            details.update(
+                {
+                    "number": 10,
+                    "head_sha": kwargs.get("head_sha"),
+                    "base_sha": kwargs.get("expected_base_sha"),
+                }
+            )
+        return lck_models.EffectReceipt(self.name, self.action, details)
+
+
+class CliDeliveryRunner:
+    """Deterministic external boundary for the real LCK Delivery CLI path."""
+
+    branch = "task/160-delivery-lifecycle-control-lck"
+    base_sha = "a" * 40
+    old_head = "d" * 40
+    new_head = "b" * 40
+    tree_oid = "c" * 40
+
+    def __init__(self) -> None:
+        self.commands: list[tuple[str, ...]] = []
+        self.command_ids: list[str] = []
+        self.remote_oid: str | None = None
+        self.upstream: str | None = None
+        self.open_pr = False
+        self.project_status = "In Progress"
+        self.dirty = True
+
+    def _result(
+        self,
+        command_id: str,
+        command: tuple[str, ...],
+        *,
+        stdout: str = "",
+        returncode: int = 0,
+        stderr: str = "",
+    ) -> CommandResult:
+        return CommandResult(
+            command_id=command_id,
+            argv=command,
+            returncode=returncode,
+            stdout=f"{stdout}\n" if stdout else "",
+            stderr=stderr,
+        )
+
+    def _issue_payload(self) -> dict[str, Any]:
+        body = """### Critical Outcome
+Caller: task-delivery-runner initial Delivery
+Capability: LCK owns deterministic initial Delivery completion
+Observable result: a semantically completed Task reaches READY_FOR_REVIEW
+Verification test: tests/tools/lck/test_delivery.py::test_task_160_critical_outcome_initial_delivery_is_lck_owned
+"""
+        return {
+            "number": 160,
+            "title": "[Task] 将 Delivery lifecycle control 迁移至 LCK",
+            "body": body,
+            "comments": [],
+            "state": "OPEN",
+            "labels": [
+                {"name": "type:task"},
+                {"name": "codex:ready"},
+            ],
+            "projectItems": [{"status": {"name": self.project_status}}],
+            "url": "https://github.com/owner/repo/issues/160",
+            "closedAt": None,
+            "closedByPullRequestsReferences": [],
+        }
+
+    def _pr_payload(self) -> dict[str, Any]:
+        return {
+            "number": 165,
+            "url": "https://github.com/owner/repo/pull/165",
+            "state": "OPEN",
+            "isDraft": False,
+            "baseRefName": "main",
+            "baseRefOid": self.base_sha,
+            "headRefName": self.branch,
+            "headRefOid": self.new_head,
+            "statusCheckRollup": [
+                {"name": "quality", "conclusion": "SUCCESS"},
+            ],
+        }
+
+    def _graphql_payload(self, command: tuple[str, ...]) -> str:
+        query = command[4] if len(command) > 4 else ""
+        if "closedByPullRequestsReferences" in query:
+            issue: dict[str, Any] = {
+                "state": "OPEN",
+                "closedAt": None,
+                "closedByPullRequestsReferences": {
+                    "nodes": [],
+                    "pageInfo": {"hasNextPage": False},
+                },
+                "timelineItems": {
+                    "nodes": [],
+                    "pageInfo": {"hasPreviousPage": False},
+                },
+            }
+        elif "projectItems(first:20)" in query and "blockedBy" not in query:
+            issue = {
+                "number": 160,
+                "projectItems": {
+                    "nodes": [
+                        {
+                            "project": {
+                                "number": 1,
+                                "title": "Quant System Development",
+                                "owner": {"login": "owner"},
+                            },
+                            "content": {
+                                "number": 160,
+                                "repository": {"nameWithOwner": "owner/repo"},
+                            },
+                            "fieldValues": {
+                                "nodes": [
+                                    {
+                                        "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                        "name": self.project_status,
+                                        "field": {"name": "Status"},
+                                    }
+                                ],
+                                "pageInfo": {"hasNextPage": False},
+                            },
+                        }
+                    ],
+                    "pageInfo": {"hasNextPage": False},
+                },
+            }
+        else:
+            issue = {
+                "issueType": {"name": "Task"},
+                "parent": None,
+                "subIssues": {
+                    "nodes": [],
+                    "pageInfo": {"hasNextPage": False},
+                },
+                "blockedBy": {
+                    "nodes": [],
+                    "pageInfo": {"hasNextPage": False},
+                },
+                "blocking": {
+                    "nodes": [],
+                    "pageInfo": {"hasNextPage": False},
+                },
+            }
+        return json.dumps({"data": {"repository": {"issue": issue}}})
+
+    def run(
+        self,
+        argv: list[str] | tuple[str, ...],
+        *,
+        command_id: str,
+        **_: Any,
+    ) -> CommandResult:
+        command = tuple(str(item) for item in argv)
+        self.commands.append(command)
+        self.command_ids.append(command_id)
+        args = list(command[1:]) if command and command[0] == "git" else list(command)
+
+        if command and command[0] == "uv":
+            return self._result(command_id, command, stdout="1 passed")
+        if command_id == "lck-formal-delivery-validation":
+            return self._result(
+                command_id, command, stdout=json.dumps({"status": "pass"})
+            )
+
+        if args[:1] == ["fetch"]:
+            return self._result(command_id, command)
+        if (
+            args[:1] == ["show"]
+            and len(args) == 2
+            and args[1].endswith(":.github/workflows/ci.yml")
+        ):
+            return self._result(
+                command_id,
+                command,
+                stdout=REQUIRED_CHECKS_WORKFLOW_TEXT,
+            )
+        if args == ["branch", "--show-current"]:
+            return self._result(command_id, command, stdout=self.branch)
+        if args == ["rev-parse", "HEAD"]:
+            return self._result(
+                command_id,
+                command,
+                stdout=self.new_head if not self.dirty else self.old_head,
+            )
+        if args == ["rev-parse", "HEAD^"]:
+            return self._result(command_id, command, stdout=self.old_head)
+        if args == ["rev-parse", "HEAD^{tree}"]:
+            return self._result(command_id, command, stdout=self.tree_oid)
+        if args == ["rev-parse", "FETCH_HEAD"]:
+            return self._result(command_id, command, stdout=self.remote_oid or "")
+        if args == [
+            "rev-parse",
+            "--abbrev-ref",
+            "--symbolic-full-name",
+            "@{upstream}",
+        ]:
+            return self._result(command_id, command, stdout=self.upstream or "")
+        if args == ["rev-parse", "refs/heads/main"]:
+            return self._result(command_id, command, stdout=self.base_sha)
+        if args == ["rev-parse", "refs/remotes/origin/main"]:
+            return self._result(command_id, command, stdout=self.base_sha)
+        if args[:1] == ["rev-parse"] and len(args) == 2:
+            return self._result(
+                command_id,
+                command,
+                stdout=self.new_head if not self.dirty else self.old_head,
+            )
+        if args[:2] == ["for-each-ref", "--format=%(refname:short)"]:
+            return self._result(command_id, command, stdout=self.branch)
+        if args[:3] == ["ls-remote", "--heads", "origin"]:
+            if self.remote_oid is None:
+                return self._result(command_id, command)
+            return self._result(
+                command_id,
+                command,
+                stdout=f"{self.remote_oid}\trefs/heads/{self.branch}",
+            )
+        if args == ["ls-remote", "origin", "refs/heads/main"]:
+            return self._result(
+                command_id,
+                command,
+                stdout=f"{self.base_sha}\trefs/heads/main",
+            )
+        if args[:2] == ["status", "--short"] or args[:2] == [
+            "status",
+            "--porcelain=v1",
+        ]:
+            return self._result(
+                command_id, command, stdout=" M candidate.py" if self.dirty else ""
+            )
+        if args[:2] == ["diff", "--cached"] and "--name-only" in args:
+            return self._result(command_id, command, stdout="candidate.py")
+        if args[:2] == ["diff", "--cached"] and "--quiet" in args:
+            return self._result(command_id, command, returncode=1)
+        if args == ["diff", "--quiet"] or (
+            len(args) == 3 and args[:2] == ["diff", "--quiet"]
+        ):
+            return self._result(command_id, command)
+        if args == ["diff", "--cached", "--check"]:
+            return self._result(command_id, command)
+        if args == ["diff", "--name-only"]:
+            return self._result(command_id, command, stdout="candidate.py")
+        if args[:2] == ["branch", "--set-upstream-to"]:
+            self.upstream = args[2]
+            return self._result(command_id, command)
+        if args == ["add", "-A", "--", ":/"]:
+            return self._result(command_id, command)
+        if args == ["write-tree"]:
+            return self._result(command_id, command, stdout=self.tree_oid)
+        if args[:2] == ["commit", "-m"]:
+            self.dirty = False
+            return self._result(command_id, command)
+        if args[:1] == ["push"]:
+            self.remote_oid = self.new_head
+            if "-u" in args:
+                self.upstream = f"origin/{self.branch}"
+            return self._result(command_id, command)
+        if args[:3] == ["merge-base", "--is-ancestor", self.remote_oid or ""]:
+            return self._result(command_id, command)
+        if args[:2] == ["worktree", "list"]:
+            return self._result(
+                command_id,
+                command,
+                stdout=f"worktree /tmp/test-repo\nbranch refs/heads/{self.branch}",
+            )
+
+        if command[:3] == ("gh", "issue", "view"):
+            if (
+                "--json" in command
+                and command[command.index("--json") + 1] == "projectItems"
+            ):
+                return self._result(
+                    command_id,
+                    command,
+                    stdout=json.dumps(
+                        {"projectItems": [{"status": {"name": self.project_status}}]}
+                    ),
+                )
+            return self._result(
+                command_id, command, stdout=json.dumps(self._issue_payload())
+            )
+        if command[:3] == ("gh", "api", "graphql"):
+            return self._result(
+                command_id, command, stdout=self._graphql_payload(command)
+            )
+        if command[:3] == ("gh", "pr", "list"):
+            state_index = command.index("--state") + 1
+            state = command[state_index]
+            if not self.open_pr:
+                return self._result(command_id, command, stdout="[]")
+            if state == "merged":
+                return self._result(command_id, command, stdout="[]")
+            return self._result(
+                command_id, command, stdout=json.dumps([self._pr_payload()])
+            )
+        if command[:3] == ("gh", "pr", "view"):
+            return self._result(
+                command_id, command, stdout=json.dumps(self._pr_payload())
+            )
+        if command[:3] == ("gh", "pr", "create"):
+            self.open_pr = True
+            return self._result(
+                command_id, command, stdout="https://github.com/owner/repo/pull/165"
+            )
+        if command[:3] == ("gh", "project", "item-edit"):
+            self.project_status = "Review"
+            return self._result(command_id, command)
+        if command[:3] == (
+            "gh",
+            "api",
+            "repos/owner/repo/branches/main/protection/required_status_checks",
+        ):
+            return self._result(
+                command_id, command, stdout=json.dumps({"contexts": []})
+            )
+        if command[:3] == ("gh", "issue", "view") and command[-1] == "projectItems":
+            return self._result(
+                command_id,
+                command,
+                stdout=json.dumps(
+                    {"projectItems": [{"status": {"name": self.project_status}}]}
+                ),
+            )
+        if command[:2] == ("gh", "api"):
+            return self._result(
+                command_id, command, returncode=1, stderr="404 not configured"
+            )
+
+        return self._result(command_id, command)
+
+
+def test_delivery_complete_revalidates_clean_committed_head_and_stops_at_review_boundary(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "tests" / "test_critical_path.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("def test_critical_path(): pass\n", encoding="utf-8")
+    head = "b" * 40
+    pre = _live_state(
+        head=head,
+        clean=True,
+        project_status="In Progress",
+        open_pr=None,
+        remote_oid=None,
+    )
+    final_pr = {
+        "number": 10,
+        "state": "OPEN",
+        "isDraft": False,
+        "headRefOid": head,
+        "baseRefOid": SHA,
+    }
+    final = _live_state(
+        head=head,
+        clean=True,
+        project_status="Review",
+        open_pr=final_pr,
+        remote_oid=head,
+    )
+    remote = _live_state(
+        head=head,
+        clean=True,
+        project_status="In Progress",
+        open_pr=None,
+        remote_oid=head,
+    )
+    with_pr = _live_state(
+        head=head,
+        clean=True,
+        project_status="In Progress",
+        open_pr=final_pr,
+        remote_oid=head,
+    )
+    runner = CompletionRunner()
+    resolver = SequenceResolver(
+        tmp_path,
+        runner,
+        [pre, pre, remote, with_pr, with_pr, final],
+    )
+    commit = StubCommit(dirty=False)
+    remote = StubEffect("ensure_remote_branch", "created")
+    pr = StubEffect("ensure_open_pr", "created")
+    status = StubEffect("set_review_status", "updated")
+
+    result = lck_delivery.DeliveryCompleter(
+        cast(Any, resolver),
+        formal_validation=cast(Any, StubValidation()),
+        commit_effect=cast(Any, commit),
+        remote_effect=cast(Any, remote),
+        pr_effect=cast(Any, pr),
+        status_effect=cast(Any, status),
+        checks_gate=cast(Any, StubChecks()),
+    ).complete(
+        160,
+        commit_message="Implement LCK Delivery cutover",
+        summary="Move initial Delivery mechanics into LCK.",
+    )
+
+    assert result.status == "READY_FOR_REVIEW"
+    assert (
+        result.to_dict()["human_boundary"]
+        == "Independent Review must be started separately"
+    )
+    assert commit.calls == ["current_head_tree", "verify_tree_unchanged"]
+    assert remote.calls == pr.calls == status.calls == 1
+    assert not any(
+        "review" in " ".join(command).casefold() for command in runner.commands
+    )
+
+
+def test_task_160_critical_outcome_initial_delivery_is_lck_owned(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    root = Path(__file__).parents[3]
+    agent_skill = (root / ".agents/skills/task-delivery-runner/SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    claude_skill = (root / ".claude/skills/task-delivery-runner/SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    assert ".agents/skills/task-delivery-runner/SKILL.md" in claude_skill
+    assert len(claude_skill.splitlines()) < 15
+    assert "python -m tools.lck delivery prepare" in agent_skill
+    assert "python -m tools.lck delivery complete" in agent_skill
+    initial_section = agent_skill.split("## Review remediation", 1)[0]
+    for direct_write in ("git commit", "git push", "gh pr create"):
+        assert direct_write not in initial_section
+    target = tmp_path / "tests" / "tools" / "lck" / "test_delivery.py"
+    target.parent.mkdir(parents=True)
+    target.write_text(
+        "def test_task_160_critical_outcome_initial_delivery_is_lck_owned(): pass\n",
+        encoding="utf-8",
+    )
+    tool = tmp_path / "tools" / "lck" / "validation_runner.py"
+    tool.parent.mkdir(parents=True)
+    tool.write_text("# deterministic external validation boundary\n", encoding="utf-8")
+
+    runner = CliDeliveryRunner()
+    monkeypatch.setattr(lck_state, "CommandRunner", lambda _repo_root: runner)
+
+    exit_code = lck_cli.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--repository",
+            "owner/repo",
+            "delivery",
+            "complete",
+            "160",
+            "--commit-message",
+            "Implement LCK Delivery cutover",
+            "--summary",
+            "Move initial Delivery mechanics into LCK.",
+        ]
+    )
+    output = capsys.readouterr().out
+    payload = json.loads(output)
+
+    assert exit_code == 0, output
+    assert payload["status"] == "READY_FOR_REVIEW"
+    assert payload["human_boundary"] == "Independent Review must be started separately"
+    assert "operation_snapshot" not in payload
+    receipt = lck_receipts.AuditReceiptStore(tmp_path).read(
+        payload["receipt_reference"]
+    )
+    assert (
+        receipt["operation_snapshot"]["operation"]
+        == lck_models.Phase.DELIVERY_COMPLETE.value
+    )
+    assert (
+        receipt["operation_snapshot"]["state"]["issue"]["project_status"]
+        == "In Progress"
+    )
+    assert payload["effects"][-1]["effect"] == "set_review_status"
+    assert payload["effects"][-1]["action"] in {"updated", "already-review"}
+    assert runner.remote_oid == runner.new_head
+    assert runner.open_pr is True
+    assert "lck-critical-outcome" in runner.command_ids
+    assert "lck-formal-delivery-validation" in runner.command_ids
+    assert "lck-commit-current-tree" in runner.command_ids
+    assert "lck-push-task-branch" in runner.command_ids
+    assert any(
+        command[0] == "gh" and command[1:3] == ("pr", "create")
+        for command in runner.commands
+    )
+    assert any(
+        command[0] == "gh" and command[1:3] == ("project", "item-edit")
+        for command in runner.commands
+    )
+    assert [receipt["effect"] for receipt in payload["effects"]] == [
+        "commit_current_tree",
+        "ensure_remote_branch",
+        "ensure_open_pr",
+        "set_review_status",
+    ]
+
+
+def test_lck_rollback_procedure_reverts_candidate_and_requires_fresh_review(
+    tmp_path: Path,
+) -> None:
+    repo, _ = _repo(tmp_path)
+    last_reviewed_head = _git(repo, "rev-parse", "HEAD")
+
+    _git(repo, "switch", "-c", "task/163-activation")
+    (repo / "activation.txt").write_text("candidate\n", encoding="utf-8")
+    _git(repo, "add", "activation.txt")
+    _git(repo, "commit", "-m", "prepare Task 163 activation")
+    candidate_head = _git(repo, "rev-parse", "HEAD")
+
+    _git(repo, "switch", "main")
+    _git(repo, "merge", "--squash", candidate_head)
+    _git(repo, "commit", "-m", "squash Task 163 candidate")
+    activated_head = _git(repo, "rev-parse", "HEAD")
+    assert activated_head != last_reviewed_head
+
+    # Simulate activation failure recovery with one controlled revert of the
+    # candidate merge, without reactivating any legacy workflow path.
+    _git(repo, "revert", "--no-edit", activated_head)
+    rollback_head = _git(repo, "rev-parse", "HEAD")
+    assert rollback_head != activated_head
+    assert _git(repo, "show", "-s", "--format=%P", rollback_head) == activated_head
+    assert _git(repo, "diff", "--quiet", last_reviewed_head, "HEAD") == ""
+    assert _git(repo, "status", "--porcelain") == ""
+
+    # A later activation candidate must have a new reviewed head; the old
+    # Review identity cannot authorize it after rollback.
+    _git(repo, "switch", "-c", "task/163-activation-retry")
+    (repo / "activation.txt").write_text("retry\n", encoding="utf-8")
+    _git(repo, "add", "activation.txt")
+    _git(repo, "commit", "-m", "prepare fresh Task 163 activation")
+    fresh_head = _git(repo, "rev-parse", "HEAD")
+    assert fresh_head not in {last_reviewed_head, activated_head, rollback_head}
+
+    reviewed_identity = lck_review_workspace.ReviewIdentity(
+        task_number=163,
+        pr_number=168,
+        base_sha=last_reviewed_head,
+        head_sha=activated_head,
+        task_body_sha256="a" * 64,
+        merge_base_sha=last_reviewed_head,
+        effective_diff_sha256="b" * 64,
+        changed_files=("activation.txt",),
+    )
+    current_identity = lck_review_workspace.ReviewIdentity(
+        task_number=163,
+        pr_number=168,
+        base_sha=last_reviewed_head,
+        head_sha=fresh_head,
+        task_body_sha256="a" * 64,
+        merge_base_sha=last_reviewed_head,
+        effective_diff_sha256="b" * 64,
+        changed_files=("activation.txt",),
+    )
+    with pytest.raises(lck_models.ReviewStaleError, match="REVIEW_STALE_HEAD"):
+        lck_review_workspace._assert_review_applicable(
+            reviewed_identity, current_identity
+        )
+
+
+def _with_checks(
+    state: lck_models.LiveState, checks: dict[str, Any]
+) -> lck_models.LiveState:
+    pr = dict(state.open_pr or {})
+    items = (
+        checks.get("items", {}).get("items", [])
+        if isinstance(checks.get("items"), dict)
+        else []
+    )
+    pr["statusCheckRollup"] = [
+        {"name": item.get("name"), "conclusion": item.get("state")}
+        for item in items
+        if isinstance(item, dict)
+    ]
+    return lck_models.LiveState(
+        task_number=state.task_number,
+        repository=state.repository,
+        issue=state.issue,
+        relationships=state.relationships,
+        git=state.git,
+        target_branch=state.target_branch,
+        local_task_branch=state.local_task_branch,
+        local_task_head=state.local_task_head,
+        remote_task_branch=state.remote_task_branch,
+        remote_task_oid=state.remote_task_oid,
+        open_pr=pr,
+        merged_pr_numbers=state.merged_pr_numbers,
+        merged=state.merged,
+        checks=checks,
+        cleanup=state.cleanup,
+        status=state.status,
+        stop_reasons=state.stop_reasons,
+        warnings=state.warnings,
+        task_contract=state.task_contract,
+    )
+
+
+def _checks(*, category: str, state_name: str) -> dict[str, Any]:
+    return {
+        "count": 1,
+        "success": 1 if category == "success" else 0,
+        "pending": 1 if category == "pending" else 0,
+        "failed": 1 if category == "failed" else 0,
+        "skipped_or_unknown": 1 if category == "skipped-or-unknown" else 0,
+        "all_success": category == "success",
+        "items": {
+            "items": [{"name": "quality", "state": state_name, "category": category}],
+            "count": 1,
+            "truncated": False,
+        },
+    }
+
+
+def test_repository_required_checks_policy_is_bound_to_exact_base_commit(
+    tmp_path: Path,
+) -> None:
+    repo, _ = _repo(tmp_path)
+    base_sha = _git(repo, "rev-parse", "HEAD")
+    (repo / ".github" / "workflows" / "ci.yml").write_text(
+        "name: CI\njobs:\n  candidate-only:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo candidate\n",
+        encoding="utf-8",
+    )
+    resolver = _resolver_for_repo(repo)
+
+    policy = lck_state._repository_required_checks_at_commit(resolver, base_sha)
+
+    assert policy["configuration"] == "repository-base-ci"
+    assert policy["source_sha"] == base_sha
+    assert policy["source"] == f"git:{base_sha}:.github/workflows/ci.yml:jobs"
+    assert policy["contexts"]["items"] == ["quality"]
+    assert policy["workflow_path"] == ".github/workflows/ci.yml"
+    assert policy["contract_sha256"] == sha256_json(
+        {"workflow": ".github/workflows/ci.yml", "required-checks": ["quality"]}
+    )
+
+
+def test_required_checks_policy_never_falls_back_to_working_tree(
+    tmp_path: Path,
+) -> None:
+    repo, _ = _repo(tmp_path)
+    _git(repo, "rm", ".github/workflows/ci.yml")
+    _git(repo, "commit", "-m", "remove canonical CI")
+    base_sha = _git(repo, "rev-parse", "HEAD")
+    _write_required_checks_workflow(repo)
+    resolver = _resolver_for_repo(repo)
+
+    with pytest.raises(lck_models.LckStopError, match="unavailable at trusted base"):
+        lck_state._repository_required_checks_at_commit(resolver, base_sha)
+
+
+def test_review_required_checks_policy_is_governed_by_pr_base_not_candidate_head(
+    tmp_path: Path,
+) -> None:
+    repo, _ = _repo(tmp_path)
+    base_sha = _git(repo, "rev-parse", "HEAD")
+    branch = "task/160-delivery-cutover"
+    _git(repo, "switch", "-c", branch)
+    workflow = repo / ".github" / "workflows" / "ci.yml"
+    workflow.write_text(
+        "name: CI\njobs:\n  self-approved:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo candidate\n",
+        encoding="utf-8",
+    )
+    _git(repo, "add", ".github/workflows/ci.yml")
+    _git(repo, "commit", "-m", "candidate attempts to weaken checks")
+    head_sha = _git(repo, "rev-parse", "HEAD")
+
+    original = _live_state(
+        head=head_sha,
+        clean=True,
+        project_status="Review",
+        open_pr={
+            "number": 10,
+            "state": "OPEN",
+            "isDraft": False,
+            "headRefOid": head_sha,
+            "baseRefOid": base_sha,
+        },
+        remote_oid=head_sha,
+    )
+    state = replace(
+        original,
+        git={
+            **original.git,
+            "local_main_sha": base_sha,
+            "remote_main_sha": base_sha,
+        },
+    )
+
+    class ExactResolver:
+        repo_root = repo
+        runner = CommandRunner(repo)
+
+        def resolve(self, _task: int) -> lck_models.LiveState:
+            return state
+
+    snapshot = lck_state.OperationSnapshotBuilder(cast(Any, ExactResolver())).acquire(
+        160,
+        operation="review-complete",
+        include_required_checks=True,
+    )
+
+    assert snapshot.required_checks is not None
+    assert snapshot.required_checks["source_sha"] == base_sha
+    assert snapshot.required_checks["contexts"]["items"] == ["quality"]
+    assert "self-approved" in _git(repo, "show", f"{head_sha}:.github/workflows/ci.yml")
+
+
+def test_delivery_does_not_require_required_check_policy_before_effects(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "tests" / "test_critical_path.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("def test_critical_path(): pass\n", encoding="utf-8")
+    head = "b" * 40
+    state = _live_state(
+        head=head,
+        clean=True,
+        project_status="In Progress",
+        open_pr=None,
+        remote_oid=None,
+    )
+    snapshot = _snapshot(
+        state,
+        required={
+            "configuration": "plan-limited-403",
+            "contexts": {"items": [], "count": 0, "truncated": False},
+        },
+    )
+    runner = CompletionRunner()
+    resolver = SequenceResolver(tmp_path, runner, [state])
+    commit = StubCommit(dirty=False)
+    remote = StubEffect("ensure_remote_branch", "created")
+    pr = StubEffect("ensure_open_pr", "created")
+    status = StubEffect("set_review_status", "updated")
+
+    result = lck_delivery.DeliveryCompleter(
+        cast(Any, resolver),
+        formal_validation=cast(Any, StubValidation()),
+        commit_effect=cast(Any, commit),
+        remote_effect=cast(Any, remote),
+        pr_effect=cast(Any, pr),
+        status_effect=cast(Any, status),
+        checks_gate=cast(Any, StubChecks()),
+    ).complete(
+        160,
+        commit_message="candidate",
+        summary="candidate",
+        operation_snapshot=snapshot,
+    )
+
+    assert result.status == "READY_FOR_REVIEW"
+    assert commit.calls == ["current_head_tree", "verify_tree_unchanged"]
+    assert remote.calls == 1
+    assert pr.calls == 1
+    assert status.calls == 1
+
+
+def test_strict_checks_gate_requires_named_required_check_success(
+    tmp_path: Path,
+) -> None:
+    head = "b" * 40
+    base = _live_state(
+        head=head,
+        clean=True,
+        project_status="Review",
+        open_pr={
+            "number": 10,
+            "state": "OPEN",
+            "isDraft": False,
+            "headRefOid": head,
+            "baseRefOid": SHA,
+        },
+        remote_oid=head,
+    )
+    state = _with_checks(base, _checks(category="success", state_name="SUCCESS"))
+    resolver = SequenceResolver(tmp_path, CompletionRunner(), [state])
+    snapshot = _snapshot(
+        state,
+        required={
+            **_required_policy("quality"),
+        },
+    )
+
+    result = lck_validation.DeliveryChecksGate(cast(Any, resolver)).evaluate(snapshot)
+
+    assert result["status"] == "pass"
+    assert result["required"] == ["quality"]
+    assert resolver.calls == 0
+
+
+def test_strict_checks_gate_stops_on_failed_check(tmp_path: Path) -> None:
+    head = "b" * 40
+    base = _live_state(
+        head=head,
+        clean=True,
+        project_status="Review",
+        open_pr={
+            "number": 10,
+            "state": "OPEN",
+            "isDraft": False,
+            "headRefOid": head,
+            "baseRefOid": SHA,
+        },
+        remote_oid=head,
+    )
+    state = _with_checks(base, _checks(category="failed", state_name="FAILURE"))
+    resolver = SequenceResolver(tmp_path, CompletionRunner(), [state])
+
+    gate = lck_validation.DeliveryChecksGate(cast(Any, resolver))
+    with pytest.raises(lck_models.LckStopError, match="checks failed"):
+        gate.evaluate(
+            _snapshot(
+                state,
+                required={
+                    **_required_policy("quality"),
+                },
+            )
+        )
+    assert gate.last_result is not None
+    assert gate.last_result["status"] == "fail"
+    assert gate.last_result["check_state"] == "failed"
+    assert resolver.calls == 0
+
+
+def test_strict_checks_gate_pending_stops_without_polling(tmp_path: Path) -> None:
+    head = "b" * 40
+    base = _live_state(
+        head=head,
+        clean=True,
+        project_status="Review",
+        open_pr={
+            "number": 10,
+            "state": "OPEN",
+            "isDraft": False,
+            "headRefOid": head,
+            "baseRefOid": SHA,
+        },
+        remote_oid=head,
+    )
+    state = _with_checks(base, _checks(category="pending", state_name="IN_PROGRESS"))
+    resolver = SequenceResolver(tmp_path, CompletionRunner(), [state])
+
+    with pytest.raises(lck_models.LckStopError, match="strict check gate"):
+        lck_validation.DeliveryChecksGate(cast(Any, resolver)).evaluate(
+            _snapshot(
+                state,
+                required={
+                    **_required_policy("quality"),
+                },
+            )
+        )
+    assert resolver.calls == 0
+
+
+def test_strict_checks_gate_rejects_legacy_plan_limited_policy(
+    tmp_path: Path,
+) -> None:
+    head = "b" * 40
+    base = _live_state(
+        head=head,
+        clean=True,
+        project_status="Review",
+        open_pr={
+            "number": 10,
+            "state": "OPEN",
+            "isDraft": False,
+            "headRefOid": head,
+            "baseRefOid": SHA,
+        },
+        remote_oid=head,
+    )
+    state = _with_checks(base, _checks(category="success", state_name="SUCCESS"))
+    resolver = SequenceResolver(tmp_path, CompletionRunner(), [state])
+    snapshot = _snapshot(
+        state,
+        required={
+            "configuration": "plan-limited-403",
+            "failure": {"category": "plan-limit"},
+            "contexts": {"items": [], "count": 0, "truncated": False},
+        },
+    )
+
+    with pytest.raises(lck_models.LckStopError, match="canonical-CI check contract"):
+        lck_validation.DeliveryChecksGate(cast(Any, resolver)).evaluate(snapshot)
+    assert resolver.calls == 0
+
+
+class FailingChecks:
+    def observe(self, snapshot: lck_models.OperationSnapshot) -> dict[str, Any]:
+        pr = snapshot.state.open_pr or {}
+        return {
+            "status": "observed",
+            "gate": "non-blocking",
+            "check_state": "failed",
+            "pr": {
+                "number": pr.get("number", 10),
+                "head_sha": pr.get("headRefOid", "b" * 40),
+                "base_sha": pr.get("baseRefOid", SHA),
+            },
+        }
+
+    def observe_exact_pr(self, *_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        return {
+            "status": "observed",
+            "gate": "non-blocking",
+            "check_state": "failed",
+            "pr": {
+                "number": 10,
+                "head_sha": "b" * 40,
+                "base_sha": SHA,
+            },
+        }
+
+    def evaluate(self, _snapshot: lck_models.OperationSnapshot) -> dict[str, Any]:
+        raise lck_models.LckStopError("checks failed")
+
+    def query_exact_pr(self, *_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        raise lck_models.LckStopError("checks failed")
+
+
+def test_delivery_complete_critical_outcome_failure_blocks_commit_and_remote(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "tests" / "test_critical_path.py"
+    target.parent.mkdir(parents=True)
+    target.write_text(
+        "def test_critical_path(): pass\
+",
+        encoding="utf-8",
+    )
+    pre = _live_state(
+        head="d" * 40,
+        clean=False,
+        project_status="In Progress",
+        open_pr=None,
+        remote_oid=None,
+    )
+    runner = CompletionRunner(critical_returncode=1)
+    resolver = SequenceResolver(tmp_path, runner, [pre])
+    commit = StubCommit(dirty=True)
+    remote = StubEffect("ensure_remote_branch", "created")
+    handler = lck_delivery.DeliveryCompleter(
+        cast(Any, resolver),
+        formal_validation=cast(Any, StubValidation()),
+        commit_effect=cast(Any, commit),
+        remote_effect=cast(Any, remote),
+        pr_effect=cast(Any, StubEffect("ensure_open_pr", "created")),
+        status_effect=cast(Any, StubEffect("set_review_status", "updated")),
+        checks_gate=cast(Any, StubChecks()),
+    )
+
+    with pytest.raises(lck_models.LckStopError, match="Critical Outcome FAIL"):
+        handler.complete(
+            160,
+            commit_message="Implement LCK Delivery cutover",
+            summary="Move initial Delivery mechanics into LCK.",
+        )
+
+    assert commit.calls == ["stage_candidate_tree"]
+    assert remote.calls == 0
+
+    store = lck_receipts.AuditReceiptStore(tmp_path)
+    payload = lck_receipts._write_failure_receipt(
+        operation="delivery-complete",
+        task_number=160,
+        operation_id="c" * 32,
+        status="stop",
+        code=None,
+        error="Critical Outcome FAIL: test exited 1",
+        handler=handler,
+        store=store,
+    )
+    receipt = store.read(payload["receipt_reference"])
+
+    assert handler.last_critical_outcome is not None
+    assert receipt["audit"]["critical_outcome"]["status"] == "fail"
+    assert receipt["audit"]["critical_outcome"]["exit_code"] == 1
+    assert receipt["audit"]["critical_outcome"]["summary"] == "1 failed"
+
+
+def test_delivery_failure_receipt_preserves_failed_formal_validation_payload(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "tests" / "test_critical_path.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("def test_critical_path(): pass\n", encoding="utf-8")
+    state = _live_state(
+        head="d" * 40,
+        clean=False,
+        project_status="In Progress",
+        open_pr=None,
+        remote_oid=None,
+    )
+    validation_payload = {
+        "schema_version": 1,
+        "operation": "workflow-validation",
+        "run_id": "val-delivery-receipt",
+        "phase": "delivery",
+        "base_sha": SHA,
+        "status": "fail",
+        "command_count": 1,
+        "passed": 0,
+        "failed": 1,
+        "commands": [
+            {
+                "command_id": "pytest",
+                "status": "fail",
+                "exit_code": 1,
+                "duration_ms": 37,
+                "summary": "1 failed",
+                "log_path": ".agents/validation.local/pytest.log",
+                "diagnostic": "assertion failed",
+            }
+        ],
+        "limitations": [],
+        "output_dir": ".agents/validation.local",
+    }
+
+    class FailingFormalValidationRunner(CompletionRunner):
+        def run(
+            self,
+            argv: list[str] | tuple[str, ...],
+            *,
+            command_id: str,
+            **kwargs: Any,
+        ) -> CommandResult:
+            if command_id == "lck-formal-delivery-validation":
+                command = tuple(str(item) for item in argv)
+                self.commands.append(command)
+                return CommandResult(
+                    command_id,
+                    command,
+                    1,
+                    json.dumps(validation_payload),
+                    "",
+                )
+            return super().run(argv, command_id=command_id, **kwargs)
+
+    runner = FailingFormalValidationRunner()
+    resolver = SequenceResolver(tmp_path, runner, [state])
+    handler = lck_delivery.DeliveryCompleter(
+        cast(Any, resolver),
+        formal_validation=cast(Any, lck_validation.FormalValidationGate(resolver)),
+        commit_effect=cast(Any, StubCommit(dirty=True)),
+        remote_effect=cast(Any, StubEffect("ensure_remote_branch", "created")),
+        pr_effect=cast(Any, StubEffect("ensure_open_pr", "created")),
+        status_effect=cast(Any, StubEffect("set_review_status", "updated")),
+        checks_gate=cast(Any, StubChecks()),
+    )
+
+    with pytest.raises(
+        lck_models.LckStopError, match="formal Delivery validation failed"
+    ):
+        handler.complete(
+            160,
+            commit_message="Implement LCK Delivery cutover",
+            summary="Move initial Delivery mechanics into LCK.",
+        )
+
+    store = lck_receipts.AuditReceiptStore(tmp_path)
+    payload = lck_receipts._write_failure_receipt(
+        operation="delivery-complete",
+        task_number=160,
+        operation_id="e" * 32,
+        status="stop",
+        code=None,
+        error="formal Delivery validation failed: fail",
+        handler=handler,
+        store=store,
+    )
+    receipt = store.read(payload["receipt_reference"])
+
+    assert receipt["audit"]["validation"] == validation_payload
+
+
+def test_delivery_failure_receipt_preserves_completed_operation_evidence(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "tests" / "test_critical_path.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("def test_critical_path(): pass\n", encoding="utf-8")
+    head = "b" * 40
+    state = _live_state(
+        head=head,
+        clean=True,
+        project_status="In Progress",
+        open_pr=None,
+        remote_oid=None,
+    )
+
+    class FailingFinalRunner(CompletionRunner):
+        def run(
+            self,
+            argv: list[str] | tuple[str, ...],
+            *,
+            command_id: str,
+            **kwargs: Any,
+        ) -> CommandResult:
+            result = super().run(argv, command_id=command_id, **kwargs)
+            if tuple(argv[:2]) == ("git", "status"):
+                return CommandResult(command_id, tuple(argv), 0, " M candidate\n", "")
+            return result
+
+    runner = FailingFinalRunner()
+    resolver = SequenceResolver(tmp_path, runner, [state])
+    checks = StubChecks()
+    handler = lck_delivery.DeliveryCompleter(
+        cast(Any, resolver),
+        formal_validation=cast(Any, StubValidation()),
+        commit_effect=cast(Any, StubCommit(dirty=False)),
+        remote_effect=cast(Any, StubEffect("ensure_remote_branch", "created")),
+        pr_effect=cast(Any, StubEffect("ensure_open_pr", "created")),
+        status_effect=cast(Any, StubEffect("set_review_status", "updated")),
+        checks_gate=cast(Any, checks),
+    )
+
+    with pytest.raises(lck_models.LckStopError, match="local postcondition failed"):
+        handler.complete(
+            160,
+            commit_message="Implement LCK Delivery cutover",
+            summary="Move initial Delivery mechanics into LCK.",
+        )
+
+    store = lck_receipts.AuditReceiptStore(tmp_path)
+    payload = lck_receipts._write_failure_receipt(
+        operation="delivery-complete",
+        task_number=160,
+        operation_id="d" * 32,
+        status="stop",
+        code=None,
+        error="Delivery local postcondition failed",
+        handler=handler,
+        store=store,
+    )
+    receipt = store.read(payload["receipt_reference"])
+
+    assert handler.last_snapshot is not None
+    assert receipt["operation_snapshot"] == handler.last_snapshot.to_dict()
+    assert receipt["audit"]["critical_outcome"]["status"] == "pass"
+    assert receipt["audit"]["validation"]["status"] == "pass"
+    assert receipt["audit"]["checks"] == handler.last_checks
+    assert receipt["audit"]["checks"]["pr"] == {
+        "number": 10,
+        "head_sha": "b" * 40,
+        "base_sha": SHA,
+    }
+    assert [item["effect"] for item in receipt["audit"]["effects"]] == [
+        "commit_current_tree",
+        "ensure_remote_branch",
+        "ensure_open_pr",
+        "set_review_status",
+    ]
+
+
+def test_delivery_complete_freezes_authority_for_the_operation(tmp_path: Path) -> None:
+    target = tmp_path / "tests" / "test_critical_path.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("def test_critical_path(): pass\n", encoding="utf-8")
+    pre = _live_state(
+        head="d" * 40,
+        clean=False,
+        project_status="In Progress",
+        open_pr=None,
+        remote_oid=None,
+    )
+    changed_issue = dict(pre.issue or {})
+    changed_issue["body_sha256"] = "f" * 64
+    changed = lck_models.LiveState(
+        **{
+            **pre.__dict__,
+            "issue": changed_issue,
+            "git": {**pre.git, "remote_main_sha": "f" * 40},
+        }
+    )
+    resolver = SequenceResolver(tmp_path, CompletionRunner(), [pre, changed])
+
+    result = lck_delivery.DeliveryCompleter(
+        cast(Any, resolver),
+        formal_validation=cast(Any, StubValidation()),
+        commit_effect=cast(Any, StubCommit(dirty=True)),
+        remote_effect=cast(Any, StubEffect("ensure_remote_branch", "created")),
+        pr_effect=cast(Any, StubEffect("ensure_open_pr", "created")),
+        status_effect=cast(Any, StubEffect("set_review_status", "updated")),
+        checks_gate=cast(Any, StubChecks()),
+    ).complete(
+        160,
+        commit_message="Implement LCK Delivery cutover",
+        summary="Move initial Delivery mechanics into LCK.",
+    )
+
+    assert result.status == "READY_FOR_REVIEW"
+    assert result.operation_snapshot.state.issue["body_sha256"] == "e" * 64
+    assert result.operation_snapshot.state.git["remote_main_sha"] == SHA
+    assert resolver.calls == 1
+
+
+def test_failed_checks_do_not_block_delivery_project_status_transition(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "tests" / "test_critical_path.py"
+    target.parent.mkdir(parents=True)
+    target.write_text(
+        "def test_critical_path(): pass\
+",
+        encoding="utf-8",
+    )
+    head = "b" * 40
+    pre = _live_state(
+        head=head,
+        clean=True,
+        project_status="In Progress",
+        open_pr=None,
+        remote_oid=None,
+    )
+    remote = _live_state(
+        head=head,
+        clean=True,
+        project_status="In Progress",
+        open_pr=None,
+        remote_oid=head,
+    )
+    pr = {
+        "number": 10,
+        "state": "OPEN",
+        "isDraft": False,
+        "headRefOid": head,
+        "baseRefOid": SHA,
+    }
+    with_pr = _live_state(
+        head=head,
+        clean=True,
+        project_status="In Progress",
+        open_pr=pr,
+        remote_oid=head,
+    )
+    runner = CompletionRunner()
+    resolver = SequenceResolver(tmp_path, runner, [pre, pre, remote, with_pr])
+    status = StubEffect("set_review_status", "updated")
+
+    result = lck_delivery.DeliveryCompleter(
+        cast(Any, resolver),
+        formal_validation=cast(Any, StubValidation()),
+        commit_effect=cast(Any, StubCommit(dirty=False)),
+        remote_effect=cast(Any, StubEffect("ensure_remote_branch", "created")),
+        pr_effect=cast(Any, StubEffect("ensure_open_pr", "created")),
+        status_effect=cast(Any, status),
+        checks_gate=cast(Any, FailingChecks()),
+    ).complete(
+        160,
+        commit_message="Implement LCK Delivery cutover",
+        summary="Move initial Delivery mechanics into LCK.",
+    )
+
+    assert result.status == "READY_FOR_REVIEW"
+    assert status.calls == 1
+
+
+def test_initial_delivery_reaches_ready_for_review_with_pending_checks(
+    tmp_path: Path,
+) -> None:
+    """Critical Outcome: pending CI is observed but is not a Delivery veto."""
+    target = tmp_path / "tests" / "test_critical_path.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("def test_critical_path(): pass\n", encoding="utf-8")
+    head = "b" * 40
+    pr = {
+        "number": 10,
+        "state": "OPEN",
+        "isDraft": False,
+        "headRefOid": head,
+        "baseRefOid": SHA,
+        "statusCheckRollup": [
+            {"name": "quality", "status": "IN_PROGRESS", "conclusion": None}
+        ],
+    }
+    state = _live_state(
+        head=head,
+        clean=True,
+        project_status="In Progress",
+        open_pr=pr,
+        remote_oid=head,
+    )
+    resolver = SequenceResolver(tmp_path, CompletionRunner(), [state])
+    status = StubEffect("set_review_status", "updated")
+
+    result = lck_delivery.DeliveryCompleter(
+        cast(Any, resolver),
+        formal_validation=cast(Any, StubValidation()),
+        commit_effect=cast(Any, StubCommit(dirty=False)),
+        remote_effect=cast(Any, StubEffect("ensure_remote_branch", "already-present")),
+        pr_effect=cast(Any, StubEffect("ensure_open_pr", "already-present")),
+        status_effect=cast(Any, status),
+    ).complete(
+        160,
+        commit_message="Move required checks to Review and Merge gates",
+        summary="Publish the validated candidate without waiting for CI.",
+    )
+
+    assert result.status == "READY_FOR_REVIEW"
+    assert result.checks["status"] == "observed"
+    assert result.checks["check_state"] == "pending"
+    assert status.calls == 1
+
+
+def test_delivery_complete_does_not_requery_checks_after_gate(tmp_path: Path) -> None:
+    target = tmp_path / "tests" / "test_critical_path.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("def test_critical_path(): pass\n", encoding="utf-8")
+    head = "b" * 40
+    snapshot_state = _live_state(
+        head=head,
+        clean=True,
+        project_status="In Progress",
+        open_pr=None,
+        remote_oid=None,
+    )
+    later_pr = {
+        "number": 10,
+        "state": "OPEN",
+        "isDraft": False,
+        "headRefOid": head,
+        "baseRefOid": SHA,
+    }
+    later_state = _with_checks(
+        _live_state(
+            head=head,
+            clean=True,
+            project_status="Review",
+            open_pr=later_pr,
+            remote_oid=head,
+        ),
+        _checks(category="failed", state_name="FAILURE"),
+    )
+    resolver = SequenceResolver(
+        tmp_path, CompletionRunner(), [snapshot_state, later_state]
+    )
+    checks = StubChecks()
+
+    result = lck_delivery.DeliveryCompleter(
+        cast(Any, resolver),
+        formal_validation=cast(Any, StubValidation()),
+        commit_effect=cast(Any, StubCommit(dirty=False)),
+        remote_effect=cast(Any, StubEffect("ensure_remote_branch", "created")),
+        pr_effect=cast(Any, StubEffect("ensure_open_pr", "created")),
+        status_effect=cast(Any, StubEffect("set_review_status", "updated")),
+        checks_gate=cast(Any, checks),
+    ).complete(
+        160,
+        commit_message="Implement LCK Delivery cutover",
+        summary="Move initial Delivery mechanics into LCK.",
+    )
+
+    assert result.status == "READY_FOR_REVIEW"
+    assert checks.calls == 1
+    assert resolver.calls == 1
+
+
+def test_set_review_status_requires_matching_checks_receipt(tmp_path: Path) -> None:
+    head = "b" * 40
+    state = _live_state(
+        head=head,
+        clean=True,
+        project_status="In Progress",
+        open_pr=None,
+        remote_oid=head,
+    )
+    resolver = SequenceResolver(tmp_path, CompletionRunner(), [state])
+    effect = lck_effects.SetReviewStatusEffect(cast(Any, resolver))
+
+    with pytest.raises(
+        lck_models.LckStopError, match="checks receipt PR identity mismatch"
+    ):
+        effect.execute(
+            state,
+            expected_pr={"number": 10, "head_sha": head, "base_sha": SHA},
+            checks_result={
+                "status": "pass",
+                "pr": {"number": 11, "head_sha": head, "base_sha": SHA},
+            },
+        )
+
+    assert resolver.calls == 0
+
+
+def test_set_review_status_rejects_failed_checks_receipt_before_mutation(
+    tmp_path: Path,
+) -> None:
+    head = "b" * 40
+    state = _live_state(
+        head=head,
+        clean=True,
+        project_status="In Progress",
+        open_pr=None,
+        remote_oid=head,
+    )
+    runner = CompletionRunner()
+    resolver = SequenceResolver(tmp_path, runner, [state])
+    identity = {"number": 10, "head_sha": head, "base_sha": SHA}
+
+    with pytest.raises(lck_models.LckStopError, match="PR checks receipt is invalid"):
+        lck_effects.SetReviewStatusEffect(cast(Any, resolver)).execute(
+            state,
+            expected_pr=identity,
+            checks_result={"status": "stop", "pr": identity},
+        )
+
+    assert not any(command[:2] == ("gh", "project") for command in runner.commands)
+    assert resolver.calls == 0
+
+
+def test_set_review_status_accepts_nonblocking_checks_observation(
+    tmp_path: Path,
+) -> None:
+    head = "b" * 40
+    state = _live_state(
+        head=head,
+        clean=True,
+        project_status="Review",
+        open_pr=None,
+        remote_oid=head,
+    )
+    resolver = SequenceResolver(tmp_path, CompletionRunner(), [state])
+    identity = {"number": 10, "head_sha": head, "base_sha": SHA}
+
+    receipt = lck_effects.SetReviewStatusEffect(cast(Any, resolver)).execute(
+        state,
+        expected_pr=identity,
+        checks_result={
+            "status": "observed",
+            "gate": "non-blocking",
+            "check_state": "pending",
+            "pr": identity,
+        },
+    )
+
+    assert receipt.action == "already-review"
+
+
+def test_set_review_status_rejects_ready_without_mutation(tmp_path: Path) -> None:
+    head = "b" * 40
+    state = _live_state(
+        head=head,
+        clean=True,
+        project_status="Ready",
+        open_pr=None,
+        remote_oid=head,
+    )
+    runner = CompletionRunner()
+    resolver = SequenceResolver(tmp_path, runner, [state])
+    identity = {"number": 10, "head_sha": head, "base_sha": SHA}
+
+    with pytest.raises(
+        lck_models.LckStopError,
+        match="requires In Progress before Review",
+    ):
+        lck_effects.SetReviewStatusEffect(cast(Any, resolver)).execute(
+            state,
+            expected_pr=identity,
+            checks_result={"status": "observed", "pr": identity},
+        )
+
+    assert not any(command[:2] == ("gh", "project") for command in runner.commands)

--- a/tests/tools/lck/test_documentation.py
+++ b/tests/tools/lck/test_documentation.py
@@ -1,0 +1,353 @@
+# ruff: noqa: E402, I001
+
+"""Acceptance tests for the enabled Documentation LCK profile."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+ROOT = Path(__file__).parents[3]
+AGENT_WORKFLOW = str(ROOT / "tools" / "agent_workflow")
+if AGENT_WORKFLOW not in sys.path:
+    sys.path.insert(0, AGENT_WORKFLOW)
+
+from tools.lck.documentation_policy import (  # type: ignore[import-not-found]  # noqa: E402
+    DocumentationPolicyStatus,
+    DocumentationTemplateError,
+    documentation_template_contract,
+    documentation_contract_snapshot,
+    evaluate_documentation_changes,
+)
+from tools.lck import (  # type: ignore[import-not-found]  # noqa: E402
+    delivery as lck_delivery,
+    issue_profiles as lck_profiles,
+)
+from tools.lck.models import Phase  # type: ignore[import-not-found]  # noqa: E402
+from tools.lck.profile_policies import (  # type: ignore[import-not-found]  # noqa: E402
+    DocumentationReclassificationRequired,
+    DocumentationValidationGate,
+)
+from .support import (  # noqa: E402
+    FakeRunner,
+    _install_facts,
+    _issue,
+    _relationships,
+    _resolver,
+)
+from tools.lck.feature_audit import (  # type: ignore[import-not-found]  # noqa: E402
+    _formal_blockers_gate,
+    _relationship_snapshot,
+)
+from tools.lck.common import CommandRunner  # type: ignore[import-not-found]  # noqa: E402
+
+
+DOCUMENTATION_BODY = """### Documentation Goal
+
+Explain the supported contract.
+
+### Requirements
+
+- Keep the documented behavior factual.
+
+### Acceptance Criteria
+
+- A reader can follow the contract.
+"""
+
+
+def test_documentation_profile_uses_shared_lifecycle_without_critical_outcome(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The supported Documentation Delivery path selects shared profile gates."""
+
+    resolution = lck_profiles.resolve_leaf_issue_profile(
+        {"labels": ["type:documentation"]}
+    )
+    assert resolution.resolved
+    assert resolution.profile is lck_profiles.DOCUMENTATION_PROFILE
+    assert resolution.profile.lifecycle_enabled
+    assert not resolution.profile.requires_critical_outcome
+    assert resolution.profile.branch_namespace == "documentation/"
+
+    issue = _issue()
+    issue.update(
+        {
+            "labels": {"items": ["type:documentation", "codex:ready"]},
+            "body": DOCUMENTATION_BODY,
+            "documentation_contract": documentation_contract_snapshot(
+                DOCUMENTATION_BODY
+            ),
+        }
+    )
+    fake = FakeRunner(branch="main")
+    _install_facts(
+        monkeypatch,
+        fake,
+        issue=issue,
+        relationships=_relationships(issue_type="Documentation"),
+    )
+
+    # The profile resolver and eligibility are the same shared controller
+    # entrypoints used by Task; only the profile-specific gate is different.
+    state = _resolver(fake).resolve(159)
+    decision = lck_delivery.PhaseEligibilityResolver().resolve(
+        state, Phase.DELIVERY_PREPARE
+    )
+    assert decision.eligible
+    assert "verify_critical_outcome" not in decision.capabilities
+
+    # This is intentionally a policy-only probe: no Critical Outcome verifier
+    # is invoked for a Documentation candidate.
+    resolver = cast(Any, type("Resolver", (), {"repo_root": tmp_path})())
+    resolver.runner = fake
+
+    class DocumentationGate:
+        def run(self, _base_sha: str) -> dict[str, Any]:
+            return {
+                "status": "pass",
+                "policy_id": "test-documentation-policy",
+            }
+
+    completer = lck_delivery.DeliveryCompleter(
+        resolver,
+        services=(DocumentationGate(),),
+    )
+    result = completer._run_profile_gates(
+        state,
+        "a" * 40,
+        progress=cast(Any, type("Progress", (), {"running": lambda *_args: None})()),
+    )
+    assert result is None
+
+
+def test_documentation_contract_is_typed_and_does_not_execute_context() -> None:
+    valid = documentation_contract_snapshot(DOCUMENTATION_BODY)
+    assert valid["status"] == DocumentationPolicyStatus.PASS
+    assert valid["required_sections"] == [
+        "Documentation Goal",
+        "Requirements",
+        "Acceptance Criteria",
+    ]
+    assert valid["empty_sections"] == []
+
+    invalid = documentation_contract_snapshot(
+        DOCUMENTATION_BODY + "\n### Documentation Goal\n"
+    )
+    assert invalid["status"] == DocumentationPolicyStatus.RECLASSIFICATION_REQUIRED
+    assert "duplicate sections" in str(invalid["detail"])
+
+    empty = documentation_contract_snapshot(
+        "### Documentation Goal\n\n### Requirements\n\n### Acceptance Criteria\n"
+    )
+    assert empty["status"] == DocumentationPolicyStatus.RECLASSIFICATION_REQUIRED
+    assert empty["empty_sections"] == [
+        "Documentation Goal",
+        "Requirements",
+        "Acceptance Criteria",
+    ]
+
+
+def test_live_relationship_normalization_preserves_documentation_blocker_contract() -> (
+    None
+):
+    """A typed Documentation blocker remains resolvable after GraphQL normalization."""
+
+    class Runner:
+        def run(self, argv: Any, *, command_id: str, **_: Any) -> Any:
+            return type(
+                "Result",
+                (),
+                {
+                    "returncode": 0,
+                    "stdout": json.dumps(
+                        {
+                            "data": {
+                                "repository": {
+                                    "issue": {
+                                        "number": 300,
+                                        "title": "Task with Documentation blocker",
+                                        "state": "OPEN",
+                                        "blockedBy": {
+                                            "nodes": [
+                                                {
+                                                    "number": 212,
+                                                    "title": "Typed Documentation activation",
+                                                    "state": "CLOSED",
+                                                    "body": DOCUMENTATION_BODY,
+                                                    "labels": {
+                                                        "nodes": [
+                                                            {
+                                                                "name": "type:documentation"
+                                                            }
+                                                        ],
+                                                        "pageInfo": {
+                                                            "hasNextPage": False
+                                                        },
+                                                    },
+                                                }
+                                            ],
+                                            "pageInfo": {"hasNextPage": False},
+                                        },
+                                        "blocking": {
+                                            "nodes": [],
+                                            "pageInfo": {"hasNextPage": False},
+                                        },
+                                        "subIssues": {
+                                            "nodes": [],
+                                            "pageInfo": {"hasNextPage": False},
+                                        },
+                                        "issueType": {"name": "Task"},
+                                        "parent": None,
+                                    }
+                                }
+                            }
+                        }
+                    ),
+                    "stderr": "",
+                },
+            )()
+
+    relationships = _relationship_snapshot(Runner(), "owner/repo", 300, [])
+    blocker = relationships["blocked_by"]["items"][0]
+
+    assert blocker["documentation_contract"] == documentation_contract_snapshot(
+        DOCUMENTATION_BODY
+    )
+    assert blocker["documentation_contract"]["status"] == "pass"
+    assert _formal_blockers_gate(relationships)["status"] == "pass"
+
+
+def test_documentation_contract_is_bound_to_the_form_schema() -> None:
+    schema = documentation_template_contract(
+        ROOT / ".github/ISSUE_TEMPLATE/documentation.yml"
+    )
+    assert schema.field_ids == ("objective", "requirements", "acceptance_criteria")
+    assert schema.section_labels == (
+        "Documentation Goal",
+        "Requirements",
+        "Acceptance Criteria",
+    )
+
+
+def test_documentation_contract_fails_closed_when_form_schema_is_unavailable(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(DocumentationTemplateError):
+        documentation_template_contract(tmp_path / "missing.yml")
+
+
+@pytest.mark.parametrize(
+    "changed_files",
+    [
+        ("src/tracequant/config.py",),
+        ("tests/test_runtime.py",),
+        ("tools/lck/__main__.py",),
+        ("AGENTS.md",),
+        ("docs/AGENTS.md",),
+        ("docs/architecture/AGENTS.md",),
+        ("docs/CLAUDE.md",),
+        ("docs/reference/CLAUDE.md",),
+        (".agents/policies/workflow-evidence.md",),
+        ("docs/development/issue-workflow.md",),
+        ("docs/workflows/lck.md",),
+    ],
+)
+def test_documentation_safe_change_policy_requires_reclassification(
+    changed_files: tuple[str, ...],
+) -> None:
+    result = evaluate_documentation_changes(changed_files)
+    assert result.status is DocumentationPolicyStatus.RECLASSIFICATION_REQUIRED
+    assert result.disallowed_files == changed_files
+    assert "reclassification or split required" in result.detail
+
+
+def test_documentation_safe_change_policy_allows_readme_and_reference_docs() -> None:
+    result = evaluate_documentation_changes(
+        ("README.md", "docs/architecture/domain-models.md")
+    )
+    assert result.status is DocumentationPolicyStatus.PASS
+    assert result.disallowed_files == ()
+
+
+def test_documentation_validation_gate_uses_typed_policy_without_issue_commands(
+    tmp_path: Path,
+) -> None:
+    class Runner:
+        def run(self, argv: Any, *, command_id: str, **_: Any) -> Any:
+            command = tuple(argv)
+            if command == ("git", "merge-base", "a" * 40, "HEAD"):
+                return type(
+                    "Result",
+                    (),
+                    {"returncode": 0, "stdout": "b" * 40 + "\n", "stderr": ""},
+                )()
+            if command[:3] == ("git", "diff", "--cached"):
+                stdout = "README.md\n"
+            else:
+                raise AssertionError(command)
+            return type(
+                "Result",
+                (),
+                {"returncode": 0, "stdout": stdout, "stderr": ""},
+            )()
+
+    resolver = type("Resolver", (), {"runner": Runner(), "repo_root": tmp_path})()
+    result = DocumentationValidationGate(cast(Any, resolver)).run("a" * 40)
+    assert result["status"] == DocumentationPolicyStatus.PASS
+    assert result["policy_id"] == "repository-documentation-safe-v1"
+    assert result["effective_diff"]["source"] == "index"
+
+
+def test_documentation_validation_gate_uses_effective_diff_for_stale_branch_base(
+    tmp_path: Path,
+) -> None:
+    """A stale branch remains subject to the Review effective-diff boundary."""
+
+    import subprocess
+
+    def git(*args: str) -> str:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout.strip()
+
+    subprocess.run(
+        ["git", "init", "-b", "main", str(tmp_path)],
+        check=True,
+        capture_output=True,
+    )
+    git("config", "user.name", "TraceQuant Test")
+    git("config", "user.email", "tracequant-test@example.invalid")
+    (tmp_path / "README.md").write_text("seed\n", encoding="utf-8")
+    git("add", "README.md")
+    git("commit", "-m", "seed")
+    git("switch", "-c", "documentation/stale")
+    git("switch", "main")
+    (tmp_path / "tools.md").write_text("behavior\n", encoding="utf-8")
+    git("add", "tools.md")
+    git("commit", "-m", "main independently adds content")
+    current_main = git("rev-parse", "HEAD")
+    git("switch", "documentation/stale")
+    (tmp_path / "tools.md").write_text("behavior\n", encoding="utf-8")
+    git("add", "tools.md")
+
+    resolver = type(
+        "Resolver",
+        (),
+        {"runner": CommandRunner(tmp_path), "repo_root": tmp_path},
+    )()
+    with pytest.raises(
+        DocumentationReclassificationRequired,
+        match="DOCUMENTATION_RECLASSIFICATION_REQUIRED",
+    ):
+        DocumentationValidationGate(cast(Any, resolver)).run(current_main)

--- a/tests/tools/lck/test_feature_audit.py
+++ b/tests/tools/lck/test_feature_audit.py
@@ -1,0 +1,518 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+SCRIPT = Path(__file__).parents[3] / "tools" / "lck" / "feature_audit.py"
+PYTHON = os.environ.get("WORKFLOW_TEST_PYTHON", sys.executable)
+
+
+def _write_fake_tools(tmp_path: Path) -> Path:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+
+    def add_windows_launcher(name: str) -> None:
+        if os.name != "nt":
+            return
+        launcher = bin_dir / f"{name}.cmd"
+        launcher.write_text(
+            f'@echo off\r\n"{PYTHON}" "{bin_dir / name}" %*\r\n',
+            encoding="utf-8",
+        )
+
+    git_script = bin_dir / "git"
+    git_script.write_text(
+        f"""#!{PYTHON}
+import json, os, sys
+from pathlib import Path
+state=json.loads(Path(os.environ['FAKE_WORKFLOW_STATE']).read_text(encoding='utf-8'))
+args=sys.argv[1:]
+def out(value=''):
+    sys.stdout.write(str(value))
+    if value and not str(value).endswith('\\n'): sys.stdout.write('\\n')
+if args[:2] == ['fetch','--prune']:
+    if not state.get('fetch_ok', True):
+        sys.stderr.write(r'failed at C:/Users/Maple/repo and /home/maple/repo')
+        sys.exit(1)
+    sys.exit(0)
+elif args[:3] == ['remote','get-url','origin']: out('https://github.com/owner/repo.git')
+elif args[:2] == ['branch','--show-current']: out(state.get('branch','main'))
+elif args[:2] == ['rev-parse','HEAD']: out(state.get('git_head','a'*40))
+elif args[:2] == ['rev-parse','refs/heads/main']: out(state.get('local_main',state.get('origin_main','b'*40)))
+elif args[:2] == ['rev-parse','refs/remotes/origin/main']: out(state.get('origin_main','b'*40))
+elif args[:3] == ['ls-remote','origin','refs/heads/main']:
+    out(state.get('origin_main','b'*40)+'\trefs/heads/main')
+elif args[:1] == ['rev-parse'] and args[1].startswith('refs/heads/'):
+    branch=args[1].removeprefix('refs/heads/')
+    out(state.get('local_branch_tips',{{}}).get(branch, state.get('pr',{{}}).get('headRefOid','d'*40)))
+elif args[:2] == ['status','--short']: out('\\n'.join(state.get('status',[])))
+elif args[:3] == ['diff','--cached','--name-only']: out('\\n'.join(state.get('staged',[])))
+elif args[:2] == ['diff','--name-only']: out('\\n'.join(state.get('changed',[])))
+elif args[:3] == ['worktree','list','--porcelain']:
+    lines=['worktree <repo>','HEAD '+state.get('git_head','a'*40),'branch refs/heads/main']
+    for branch in state.get('extra_worktree_branches',[]):
+        lines.extend(['worktree <repo-'+branch+'>','HEAD '+state.get('pr',{{}}).get('headRefOid','d'*40),'branch refs/heads/'+branch])
+    out('\\n'.join(lines))
+elif args[:3] == ['log','-1','--format=%H']: out(state.get('runner_source_sha','c'*40))
+elif args[:2] == ['ls-remote','--heads']:
+    if state.get('remote_branch_exists',True):
+        out(state.get('remote_branch_tips',{{}}).get(args[-1], state.get('pr',{{}}).get('headRefOid','d'*40))+'\\trefs/heads/'+args[-1])
+elif args[:3] == ['show-ref','--verify','--quiet']:
+    sys.exit(0 if state.get('local_branch_exists',True) else 1)
+elif args[:1] == ['merge-base']:
+    out(state.get('branch_base', state.get('origin_main','b'*40)))
+elif args[:2] == ['merge-base','--is-ancestor']:
+    sys.exit(0 if state.get('merge_on_main', True) else 1)
+elif args[:2] == ['diff','--quiet']:
+    sys.exit(0 if state.get('tree_equal', True) else 1)
+elif args[:2] == ['diff','--check']: sys.exit(0)
+else:
+    sys.stderr.write('unsupported fake git: '+' '.join(args))
+    sys.exit(1)
+""",
+        encoding="utf-8",
+    )
+    gh_script = bin_dir / "gh"
+    gh_script.write_text(
+        f"""#!{PYTHON}
+import json, os, sys
+from pathlib import Path
+state=json.loads(Path(os.environ['FAKE_WORKFLOW_STATE']).read_text(encoding='utf-8'))
+args=sys.argv[1:]
+def dump(value): print(json.dumps(value, ensure_ascii=False))
+if args[:2] == ['repo','view']:
+    dump({{'nameWithOwner':'owner/repo'}})
+elif args[:2] == ['issue','view']:
+    number=args[2]
+    issue=state.get('issues',{{}}).get(number)
+    if issue is None: sys.stderr.write('404 issue'); sys.exit(1)
+    dump(issue)
+elif args[:2] == ['pr','view']:
+    number=args[2]
+    dump(state.get('prs',{{}}).get(number, state['pr']))
+elif args[:2] == ['pr','diff']:
+    if not state.get('diff_available', True):
+        sys.stderr.write('diff unavailable')
+        sys.exit(1)
+    sys.stdout.write(state.get('diff','diff --git a/a b/a\\n'))
+elif args[:2] == ['api','graphql']:
+    query=' '.join(args)
+    if 'pullRequest' in query and 'reviewThreads' in query:
+        dump({{'data':{{'repository':{{'pullRequest':{{'reviewThreads':state.get('threads',{{'nodes':[],'pageInfo':{{'hasNextPage':False}}}})}}}}}}}})
+    elif 'timelineItems' in query:
+        number_value=None
+        for arg in args:
+            if arg.startswith('number='):
+                number_value=arg.split('=',1)[1]
+        issue=state.get('issues',{{}}).get(number_value)
+        dump({{'data':{{'repository':{{'issue':issue}}}}}})
+    elif 'projectItems(first:20)' in query and 'blockedBy' not in query:
+        number_value=None
+        for arg in args:
+            if arg.startswith('number='):
+                number_value=arg.split('=',1)[1]
+        issue=state.get('issues',{{}}).get(number_value)
+        status=None
+        if issue is not None:
+            items=issue.get('projectItems',[])
+            if items:
+                status=items[0].get('status',{{}}).get('name')
+        fields=[] if status is None else [{{'__typename':'ProjectV2ItemFieldSingleSelectValue','name':status,'field':{{'name':'Status'}}}}]
+        project_items={{'nodes':[{{'project':{{'number':1,'title':'Quant System Development','owner':{{'login':'owner'}}}},'content':{{'number':int(number_value),'repository':{{'nameWithOwner':'owner/repo'}}}},'fieldValues':{{'nodes':fields,'pageInfo':{{'hasNextPage':False}}}}}}],'pageInfo':{{'hasNextPage':False}}}}
+        dump({{'data':{{'repository':{{'issue':{{'number':int(number_value),'projectItems':project_items}}}}}}}})
+    else:
+        number_value=None
+        for arg in args:
+            if arg.startswith('number='):
+                number_value=arg.split('=',1)[1]
+        relation=state.get('relationships_by_issue',{{}}).get(number_value, state.get('relationships'))
+        dump({{'data':{{'repository':{{'issue':relation}}}}}})
+elif args and args[0] == 'api' and 'required_status_checks' in args[1]:
+    mode=state.get('required_checks_mode','available')
+    if mode == 'plan-limit-403':
+        sys.stderr.write('HTTP 403 Branch protection for private repositories is not included in this GitHub plan')
+        sys.exit(1)
+    if mode == '403':
+        sys.stderr.write('HTTP 403 Resource not accessible by integration')
+        sys.exit(1)
+    if mode == '404': sys.stderr.write('HTTP 404 Not Found'); sys.exit(1)
+    dump(state.get('required_checks',{{'contexts':['CI']}}))
+else:
+    sys.stderr.write('unsupported fake gh: '+' '.join(args))
+    sys.exit(1)
+""",
+        encoding="utf-8",
+    )
+    git_script.chmod(0o755)
+    gh_script.chmod(0o755)
+    add_windows_launcher("git")
+    add_windows_launcher("gh")
+    return bin_dir
+
+
+def _base_state() -> dict[str, Any]:
+    task_issue = {
+        "number": 70,
+        "title": "[Task] Optimize workflow",
+        "state": "OPEN",
+        "labels": [{"name": "type:task"}, {"name": "codex:ready"}],
+        "projectItems": [{"status": {"name": "Ready"}}],
+        "url": "https://github.com/owner/repo/issues/70",
+        "closedAt": None,
+        "closedByPullRequestsReferences": [],
+        "timelineItems": {"nodes": [], "pageInfo": {"hasPreviousPage": False}},
+    }
+    child_issue = {
+        "number": 63,
+        "title": "[Task] Child",
+        "state": "CLOSED",
+        "labels": [{"name": "type:task"}, {"name": "codex:ready"}],
+        "projectItems": [{"status": {"name": "Done"}}],
+        "url": "https://github.com/owner/repo/issues/63",
+        "closedAt": "2026-07-26T00:00:00Z",
+        "closedByPullRequestsReferences": [
+            {
+                "number": 67,
+                "state": "MERGED",
+                "mergedAt": "2026-07-26T00:00:00Z",
+                "url": "https://github.com/owner/repo/pull/67",
+                "merged": True,
+                "repository": {"nameWithOwner": "owner/repo"},
+            }
+        ],
+        "timelineItems": {
+            "nodes": [
+                {
+                    "__typename": "ClosedEvent",
+                    "createdAt": "2026-07-26T00:00:00Z",
+                    "closer": {
+                        "__typename": "PullRequest",
+                        "number": 67,
+                        "state": "MERGED",
+                        "merged": True,
+                        "mergedAt": "2026-07-26T00:00:00Z",
+                        "url": "https://github.com/owner/repo/pull/67",
+                        "repository": {"nameWithOwner": "owner/repo"},
+                    },
+                }
+            ],
+            "pageInfo": {"hasPreviousPage": False},
+        },
+    }
+    return {
+        "branch": "task-70",
+        "git_head": "1" * 40,
+        "origin_main": "2" * 40,
+        "runner_source_sha": "3" * 40,
+        "status": [],
+        "staged": [],
+        "changed": ["tools/lck/feature_audit.py"],
+        "remote_branch_exists": True,
+        "local_branch_exists": True,
+        "issues": {"70": task_issue, "63": child_issue},
+        "relationships_by_issue": {
+            "63": {
+                "number": 63,
+                "title": "[Task] Child",
+                "state": "CLOSED",
+                "issueType": {"name": "Task"},
+                "parent": {
+                    "number": 62,
+                    "title": "[Feature] Workflow",
+                    "state": "OPEN",
+                },
+                "subIssues": {"nodes": [], "pageInfo": {"hasNextPage": False}},
+                "blockedBy": {"nodes": []},
+                "blocking": {"nodes": []},
+            }
+        },
+        "relationships": {
+            "number": 70,
+            "title": "[Task] Optimize workflow",
+            "state": "OPEN",
+            "issueType": {"name": "Task"},
+            "parent": {"number": 62, "title": "[Feature] Workflow", "state": "OPEN"},
+            "subIssues": {"nodes": [], "pageInfo": {"hasNextPage": False}},
+            "blockedBy": {"nodes": []},
+            "blocking": {"nodes": []},
+        },
+        "prs": {
+            "67": {
+                "number": 67,
+                "title": "[Task] Child",
+                "state": "MERGED",
+                "isDraft": False,
+                "url": "https://github.com/owner/repo/pull/67",
+                "baseRefName": "main",
+                "baseRefOid": "0" * 40,
+                "headRefName": "task-63",
+                "headRefOid": "6" * 40,
+                "mergeCommit": {"oid": "7" * 40},
+                "mergedAt": "2026-07-26T00:00:00Z",
+                "mergeable": "UNKNOWN",
+                "reviewDecision": "APPROVED",
+                "files": [{"path": "child.py"}],
+                "commits": [{"oid": "6" * 40, "messageHeadline": "Child"}],
+                "statusCheckRollup": [{"name": "CI", "conclusion": "SUCCESS"}],
+                "reviews": [],
+                "closingIssuesReferences": [{"number": 63}],
+            }
+        },
+        "pr": {
+            "number": 71,
+            "title": "[Task] Optimize workflow",
+            "state": "OPEN",
+            "isDraft": False,
+            "url": "https://github.com/owner/repo/pull/71",
+            "baseRefName": "main",
+            "baseRefOid": "2" * 40,
+            "headRefName": "task-70",
+            "headRefOid": "4" * 40,
+            "mergeCommit": None,
+            "mergedAt": None,
+            "mergeable": "MERGEABLE",
+            "reviewDecision": "",
+            "files": [{"path": f"file-{index}.py"} for index in range(120)],
+            "commits": [{"oid": "4" * 40, "messageHeadline": "Implement"}],
+            "statusCheckRollup": [{"name": "CI", "conclusion": "SUCCESS"}],
+            "reviews": [],
+            "closingIssuesReferences": [{"number": 70}],
+        },
+        "threads": {
+            "nodes": [],
+            "pageInfo": {"hasNextPage": False},
+        },
+        "required_checks": {"contexts": ["CI"]},
+        "required_checks_mode": "available",
+        "diff": "diff --git a/file.py b/file.py\n+safe content\n",
+    }
+
+
+def _write_repo(
+    tmp_path: Path, state: dict[str, Any]
+) -> tuple[Path, Path, dict[str, str]]:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".gitignore").write_text(
+        ".agents/evidence.local/\n.agents/validation.local/\n",
+        encoding="utf-8",
+    )
+    state_path = tmp_path / "state.json"
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    bin_dir = _write_fake_tools(tmp_path)
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+    env["FAKE_WORKFLOW_STATE"] = str(state_path)
+    env["PYTHONUTF8"] = "1"
+    env["PYTHONIOENCODING"] = "utf-8"
+    return repo, state_path, env
+
+
+def _run(
+    repo: Path, env: dict[str, str], *args: str
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [PYTHON, str(SCRIPT), *args, "--repo-root", str(repo)],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+    )
+
+
+LEGACY_TASK_COMMANDS = (
+    "delivery-preflight",
+    "delivery-readiness",
+    "pr-review-snapshot",
+    "pr-review-recheck",
+    "closeout-plan",
+    "closeout-final",
+)
+LEGACY_TASK_CONTROL_TOKENS = (
+    "write_actions_allowed",
+    "review-remediation",
+    "_compute_preflight_disposition",
+    "_delivery_preflight",
+    "_task_pr_snapshot",
+    "_closeout_plan",
+)
+
+
+def _feature_state() -> dict[str, Any]:
+    state = _base_state()
+    state["issues"]["62"] = {
+        "number": 62,
+        "title": "[Feature] Workflow",
+        "state": "OPEN",
+        "labels": [{"name": "type:feature"}],
+        "projectItems": [{"status": {"name": "In Progress"}}],
+        "url": "https://github.com/owner/repo/issues/62",
+        "closedAt": None,
+        "closedByPullRequestsReferences": [],
+        "timelineItems": {"nodes": [], "pageInfo": {"hasPreviousPage": False}},
+    }
+    state["relationships"] = {
+        "number": 62,
+        "title": "[Feature] Workflow",
+        "state": "OPEN",
+        "issueType": {"name": "Feature"},
+        "parent": None,
+        "subIssues": {
+            "nodes": [
+                {
+                    "number": 63,
+                    "title": "[Task] Child",
+                    "state": "CLOSED",
+                    "labels": {"nodes": [{"name": "type:task"}]},
+                }
+            ],
+            "pageInfo": {"hasNextPage": False},
+        },
+        "blockedBy": {"nodes": [], "pageInfo": {"hasNextPage": False}},
+        "blocking": {"nodes": [], "pageInfo": {"hasNextPage": False}},
+    }
+    return state
+
+
+def test_help_exposes_feature_audit_only() -> None:
+    for command in ("feature-audit-snapshot", "feature-audit-recheck"):
+        result = subprocess.run(
+            [PYTHON, str(SCRIPT), command, "--help"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+
+    top = subprocess.run(
+        [PYTHON, str(SCRIPT), "--help"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+    )
+    assert top.returncode == 0, top.stderr
+    for command in LEGACY_TASK_COMMANDS:
+        assert command not in top.stdout
+
+
+def test_legacy_task_control_cli_and_semantics_are_physically_removed() -> None:
+    source = SCRIPT.read_text(encoding="utf-8")
+    for token in (*LEGACY_TASK_COMMANDS, *LEGACY_TASK_CONTROL_TOKENS):
+        assert token not in source
+
+
+def test_feature_snapshot_collects_direct_child_and_pr_evidence(tmp_path: Path) -> None:
+    state = _feature_state()
+    repo, _, env = _write_repo(tmp_path, state)
+    result = _run(repo, env, "feature-audit-snapshot", "--feature", "62")
+    assert result.returncode == 0, result.stderr
+    value = json.loads(result.stdout)
+    assert value["operation"] == "feature-audit-snapshot"
+    assert value["gates"]["formal_blockers"]["status"] == "pass"
+    child = value["observed"]["direct_children"]["items"][0]
+    assert child["relationship_evidence"]["parent"]["number"] == 62
+    assert child["pull_request_evidence"]["items"][0]["number"] == 67
+    assert child["pull_request_evidence"]["items"][0]["checks_all_success"] is True
+
+
+def test_feature_recheck_detects_direct_child_set_drift(tmp_path: Path) -> None:
+    state = _feature_state()
+    repo, state_path, env = _write_repo(tmp_path, state)
+    first = _run(repo, env, "feature-audit-snapshot", "--feature", "62")
+    assert first.returncode == 0, first.stderr
+    first_value = json.loads(first.stdout)
+
+    state["issues"]["64"] = dict(
+        state["issues"]["63"], number=64, title="[Task] Another"
+    )
+    state["relationships"]["subIssues"]["nodes"].append(
+        {
+            "number": 64,
+            "title": "[Task] Another",
+            "state": "CLOSED",
+            "labels": {"nodes": [{"name": "type:task"}]},
+        }
+    )
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    second = _run(
+        repo,
+        env,
+        "feature-audit-recheck",
+        "--snapshot-id",
+        first_value["snapshot_id"],
+    )
+    assert second.returncode == 0, second.stderr
+    value = json.loads(second.stdout)
+    assert value["stability"]["stable"] is False
+    assert value["gates"]["feature_audit_stability"]["status"] == "fail"
+    assert "direct_child_set_digest" in value["stability"]["changed_fields"]["items"]
+
+
+def test_feature_recheck_detects_child_lifecycle_drift_without_set_change(
+    tmp_path: Path,
+) -> None:
+    state = _feature_state()
+    repo, state_path, env = _write_repo(tmp_path, state)
+    first = _run(repo, env, "feature-audit-snapshot", "--feature", "62")
+    assert first.returncode == 0, first.stderr
+    snapshot_id = json.loads(first.stdout)["snapshot_id"]
+
+    state["issues"]["63"]["projectItems"] = [{"status": {"name": "Review"}}]
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    second = _run(repo, env, "feature-audit-recheck", "--snapshot-id", snapshot_id)
+    assert second.returncode == 0, second.stderr
+    value = json.loads(second.stdout)
+    assert value["gates"]["feature_audit_stability"]["status"] == "fail"
+    assert (
+        "direct_child_evidence_digest" in value["stability"]["changed_fields"]["items"]
+    )
+
+
+def test_feature_blocker_gate_fails_for_open_blocker(tmp_path: Path) -> None:
+    state = _feature_state()
+    state["relationships"]["blockedBy"]["nodes"] = [
+        {"number": 72, "title": "[Task] Dependency", "state": "OPEN"}
+    ]
+    repo, _, env = _write_repo(tmp_path, state)
+    result = _run(repo, env, "feature-audit-snapshot", "--feature", "62")
+    assert result.returncode == 0, result.stderr
+    gate = json.loads(result.stdout)["gates"]["formal_blockers"]
+    assert gate["status"] == "fail"
+    assert "unresolved=1" in gate["detail"]
+
+
+def test_feature_blocker_gate_is_unknown_when_relationships_unavailable(
+    tmp_path: Path,
+) -> None:
+    state = _feature_state()
+    state["relationships"] = None
+    repo, _, env = _write_repo(tmp_path, state)
+    result = _run(repo, env, "feature-audit-snapshot", "--feature", "62")
+    assert result.returncode == 0, result.stderr
+    value = json.loads(result.stdout)
+    assert value["gates"]["formal_blockers"]["status"] == "unknown"
+
+
+def test_feature_fetch_failure_is_explicit_unknown_gate(tmp_path: Path) -> None:
+    state = _feature_state()
+    state["fetch_ok"] = False
+    repo, _, env = _write_repo(tmp_path, state)
+    result = _run(repo, env, "feature-audit-snapshot", "--feature", "62")
+    assert result.returncode == 0, result.stderr
+    value = json.loads(result.stdout)
+    assert value["gates"]["origin_fetch"]["status"] == "unknown"
+    assert any(item["command_id"] == "git-fetch-origin" for item in value["warnings"])
+    serialized = json.dumps(value)
+    assert "C:/Users" not in serialized
+    assert "/home/maple" not in serialized
+    assert "<absolute-path-redacted>" in serialized

--- a/tests/tools/lck/test_issue_form_contract.py
+++ b/tests/tools/lck/test_issue_form_contract.py
@@ -1,0 +1,133 @@
+# ruff: noqa: E402
+
+"""Tests for the profile-neutral Issue Form contract parser."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parents[3]
+AGENT_WORKFLOW = str(ROOT / "tools" / "agent_workflow")
+if AGENT_WORKFLOW not in sys.path:
+    sys.path.insert(0, AGENT_WORKFLOW)
+
+from tools.lck.issue_forms import (  # type: ignore[import-not-found]
+    IssueFormTemplateError,
+    issue_form_contract_snapshot,
+    load_issue_form_template,
+)
+
+TEMPLATE = """\
+name: Synthetic form
+body:
+  - type: markdown
+    attributes:
+      value: ignored
+  - type: textarea
+    id: first_field
+    attributes:
+      label: First Field
+    validations:
+      required: true
+  - type: textarea
+    id: second_field
+    attributes:
+      label: Second Field
+    validations:
+      required: true
+  - type: textarea
+    id: optional_field
+    attributes:
+      label: Optional Field
+    validations:
+      required: false
+"""
+
+
+def _write_template(tmp_path: Path, content: str = TEMPLATE) -> Path:
+    path = tmp_path / "synthetic.yml"
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _body(*, first: str = "first content", second: str = "second content") -> str:
+    return f"# First Field\n\n{first}\n\n###    Second Field\n\n{second}"
+
+
+def test_generic_parser_reads_required_textareas_and_equivalent_heading_spacing(
+    tmp_path: Path,
+) -> None:
+    path = _write_template(tmp_path)
+
+    template = load_issue_form_template(path, form_name="Synthetic")
+    snapshot = issue_form_contract_snapshot(
+        _body(),
+        template_path=path,
+        form_name="Synthetic",
+        template_display_path="synthetic.yml",
+    )
+
+    assert template.field_ids == ("first_field", "second_field")
+    assert template.section_labels == ("First Field", "Second Field")
+    assert snapshot == {
+        "status": "pass",
+        "required_sections": ["First Field", "Second Field"],
+        "missing_sections": [],
+        "duplicate_sections": [],
+        "empty_sections": [],
+        "template_path": "synthetic.yml",
+    }
+
+
+@pytest.mark.parametrize(
+    "template",
+    (
+        "body: [",
+        "body: []",
+        "body:\n  - type: textarea\n    id: one\n    attributes:\n      label: One\n    validations:\n      required: true\n  - type: textarea\n    id: one\n    attributes:\n      label: Two\n    validations:\n      required: true\n",
+        "body:\n  - type: textarea\n    id: one\n    attributes:\n      label: One\n    validations:\n      required: true\n  - type: textarea\n    id: two\n    attributes:\n      label:  One  \n    validations:\n      required: true\n",
+    ),
+)
+def test_template_failures_are_rejected_before_rendered_contract_parsing(
+    tmp_path: Path,
+    template: str,
+) -> None:
+    with pytest.raises(IssueFormTemplateError):
+        load_issue_form_template(_write_template(tmp_path, template))
+
+
+@pytest.mark.parametrize(
+    ("body", "field", "detail"),
+    (
+        (_body(second=""), "Second Field", "empty sections: Second Field"),
+        ("# First Field\n\nfirst content", "Second Field", "missing sections"),
+        (
+            _body() + "\n\n## First Field\n\nconflict",
+            "First Field",
+            "duplicate sections: First Field",
+        ),
+    ),
+)
+def test_rendered_contract_failures_are_bounded_and_fail_closed(
+    tmp_path: Path,
+    body: str,
+    field: str,
+    detail: str,
+) -> None:
+    snapshot = issue_form_contract_snapshot(
+        body,
+        template_path=_write_template(tmp_path),
+        form_name="Synthetic",
+        template_display_path="synthetic.yml",
+    )
+
+    assert snapshot["status"] == "reclassification_required"
+    assert field in (
+        snapshot["missing_sections"]
+        + snapshot["duplicate_sections"]
+        + snapshot["empty_sections"]
+    )
+    assert detail in snapshot["detail"]

--- a/tests/tools/lck/test_issue_profiles.py
+++ b/tests/tools/lck/test_issue_profiles.py
@@ -1,0 +1,166 @@
+# ruff: noqa: E402, I001
+
+"""Acceptance tests for the canonical LCK leaf Issue profile resolver."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+ROOT = Path(__file__).parents[3]
+AGENT_WORKFLOW = str(ROOT / "tools" / "agent_workflow")
+if AGENT_WORKFLOW not in sys.path:
+    sys.path.insert(0, AGENT_WORKFLOW)
+
+from tools.lck.models import Phase  # type: ignore[import-not-found]  # noqa: E402
+from tools.lck import (  # type: ignore[import-not-found]  # noqa: E402
+    eligibility as lck_eligibility,
+    issue_profiles as lck_profiles,
+)
+from .support import (  # noqa: E402
+    FakeRunner,
+    _install_facts,
+    _issue,
+    _relationships,
+    _resolver,
+    _review_state,
+)
+
+
+def _issue_with_labels(*labels: str, title: str = "ordinary title") -> dict[str, Any]:
+    return {
+        "labels": list(labels),
+        "title": title,
+        "body": "body text that must not participate in type resolution",
+    }
+
+
+def test_leaf_issue_profile_resolution_is_exact_and_fail_closed() -> None:
+    profiles = {
+        "type:task": ("task", True, "task/", True),
+        "type:bug": ("bug", False, "bug/", True),
+        "type:documentation": ("documentation", False, "documentation/", True),
+        "type:research": ("research", False, "research/", True),
+    }
+
+    for label, expected in profiles.items():
+        resolution = lck_profiles.resolve_leaf_issue_profile(_issue_with_labels(label))
+        assert resolution.resolved
+        assert resolution.profile is not None
+        profile = resolution.profile
+        assert (
+            profile.issue_kind.value,
+            profile.requires_critical_outcome,
+            profile.branch_namespace,
+            profile.lifecycle_enabled,
+        ) == expected
+        assert profile.canonical_type_label == label
+        assert profile.eligibility_policy == expected[0]
+        assert profile.validation_policy == expected[0]
+        assert profile.completion_policy == expected[0]
+
+    invalid_cases = (
+        (_issue_with_labels(), "MISSING_TYPE"),
+        (_issue_with_labels("type:task", "type:bug"), "MULTIPLE_TYPES"),
+        (_issue_with_labels("type:task", "type:task"), "MULTIPLE_TYPES"),
+        (_issue_with_labels("type:unknown"), "UNKNOWN_TYPE"),
+        (_issue_with_labels("type:feature"), "NON_LEAF_TYPE"),
+        (_issue_with_labels("type:epic"), "NON_LEAF_TYPE"),
+    )
+    for issue, expected_status in invalid_cases:
+        resolution = lck_profiles.resolve_leaf_issue_profile(issue)
+        assert not resolution.resolved
+        assert resolution.terminal_status == expected_status
+        assert resolution.profile is None
+
+    # The resolver has one input authority: changing title/body or supplying a
+    # GitHub Issue Type-shaped field cannot reclassify the canonical label.
+    resolution = lck_profiles.resolve_leaf_issue_profile(
+        {
+            "labels": [{"name": "type:task"}],
+            "title": "[Bug] type:bug",
+            "body": "### Objective\nThis is not a type carrier.",
+            "issue_type": "Bug",
+        }
+    )
+    assert resolution.profile is lck_profiles.TASK_PROFILE
+
+
+def test_bug_profile_is_enabled_without_a_task_critical_outcome(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = FakeRunner(branch="main")
+    issue = _issue()
+    issue["labels"] = {"items": ["type:bug", "codex:ready"]}
+    issue["body"] = """
+### Observed
+
+The bug workflow is rejected as a non-task issue.
+
+### Expected
+
+An implementation-bearing Bug can use the shared lifecycle directly.
+
+### Reproduction / Evidence
+
+The current profile resolver reports type:bug as disabled.
+
+### Acceptance Criteria
+
+- The Bug profile is eligible without a fabricated Critical Outcome.
+"""
+    from tools.lck.bug_policy import bug_contract_snapshot  # type: ignore[import-not-found]
+
+    issue["bug_contract"] = bug_contract_snapshot(issue["body"])
+    _install_facts(
+        monkeypatch,
+        fake,
+        issue=issue,
+        relationships=_relationships(issue_type="Task"),
+    )
+
+    state = _resolver(fake).resolve(159)
+    decision = lck_eligibility.PhaseEligibilityResolver().resolve(
+        state, Phase.DELIVERY_PREPARE
+    )
+
+    assert decision.eligible
+    assert "verify_critical_outcome" not in decision.capabilities
+    assert "prepare_task_workspace" in decision.capabilities
+    assert decision.issue_profile is not None
+    assert decision.issue_profile["profile"]["canonical_type_label"] == "type:bug"
+
+
+def test_task_profile_uses_labels_without_issue_type_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = FakeRunner(branch="main")
+    issue = _issue()
+    _install_facts(
+        monkeypatch,
+        fake,
+        issue=issue,
+        relationships=_relationships(issue_type="Bug"),
+    )
+
+    state = _resolver(fake).resolve(159)
+    decision = lck_eligibility.PhaseEligibilityResolver().resolve(
+        state, Phase.DELIVERY_PREPARE
+    )
+
+    assert decision.eligible
+    assert state.issue_profile is not None
+    assert state.issue_profile["profile"]["issue_kind"] == "task"
+    assert state.target_branch == "task/159-lck-core-live-state-resolution"
+
+
+def test_remediation_no_change_exposes_only_close_capability() -> None:
+    decision = lck_eligibility.PhaseEligibilityResolver().resolve(
+        _review_state(clean=True), Phase.REMEDIATION_NO_CHANGE
+    )
+
+    assert decision.eligible
+    assert decision.capabilities == ("close_no_change_remediation",)

--- a/tests/tools/lck/test_issue_templates.py
+++ b/tests/tools/lck/test_issue_templates.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+
+import yaml  # type: ignore[import-untyped]  # PyYAML is an existing test dependency.
+
+ROOT = Path(__file__).parents[3]
+
+
+def _load_documentation_form() -> dict[str, Any]:
+    path = ROOT / ".github" / "ISSUE_TEMPLATE" / "documentation.yml"
+    value = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(value, dict)
+    return cast(dict[str, Any], value)
+
+
+def test_documentation_issue_form_is_minimum_sufficient_leaf_contract() -> None:
+    form = _load_documentation_form()
+
+    assert form["name"] == "Documentation"
+    assert form["title"] == "[Documentation] "
+    assert form["labels"] == ["type:documentation", "codex:needs-spec"]
+
+    body = form["body"]
+    assert isinstance(body, list)
+    markdown = body[0]
+    fields = body[1:]
+    assert markdown["type"] == "markdown"
+    guidance = markdown["attributes"]["value"]
+    assert "新增、修正或收敛文档事实" in guidance
+    assert "runtime、业务源码、测试、CI、Agent control behavior" in guidance
+    assert "文件扩展名本身不能决定工作是否属于 Documentation" in guidance
+
+    assert [field["type"] for field in fields] == ["textarea"] * 4
+    assert [field["id"] for field in fields] == [
+        "objective",
+        "requirements",
+        "acceptance_criteria",
+        "additional_context",
+    ]
+    assert [field["attributes"]["label"] for field in fields] == [
+        "Documentation Goal",
+        "Requirements",
+        "Acceptance Criteria",
+        "Additional documentation context",
+    ]
+    assert [field["validations"]["required"] for field in fields] == [
+        True,
+        True,
+        True,
+        False,
+    ]
+
+    submitted = {
+        "objective": "Clarify the current data contract.",
+        "requirements": "Document the accepted timestamp and nullability rules.",
+        "acceptance_criteria": "Readers can identify the contract without consulting source code.",
+    }
+    rendered = "\n\n".join(
+        f"### {field['attributes']['label']}\n\n{submitted[field['id']]}"
+        for field in fields
+        if field["id"] in submitted
+    )
+    assert rendered == (
+        "### Documentation Goal\n\nClarify the current data contract.\n\n"
+        "### Requirements\n\nDocument the accepted timestamp and nullability rules.\n\n"
+        "### Acceptance Criteria\n\nReaders can identify the contract without consulting source code."
+    )
+    assert "Additional documentation context" not in rendered
+    assert "N/A" not in rendered

--- a/tests/tools/lck/test_markdown_sections.py
+++ b/tests/tools/lck/test_markdown_sections.py
@@ -1,0 +1,244 @@
+# ruff: noqa: E402
+
+"""Regression tests for shared typed Issue Markdown section extraction."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parents[3]
+AGENT_WORKFLOW = str(ROOT / "tools" / "agent_workflow")
+if AGENT_WORKFLOW not in sys.path:
+    sys.path.insert(0, AGENT_WORKFLOW)
+
+from tools.lck.bug_policy import bug_contract_snapshot  # type: ignore[import-not-found]
+from tools.lck.documentation_policy import (  # type: ignore[import-not-found]
+    documentation_contract_snapshot,
+)
+from tools.lck.markdown_sections import (  # type: ignore[import-not-found]
+    extract_markdown_sections,
+)
+from tools.lck.research_policy import (
+    research_contract_snapshot,  # type: ignore[import-not-found]
+)
+
+SECTION_BODIES = {
+    "bug": (
+        "Observed",
+        "Expected",
+        "Reproduction / Evidence",
+        "Acceptance Criteria",
+    ),
+    "documentation": (
+        "Documentation Goal",
+        "Requirements",
+        "Acceptance Criteria",
+    ),
+    "research": (
+        "Question / Decision Needed",
+        "Context",
+        "Scope",
+        "Non-goals",
+        "Evidence / Evaluation Criteria",
+        "Expected Outcome / Artifact",
+    ),
+}
+
+
+def _body(headings: tuple[str, ...], level: int = 3) -> str:
+    return "\n\n".join(
+        f"{'#' * level} {heading}\n\ncontent for {heading}" for heading in headings
+    )
+
+
+@pytest.mark.parametrize("level", (1, 2, 3, 6))
+@pytest.mark.parametrize("profile", ("bug", "documentation", "research"))
+def test_typed_contracts_accept_equivalent_heading_levels(
+    profile: str,
+    level: int,
+) -> None:
+    body = _body(SECTION_BODIES[profile], level)
+    snapshots = {
+        "bug": bug_contract_snapshot,
+        "documentation": documentation_contract_snapshot,
+        "research": research_contract_snapshot,
+    }
+
+    assert snapshots[profile](body)["status"] == "pass"
+
+
+def test_extractor_ignores_plain_text_and_fenced_headings() -> None:
+    sections = extract_markdown_sections(
+        """A plain Section Name does not count.
+
+```markdown
+# Section Name
+### Section Name
+```
+
+## Section Name
+
+real content
+"""
+    )
+
+    assert [(section.name, section.level) for section in sections] == [
+        ("Section Name", 2)
+    ]
+    assert sections[0].content == "real content"
+
+
+def test_extractor_ignores_tilde_fenced_headings() -> None:
+    sections = extract_markdown_sections(
+        """~~~text
+## Section Name
+~~~
+
+### Other
+content
+"""
+    )
+
+    assert [section.name for section in sections] == ["Other"]
+
+
+def test_sections_end_at_next_heading_regardless_of_level() -> None:
+    sections = extract_markdown_sections(
+        """### Reproduction / Evidence
+introductory evidence
+
+#### Confirmed regression
+nested evidence
+
+### Acceptance Criteria
+criterion
+        """
+    )
+
+    assert [(section.name, section.level) for section in sections] == [
+        ("Reproduction / Evidence", 3),
+        ("Confirmed regression", 4),
+        ("Acceptance Criteria", 3),
+    ]
+    assert sections[0].content == "introductory evidence"
+
+
+def test_named_sections_keep_deeper_noncanonical_headings_as_content() -> None:
+    sections = extract_markdown_sections(
+        """# Observed
+
+#### Confirmed regression
+evidence
+
+### Expected
+expected behavior
+""",
+        canonical_names=("Observed", "Expected"),
+    )
+
+    assert [section.name for section in sections] == ["Observed", "Expected"]
+    assert sections[0].content == "#### Confirmed regression\nevidence"
+
+
+def test_named_sections_use_peer_noncanonical_headings_as_boundaries() -> None:
+    sections = extract_markdown_sections(
+        """### Observed
+
+observed content
+
+### Optional Context
+
+context must not be part of Observed
+
+### Expected
+expected behavior
+""",
+        canonical_names=("Observed", "Expected"),
+    )
+
+    assert [section.name for section in sections] == ["Observed", "Expected"]
+    assert sections[0].content == "observed content"
+
+
+@pytest.mark.parametrize("profile", ("bug", "documentation", "research"))
+def test_typed_contracts_accept_mixed_heading_levels(profile: str) -> None:
+    headings = SECTION_BODIES[profile]
+    levels = (1, 3, 2, 6, 4, 5)
+    body = "\n\n".join(
+        f"{'#' * levels[index]} {heading}\n\ncontent for {heading}"
+        for index, heading in enumerate(headings)
+    )
+    snapshots = {
+        "bug": bug_contract_snapshot,
+        "documentation": documentation_contract_snapshot,
+        "research": research_contract_snapshot,
+    }
+
+    assert snapshots[profile](body)["status"] == "pass"
+
+
+@pytest.mark.parametrize("first_content", ("", "..."))
+def test_bug_contract_rejects_mixed_level_empty_or_placeholder_first_section(
+    first_content: str,
+) -> None:
+    body = "\n\n".join(
+        (
+            f"{'#' * level} {heading}\n\n{first_content if index == 0 else f'valid {heading}'}"
+        )
+        for index, (heading, level) in enumerate(
+            zip(SECTION_BODIES["bug"], (1, 3, 2, 6), strict=True)
+        )
+    )
+
+    contract = bug_contract_snapshot(body)
+
+    assert contract["status"] == "reclassification_required"
+    assert "Observed" in (
+        contract["empty_sections"] + contract["insufficient_sections"]
+    )
+
+
+@pytest.mark.parametrize("profile", ("bug", "documentation", "research"))
+def test_typed_contracts_fail_closed_for_duplicate_missing_and_fenced_sections(
+    profile: str,
+) -> None:
+    headings = SECTION_BODIES[profile]
+    snapshots = {
+        "bug": bug_contract_snapshot,
+        "documentation": documentation_contract_snapshot,
+        "research": research_contract_snapshot,
+    }
+    snapshot = snapshots[profile]
+
+    duplicate = _body(headings) + f"\n\n# {headings[0]}\n\nconflict"
+    missing = _body(headings[1:])
+    fenced = f"```markdown\n# {headings[0]}\n\nexample\n```\n\n" + _body(headings[1:])
+
+    assert snapshot(duplicate)["status"] == "reclassification_required"
+    assert snapshot(missing)["status"] == "reclassification_required"
+    assert snapshot(fenced)["status"] == "reclassification_required"
+
+
+@pytest.mark.parametrize("profile", ("bug", "documentation", "research"))
+def test_typed_contracts_do_not_absorb_optional_context_after_empty_section(
+    profile: str,
+) -> None:
+    headings = SECTION_BODIES[profile]
+    body = "\n\n".join(
+        f"### {heading}\n\n{f'content for {heading}' if index < len(headings) - 1 else ''}"
+        for index, heading in enumerate(headings)
+    )
+    body += "\n\n### Optional Context\n\ncontext must not satisfy a required section"
+    snapshots = {
+        "bug": bug_contract_snapshot,
+        "documentation": documentation_contract_snapshot,
+        "research": research_contract_snapshot,
+    }
+
+    contract = snapshots[profile](body)
+
+    assert contract["status"] == "reclassification_required"
+    assert contract["empty_sections"] == [headings[-1]]

--- a/tests/tools/lck/test_pr_resolve.py
+++ b/tests/tools/lck/test_pr_resolve.py
@@ -1,0 +1,633 @@
+# ruff: noqa: E402, I001
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+AGENT_WORKFLOW = str(Path(__file__).parents[3] / "tools" / "agent_workflow")
+if AGENT_WORKFLOW not in sys.path:
+    sys.path.insert(0, AGENT_WORKFLOW)
+
+from tools.lck.github_prs import PrResolveError, resolve_or_create_pr  # type: ignore[import-not-found]  # noqa: E402
+from tools.lck.common import CommandRunner  # type: ignore[import-not-found]  # noqa: E402
+
+PYTHON = sys.executable
+REPO = "PhoenixSss/tracequant"
+
+
+def _write_fake_gh(bin_dir: Path, state_path: Path) -> None:
+    gh = bin_dir / "gh"
+    # Use {{ }} for all Python braces in the generated script;
+    # only {PYTHON} and {state_path!r} are f-string interpolations.
+    script = (
+        f"""#!{PYTHON}\n"""
+        """import json, sys\n"""
+        """from pathlib import Path\n"""
+        f"""state = json.loads(Path({str(state_path)!r}).read_text(encoding='utf-8'))\n"""
+        """args = sys.argv[1:]\n"""
+        """\n"""
+        """def out(value):\n"""
+        """    print(json.dumps(value, ensure_ascii=False))\n"""
+        """\n"""
+        """if args[:2] == ['pr', 'list']:\n"""
+        """    if state.get('list_fail', False):\n"""
+        """        sys.stderr.write(state.get('list_stderr', 'gh pr list failed'))\n"""
+        """        sys.exit(state.get('list_exit', 1))\n"""
+        """    if state.get('list_empty', False):\n"""
+        """        print('')\n"""
+        """        sys.exit(0)\n"""
+        """    out(state.get('pr_list', []))\n"""
+        """\n"""
+        """elif args[:2] == ['pr', 'create']:\n"""
+        """    if state.get('create_fail', False):\n"""
+        """        sys.stderr.write(state.get('create_stderr', 'gh pr create failed'))\n"""
+        """        sys.exit(state.get('create_exit', 1))\n"""
+        """    if state.get('create_empty', False):\n"""
+        """        print('')\n"""
+        """        sys.exit(0)\n"""
+        f"""    url = state.get('create_url', 'https://github.com/{REPO}/pull/' + str(state.get('pr_number', 111)))\n"""
+        """    print(url)\n"""
+        """\n"""
+        """elif args[:2] == ['pr', 'view']:\n"""
+        """    if state.get('view_fail', False):\n"""
+        """        sys.stderr.write(state.get('view_stderr', 'gh pr view failed'))\n"""
+        """        sys.exit(state.get('view_exit', 1))\n"""
+        """    if state.get('view_empty', False):\n"""
+        """        print('')\n"""
+        """        sys.exit(0)\n"""
+        """    if state.get('view_invalid_json', False):\n"""
+        """        print('not json')\n"""
+        """        sys.exit(0)\n"""
+        f"""    pr_num = state.get('pr_number', 111)\n"""
+        """    out(state.get('pr_identity', {\n"""
+        """        'number': pr_num,\n"""
+        f"""        'url': f'https://github.com/{REPO}/pull/{{pr_num}}',\n"""
+        """        'state': 'OPEN',\n"""
+        """        'isDraft': False,\n"""
+        """        'baseRefName': 'main',\n"""
+        """        'baseRefOid': state.get('base_sha', 'b' * 40),\n"""
+        """        'headRefName': state.get('branch', 'task-110'),\n"""
+        """        'headRefOid': state.get('head_sha', 'h' * 40),\n"""
+        """    }))\n"""
+        """\n"""
+        """else:\n"""
+        """    sys.stderr.write('unsupported fake gh: ' + ' '.join(args))\n"""
+        """    sys.exit(1)\n"""
+    )
+    gh.write_text(script, encoding="utf-8")
+    gh.chmod(0o755)
+
+
+def _fake_git(_bin_dir: Path) -> None:
+    pass
+
+
+def _setup(
+    tmp_path: Path, state_overrides: dict[str, Any] | None = None
+) -> tuple[Path, CommandRunner, list[dict[str, Any]]]:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".gitignore").write_text(
+        ".agents/evidence.local/\n.agents/validation.local/\n",
+        encoding="utf-8",
+    )
+    state_path = tmp_path / "state.json"
+    state: dict[str, Any] = {
+        "pr_list": [],
+        "pr_number": 111,
+        "branch": "task-110",
+        "base_sha": "b" * 40,
+        "head_sha": "h" * 40,
+    }
+    if state_overrides:
+        state.update(state_overrides)
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_fake_gh(bin_dir, state_path)
+    _fake_git(bin_dir)
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+    # Update PATH for subprocess calls from CommandRunner
+    os.environ["PATH"] = env["PATH"]
+    runner = CommandRunner(repo)
+    return repo, runner, []
+
+
+# --- Resolve existing PR ---
+
+
+def test_resolve_existing_single_pr(tmp_path: Path) -> None:
+    repo, runner, warnings = _setup(
+        tmp_path,
+        {
+            "pr_list": [
+                {
+                    "number": 111,
+                    "url": f"https://github.com/{REPO}/pull/111",
+                    "state": "OPEN",
+                    "isDraft": False,
+                    "baseRefName": "main",
+                    "headRefName": "task-110",
+                    "headRefOid": "h" * 40,
+                }
+            ],
+        },
+    )
+    result = resolve_or_create_pr(
+        runner,
+        REPO,
+        "task-110",
+        "main",
+        "[Task] Test PR",
+        None,
+        "h" * 40,
+        "b" * 40,
+        warnings,
+    )
+    assert result["action"] == "resolved"
+    assert result["number"] == 111
+    assert result["state"] == "OPEN"
+    assert result["head_sha"] == "h" * 40
+    assert result["base_sha"] == "b" * 40
+    assert result["head_branch"] == "task-110"
+    assert result["base_branch"] == "main"
+    assert result["is_draft"] is False
+
+
+# --- Create PR ---
+
+
+def test_create_when_no_pr_exists(tmp_path: Path) -> None:
+    repo, runner, warnings = _setup(
+        tmp_path,
+        {
+            "pr_list": [],
+            "create_url": f"https://github.com/{REPO}/pull/111",
+        },
+    )
+    result = resolve_or_create_pr(
+        runner,
+        REPO,
+        "task-110",
+        "main",
+        "[Task] Test PR",
+        None,
+        "h" * 40,
+        "b" * 40,
+        warnings,
+    )
+    assert result["action"] == "created"
+    assert result["number"] == 111
+    assert result["state"] == "OPEN"
+    assert result["head_sha"] == "h" * 40
+
+
+# --- Fail: multiple PRs ---
+
+
+def test_fail_multiple_matching_prs(tmp_path: Path) -> None:
+    repo, runner, warnings = _setup(
+        tmp_path,
+        {
+            "pr_list": [
+                {
+                    "number": 111,
+                    "url": f"https://github.com/{REPO}/pull/111",
+                    "state": "OPEN",
+                    "isDraft": False,
+                    "baseRefName": "main",
+                    "headRefName": "task-110",
+                    "headRefOid": "h" * 40,
+                },
+                {
+                    "number": 112,
+                    "url": f"https://github.com/{REPO}/pull/112",
+                    "state": "OPEN",
+                    "isDraft": False,
+                    "baseRefName": "main",
+                    "headRefName": "task-110",
+                    "headRefOid": "h" * 40,
+                },
+            ],
+        },
+    )
+    with pytest.raises(PrResolveError, match="multiple matching PRs"):
+        resolve_or_create_pr(
+            runner,
+            REPO,
+            "task-110",
+            "main",
+            "[Task] Test PR",
+            None,
+            None,
+            None,
+            warnings,
+        )
+
+
+# --- Fail: pr list non-zero exit ---
+
+
+def test_fail_pr_list_nonzero_exit(tmp_path: Path) -> None:
+    repo, runner, warnings = _setup(
+        tmp_path,
+        {"list_fail": True, "list_exit": 1, "list_stderr": "gh pr list failed"},
+    )
+    with pytest.raises(PrResolveError, match="gh pr list failed"):
+        resolve_or_create_pr(
+            runner,
+            REPO,
+            "task-110",
+            "main",
+            "[Task] Test PR",
+            None,
+            None,
+            None,
+            warnings,
+        )
+    assert len(warnings) == 1
+
+
+# --- Fail: pr list empty stdout ---
+
+
+def test_fail_pr_list_empty_stdout(tmp_path: Path) -> None:
+    repo, runner, warnings = _setup(tmp_path, {"list_empty": True})
+    with pytest.raises(PrResolveError, match="empty stdout"):
+        resolve_or_create_pr(
+            runner,
+            REPO,
+            "task-110",
+            "main",
+            "[Task] Test PR",
+            None,
+            None,
+            None,
+            warnings,
+        )
+
+
+# --- Fail: pr create non-zero exit ---
+
+
+def test_fail_pr_create_nonzero_exit(tmp_path: Path) -> None:
+    repo, runner, warnings = _setup(
+        tmp_path,
+        {
+            "pr_list": [],
+            "create_fail": True,
+            "create_exit": 1,
+            "create_stderr": "gh pr create failed",
+        },
+    )
+    with pytest.raises(PrResolveError, match="gh pr create failed"):
+        resolve_or_create_pr(
+            runner,
+            REPO,
+            "task-110",
+            "main",
+            "[Task] Test PR",
+            None,
+            None,
+            None,
+            warnings,
+        )
+    assert len(warnings) == 1
+
+
+# --- Fail: pr create empty stdout ---
+
+
+def test_fail_pr_create_empty_stdout(tmp_path: Path) -> None:
+    repo, runner, warnings = _setup(tmp_path, {"pr_list": [], "create_empty": True})
+    with pytest.raises(PrResolveError, match="empty stdout"):
+        resolve_or_create_pr(
+            runner,
+            REPO,
+            "task-110",
+            "main",
+            "[Task] Test PR",
+            None,
+            None,
+            None,
+            warnings,
+        )
+
+
+# --- Fail: pr view non-zero exit ---
+
+
+def test_fail_pr_view_nonzero_exit(tmp_path: Path) -> None:
+    repo, runner, warnings = _setup(
+        tmp_path,
+        {
+            "pr_list": [
+                {
+                    "number": 111,
+                    "url": f"https://github.com/{REPO}/pull/111",
+                    "state": "OPEN",
+                    "isDraft": False,
+                    "baseRefName": "main",
+                    "headRefName": "task-110",
+                    "headRefOid": "h" * 40,
+                }
+            ],
+            "view_fail": True,
+            "view_exit": 1,
+            "view_stderr": "gh pr view failed",
+        },
+    )
+    with pytest.raises(PrResolveError, match="gh pr view"):
+        resolve_or_create_pr(
+            runner,
+            REPO,
+            "task-110",
+            "main",
+            "[Task] Test PR",
+            None,
+            None,
+            None,
+            warnings,
+        )
+    assert len(warnings) == 1
+
+
+# --- Fail: pr view empty stdout ---
+
+
+def test_fail_pr_view_empty_stdout(tmp_path: Path) -> None:
+    repo, runner, warnings = _setup(
+        tmp_path,
+        {
+            "pr_list": [
+                {
+                    "number": 111,
+                    "url": f"https://github.com/{REPO}/pull/111",
+                    "state": "OPEN",
+                    "isDraft": False,
+                    "baseRefName": "main",
+                    "headRefName": "task-110",
+                    "headRefOid": "h" * 40,
+                }
+            ],
+            "view_empty": True,
+        },
+    )
+    with pytest.raises(PrResolveError, match="empty stdout"):
+        resolve_or_create_pr(
+            runner,
+            REPO,
+            "task-110",
+            "main",
+            "[Task] Test PR",
+            None,
+            None,
+            None,
+            warnings,
+        )
+
+
+# --- Fail: pr view invalid JSON ---
+
+
+def test_fail_pr_view_invalid_json(tmp_path: Path) -> None:
+    repo, runner, warnings = _setup(
+        tmp_path,
+        {
+            "pr_list": [
+                {
+                    "number": 111,
+                    "url": f"https://github.com/{REPO}/pull/111",
+                    "state": "OPEN",
+                    "isDraft": False,
+                    "baseRefName": "main",
+                    "headRefName": "task-110",
+                    "headRefOid": "h" * 40,
+                }
+            ],
+            "view_invalid_json": True,
+        },
+    )
+    with pytest.raises(PrResolveError, match="invalid JSON"):
+        resolve_or_create_pr(
+            runner,
+            REPO,
+            "task-110",
+            "main",
+            "[Task] Test PR",
+            None,
+            None,
+            None,
+            warnings,
+        )
+
+
+# --- Fail: identity mismatch - base SHA ---
+
+
+def test_fail_identity_mismatch_base_sha(tmp_path: Path) -> None:
+    repo, runner, warnings = _setup(
+        tmp_path,
+        {
+            "pr_list": [
+                {
+                    "number": 111,
+                    "url": f"https://github.com/{REPO}/pull/111",
+                    "state": "OPEN",
+                    "isDraft": False,
+                    "baseRefName": "main",
+                    "headRefName": "task-110",
+                    "headRefOid": "h" * 40,
+                }
+            ],
+            "base_sha": "w" * 40,
+        },
+    )
+    with pytest.raises(PrResolveError, match="base SHA mismatch"):
+        resolve_or_create_pr(
+            runner,
+            REPO,
+            "task-110",
+            "main",
+            "[Task] Test PR",
+            None,
+            "h" * 40,
+            "b" * 40,
+            warnings,
+        )
+
+
+# --- Fail: identity mismatch - head SHA ---
+
+
+def test_fail_identity_mismatch_head_sha(tmp_path: Path) -> None:
+    repo, runner, warnings = _setup(
+        tmp_path,
+        {
+            "pr_list": [
+                {
+                    "number": 111,
+                    "url": f"https://github.com/{REPO}/pull/111",
+                    "state": "OPEN",
+                    "isDraft": False,
+                    "baseRefName": "main",
+                    "headRefName": "task-110",
+                    "headRefOid": "w" * 40,
+                }
+            ],
+            # Also set head_sha so pr_identity returns mismatched value
+            "head_sha": "w" * 40,
+        },
+    )
+    with pytest.raises(PrResolveError, match="head SHA mismatch"):
+        resolve_or_create_pr(
+            runner,
+            REPO,
+            "task-110",
+            "main",
+            "[Task] Test PR",
+            None,
+            "h" * 40,
+            "b" * 40,
+            warnings,
+        )
+
+
+# --- Fail: identity mismatch - branch ---
+
+
+def test_fail_identity_mismatch_branch(tmp_path: Path) -> None:
+    repo, runner, warnings = _setup(
+        tmp_path,
+        {
+            "pr_list": [
+                {
+                    "number": 111,
+                    "url": f"https://github.com/{REPO}/pull/111",
+                    "state": "OPEN",
+                    "isDraft": False,
+                    "baseRefName": "main",
+                    "headRefName": "other-branch",
+                    "headRefOid": "h" * 40,
+                }
+            ],
+            "branch": "other-branch",
+        },
+    )
+    with pytest.raises(PrResolveError, match="head branch mismatch"):
+        resolve_or_create_pr(
+            runner,
+            REPO,
+            "task-110",
+            "main",
+            "[Task] Test PR",
+            None,
+            "h" * 40,
+            "b" * 40,
+            warnings,
+        )
+
+
+# --- Fail: identity mismatch - draft ---
+
+
+def test_fail_identity_mismatch_draft(tmp_path: Path) -> None:
+    repo, runner, warnings = _setup(
+        tmp_path,
+        {
+            "pr_list": [
+                {
+                    "number": 111,
+                    "url": f"https://github.com/{REPO}/pull/111",
+                    "state": "OPEN",
+                    "isDraft": False,
+                    "baseRefName": "main",
+                    "headRefName": "task-110",
+                    "headRefOid": "h" * 40,
+                }
+            ],
+            "pr_identity": {
+                "number": 111,
+                "url": f"https://github.com/{REPO}/pull/111",
+                "state": "OPEN",
+                "isDraft": True,
+                "baseRefName": "main",
+                "baseRefOid": "b" * 40,
+                "headRefName": "task-110",
+                "headRefOid": "h" * 40,
+            },
+        },
+    )
+    with pytest.raises(PrResolveError, match="Draft"):
+        resolve_or_create_pr(
+            runner,
+            REPO,
+            "task-110",
+            "main",
+            "[Task] Test PR",
+            None,
+            "h" * 40,
+            "b" * 40,
+            warnings,
+        )
+
+
+# --- PR create uses body file ---
+
+
+def test_pr_create_with_body_file(tmp_path: Path) -> None:
+    body_file = tmp_path / "pr_body.md"
+    body_file.write_text("PR body content", encoding="utf-8")
+    repo, runner, warnings = _setup(
+        tmp_path,
+        {
+            "pr_list": [],
+            "create_url": f"https://github.com/{REPO}/pull/111",
+        },
+    )
+    result = resolve_or_create_pr(
+        runner,
+        REPO,
+        "task-110",
+        "main",
+        "[Task] Test PR",
+        body_file,
+        "h" * 40,
+        "b" * 40,
+        warnings,
+    )
+    assert result["action"] == "created"
+    assert result["number"] == 111
+
+
+# --- PR create with invalid URL format ---
+
+
+def test_fail_pr_create_invalid_url_format(tmp_path: Path) -> None:
+    repo, runner, warnings = _setup(
+        tmp_path,
+        {
+            "pr_list": [],
+            "create_url": "not a valid url",
+        },
+    )
+    with pytest.raises(PrResolveError, match="does not contain a PR URL"):
+        resolve_or_create_pr(
+            runner,
+            REPO,
+            "task-110",
+            "main",
+            "[Task] Test PR",
+            None,
+            None,
+            None,
+            warnings,
+        )

--- a/tests/tools/lck/test_prepare.py
+++ b/tests/tools/lck/test_prepare.py
@@ -1,0 +1,451 @@
+# ruff: noqa: E402, I001
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import (
+    Any,
+    cast,
+)
+
+import pytest
+
+AGENT_WORKFLOW = str(Path(__file__).parents[3] / "tools" / "agent_workflow")
+if AGENT_WORKFLOW not in sys.path:
+    sys.path.insert(0, AGENT_WORKFLOW)
+
+from tools.lck import (  # type: ignore[import-not-found]  # noqa: E402
+    delivery as lck_delivery,
+    effects as lck_effects,
+    eligibility as lck_eligibility,
+    models as lck_models,
+    state as lck_state,
+)
+from tools.lck.github_prs import resolve_open_pr  # type: ignore[import-not-found]  # noqa: E402
+from tools.lck.common import (  # type: ignore[import-not-found]  # noqa: E402
+    CommandResult,
+    WorkflowToolError,
+)
+from .support import (  # noqa: E402
+    FakeRunner,
+    SHA,
+    _git_snapshot,
+    _install_facts,
+    _issue,
+    _open_pr,
+    _relationships,
+    _resolver,
+)
+
+
+class ProjectStatusRunner(FakeRunner):
+    def __init__(self, *, project_status: str = "Ready", **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.project_status = project_status
+
+    def run(
+        self,
+        argv: list[str] | tuple[str, ...],
+        *,
+        command_id: str,
+        **kwargs: Any,
+    ) -> CommandResult:
+        command = tuple(str(item) for item in argv)
+        if command[:3] == ("gh", "issue", "view") and command[-1] == "projectItems":
+            self.commands.append(command)
+            return CommandResult(
+                command_id=command_id,
+                argv=command,
+                returncode=0,
+                stdout=json.dumps(
+                    {"projectItems": [{"status": {"name": self.project_status}}]}
+                ),
+                stderr="",
+            )
+        return super().run(argv, command_id=command_id, **kwargs)
+
+
+def _install_project_status_write(
+    monkeypatch: pytest.MonkeyPatch,
+    fake: ProjectStatusRunner,
+    issue: dict[str, Any],
+    *,
+    update_status: bool = True,
+    fail: bool = False,
+) -> list[str]:
+    writes: list[str] = []
+
+    def write(
+        runner: Any,
+        repository: str,
+        task: int,
+        *,
+        value: str,
+        **_kwargs: Any,
+    ) -> None:
+        assert runner is fake
+        assert repository == "owner/repo"
+        assert task == 159
+        writes.append(value)
+        if fail:
+            raise WorkflowToolError("simulated status write failure")
+        if update_status:
+            fake.project_status = value
+            issue["project_status"] = value
+
+    monkeypatch.setattr(lck_effects, "set_project_status_with_runner", write)
+    return writes
+
+
+def test_lck_live_snapshot_overrides_legacy_read_only_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = FakeRunner(branch="main")
+    _install_facts(monkeypatch, fake)
+    monkeypatch.setenv("WORKFLOW_EVIDENCE_READ_ONLY", "1")
+    observed: dict[str, Any] = {}
+
+    def live_snapshot(*_args: Any, **kwargs: Any) -> dict[str, Any]:
+        observed.update(kwargs)
+        return _git_snapshot(fake)
+
+    monkeypatch.setattr(lck_state, "_git_snapshot", live_snapshot)
+    _resolver(fake).resolve(159)
+
+    assert observed == {"read_only_local_refs": True}
+
+
+@pytest.mark.parametrize(
+    ("blocked_by", "expected_detail"),
+    [
+        (
+            {"items": [], "count": 0, "truncated": True},
+            "truncated",
+        ),
+        (
+            {"items": []},
+            "malformed",
+        ),
+        (
+            {"items": [], "count": 1, "truncated": False},
+            "count mismatch",
+        ),
+        (
+            {
+                "items": [{"number": 300, "state": "UNKNOWN"}],
+                "count": 1,
+                "truncated": False,
+            },
+            "unknown_state",
+        ),
+        (
+            {
+                "items": [{"number": 301, "state": "OPEN"}],
+                "count": 1,
+                "truncated": False,
+            },
+            "unresolved",
+        ),
+    ],
+)
+def test_formal_blocker_gate_stops_before_workspace_write(
+    monkeypatch: pytest.MonkeyPatch,
+    blocked_by: dict[str, Any],
+    expected_detail: str,
+) -> None:
+    fake = FakeRunner(branch="main")
+    _install_facts(
+        monkeypatch,
+        fake,
+        relationships=_relationships(blocked_by=blocked_by),
+    )
+
+    with pytest.raises(lck_models.LckStopError, match="formal blocker gate") as error:
+        lck_delivery.DeliveryPreparer(_resolver(fake)).prepare(159)
+
+    assert expected_detail in str(error.value)
+    assert fake.branch == "main"
+    assert not any(command[:2] == ("git", "switch") for command in fake.commands)
+
+
+def test_non_task_delivery_prepare_stops_before_workspace_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = FakeRunner(branch="main")
+    issue = _issue()
+    issue["labels"] = {"items": ["type:feature", "codex:ready"]}
+    _install_facts(
+        monkeypatch,
+        fake,
+        issue=issue,
+        relationships=_relationships(issue_type="Feature"),
+    )
+
+    with pytest.raises(lck_models.LckStopError, match="type:task"):
+        lck_delivery.DeliveryPreparer(_resolver(fake)).prepare(159)
+
+    assert fake.branch == "main"
+    assert not any(command[:2] == ("git", "switch") for command in fake.commands)
+
+
+def test_lifecycle_label_conflict_stops_before_workspace_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = FakeRunner(branch="main")
+    issue = _issue()
+    issue["labels"] = {"items": ["type:task", "codex:ready", "codex:needs-spec"]}
+    _install_facts(monkeypatch, fake, issue=issue)
+
+    with pytest.raises(lck_models.LckStopError, match="lifecycle labels"):
+        lck_delivery.DeliveryPreparer(_resolver(fake)).prepare(159)
+
+    assert fake.branch == "main"
+    assert not any(command[:2] == ("git", "switch") for command in fake.commands)
+
+
+def test_resolve_open_pr_observes_draft_pr() -> None:
+    branch = "task/159-lck-core-live-state-resolution"
+    draft_pr = _open_pr(branch, is_draft=True)
+    fake = FakeRunner(open_pr=draft_pr)
+
+    observed = resolve_open_pr(
+        cast(Any, fake),
+        "owner/repo",
+        branch,
+        "main",
+        [],
+    )
+
+    assert observed is not None
+    assert observed["isDraft"] is True
+
+
+def test_multiple_task_branches_stop_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = FakeRunner(
+        branch="main",
+        local_branches={
+            "task/159-lck-core-live-state-resolution",
+            "task-159",
+        },
+    )
+    _install_facts(monkeypatch, fake)
+
+    state = _resolver(fake).resolve(159)
+
+    assert state.status is lck_models.ResolutionStatus.STOP
+    assert any(
+        "multiple Task branch candidates" in reason for reason in state.stop_reasons
+    )
+
+
+def test_delivery_prepare_creates_then_reuses_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = ProjectStatusRunner(branch="main")
+    issue = _issue()
+    writes = _install_project_status_write(monkeypatch, fake, issue)
+    _install_facts(monkeypatch, fake, issue=issue)
+    preparer = lck_delivery.DeliveryPreparer(_resolver(fake))
+
+    created = preparer.prepare(159)
+    reused = preparer.prepare(159)
+
+    assert created.action == "created-from-main"
+    assert reused.action == "already-prepared"
+    assert created.to_dict()["task_contract"]["body"] == "Task Contract"
+    assert created.effects[0].to_dict() == {
+        "effect": "set_in_progress_status",
+        "action": "updated",
+        "details": {
+            "previous_status": "Ready",
+            "status": "In Progress",
+            "postcondition": "verified",
+        },
+    }
+    assert reused.effects[0].action == "already-in-progress"
+    assert writes == ["In Progress"]
+    assert fake.branch == "task/159-lck-core-live-state-resolution"
+    assert sum(command[:2] == ("git", "switch") for command in fake.commands) == 1
+    assert not any(
+        command[:2] in {("git", "commit"), ("git", "push")}
+        or (command[:3] == ("gh", "pr", "create"))
+        for command in fake.commands
+    )
+
+
+def test_delivery_prepare_stops_on_divergent_main_without_branch_creation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = FakeRunner(
+        branch="main",
+        local_main_sha=SHA,
+        remote_main_sha="b" * 40,
+    )
+    _install_facts(monkeypatch, fake)
+
+    with pytest.raises(
+        lck_models.LckStopError, match="HEAD == local main == origin/main"
+    ):
+        lck_delivery.DeliveryPreparer(_resolver(fake)).prepare(159)
+
+    assert fake.branch == "main"
+    assert not any(command[:3] == ("git", "switch", "-c") for command in fake.commands)
+
+
+def test_delivery_prepare_restores_remote_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    branch = "task/159-lck-core-live-state-resolution"
+    fake = ProjectStatusRunner(branch="main", remote_branches={branch: SHA})
+    issue = _issue()
+    writes = _install_project_status_write(monkeypatch, fake, issue)
+    _install_facts(monkeypatch, fake, issue=issue)
+
+    context = lck_delivery.DeliveryPreparer(_resolver(fake)).prepare(159)
+
+    assert context.action == "restored-from-remote"
+    assert context.effects[0].action == "updated"
+    assert writes == ["In Progress"]
+    assert fake.branch == branch
+    assert branch in fake.local_branches
+
+
+def test_delivery_prepare_stops_before_status_write_when_workspace_postcondition_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = ProjectStatusRunner(branch="main")
+    issue = _issue()
+    writes = _install_project_status_write(monkeypatch, fake, issue)
+    _install_facts(monkeypatch, fake, issue=issue)
+    preparer = lck_delivery.DeliveryPreparer(_resolver(fake))
+
+    def fail_postcondition(_branch: str, _expected_head: str | None) -> None:
+        raise lck_models.LckStopError("simulated workspace postcondition failure")
+
+    monkeypatch.setattr(preparer, "_verify_workspace", fail_postcondition)
+
+    with pytest.raises(
+        lck_models.LckStopError, match="workspace postcondition failure"
+    ):
+        preparer.prepare(159)
+
+    assert writes == []
+    assert not any(command[:3] == ("gh", "issue", "view") for command in fake.commands)
+
+
+def test_delivery_prepare_status_write_failure_stops_after_reusable_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = ProjectStatusRunner(branch="main")
+    issue = _issue()
+    writes = _install_project_status_write(monkeypatch, fake, issue, fail=True)
+    _install_facts(monkeypatch, fake, issue=issue)
+
+    with pytest.raises(lck_models.LckStopError, match="status write failure"):
+        lck_delivery.DeliveryPreparer(_resolver(fake)).prepare(159)
+
+    assert writes == ["In Progress"]
+    assert fake.branch == "task/159-lck-core-live-state-resolution"
+    assert fake.project_status == "Ready"
+
+
+def test_delivery_prepare_status_postcondition_failure_stops_and_reuses_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = ProjectStatusRunner(branch="main")
+    issue = _issue()
+    writes = _install_project_status_write(
+        monkeypatch, fake, issue, update_status=False
+    )
+    _install_facts(monkeypatch, fake, issue=issue)
+
+    with pytest.raises(lck_models.LckStopError, match="postcondition failed"):
+        lck_delivery.DeliveryPreparer(_resolver(fake)).prepare(159)
+
+    branch = "task/159-lck-core-live-state-resolution"
+    assert writes == ["In Progress"]
+    assert fake.branch == branch
+    assert branch in fake.local_branches
+
+    fake.project_status = "In Progress"
+    issue["project_status"] = "In Progress"
+    recovered = lck_delivery.DeliveryPreparer(_resolver(fake)).prepare(159)
+
+    assert recovered.action == "already-prepared"
+    assert recovered.effects[0].action == "already-in-progress"
+    assert writes == ["In Progress"]
+
+
+def test_delivery_complete_ready_requires_delivery_prepare(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = FakeRunner()
+    _install_facts(monkeypatch, fake)
+    state = _resolver(fake).resolve(159)
+
+    decision = lck_eligibility.PhaseEligibilityResolver().resolve(
+        state, lck_models.Phase.DELIVERY_COMPLETE
+    )
+
+    assert decision.eligible is False
+    assert (
+        "Delivery Complete requires Project Status In Progress; "
+        "run Delivery Prepare first"
+    ) in decision.reasons
+    assert "Project Status is unavailable or unknown" not in decision.reasons
+
+
+def test_dirty_unrelated_worktree_is_not_switched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    branch = "task/159-lck-core-live-state-resolution"
+    fake = FakeRunner(
+        branch="main",
+        local_branches={branch},
+        clean=False,
+    )
+    _install_facts(monkeypatch, fake)
+
+    with pytest.raises(lck_models.LckStopError, match="dirty unrelated worktree"):
+        lck_delivery.DeliveryPreparer(_resolver(fake)).prepare(159)
+
+
+def test_dirty_current_task_worktree_is_not_prepared(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    branch = "task/159-lck-core-live-state-resolution"
+    fake = FakeRunner(
+        branch=branch,
+        local_branches={branch},
+        clean=False,
+    )
+    _install_facts(monkeypatch, fake)
+
+    with pytest.raises(lck_models.LckStopError, match="clean worktree"):
+        lck_delivery.DeliveryPreparer(_resolver(fake)).prepare(159)
+
+    assert fake.branch == branch
+    assert not any(command[:2] == ("git", "switch") for command in fake.commands)
+
+
+def test_delivery_prepare_requires_valid_critical_outcome(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = FakeRunner()
+    issue = _issue()
+    issue["critical_outcome"] = {"status": "invalid", "detail": "missing"}
+    _install_facts(monkeypatch, fake, issue=issue)
+    state = _resolver(fake).resolve(159)
+
+    decision = lck_eligibility.PhaseEligibilityResolver().resolve(
+        state, lck_models.Phase.DELIVERY_PREPARE
+    )
+
+    assert decision.eligible is False
+    assert any(
+        "Critical Outcome contract invalid" in reason for reason in decision.reasons
+    )

--- a/tests/tools/lck/test_profile_architecture.py
+++ b/tests/tools/lck/test_profile_architecture.py
@@ -1,0 +1,443 @@
+# ruff: noqa: E402, I001
+
+"""Regression coverage for the formal typed-profile LCK architecture."""
+
+from __future__ import annotations
+
+import ast
+import sys
+from collections.abc import Iterable, Mapping
+from dataclasses import FrozenInstanceError, fields, replace
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+ROOT = Path(__file__).parents[3]
+AGENT_WORKFLOW = str(ROOT / "tools" / "agent_workflow")
+if AGENT_WORKFLOW not in sys.path:
+    sys.path.insert(0, AGENT_WORKFLOW)
+
+from tools.lck import issue_forms as issue_form_contract  # type: ignore[import-not-found]  # noqa: E402
+from tools.lck.bug_policy import bug_contract_snapshot  # type: ignore[import-not-found]  # noqa: E402
+from tools.lck.documentation_policy import (  # type: ignore[import-not-found]  # noqa: E402
+    documentation_contract_snapshot,
+)
+from tools.lck import (  # type: ignore[import-not-found]  # noqa: E402
+    eligibility as lck_eligibility,
+    models as lck_models,
+)
+from tools.lck.issue_profiles import (  # type: ignore[import-not-found]  # noqa: E402
+    BUG_PROFILE,
+    DOCUMENTATION_PROFILE,
+    TASK_PROFILE,
+    LeafIssueWorkflowProfile,
+)
+from tools.lck.profile_policies import (  # type: ignore[import-not-found]  # noqa: E402
+    DEFAULT_PROFILE_POLICY_REGISTRY,
+    PolicyBlocker,
+    PolicyContext,
+    ProfileEffectDescriptor,
+    ProfileEvidenceEnvelope,
+    ProfileEvidenceRecord,
+    ProfilePolicyError,
+    ProfilePolicyRegistry,
+    validate_profile_candidate,
+    validate_profile_contract,
+    validate_profile_review,
+)
+from tools.lck.research_policy import research_contract_snapshot  # type: ignore[import-not-found]  # noqa: E402
+from .support import _review_state, _task_contract  # noqa: E402
+
+
+def _imported_modules(tree: ast.AST) -> set[str]:
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name.rsplit(".", 1)[-1] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            modules.add(node.module.rsplit(".", 1)[-1])
+    return modules
+
+
+def _referenced_symbols(tree: ast.AST) -> set[str]:
+    symbols: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name):
+            symbols.add(node.id)
+        elif isinstance(node, ast.Attribute):
+            symbols.add(node.attr)
+    return symbols
+
+
+def _profile_identity_references(tree: ast.AST) -> list[ast.AST]:
+    identity = {"profile_id", "issue_kind", "canonical_type_label"}
+    references: list[ast.AST] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name) and node.id in identity:
+            references.append(node)
+        elif isinstance(node, ast.Attribute) and node.attr in identity:
+            references.append(node)
+        elif isinstance(node, ast.Constant) and node.value in identity:
+            references.append(node)
+    return references
+
+
+def test_all_phase_controllers_use_only_generic_policy_capabilities() -> None:
+    controller_names = (
+        "eligibility.py",
+        "delivery.py",
+        "review.py",
+        "review_workspace.py",
+        "remediation.py",
+        "validation_gates.py",
+        "closeout.py",
+    )
+    forbidden_modules = {
+        "critical_outcome",
+        "bug_policy",
+        "documentation_policy",
+        "research_policy",
+    }
+    forbidden_symbols = {
+        "CriticalOutcomeGate",
+        "DocumentationReclassificationRequired",
+        "DocumentationValidationGate",
+        "ResearchOutcomeEffect",
+        "ResearchOutcomeRequired",
+        "ResearchReclassificationRequired",
+        "ResearchValidationGate",
+        "_run_critical_outcome",
+    }
+    controller_root = ROOT / "tools/lck"
+    for name in controller_names:
+        tree = ast.parse((controller_root / name).read_text(encoding="utf-8"))
+        assert _imported_modules(tree).isdisjoint(forbidden_modules), name
+        assert _referenced_symbols(tree).isdisjoint(forbidden_symbols), name
+
+    policy_tree = ast.parse(
+        (controller_root / "profile_policies.py").read_text(encoding="utf-8")
+    )
+    assert {
+        "critical_outcome",
+        "bug_policy",
+        "documentation_policy",
+        "research_policy",
+    } <= _imported_modules(policy_tree)
+
+
+def test_phase_controllers_do_not_branch_on_profile_identity() -> None:
+    controller_root = ROOT / "tools/lck"
+    for name in (
+        "eligibility.py",
+        "delivery.py",
+        "review.py",
+        "review_workspace.py",
+        "remediation.py",
+        "closeout.py",
+        "validation_gates.py",
+    ):
+        tree = ast.parse((controller_root / name).read_text(encoding="utf-8"))
+        assert not _profile_identity_references(tree), name
+
+    probes = (
+        'if state.issue_profile["profile"]["profile_id"] == "task": pass',
+        'if getattr(state, "profile_id", None) == "task": pass',
+        'if state.issue_profile.get("canonical_type_label") == "type:task": pass',
+    )
+    for source in probes:
+        assert _profile_identity_references(ast.parse(source)), source
+
+
+def test_typed_policies_share_one_issue_form_parser(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, ...]] = []
+    original = issue_form_contract.extract_markdown_sections
+
+    def observe(body: str, *, canonical_names: Any = None) -> Any:
+        calls.append(tuple(canonical_names or ()))
+        return original(body, canonical_names=canonical_names)
+
+    monkeypatch.setattr(issue_form_contract, "extract_markdown_sections", observe)
+    bug_body = "\n\n".join(
+        f"### {heading}\n\ncontent"
+        for heading in (
+            "Observed",
+            "Expected",
+            "Reproduction / Evidence",
+            "Acceptance Criteria",
+        )
+    )
+    documentation_body = "\n\n".join(
+        f"# {heading}\n\ncontent"
+        for heading in ("Documentation Goal", "Requirements", "Acceptance Criteria")
+    )
+    research_body = "\n\n".join(
+        f"###### {heading}\n\ncontent"
+        for heading in (
+            "Question / Decision Needed",
+            "Context",
+            "Scope",
+            "Non-goals",
+            "Evidence / Evaluation Criteria",
+            "Expected Outcome / Artifact",
+        )
+    )
+
+    assert bug_contract_snapshot(bug_body)["status"] == "pass"
+    assert documentation_contract_snapshot(documentation_body)["status"] == "pass"
+    assert research_contract_snapshot(research_body)["status"] == "pass"
+    assert calls == [
+        ("Observed", "Expected", "Reproduction / Evidence", "Acceptance Criteria"),
+        ("Documentation Goal", "Requirements", "Acceptance Criteria"),
+        (
+            "Question / Decision Needed",
+            "Context",
+            "Scope",
+            "Non-goals",
+            "Evidence / Evaluation Criteria",
+            "Expected Outcome / Artifact",
+        ),
+    ]
+
+    generic_source = (
+        (ROOT / "tools/lck/issue_forms.py").read_text(encoding="utf-8").casefold()
+    )
+    assert not any(
+        name in generic_source for name in ("bug", "documentation", "research")
+    )
+    for policy_name in (
+        "bug_policy.py",
+        "documentation_policy.py",
+        "research_policy.py",
+    ):
+        policy_source = (ROOT / "tools/lck" / policy_name).read_text(encoding="utf-8")
+        assert "parse_issue_form_contract" in policy_source
+        assert "yaml.safe_load" not in policy_source
+
+
+def test_shared_facts_are_mechanical_and_blockers_are_policy_owned() -> None:
+    shared_path = ROOT / "tools/lck/shared_facts.py"
+    shared_tree = ast.parse(shared_path.read_text(encoding="utf-8"))
+    assert not _profile_identity_references(shared_tree)
+    assert _imported_modules(shared_tree).isdisjoint(
+        {"issue_profiles", "profile_policies", "eligibility", "workflow_evidence"}
+    )
+
+    core_root = ROOT / "tools/lck"
+    for path in core_root.glob("*.py"):
+        if path.name not in {"shared_facts.py", "__init__.py"}:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            assert "workflow_evidence" not in _imported_modules(tree), path.name
+
+    open_gate = lck_eligibility.evaluate_shared_blockers(
+        {
+            "available": True,
+            "blocked_by": {
+                "items": [{"number": 1, "state": "OPEN"}],
+                "count": 1,
+                "truncated": False,
+            },
+        }
+    )
+    closed_gate = lck_eligibility.evaluate_shared_blockers(
+        {
+            "available": True,
+            "blocked_by": {
+                "items": [{"number": 1, "state": "CLOSED"}],
+                "count": 1,
+                "truncated": False,
+            },
+        }
+    )
+    assert open_gate["status"] == "fail"
+    assert closed_gate["status"] == "pass"
+    assert all(
+        callable(getattr(policy, "evaluate_blockers", None))
+        for policy in DEFAULT_PROFILE_POLICY_REGISTRY.policies.values()
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        'facts["research_outcome"] = "IMPLEMENT"',
+        'facts.get("critical_outcome")',
+        "def normalize_profile_specific_fact(value): return value",
+    ),
+)
+def test_shared_facts_guard_rejects_profile_owned_semantics(source: str) -> None:
+    markers = {"research_outcome", "critical_outcome", "profile_specific"}
+    text = ast.unparse(ast.parse(source))
+    assert any(marker in text for marker in markers), source
+
+
+class RegistryExtensionPolicy:
+    """Minimal test double proving the registry remains an explicit seam."""
+
+    profile_id = "extension"
+    canonical_type_label = "type:extension"
+
+    def validate_contract(
+        self, context: PolicyContext, leaf_contract: Mapping[str, Any]
+    ) -> ProfileEvidenceRecord:
+        del context, leaf_contract
+        return ProfileEvidenceRecord("extension.contract.v1", 1, {})
+
+    def evaluate_blockers(
+        self,
+        context: PolicyContext,
+        leaf_contract: Mapping[str, Any],
+        contract_evidence: ProfileEvidenceRecord,
+    ) -> Iterable[PolicyBlocker]:
+        del context, leaf_contract, contract_evidence
+        return ()
+
+    def validate_candidate(
+        self,
+        context: PolicyContext,
+        leaf_contract: Mapping[str, Any],
+        contract_evidence: ProfileEvidenceRecord,
+    ) -> ProfileEvidenceRecord:
+        del context, leaf_contract, contract_evidence
+        return ProfileEvidenceRecord("extension.candidate.v1", 1, {})
+
+    def validate_evidence(self, record: ProfileEvidenceRecord) -> bool:
+        return bool(record.schema_version == 1)
+
+
+def test_registry_contains_only_formal_profiles_and_preserves_extension_seam() -> None:
+    expected = {"task", "bug", "documentation", "research"}
+    assert set(DEFAULT_PROFILE_POLICY_REGISTRY.policies) == expected
+    assert set(DEFAULT_PROFILE_POLICY_REGISTRY.policies_by_type_label) == {
+        f"type:{profile_id}" for profile_id in expected
+    }
+    assert all(
+        DEFAULT_PROFILE_POLICY_REGISTRY.resolve(profile_id).profile_id == profile_id
+        for profile_id in expected
+    )
+
+    extension = RegistryExtensionPolicy()
+    registry = ProfilePolicyRegistry.from_policies(extension)
+    profile = replace(
+        TASK_PROFILE,
+        profile_id=extension.profile_id,
+        canonical_type_label=extension.canonical_type_label,
+    )
+    assert registry.resolve(profile) is extension
+    assert extension.profile_id not in DEFAULT_PROFILE_POLICY_REGISTRY.policies
+    with pytest.raises(ProfilePolicyError, match="not registered"):
+        DEFAULT_PROFILE_POLICY_REGISTRY.resolve("type:retired")
+    with pytest.raises(TypeError):
+        registry.policies["other"] = extension
+
+
+def test_generic_kernel_models_have_no_profile_specific_fixed_slots() -> None:
+    assert {field.name for field in fields(ProfileEffectDescriptor)} == {
+        "effect_kind",
+        "schema_version",
+        "parameters",
+        "postcondition",
+        "receipt",
+    }
+    assert {field.name for field in fields(ProfileEvidenceEnvelope)} == {
+        "profile_id",
+        "schema_version",
+        "contract",
+        "candidate",
+        "review",
+        "completion",
+    }
+    for model in (lck_models.LiveState, lck_models.OperationSnapshot):
+        names = {field.name.casefold() for field in fields(model)}
+        assert not {"task_profile", "bug_profile", "documentation_profile"} & names
+        assert "profile_id" not in names
+
+
+def test_kernel_snapshots_are_frozen_at_the_model_boundary() -> None:
+    state = _review_state()
+    snapshots = (
+        (lck_models.LiveState, state, "issue_number", 160),
+        (
+            lck_models.OperationSnapshot,
+            lck_models.OperationSnapshot(operation="test", state=state),
+            "operation",
+            "changed",
+        ),
+    )
+    for model, snapshot, field_name, replacement in snapshots:
+        assert model.__dataclass_params__.frozen, model
+        with pytest.raises(FrozenInstanceError):
+            setattr(snapshot, field_name, replacement)
+
+
+def test_leaf_contract_is_separate_from_profile_evidence_envelope() -> None:
+    leaf_contract = _task_contract()
+    state = lck_models.LiveState(
+        issue_number=159,
+        issue={"number": 159, "body_sha256": leaf_contract["body_sha256"]},
+        target_branch="task/159-lck-core-live-state-resolution",
+        leaf_contract=leaf_contract,
+    )
+    contract_result = validate_profile_contract(
+        TASK_PROFILE,
+        leaf_contract,
+        context=PolicyContext(profile=TASK_PROFILE, issue=leaf_contract),
+    )
+    assert contract_result.valid
+    assert contract_result.evidence is not None
+    envelope = ProfileEvidenceEnvelope(
+        profile_id=TASK_PROFILE.profile_id,
+        contract=contract_result.evidence,
+    ).validated(leaf_contract=state.leaf_contract)
+
+    assert state.leaf_contract == leaf_contract
+    assert "body" not in envelope.to_dict()["contract"]["payload"]
+    assert "leaf_contract" not in envelope.to_dict()
+    assert envelope.to_dict()["contract"]["payload"]["contract_ref"] == {
+        "number": 159,
+        "body_sha256": leaf_contract["body_sha256"],
+    }
+
+
+def test_formal_candidate_and_review_stages_use_the_policy_registry() -> None:
+    leaf_contract = _task_contract()
+    context = PolicyContext(
+        profile=TASK_PROFILE,
+        issue=leaf_contract,
+        critical_outcome=lambda: {"status": "pass"},
+    )
+    contract = validate_profile_contract(
+        TASK_PROFILE, leaf_contract, context=context
+    ).evidence
+    assert contract is not None
+    candidate = validate_profile_candidate(
+        TASK_PROFILE,
+        leaf_contract,
+        contract_evidence=contract,
+        context=context,
+    )
+    assert candidate.kind == "task.candidate.v1"
+    review = validate_profile_review(
+        TASK_PROFILE,
+        leaf_contract,
+        {"verdict": "PASS"},
+    )
+    assert review.evidence is not None
+    assert review.evidence.kind == "task.review.v1"
+
+
+@pytest.mark.parametrize("profile", (TASK_PROFILE, BUG_PROFILE, DOCUMENTATION_PROFILE))
+def test_non_research_review_rejects_research_outcome_at_policy_boundary(
+    profile: LeafIssueWorkflowProfile,
+) -> None:
+    with pytest.raises(
+        ProfilePolicyError,
+        match="--research-outcome is supported only for Research Issues",
+    ):
+        validate_profile_review(
+            profile,
+            {"number": 219, "body_sha256": "a" * 64},
+            {"verdict": "PASS", "research_outcome": "IMPLEMENT"},
+        )

--- a/tests/tools/lck/test_receipts.py
+++ b/tests/tools/lck/test_receipts.py
@@ -1,0 +1,739 @@
+# ruff: noqa: E402, I001
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import replace
+from pathlib import Path
+from typing import (
+    Any,
+    cast,
+)
+
+import pytest
+
+AGENT_WORKFLOW = str(Path(__file__).parents[3] / "tools" / "agent_workflow")
+if AGENT_WORKFLOW not in sys.path:
+    sys.path.insert(0, AGENT_WORKFLOW)
+
+from tools.lck import (  # type: ignore[import-not-found]  # noqa: E402
+    cli as lck_cli,
+    closeout as lck_closeout,
+    delivery as lck_delivery,
+    eligibility as lck_eligibility,
+    models as lck_models,
+    receipts as lck_receipts,
+    remediation as lck_remediation,
+    review as lck_review,
+    review_workspace as lck_review_workspace,
+)
+from .support import (  # noqa: E402
+    FakeReviewChecks,
+    FakeReviewWorkspace,
+    StaticResolver,
+    SHA,
+    _review_guard,
+    _review_identity_value,
+    _review_state,
+)
+
+
+def test_closeout_failure_receipt_preserves_completed_effects(
+    tmp_path: Path,
+) -> None:
+    state = replace(
+        _review_state(),
+        merged_pr={"number": 200},
+    )
+    resolver = cast(Any, StaticResolver(tmp_path, state))
+
+    class Eligible:
+        def resolve(
+            self,
+            _state: lck_models.LiveState,
+            phase: lck_models.Phase,
+        ) -> lck_eligibility.PhaseDecision:
+            return lck_eligibility.PhaseDecision(phase=phase, eligible=True)
+
+    class Main:
+        def execute(
+            self,
+            _state: lck_models.LiveState,
+            *,
+            merge_sha: str,
+        ) -> lck_models.EffectReceipt:
+            return lck_models.EffectReceipt(
+                "synchronize_main",
+                "synchronized",
+                {"merge_sha": merge_sha},
+            )
+
+    class FailingMetadata:
+        def execute(self, _state: lck_models.LiveState) -> lck_models.EffectReceipt:
+            raise lck_models.LckStopError("metadata convergence failed")
+
+    handler = lck_closeout.CloseoutCompleter(
+        resolver,
+        eligibility=cast(Any, Eligible()),
+        main_effect=cast(Any, Main()),
+        metadata_effect=cast(Any, FailingMetadata()),
+    )
+    handler._validate_merged_identity = lambda _state: (SHA, "b" * 40)
+    handler._validate_reviewed_identity = lambda _state, _pr: {}
+
+    with pytest.raises(lck_models.LckStopError, match="metadata convergence failed"):
+        handler.complete(159)
+
+    assert [item.effect for item in handler.last_effects] == ["synchronize_main"]
+    store = lck_receipts.AuditReceiptStore(tmp_path)
+    payload = lck_receipts._write_failure_receipt(
+        operation="closeout",
+        task_number=159,
+        operation_id="e" * 32,
+        status="stop",
+        code=None,
+        error="metadata convergence failed",
+        handler=handler,
+        store=store,
+    )
+    receipt = store.read(payload["receipt_reference"])
+
+    assert receipt["audit"]["effects"] == [
+        {
+            "effect": "synchronize_main",
+            "action": "synchronized",
+            "details": {"merge_sha": "b" * 40},
+        }
+    ]
+
+
+def test_merge_preflight_failure_receipt_preserves_strict_check_evidence(
+    tmp_path: Path,
+) -> None:
+    state = _review_state()
+    resolver = cast(Any, StaticResolver(tmp_path, state))
+
+    class PassingReview:
+        def run(
+            self, _task_number: int, _state: lck_models.LiveState
+        ) -> dict[str, Any]:
+            return {"status": "pass", "review_id": "r" * 32}
+
+    class FailingChecks:
+        last_result: dict[str, Any] | None = None
+
+        def evaluate(self, snapshot: lck_models.OperationSnapshot) -> dict[str, Any]:
+            pr = snapshot.state.open_pr or {}
+            self.last_result = {
+                "status": "fail",
+                "check_state": "pending",
+                "required": ["quality"],
+                "pr": {
+                    "number": pr["number"],
+                    "head_sha": pr["headRefOid"],
+                    "base_sha": pr["baseRefOid"],
+                },
+            }
+            raise lck_models.LckStopError("PR checks are pending")
+
+    checks = FailingChecks()
+    handler = lck_review.MergePreflight(
+        resolver,
+        review_gate=cast(Any, PassingReview()),
+        checks_gate=cast(Any, checks),
+    )
+
+    with pytest.raises(lck_models.LckStopError, match="PR checks are pending"):
+        handler.run(159)
+
+    assert handler.last_checks == checks.last_result
+    store = lck_receipts.AuditReceiptStore(tmp_path)
+    payload = lck_receipts._write_failure_receipt(
+        operation="merge-preflight",
+        task_number=159,
+        operation_id="a" * 32,
+        status="stop",
+        code=None,
+        error="PR checks are pending",
+        handler=handler,
+        store=store,
+    )
+    receipt = store.read(payload["receipt_reference"])
+
+    assert receipt["audit"]["checks"] == checks.last_result
+
+
+def test_review_prepare_returns_compact_agent_view_and_full_audit_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Critical Outcome: Review Prepare separates Agent output from evidence."""
+    state = _review_state()
+    identity = _review_identity_value()
+    review_id = "b" * 32
+    review_root = tmp_path / "review-root"
+    review_root.mkdir()
+    store = lck_review_workspace.ReviewInvocationStore(tmp_path)
+    snapshot = lck_models.OperationSnapshot(
+        operation="review-prepare",
+        state=state,
+        fact_profile="review-prepare",
+        acquired_facts=("task_contract", "remote_task_branches", "open_pr", "checks"),
+    )
+    guard = _review_guard(identity, review_root=review_root)
+    guard.update(
+        {
+            "schema_version": lck_models.LCK_SCHEMA_VERSION,
+            "kind": "review-invocation-guard",
+            "review_id": review_id,
+            "snapshot": snapshot.to_dict(),
+        }
+    )
+    store.write_guard(review_id, guard)
+    context = lck_review.ReviewContext(
+        review_id=review_id,
+        task_contract=state.task_contract or {},
+        identity=identity,
+        checks={
+            "status": "observed",
+            "check_state": "pending",
+            "pr": {"number": 200, "head_sha": SHA, "base_sha": SHA},
+            "observed": {"quality": {"status": "pending"}},
+        },
+        validation={"status": "pass", "commands": [{"command_id": "pytest"}]},
+        review_root=review_root,
+    )
+
+    class FakePreparer:
+        def __init__(self, _resolver: Any) -> None:
+            pass
+
+        def prepare(self, _task_number: int) -> lck_review.ReviewContext:
+            return context
+
+    resolver = StaticResolver(tmp_path, state)
+    monkeypatch.setattr(
+        lck_cli,
+        "LiveStateResolver",
+        lambda _root, repository=None: resolver,
+    )
+    monkeypatch.setattr(lck_cli, "ReviewPreparer", FakePreparer)
+
+    exit_code = lck_cli.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--repository",
+            "owner/repo",
+            "review",
+            "prepare",
+            "159",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["kind"] == "lck-agent-view"
+    assert payload["status"] == "READY_FOR_SEMANTIC_REVIEW"
+    assert payload["review_target"] == identity.to_dict()
+    assert payload["task_contract"]["body"] == "Task Contract"
+    assert "operation_snapshot" not in payload
+    assert "observed" not in payload["checks"]
+
+    reference = payload["receipt_reference"]
+    receipt = lck_receipts.AuditReceiptStore(tmp_path).read(reference)
+    assert receipt["kind"] == "lck-audit-receipt"
+    assert receipt["operation"] == "review-prepare"
+    assert receipt["operation_snapshot"] == snapshot.to_dict()
+    assert receipt["agent_view"]["review_target"] == payload["review_target"]
+    assert receipt["audit"]["review_guard"]["review_id"] == review_id
+
+
+def test_lifecycle_agent_views_include_the_selected_issue_profile(
+    tmp_path: Path,
+) -> None:
+    profile = {
+        "status": "resolved",
+        "terminal_status": "PROFILE_ENABLED",
+        "type_labels": ["type:task"],
+        "profile": {"profile_id": "task", "canonical_type_label": "type:task"},
+    }
+    state = replace(_review_state(), issue_profile=profile)
+    snapshot = lck_models.OperationSnapshot(operation="test", state=state)
+    identity = _review_identity_value()
+    delivery = lck_delivery.DeliveryCompletionResult(
+        task_number=159,
+        status="READY_FOR_REVIEW",
+        branch=state.target_branch,
+        head_sha=SHA,
+        critical_outcome=None,
+        validation={"status": "pass"},
+        checks={"status": "observed"},
+        effects=(),
+        operation_snapshot=snapshot,
+    )
+    values = (
+        lck_delivery.DeliveryContext(
+            task_number=159,
+            repository="owner/repo",
+            branch=state.target_branch,
+            base_sha=SHA,
+            action="selected-existing-branch",
+            operation_snapshot=snapshot,
+            eligibility=lck_eligibility.PhaseDecision(
+                phase=lck_models.Phase.DELIVERY_PREPARE,
+                eligible=True,
+            ),
+        ),
+        delivery,
+        lck_review.ReviewContext(
+            review_id="a" * 32,
+            task_contract=state.task_contract or {},
+            identity=identity,
+            checks={},
+            validation={"status": "pass"},
+            review_root=tmp_path,
+            issue_profile=profile,
+        ),
+        lck_review.ReviewCompletionResult(
+            review_id="b" * 32,
+            task_number=159,
+            verdict="FAIL",
+            status="STOP_REQUIRED",
+            identity=identity,
+            record_path=tmp_path / "review.json",
+            issue_profile=profile,
+        ),
+        lck_review.MergePreflightResult(
+            task_number=159,
+            status="READY_FOR_HUMAN_MERGE",
+            pr={},
+            review={},
+            checks={},
+            blockers={},
+            mergeability="MERGEABLE",
+            operation_snapshot=snapshot,
+        ),
+        lck_closeout.CloseoutResult(
+            task_number=159,
+            status="BUSINESS_DELIVERY_COMPLETE",
+            business_delivery="COMPLETE",
+            cleanup="COMPLETE",
+            effects=(),
+            operation_snapshot=snapshot,
+        ),
+        lck_remediation.RemediationContext(
+            task_number=159,
+            review_id="c" * 32,
+            findings="finding",
+            findings_source="local-review-record",
+            operation_snapshot=snapshot,
+            action="already-prepared",
+        ),
+        lck_remediation.RemediationNoChangeResult(
+            task_number=159,
+            review_id="d" * 32,
+            head_sha=SHA,
+            pr_number=200,
+            base_sha=SHA,
+            summary="unchanged",
+            operation_snapshot=snapshot,
+            receipt_path=tmp_path / "no-change.json",
+        ),
+        lck_remediation.RemediationCompletionResult(
+            task_number=159,
+            review_id="e" * 32,
+            delivery=delivery,
+        ),
+    )
+
+    for value in values:
+        assert lck_receipts._agent_view_for_result(value)["issue_profile"] == profile
+        assert value.to_dict()["issue_profile"] == profile
+
+
+def test_delivery_prepare_receipt_preserves_status_effect_and_postcondition(
+    tmp_path: Path,
+) -> None:
+    state = _review_state()
+    state = replace(
+        state,
+        issue={**(state.issue or {}), "project_status": "Ready"},
+    )
+    snapshot = lck_models.OperationSnapshot(
+        operation=lck_models.Phase.DELIVERY_PREPARE.value,
+        state=state,
+    )
+    effect = lck_models.EffectReceipt(
+        effect="set_in_progress_status",
+        action="updated",
+        details={"status": "In Progress", "postcondition": "verified"},
+    )
+    context = lck_delivery.DeliveryContext(
+        task_number=159,
+        repository="owner/repo",
+        branch=state.target_branch,
+        base_sha=SHA,
+        action="created-from-main",
+        operation_snapshot=snapshot,
+        eligibility=lck_eligibility.PhaseDecision(
+            phase=lck_models.Phase.DELIVERY_PREPARE,
+            eligible=True,
+        ),
+        effects=(effect,),
+    )
+    store = lck_receipts.AuditReceiptStore(tmp_path)
+
+    payload = lck_receipts._write_success_receipt(
+        context,
+        operation="delivery-prepare",
+        task_number=159,
+        operation_id="f" * 32,
+        store=store,
+    )
+    receipt = store.read(payload["receipt_reference"])
+
+    assert payload["effects"] == [
+        {
+            "effect": "set_in_progress_status",
+            "action": "updated",
+            "postcondition": {
+                "status": "verified",
+                "project_status": "In Progress",
+            },
+        }
+    ]
+    assert receipt["audit"]["effects"] == [effect.to_dict()]
+    assert receipt["operation_snapshot"]["state"]["issue"]["project_status"] == (
+        "Ready"
+    )
+
+
+def test_review_prepare_failure_receipt_preserves_validation_payload(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = _review_state()
+    identity = _review_identity_value()
+    validation = {
+        "status": "fail",
+        "phase": "review",
+        "commands": [
+            {
+                "command_id": "pytest",
+                "status": "fail",
+                "exit_code": 1,
+                "diagnostic": "review validation failed",
+            }
+        ],
+        "evidence_path": ".workflow.local/lck/review-validation/run",
+    }
+
+    class FailedValidation:
+        def run(self, _root: Path, _base: str, _head: str) -> dict[str, Any]:
+            return validation
+
+    resolver = cast(Any, StaticResolver(tmp_path, state))
+    monkeypatch.setattr(
+        lck_review, "_review_identity", lambda *_args, **_kwargs: identity
+    )
+    handler = lck_review.ReviewPreparer(
+        resolver,
+        validation=cast(Any, FailedValidation()),
+        checks_gate=cast(Any, FakeReviewChecks()),
+        workspace=cast(Any, FakeReviewWorkspace(tmp_path / "review-root")),
+        store=lck_review_workspace.ReviewInvocationStore(tmp_path),
+    )
+
+    with pytest.raises(
+        lck_models.LckStopError, match="formal Review validation failed"
+    ):
+        handler.prepare(159)
+
+    store = lck_receipts.AuditReceiptStore(tmp_path)
+    payload = lck_receipts._write_failure_receipt(
+        operation="review-prepare",
+        task_number=159,
+        operation_id="c" * 32,
+        status="stop",
+        code=None,
+        error="formal Review validation failed: fail",
+        handler=handler,
+        store=store,
+    )
+    receipt = store.read(payload["receipt_reference"])
+
+    assert receipt["audit"]["validation"] == validation
+
+
+def test_lck_stop_result_has_structured_receipt_reference(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    class FailingResolver:
+        repo_root = tmp_path
+
+        def resolve(self, _task_number: int) -> lck_models.LiveState:
+            raise lck_models.LckStopError("live state is unavailable")
+
+    resolver = FailingResolver()
+    monkeypatch.setattr(
+        lck_cli,
+        "LiveStateResolver",
+        lambda _root, repository=None: resolver,
+    )
+
+    exit_code = lck_cli.main(["--repo-root", str(tmp_path), "status", "159"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 2
+    assert payload["kind"] == "lck-agent-view"
+    assert payload["operation"] == "status"
+    assert payload["status"] == "stop"
+    assert payload["next_action"]
+    receipt = lck_receipts.AuditReceiptStore(tmp_path).read(
+        payload["receipt_reference"]
+    )
+    assert receipt["outcome"]["status"] == "stop"
+    assert receipt["agent_view"]["error"] == "live state is unavailable"
+
+
+def test_remediation_no_change_cli_replay_reuses_audit_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    state = _review_state()
+    resolver = cast(Any, StaticResolver(tmp_path, state))
+    store = lck_review_workspace.ReviewInvocationStore(tmp_path)
+    review_id = store.new_id()
+    store.write_remediation_session(
+        159,
+        {
+            "schema_version": lck_models.LCK_SCHEMA_VERSION,
+            "kind": "remediation-session",
+            "task_number": 159,
+            "review_id": review_id,
+            "start_head_sha": SHA,
+            "pr_number": 200,
+            "base_sha": SHA,
+            "findings_sha256": "f" * 64,
+            "findings_source": "local-review-record",
+            "authority": "test",
+        },
+    )
+    monkeypatch.setattr(
+        lck_cli,
+        "LiveStateResolver",
+        lambda _root, repository=None: resolver,
+    )
+    argv = [
+        "--repo-root",
+        str(tmp_path),
+        "remediation",
+        "no-change",
+        "159",
+        "--review-id",
+        review_id,
+        "--summary",
+        "No implementation change required.",
+    ]
+
+    first_exit = lck_cli.main(argv)
+    first = json.loads(capsys.readouterr().out)
+    second_exit = lck_cli.main(argv)
+    second = json.loads(capsys.readouterr().out)
+
+    assert first_exit == second_exit == 0
+    assert first["replayed"] is False
+    assert second["replayed"] is True
+    assert first["receipt_reference"] == second["receipt_reference"]
+    assert second["next_action"]
+    receipt = lck_receipts.AuditReceiptStore(tmp_path).read(second["receipt_reference"])
+    assert receipt["agent_view"]["replayed"] is False
+    assert receipt["audit"]["replayed"] is False
+
+
+def test_closeout_agent_view_does_not_stop_when_research_outcome_is_pending() -> None:
+    result = lck_closeout.CloseoutResult(
+        task_number=159,
+        status="BUSINESS_DELIVERY_COMPLETE",
+        business_delivery="PENDING",
+        cleanup="COMPLETE",
+        effects=(),
+        operation_snapshot=lck_models.OperationSnapshot(
+            operation="closeout",
+            state=_review_state(),
+        ),
+        research_outcome=None,
+    )
+
+    view = lck_receipts._agent_view_for_result(result)
+
+    assert "Research Outcome" in view["next_action"]
+    assert view["next_action"] != "stop; closeout is complete"
+
+
+def test_review_complete_failure_receipt_preserves_bound_snapshot_and_checks(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    identity = _review_identity_value()
+    resolver = cast(Any, StaticResolver(tmp_path, _review_state()))
+    monkeypatch.setattr(
+        lck_review, "_review_identity", lambda *_args, **_kwargs: identity
+    )
+    store = lck_review_workspace.ReviewInvocationStore(tmp_path)
+    review_id = store.new_id()
+    review_root = tmp_path / "review-root"
+    review_root.mkdir()
+    store.write_guard(review_id, _review_guard(identity, review_root=review_root))
+
+    class FailingChecks:
+        last_result: dict[str, Any] | None = None
+
+        def evaluate(self, snapshot: lck_models.OperationSnapshot) -> dict[str, Any]:
+            self.last_result = {
+                "status": "fail",
+                "check_state": "pending",
+                "required": snapshot.required_checks["contexts"]["items"]
+                if snapshot.required_checks is not None
+                else [],
+                "pr": {"number": 200, "head_sha": SHA, "base_sha": SHA},
+            }
+            raise lck_models.LckStopError("PR checks are pending")
+
+    handler = lck_review.ReviewCompleter(
+        resolver,
+        checks_gate=cast(Any, FailingChecks()),
+        store=store,
+        workspace=cast(Any, FakeReviewWorkspace(review_root)),
+    )
+
+    with pytest.raises(lck_models.LckStopError, match="PR checks are pending"):
+        handler.complete(159, review_id, verdict="PASS")
+
+    assert handler.last_snapshot is not None
+    assert handler.last_snapshot.required_checks is not None
+    assert handler.last_snapshot.required_checks["source_sha"] == SHA
+    assert handler.last_snapshot.required_checks["contexts"]["items"] == ["quality"]
+    assert handler.last_checks == {
+        "status": "fail",
+        "check_state": "pending",
+        "required": ["quality"],
+        "pr": {"number": 200, "head_sha": SHA, "base_sha": SHA},
+    }
+
+    audit_store = lck_receipts.AuditReceiptStore(tmp_path)
+    payload = lck_receipts._write_failure_receipt(
+        operation="review-complete",
+        task_number=159,
+        operation_id="d" * 32,
+        status="stop",
+        code=None,
+        error="PR checks are pending",
+        handler=handler,
+        store=audit_store,
+    )
+    receipt = audit_store.read(payload["receipt_reference"])
+
+    assert receipt["operation_snapshot"]["required_checks"]["source_sha"] == SHA
+    assert receipt["operation_snapshot"]["required_checks"]["contexts"]["items"] == [
+        "quality"
+    ]
+    assert receipt["audit"]["checks"] == handler.last_checks
+
+
+def test_remediation_failure_receipt_preserves_nested_delivery_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = _review_state(clean=False)
+    resolver = cast(Any, StaticResolver(tmp_path, state))
+    store = lck_review_workspace.ReviewInvocationStore(tmp_path)
+    review_id = store.new_id()
+    store.write_remediation_session(
+        159,
+        {
+            "schema_version": lck_models.LCK_SCHEMA_VERSION,
+            "kind": "remediation-session",
+            "task_number": 159,
+            "review_id": review_id,
+            "start_head_sha": SHA,
+            "pr_number": 200,
+            "base_sha": SHA,
+            "findings_sha256": "f" * 64,
+            "findings_source": "local-review-record",
+            "authority": "test",
+        },
+    )
+    failed_validation = {
+        "status": "fail",
+        "commands": [
+            {
+                "command_id": "pytest",
+                "exit_code": 1,
+                "log_path": ".agents/validation.local/pytest.log",
+                "duration_ms": 23,
+                "diagnostic": "assertion failed",
+            }
+        ],
+    }
+
+    class FailingDeliveryCompleter:
+        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+            self.last_snapshot: lck_models.OperationSnapshot | None = None
+            self.last_critical_outcome: dict[str, Any] | None = None
+            self.last_validation: dict[str, Any] | None = None
+            self.last_checks: dict[str, Any] | None = {
+                "status": "observed",
+                "check_state": "pending",
+                "pr": {"number": 200, "head_sha": SHA, "base_sha": SHA},
+            }
+            self.last_effects: list[lck_models.EffectReceipt] = []
+
+        def complete(self, *_args: Any, **kwargs: Any) -> Any:
+            self.last_snapshot = kwargs["operation_snapshot"]
+            self.last_critical_outcome = {"status": "pass"}
+            self.last_validation = failed_validation
+            self.last_effects = [
+                lck_models.EffectReceipt(
+                    "commit_current_tree",
+                    "committed",
+                    {"head_sha": "b" * 40},
+                )
+            ]
+            raise lck_models.LckStopError("remote branch effect failed")
+
+    monkeypatch.setattr(lck_remediation, "DeliveryCompleter", FailingDeliveryCompleter)
+    handler = lck_remediation.RemediationCompleter(resolver, store=store)
+
+    with pytest.raises(lck_models.LckStopError, match="remote branch effect failed"):
+        handler.complete(
+            159,
+            review_id,
+            commit_message="repair",
+            summary="repair",
+        )
+
+    audit_store = lck_receipts.AuditReceiptStore(tmp_path)
+    payload = lck_receipts._write_failure_receipt(
+        operation="remediation-complete",
+        task_number=159,
+        operation_id="e" * 32,
+        status="stop",
+        code=None,
+        error="remote branch effect failed",
+        handler=handler,
+        store=audit_store,
+    )
+    receipt = audit_store.read(payload["receipt_reference"])
+
+    assert handler.last_snapshot is not None
+    assert receipt["operation_snapshot"] == handler.last_snapshot.to_dict()
+    assert receipt["audit"]["validation"] == failed_validation
+    assert receipt["audit"]["checks"] == handler.last_checks
+    assert receipt["audit"]["effects"][0]["effect"] == "commit_current_tree"

--- a/tests/tools/lck/test_remediation.py
+++ b/tests/tools/lck/test_remediation.py
@@ -1,0 +1,892 @@
+# ruff: noqa: E402, I001
+
+from __future__ import annotations
+
+import sys
+from dataclasses import replace
+from pathlib import Path
+from typing import (
+    Any,
+    cast,
+)
+
+import pytest
+
+AGENT_WORKFLOW = str(Path(__file__).parents[3] / "tools" / "agent_workflow")
+if AGENT_WORKFLOW not in sys.path:
+    sys.path.insert(0, AGENT_WORKFLOW)
+
+from tools.lck import (  # type: ignore[import-not-found]  # noqa: E402
+    delivery as lck_delivery,
+    effects as lck_effects,
+    eligibility as lck_eligibility,
+    models as lck_models,
+    profile_policies as lck_profile_policies,
+    remediation as lck_remediation,
+    review as lck_review,
+    review_workspace as lck_review_workspace,
+    validation_gates as lck_validation,
+)
+from .support import (  # noqa: E402
+    FakeRunner,
+    FakeReviewChecks,
+    FakeReviewWorkspace,
+    OwnedCandidateRunner,
+    StaticResolver,
+    SHA,
+    _install_facts,
+    _issue,
+    _open_pr,
+    _required_policy,
+    _resolver,
+    _review_guard,
+    _review_identity_value,
+    _review_state,
+    _write_owned_candidate_session,
+)
+
+
+def test_review_prepare_rejects_open_remediation_session(
+    tmp_path: Path,
+) -> None:
+    resolver = cast(Any, StaticResolver(tmp_path, _review_state(clean=True)))
+    store = lck_review_workspace.ReviewInvocationStore(tmp_path)
+    review_id = store.new_id()
+    store.write_remediation_session(
+        159,
+        {
+            "schema_version": lck_models.LCK_SCHEMA_VERSION,
+            "kind": "remediation-session",
+            "task_number": 159,
+            "review_id": review_id,
+            "start_head_sha": SHA,
+            "pr_number": 200,
+            "base_sha": SHA,
+            "findings_sha256": "f" * 64,
+            "findings_source": "local-review-record",
+            "authority": "test",
+        },
+    )
+
+    with pytest.raises(lck_models.LckStopError, match="remediation no-change"):
+        lck_review.ReviewPreparer(resolver, store=store).prepare(159)
+
+    assert resolver.calls == 0
+
+
+def test_remediation_prepare_rejects_draft_pr(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    branch = "task/159-lck-core-live-state-resolution"
+    fake = FakeRunner(
+        branch=branch, local_branches={branch}, remote_branches={branch: SHA}
+    )
+    issue = _issue()
+    issue["project_status"] = "Review"
+    _install_facts(
+        monkeypatch,
+        fake,
+        issue=issue,
+        open_pr=_open_pr(branch, is_draft=True),
+    )
+
+    state = _resolver(fake).resolve(159)
+    decision = lck_eligibility.PhaseEligibilityResolver().resolve(
+        state,
+        lck_models.Phase.REMEDIATION_PREPARE,
+    )
+
+    assert not decision.eligible
+    assert any("non-Draft" in reason for reason in decision.reasons)
+
+
+def test_remediation_requires_pr_base_to_match_current_main(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    branch = "task/159-lck-core-live-state-resolution"
+    fake = FakeRunner(
+        branch=branch, local_branches={branch}, remote_branches={branch: SHA}
+    )
+    issue = _issue()
+    issue["project_status"] = "Review"
+    pr = _open_pr(branch)
+    pr["baseRefOid"] = "b" * 40
+    _install_facts(monkeypatch, fake, issue=issue, open_pr=pr)
+
+    state = _resolver(fake).resolve(159)
+    decision = lck_eligibility.PhaseEligibilityResolver().resolve(
+        state,
+        lck_models.Phase.REMEDIATION_PREPARE,
+    )
+
+    assert not decision.eligible
+    assert any(
+        "base must match current origin/main" in reason for reason in decision.reasons
+    )
+
+
+def test_review_fail_returns_stop_required_without_starting_remediation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    identity = _review_identity_value()
+    resolver = cast(Any, StaticResolver(tmp_path, _review_state()))
+    monkeypatch.setattr(
+        lck_review, "_review_identity", lambda *_args, **_kwargs: identity
+    )
+    store = lck_review_workspace.ReviewInvocationStore(tmp_path)
+    review_id = store.new_id()
+    review_root = tmp_path / "review-root"
+    review_root.mkdir()
+    store.write_guard(review_id, _review_guard(identity, review_root=review_root))
+    findings = tmp_path / "findings.md"
+    findings.write_text("[F1][Medium] Repair this behavior.\n", encoding="utf-8")
+
+    result = lck_review.ReviewCompleter(
+        resolver,
+        checks_gate=cast(Any, FakeReviewChecks()),
+        store=store,
+        workspace=cast(Any, FakeReviewWorkspace(review_root)),
+    ).complete(159, review_id, verdict="FAIL", findings_file=findings)
+
+    assert result.status == "STOP_REQUIRED"
+    assert result.to_dict()["automatic_remediation"] is False
+    assert resolver.calls == 1
+    record = store.read_record(159, review_id)
+    assert record["findings"].startswith("[F1][Medium]")
+    assert "fresh Review Complete snapshot matched" in record["authority_note"]
+
+
+def test_remediation_prepare_uses_live_head_not_review_record_identity(
+    tmp_path: Path,
+) -> None:
+    live_head = "b" * 40
+    state = _review_state(head=live_head, base=SHA)
+    resolver = cast(Any, StaticResolver(tmp_path, state))
+    store = lck_review_workspace.ReviewInvocationStore(tmp_path)
+    review_id = store.new_id()
+    store.write_record(
+        159,
+        review_id,
+        {
+            "task_number": 159,
+            "verdict": "FAIL",
+            "identity": _review_identity_value(head=SHA).to_dict(),
+            "findings": "[F1][Medium] Semantic repair input.",
+        },
+    )
+    store.write_latest_review(159, review_id, "FAIL")
+
+    context = lck_remediation.RemediationPreparer(resolver, store=store).prepare(
+        159, review_id
+    )
+
+    assert context.to_dict()["live_target"]["head_sha"] == live_head
+    assert context.task_contract["body"] == "Task Contract"
+    assert context.to_dict()["task_contract"]["body"] == "Task Contract"
+    assert context.findings == "[F1][Medium] Semantic repair input."
+    assert (
+        "operation snapshot acquired at Remediation entry"
+        in context.to_dict()["mechanical_authority"]
+    )
+    assert (
+        "do not block Remediation Complete" in context.to_dict()["acceptance_boundary"]
+    )
+    assert "must not be fabricated" in context.to_dict()["acceptance_boundary"]
+
+
+def test_remediation_prepare_accepts_portable_findings_when_local_record_missing(
+    tmp_path: Path,
+) -> None:
+    live_head = "b" * 40
+    resolver = cast(Any, StaticResolver(tmp_path, _review_state(head=live_head)))
+    store = lck_review_workspace.ReviewInvocationStore(tmp_path)
+    review_id = store.new_id()
+    findings = tmp_path / "review-findings.md"
+    findings.write_text("[F1][High] Portable semantic finding.\n", encoding="utf-8")
+
+    context = lck_remediation.RemediationPreparer(resolver, store=store).prepare(
+        159,
+        review_id,
+        findings_file=findings,
+    )
+
+    assert context.findings == "[F1][High] Portable semantic finding.\n"
+    assert context.findings_source == "portable-findings-file"
+    assert context.to_dict()["findings_source"] == "portable-findings-file"
+    session = store.read_remediation_session(159)
+    assert session is not None
+    assert session["review_id"] == review_id
+    assert session["start_head_sha"] == live_head
+    assert session["findings_source"] == "portable-findings-file"
+    assert resolver.calls == 1
+
+
+def test_remediation_prepare_missing_local_record_requires_portable_findings(
+    tmp_path: Path,
+) -> None:
+    resolver = cast(Any, StaticResolver(tmp_path, _review_state()))
+    store = lck_review_workspace.ReviewInvocationStore(tmp_path)
+    review_id = store.new_id()
+
+    with pytest.raises(lck_models.LckStopError, match="provide --findings-file"):
+        lck_remediation.RemediationPreparer(resolver, store=store).prepare(
+            159, review_id
+        )
+
+    assert resolver.calls == 0
+
+
+def test_remediation_prepare_local_record_path_remains_primary(
+    tmp_path: Path,
+) -> None:
+    resolver = cast(Any, StaticResolver(tmp_path, _review_state()))
+    store = lck_review_workspace.ReviewInvocationStore(tmp_path)
+    review_id = store.new_id()
+    local_findings = "[F1][Medium] Local Codex review finding."
+    store.write_record(
+        159,
+        review_id,
+        {
+            "task_number": 159,
+            "verdict": "FAIL",
+            "identity": _review_identity_value().to_dict(),
+            "findings": local_findings,
+        },
+    )
+    store.write_latest_review(159, review_id, "FAIL")
+    portable = tmp_path / "portable.md"
+    portable.write_text("different portable text", encoding="utf-8")
+
+    context = lck_remediation.RemediationPreparer(resolver, store=store).prepare(
+        159, review_id, findings_file=portable
+    )
+
+    assert context.findings == local_findings
+    assert context.findings_source == "local-review-record"
+
+
+def test_remediation_complete_uses_prepared_session_without_review_record(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    start_head = SHA
+    repaired_head = "b" * 40
+    state = _review_state(head=start_head, clean=False)
+    resolver = cast(Any, StaticResolver(tmp_path, state))
+    store = lck_review_workspace.ReviewInvocationStore(tmp_path)
+    review_id = store.new_id()
+    store.write_remediation_session(
+        159,
+        {
+            "schema_version": lck_models.LCK_SCHEMA_VERSION,
+            "kind": "remediation-session",
+            "task_number": 159,
+            "review_id": review_id,
+            "start_head_sha": start_head,
+            "pr_number": 200,
+            "base_sha": SHA,
+            "findings_sha256": "f" * 64,
+            "findings_source": "portable-findings-file",
+            "authority": "test",
+        },
+    )
+
+    def fake_delivery_complete(self: Any, task_number: int, **kwargs: Any) -> Any:
+        snapshot = kwargs["operation_snapshot"]
+        return lck_delivery.DeliveryCompletionResult(
+            task_number=task_number,
+            status="READY_FOR_REVIEW",
+            branch=state.target_branch,
+            head_sha=repaired_head,
+            critical_outcome={"status": "valid"},
+            validation={"status": "pass"},
+            checks={"status": "pass"},
+            effects=(),
+            operation_snapshot=snapshot,
+        )
+
+    monkeypatch.setattr(
+        lck_delivery.DeliveryCompleter, "complete", fake_delivery_complete
+    )
+
+    result = lck_remediation.RemediationCompleter(resolver, store=store).complete(
+        159,
+        review_id,
+        commit_message="repair",
+        summary="repair",
+    )
+
+    assert result.delivery.head_sha == repaired_head
+    assert store.read_remediation_session(159) is None
+    required = store.read_review_required(159)
+    assert required is not None
+    assert required["remediated_head"] == repaired_head
+
+
+def test_remediation_no_change_closes_prepared_session_without_new_head(
+    tmp_path: Path,
+) -> None:
+    head = SHA
+    resolver = cast(Any, StaticResolver(tmp_path, _review_state(head=head, clean=True)))
+    store = lck_review_workspace.ReviewInvocationStore(tmp_path)
+    review_id = store.new_id()
+    store.write_remediation_session(
+        159,
+        {
+            "schema_version": lck_models.LCK_SCHEMA_VERSION,
+            "kind": "remediation-session",
+            "task_number": 159,
+            "review_id": review_id,
+            "start_head_sha": head,
+            "pr_number": 200,
+            "base_sha": SHA,
+            "findings_sha256": "f" * 64,
+            "findings_source": "local-review-record",
+            "authority": "test",
+        },
+    )
+
+    result = lck_remediation.RemediationNoChangeCompleter(
+        resolver, store=store
+    ).complete(
+        159,
+        review_id,
+        summary="Only deferred external acceptance evidence remains.",
+    )
+
+    payload = result.to_dict()
+    assert payload["status"] == "NO_IMPLEMENTATION_CHANGE"
+    assert payload["head_sha"] == head
+    assert payload["candidate_changed"] is False
+    assert payload["fresh_review_required"] is False
+    assert payload["session_released"] is True
+    assert payload["replayed"] is False
+    assert store.read_remediation_session(159) is None
+    assert store.read_review_required(159) is None
+    receipt = store.read_remediation_no_change_receipt(159, review_id)
+    assert receipt is not None
+    assert receipt["start_head_sha"] == head
+    assert receipt["candidate_changed"] is False
+    assert resolver.calls == 1
+
+
+def test_remediation_no_change_releases_old_session_for_new_review_prepare(
+    tmp_path: Path,
+) -> None:
+    state = _review_state(clean=True)
+    resolver = cast(Any, StaticResolver(tmp_path, state))
+    store = lck_review_workspace.ReviewInvocationStore(tmp_path)
+    old_review_id = store.new_id()
+    store.write_remediation_session(
+        159,
+        {
+            "schema_version": lck_models.LCK_SCHEMA_VERSION,
+            "kind": "remediation-session",
+            "task_number": 159,
+            "review_id": old_review_id,
+            "start_head_sha": SHA,
+            "pr_number": 200,
+            "base_sha": SHA,
+            "findings_sha256": "a" * 64,
+            "findings_source": "local-review-record",
+            "authority": "test",
+        },
+    )
+
+    lck_remediation.RemediationNoChangeCompleter(resolver, store=store).complete(
+        159, old_review_id, summary="No implementation defect remained."
+    )
+
+    new_review_id = store.new_id()
+    findings = tmp_path / "new-review-findings.md"
+    findings.write_text(
+        "[F1][Blocking] External acceptance evidence.\n", encoding="utf-8"
+    )
+    context = lck_remediation.RemediationPreparer(resolver, store=store).prepare(
+        159, new_review_id, findings_file=findings
+    )
+
+    assert context.review_id == new_review_id
+    session = store.read_remediation_session(159)
+    assert session is not None
+    assert session["review_id"] == new_review_id
+    assert session["start_head_sha"] == SHA
+
+
+def test_remediation_no_change_rejects_wrong_review_or_dirty_tree(
+    tmp_path: Path,
+) -> None:
+    store = lck_review_workspace.ReviewInvocationStore(tmp_path)
+    review_id = store.new_id()
+    store.write_remediation_session(
+        159,
+        {
+            "schema_version": lck_models.LCK_SCHEMA_VERSION,
+            "kind": "remediation-session",
+            "task_number": 159,
+            "review_id": review_id,
+            "start_head_sha": SHA,
+            "pr_number": 200,
+            "base_sha": SHA,
+            "findings_sha256": "b" * 64,
+            "findings_source": "local-review-record",
+            "authority": "test",
+        },
+    )
+    clean_resolver = cast(Any, StaticResolver(tmp_path, _review_state(clean=True)))
+
+    with pytest.raises(lck_models.LckStopError, match="review id does not match"):
+        lck_remediation.RemediationNoChangeCompleter(
+            clean_resolver, store=store
+        ).complete(159, store.new_id(), summary="wrong review")
+
+    dirty_resolver = cast(Any, StaticResolver(tmp_path, _review_state(clean=False)))
+    with pytest.raises(
+        lck_models.LckStopError, match="clean tracked and staged worktree"
+    ):
+        lck_remediation.RemediationNoChangeCompleter(
+            dirty_resolver, store=store
+        ).complete(159, review_id, summary="no change")
+
+    assert store.read_remediation_session(159) is not None
+
+
+def test_remediation_no_change_rejects_head_drift(
+    tmp_path: Path,
+) -> None:
+    store = lck_review_workspace.ReviewInvocationStore(tmp_path)
+    review_id = store.new_id()
+    store.write_remediation_session(
+        159,
+        {
+            "schema_version": lck_models.LCK_SCHEMA_VERSION,
+            "kind": "remediation-session",
+            "task_number": 159,
+            "review_id": review_id,
+            "start_head_sha": SHA,
+            "pr_number": 200,
+            "base_sha": SHA,
+            "findings_sha256": "d" * 64,
+            "findings_source": "local-review-record",
+            "authority": "test",
+        },
+    )
+    moved_head = "b" * 40
+    resolver = cast(
+        Any, StaticResolver(tmp_path, _review_state(head=moved_head, clean=True))
+    )
+
+    with pytest.raises(lck_models.LckStopError, match="target no longer matches"):
+        lck_remediation.RemediationNoChangeCompleter(resolver, store=store).complete(
+            159, review_id, summary="no change"
+        )
+
+    assert store.read_remediation_session(159) is not None
+    assert store.read_remediation_no_change_receipt(159, review_id) is None
+
+
+def test_remediation_no_change_is_idempotent_for_same_unchanged_target(
+    tmp_path: Path,
+) -> None:
+    resolver = cast(Any, StaticResolver(tmp_path, _review_state(clean=True)))
+    store = lck_review_workspace.ReviewInvocationStore(tmp_path)
+    review_id = store.new_id()
+    store.write_remediation_session(
+        159,
+        {
+            "schema_version": lck_models.LCK_SCHEMA_VERSION,
+            "kind": "remediation-session",
+            "task_number": 159,
+            "review_id": review_id,
+            "start_head_sha": SHA,
+            "pr_number": 200,
+            "base_sha": SHA,
+            "findings_sha256": "c" * 64,
+            "findings_source": "local-review-record",
+            "authority": "test",
+        },
+    )
+
+    first = lck_remediation.RemediationNoChangeCompleter(
+        resolver, store=store
+    ).complete(159, review_id, summary="No implementation change required.")
+    second = lck_remediation.RemediationNoChangeCompleter(
+        resolver, store=store
+    ).complete(159, review_id, summary="ignored on replay")
+
+    assert first.to_dict()["replayed"] is False
+    assert second.to_dict()["replayed"] is True
+    assert second.summary == "No implementation change required."
+    assert store.read_remediation_session(159) is None
+
+
+def test_remediation_complete_requires_actual_repair_changes(
+    tmp_path: Path,
+) -> None:
+    resolver = cast(Any, StaticResolver(tmp_path, _review_state(clean=True)))
+    store = lck_review_workspace.ReviewInvocationStore(tmp_path)
+    review_id = store.new_id()
+    store.write_record(
+        159,
+        review_id,
+        {
+            "task_number": 159,
+            "verdict": "FAIL",
+            "identity": _review_identity_value().to_dict(),
+            "findings": "[F1][Medium] Repair required.",
+        },
+    )
+    store.write_latest_review(159, review_id, "FAIL")
+
+    with pytest.raises(
+        lck_models.LckStopError, match="repaired head or uncommitted repair changes"
+    ):
+        lck_remediation.RemediationCompleter(resolver, store=store).complete(
+            159,
+            review_id,
+            commit_message="Repair review finding",
+            summary="Repair finding",
+        )
+
+
+def test_reuse_existing_open_pr_never_creates_a_replacement(tmp_path: Path) -> None:
+    state = _review_state()
+    resolver = cast(Any, StaticResolver(tmp_path, state))
+
+    receipt = lck_effects.ReuseExistingOpenPrEffect(resolver).execute(
+        state,
+        head_sha=SHA,
+        summary="ignored",
+        risks="ignored",
+        critical_outcome={"status": "valid"},
+        validation={"status": "pass"},
+        expected_base_sha=SHA,
+        expected_body_sha256="d" * 64,
+    )
+
+    assert receipt.effect == "reuse_open_pr"
+    assert receipt.action == "reused-current-open-pr"
+    assert any(
+        command[:3] == ("gh", "pr", "view") for command in resolver.runner.commands
+    )
+
+
+def test_remediation_requires_latest_failed_review(tmp_path: Path) -> None:
+    resolver = cast(Any, StaticResolver(tmp_path, _review_state()))
+    store = lck_review_workspace.ReviewInvocationStore(tmp_path)
+    failed_id = store.new_id()
+    newer_id = store.new_id()
+    store.write_record(
+        159,
+        failed_id,
+        {
+            "task_number": 159,
+            "verdict": "FAIL",
+            "identity": _review_identity_value().to_dict(),
+            "findings": "[F1][Medium] Old finding.",
+        },
+    )
+    store.write_latest_review(159, newer_id, "PASS")
+
+    with pytest.raises(
+        lck_models.LckStopError, match="latest completed Independent Review"
+    ):
+        lck_remediation.RemediationPreparer(resolver, store=store).prepare(
+            159, failed_id
+        )
+
+
+def test_post_remediation_boundary_blocks_another_remediation_until_review(
+    tmp_path: Path,
+) -> None:
+    resolver = cast(Any, StaticResolver(tmp_path, _review_state(head="b" * 40)))
+    store = lck_review_workspace.ReviewInvocationStore(tmp_path)
+    failed_id = store.new_id()
+    store.write_record(
+        159,
+        failed_id,
+        {
+            "task_number": 159,
+            "verdict": "FAIL",
+            "identity": _review_identity_value().to_dict(),
+            "findings": "[F1][Medium] Repair required.",
+        },
+    )
+    store.write_latest_review(159, failed_id, "FAIL")
+    store.write_review_required(159, failed_id, "b" * 40)
+
+    with pytest.raises(
+        lck_models.LckStopError, match="fresh Independent Review is required"
+    ):
+        lck_remediation.RemediationPreparer(resolver, store=store).prepare(
+            159, failed_id
+        )
+
+
+def test_accepted_fresh_review_releases_post_remediation_boundary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    identity = _review_identity_value(head="b" * 40)
+    resolver = cast(Any, StaticResolver(tmp_path, _review_state(head="b" * 40)))
+    store = lck_review_workspace.ReviewInvocationStore(tmp_path)
+    old_review_id = store.new_id()
+    store.write_review_required(159, old_review_id, "b" * 40)
+    review_id = store.new_id()
+    review_root = tmp_path / "review-root"
+    review_root.mkdir()
+    store.write_guard(
+        review_id,
+        _review_guard(identity, review_root=review_root),
+    )
+    findings = tmp_path / "findings-new.md"
+    findings.write_text("[F2][Medium] New review finding.\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        lck_review, "_review_identity", lambda *_args, **_kwargs: identity
+    )
+    result = lck_review.ReviewCompleter(
+        resolver,
+        checks_gate=cast(Any, FakeReviewChecks()),
+        store=store,
+        workspace=cast(Any, FakeReviewWorkspace(tmp_path / "review-root")),
+    ).complete(159, review_id, verdict="FAIL", findings_file=findings)
+
+    assert result.status == "STOP_REQUIRED"
+    assert store.read_review_required(159) is None
+    latest = store.read_latest_review(159)
+    assert latest is not None
+    assert latest["review_id"] == review_id
+    assert latest["verdict"] == "FAIL"
+
+
+def test_remediation_complete_can_resume_committed_new_head_and_requires_re_review(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repaired_head = "b" * 40
+    state = _review_state(head=repaired_head, clean=True)
+    resolver = cast(Any, StaticResolver(tmp_path, state))
+    store = lck_review_workspace.ReviewInvocationStore(tmp_path)
+    review_id = store.new_id()
+    store.write_record(
+        159,
+        review_id,
+        {
+            "task_number": 159,
+            "verdict": "FAIL",
+            "identity": _review_identity_value(head=SHA).to_dict(),
+            "findings": "[F1][Medium] Repair required.",
+        },
+    )
+    store.write_latest_review(159, review_id, "FAIL")
+
+    delivery_result = lck_delivery.DeliveryCompletionResult(
+        task_number=159,
+        status="READY_FOR_REVIEW",
+        branch=state.target_branch,
+        head_sha=repaired_head,
+        critical_outcome={"status": "pass"},
+        validation={"status": "pass"},
+        checks={"status": "pass"},
+        effects=(),
+        operation_snapshot=lck_models.OperationSnapshot(
+            operation=lck_models.Phase.REMEDIATION_COMPLETE.value,
+            state=state,
+            required_checks=_required_policy("quality"),
+        ),
+    )
+
+    class FakeDeliveryCompleter:
+        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+            pass
+
+        def complete(
+            self, *_args: Any, **_kwargs: Any
+        ) -> lck_delivery.DeliveryCompletionResult:
+            return delivery_result
+
+    monkeypatch.setattr(lck_remediation, "DeliveryCompleter", FakeDeliveryCompleter)
+
+    result = lck_remediation.RemediationCompleter(resolver, store=store).complete(
+        159,
+        review_id,
+        commit_message="Repair review finding",
+        summary="Repair finding",
+    )
+
+    assert result.to_dict()["status"] == "READY_FOR_NEW_REVIEW"
+    assert (
+        "remains pending for the next Independent Review"
+        in result.to_dict()["deferred_review_acceptance"]
+    )
+    assert result.to_dict()["automatic_review"] is False
+    required = store.read_review_required(159)
+    assert required is not None
+    assert required["remediated_head"] == repaired_head
+    with pytest.raises(
+        lck_models.LckStopError, match="fresh Independent Review is required"
+    ):
+        lck_remediation.RemediationPreparer(resolver, store=store).prepare(
+            159, review_id
+        )
+
+
+def test_remediation_complete_recovers_exact_owned_partial_effect_candidate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    start_head = SHA
+    candidate_head = "b" * 40
+    candidate_tree = "c" * 40
+    initial = _review_state(head=start_head, clean=True)
+    partial = replace(
+        initial,
+        git={**initial.git, "head_sha": candidate_head},
+        local_task_head=candidate_head,
+    )
+    resolver = cast(Any, StaticResolver(tmp_path, partial))
+    runner = OwnedCandidateRunner(head_sha=candidate_head, tree_oid=candidate_tree)
+    resolver.runner = runner
+    store = lck_review_workspace.ReviewInvocationStore(tmp_path)
+    review_id = store.new_id()
+    _write_owned_candidate_session(
+        store,
+        review_id,
+        start_head=start_head,
+        candidate_head=candidate_head,
+        candidate_tree=candidate_tree,
+    )
+    calls = {"critical": 0, "validation": 0}
+
+    class CriticalResult:
+        status = "pass"
+        exit_code = 0
+
+        def to_dict(self) -> dict[str, Any]:
+            return {"status": self.status, "exit_code": self.exit_code}
+
+    def verify_critical_outcome(*_args: Any, **_kwargs: Any) -> CriticalResult:
+        calls["critical"] += 1
+        return CriticalResult()
+
+    def formal_validation(
+        _self: lck_validation.FormalValidationGate, base_sha: str
+    ) -> dict[str, Any]:
+        assert base_sha == SHA
+        calls["validation"] += 1
+        return {"status": "pass"}
+
+    monkeypatch.setattr(
+        lck_profile_policies, "verify_critical_outcome", verify_critical_outcome
+    )
+    monkeypatch.setattr(lck_validation.FormalValidationGate, "run", formal_validation)
+
+    result = lck_remediation.RemediationCompleter(resolver, store=store).complete(
+        159, review_id, commit_message="repair", summary="repair"
+    )
+
+    assert result.to_dict()["status"] == "READY_FOR_NEW_REVIEW"
+    assert calls == {"critical": 1, "validation": 1}
+    assert resolver.calls == 1
+    assert [effect.action for effect in result.delivery.effects] == [
+        "already-committed-revalidated",
+        "fast-forwarded",
+        "reused-current-open-pr",
+        "already-review",
+    ]
+    assert not any(command[:2] == ("git", "commit") for command in runner.commands)
+    assert any(command[:3] == ("git", "push", "-u") for command in runner.commands)
+    assert store.read_remediation_session(159) is None
+    required = store.read_review_required(159)
+    assert required is not None
+    assert required["remediated_head"] == candidate_head
+
+
+def test_real_delivery_completer_rejects_unowned_local_ahead_remediation_candidate(
+    tmp_path: Path,
+) -> None:
+    candidate_head = "b" * 40
+    state = _review_state(head=SHA, clean=True)
+    state = replace(
+        state,
+        git={**state.git, "head_sha": candidate_head},
+        local_task_head=candidate_head,
+    )
+    resolver = cast(Any, StaticResolver(tmp_path, state))
+    snapshot = lck_models.OperationSnapshot(
+        operation=lck_models.Phase.REMEDIATION_COMPLETE.value,
+        state=state,
+    )
+
+    with pytest.raises(
+        lck_models.LckStopError,
+        match="local Task branch must match current OPEN PR head",
+    ):
+        lck_delivery.DeliveryCompleter(
+            resolver,
+            require_existing_open_pr=True,
+        ).complete(
+            159,
+            commit_message="repair",
+            summary="repair",
+            operation_snapshot=snapshot,
+            phase=lck_models.Phase.REMEDIATION_COMPLETE,
+        )
+
+    assert resolver.calls == 0
+
+
+def test_remediation_owned_candidate_recovery_rejects_replaced_local_head(
+    tmp_path: Path,
+) -> None:
+    candidate_head = "b" * 40
+    replacement_head = "d" * 40
+    state = _review_state(head=SHA, clean=True)
+    state = replace(
+        state,
+        git={**state.git, "head_sha": replacement_head},
+        local_task_head=replacement_head,
+    )
+    resolver = cast(Any, StaticResolver(tmp_path, state))
+    store = lck_review_workspace.ReviewInvocationStore(tmp_path)
+    review_id = store.new_id()
+    _write_owned_candidate_session(store, review_id, candidate_head=candidate_head)
+
+    with pytest.raises(
+        lck_models.LckStopError, match="exactly match its owned session"
+    ):
+        lck_remediation.RemediationCompleter(resolver, store=store).complete(
+            159, review_id, commit_message="repair", summary="repair"
+        )
+
+
+@pytest.mark.parametrize("moved", ["pr", "remote"])
+def test_remediation_owned_candidate_recovery_rejects_moved_remote_or_pr(
+    tmp_path: Path,
+    moved: str,
+) -> None:
+    candidate_head = "b" * 40
+    moved_head = "d" * 40
+    original = _review_state(head=SHA, clean=True)
+    pr = dict(original.open_pr or {})
+    if moved == "pr":
+        pr["headRefOid"] = moved_head
+    state = replace(
+        original,
+        git={**original.git, "head_sha": candidate_head},
+        local_task_head=candidate_head,
+        remote_task_oid=moved_head if moved == "remote" else SHA,
+        open_pr=pr,
+    )
+    resolver = cast(Any, StaticResolver(tmp_path, state))
+    store = lck_review_workspace.ReviewInvocationStore(tmp_path)
+    review_id = store.new_id()
+    _write_owned_candidate_session(store, review_id, candidate_head=candidate_head)
+
+    with pytest.raises(
+        lck_models.LckStopError, match="exactly match its owned session"
+    ):
+        lck_remediation.RemediationCompleter(resolver, store=store).complete(
+            159, review_id, commit_message="repair", summary="repair"
+        )

--- a/tests/tools/lck/test_research.py
+++ b/tests/tools/lck/test_research.py
@@ -1,0 +1,1738 @@
+# ruff: noqa: E402, I001
+
+"""Acceptance tests for the repository-backed Research LCK profile."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from dataclasses import replace
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+ROOT = Path(__file__).parents[3]
+AGENT_WORKFLOW = str(ROOT / "tools" / "agent_workflow")
+if AGENT_WORKFLOW not in sys.path:
+    sys.path.insert(0, AGENT_WORKFLOW)
+
+from tools.lck import (  # type: ignore[import-not-found]  # noqa: E402
+    closeout as lck_closeout,
+    delivery as lck_delivery,
+    eligibility as lck_eligibility,
+    effects as lck_effects,
+    issue_profiles,
+    models as lck_models,
+    review as lck_review,
+    review_workspace as lck_review_workspace,
+    shared_facts as lck_shared_facts,
+)
+from .support import FakeReviewWorkspace  # noqa: E402
+from tools.lck.research_policy import (  # type: ignore[import-not-found]  # noqa: E402
+    RESEARCH_POLICY_ID,
+    ResearchOutcome,
+    ResearchPolicyError,
+    architecture_decision_is_consistent,
+    bind_research_outcome,
+    decision_contract_snapshot,
+    evaluate_research_changes,
+    is_valid_research_contract,
+    research_artifact_binding,
+    research_contract_snapshot,
+    research_template_contract,
+    require_typed_research_outcome,
+)
+from tools.lck.profile_policies import (  # type: ignore[import-not-found]  # noqa: E402
+    ProfileEffectDescriptor,
+    ResearchValidationGate,
+    validate_profile_completion,
+)
+from tools.lck.feature_audit import (  # type: ignore[import-not-found]  # noqa: E402
+    _formal_blockers_gate,
+    _issue_view_with_contract,
+    _relationship_snapshot,
+)
+from tools.lck.common import CommandResult, sha256_json  # type: ignore[import-not-found]  # noqa: E402
+
+
+SHA = "a" * 40
+DIGEST = "b" * 64
+RESEARCH_BODY = """### Question / Decision Needed
+
+Should the supported path be implemented?
+
+### Context
+
+The decision is needed before implementation.
+
+### Scope
+
+- Repository-backed workflow behavior.
+
+### Non-goals
+
+- No runtime implementation.
+
+### Evidence / Evaluation Criteria
+
+- Confirm the contract and operational risks.
+
+### Expected Outcome / Artifact
+
+Adopt the repository-backed workflow contract and record the resulting ADR.
+"""
+
+
+def _project_field_query_payload(
+    value: str | None,
+    *,
+    owner_type: str = "User",
+    repository: str = "owner/repo",
+    issue_number: int = 199,
+    project_number: int = 1,
+    project_has_next_page: bool = False,
+    fields_have_next_page: bool = False,
+) -> dict[str, Any]:
+    field_values = [
+        {
+            "__typename": "ProjectV2ItemFieldSingleSelectValue",
+            "name": "Review",
+            "field": {"name": "Status"},
+        }
+    ]
+    if value is not None:
+        field_values.append(
+            {
+                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                "name": value,
+                "field": {"name": "Research Outcome"},
+            }
+        )
+    return {
+        "data": {
+            "repository": {
+                "issue": {
+                    "number": issue_number,
+                    "projectItems": {
+                        "nodes": [
+                            {
+                                "project": {
+                                    "number": project_number,
+                                    "title": "Quant System Development",
+                                    "owner": {
+                                        "__typename": owner_type,
+                                        "login": repository.split("/", 1)[0],
+                                    },
+                                },
+                                "content": {
+                                    "number": issue_number,
+                                    "repository": {"nameWithOwner": repository},
+                                },
+                                "fieldValues": {
+                                    "nodes": field_values,
+                                    "pageInfo": {"hasNextPage": fields_have_next_page},
+                                },
+                            }
+                        ],
+                        "pageInfo": {"hasNextPage": project_has_next_page},
+                    },
+                }
+            }
+        }
+    }
+
+
+def test_live_research_issue_contract_uses_research_form() -> None:
+    class Runner:
+        repo_root = ROOT
+
+        def run(self, argv: Any, *, command_id: str, **_: Any) -> CommandResult:
+            value: dict[str, Any]
+            if command_id == "gh-issue-project-items-199":
+                value = {
+                    "data": {
+                        "repository": {
+                            "issue": {
+                                "number": 199,
+                                "projectItems": {
+                                    "nodes": [
+                                        {
+                                            "project": {
+                                                "number": 1,
+                                                "title": "Quant System Development",
+                                                "owner": {"login": "owner"},
+                                            },
+                                            "content": {
+                                                "number": 199,
+                                                "repository": {
+                                                    "nameWithOwner": "owner/repo"
+                                                },
+                                            },
+                                            "fieldValues": {
+                                                "nodes": [
+                                                    {
+                                                        "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                                        "name": "Review",
+                                                        "field": {"name": "Status"},
+                                                    },
+                                                    {
+                                                        "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                                        "name": "NEEDS MORE EVIDENCE",
+                                                        "field": {
+                                                            "name": "Research Outcome"
+                                                        },
+                                                    },
+                                                ],
+                                                "pageInfo": {"hasNextPage": False},
+                                            },
+                                        }
+                                    ],
+                                    "pageInfo": {"hasNextPage": False},
+                                },
+                            }
+                        }
+                    }
+                }
+            else:
+                value = {
+                    "number": 199,
+                    "title": "[Research] supported workflow",
+                    "state": "OPEN",
+                    "labels": [{"name": "type:research"}],
+                    "body": RESEARCH_BODY,
+                    # The CLI projection is intentionally incomplete and
+                    # conflicts with the authoritative GraphQL status.
+                    "projectItems": [{"status": {"name": "Ready"}}],
+                }
+            return CommandResult(
+                command_id,
+                tuple(str(item) for item in argv),
+                0,
+                json.dumps(value),
+                "",
+            )
+
+    warnings: list[dict[str, Any]] = []
+    issue, contract = _issue_view_with_contract(
+        Runner(),
+        "owner/repo",
+        199,
+        warnings,
+        include_comments=False,
+        include_closure=False,
+    )
+
+    assert warnings == []
+    assert issue is not None
+    assert contract is not None
+    research_contract = issue["research_contract"]
+    assert research_contract["status"] == "pass"
+    assert research_contract["template_path"] == ".github/ISSUE_TEMPLATE/research.yml"
+    assert is_valid_research_contract(research_contract)
+    assert contract["research_contract"] == research_contract
+    assert issue["project_status"] == "Review"
+    assert issue["research_outcome"] == "NEEDS MORE EVIDENCE"
+
+
+@pytest.mark.parametrize(
+    "defect",
+    (
+        "project-pagination",
+        "field-pagination",
+        "duplicate-canonical-project",
+        "wrong-owner",
+        "wrong-project-title",
+        "wrong-content-number",
+        "wrong-content-repository",
+        "malformed-single-select",
+    ),
+)
+def test_canonical_projectv2_facts_fail_closed(defect: str) -> None:
+    project_item: dict[str, Any] = {
+        "project": {
+            "number": 1,
+            "title": "Quant System Development",
+            "owner": {"login": "owner"},
+        },
+        "content": {
+            "number": 199,
+            "repository": {"nameWithOwner": "owner/repo"},
+        },
+        "fieldValues": {
+            "nodes": [
+                {
+                    "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                    "name": "Review",
+                    "field": {"name": "Status"},
+                }
+            ],
+            "pageInfo": {"hasNextPage": False},
+        },
+    }
+    raw: dict[str, Any] = {
+        "nodes": [project_item],
+        "pageInfo": {"hasNextPage": False},
+    }
+    if defect == "project-pagination":
+        raw["pageInfo"]["hasNextPage"] = True
+    elif defect == "field-pagination":
+        project_item["fieldValues"]["pageInfo"]["hasNextPage"] = True
+    elif defect == "duplicate-canonical-project":
+        raw["nodes"].append(json.loads(json.dumps(project_item)))
+    elif defect == "wrong-owner":
+        project_item["project"]["owner"]["login"] = "someone-else"
+    elif defect == "wrong-project-title":
+        project_item["project"]["title"] = "Different Project"
+    elif defect == "wrong-content-number":
+        project_item["content"]["number"] = 200
+    elif defect == "wrong-content-repository":
+        project_item["content"]["repository"]["nameWithOwner"] = "owner/other"
+    elif defect == "malformed-single-select":
+        project_item["fieldValues"]["nodes"][0].pop("__typename")
+
+    normalized = lck_shared_facts._normalize_project_items(raw)
+
+    assert (
+        lck_shared_facts.canonical_project_field(
+            normalized,
+            repository="owner/repo",
+            issue_number=199,
+            field_name="Status",
+        )
+        is None
+    )
+
+
+def test_root_projectv2_graphql_error_is_incomplete() -> None:
+    class Runner:
+        def run(self, argv: Any, *, command_id: str, **_: Any) -> CommandResult:
+            return CommandResult(
+                command_id,
+                tuple(str(item) for item in argv),
+                0,
+                json.dumps({"errors": [{"message": "query failed"}]}),
+                "",
+            )
+
+    warnings: list[dict[str, Any]] = []
+    project_items = lck_shared_facts._issue_project_items_snapshot(
+        Runner(), "owner/repo", 199, warnings
+    )
+
+    assert project_items["complete"] is False
+    assert project_items["truncated"] is True
+    assert warnings
+
+
+def test_research_profile_binds_typed_outcome_to_reviewed_artifact(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = tmp_path / "docs" / "research" / "report.md"
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text(
+        "# Research report\n\nResearch Outcome: DO NOT IMPLEMENT\n\nEvidence.\n",
+        encoding="utf-8",
+    )
+
+    binding = research_artifact_binding(
+        tmp_path,
+        task_number=199,
+        pr_number=299,
+        base_sha=SHA,
+        head_sha="c" * 40,
+        task_body_sha256=DIGEST,
+        merge_base_sha=SHA,
+        effective_diff_sha256="d" * 64,
+        changed_files=("docs/research/report.md",),
+    )
+
+    assert binding["policy_id"] == RESEARCH_POLICY_ID
+    assert binding["outcome"] == ResearchOutcome.DO_NOT_IMPLEMENT.value
+    assert binding["outcome_status"] == "typed"
+    assert binding["task_number"] == 199
+    assert binding["pr_number"] == 299
+    assert binding["artifact_files"] == ["docs/research/report.md"]
+    assert binding["artifact_digests"][0]["path"] == "docs/research/report.md"
+    assert require_typed_research_outcome(binding) is ResearchOutcome.DO_NOT_IMPLEMENT
+
+    rebound = bind_research_outcome(binding, "DO NOT IMPLEMENT")
+    assert rebound == binding
+
+    # Exercise the actual shared LCK lifecycle gates that the Critical Outcome
+    # names: Research Delivery, Review Complete, human-merge readiness, the
+    # closed-PR Closeout path, Project Research Outcome, and blocker admission.
+    report = tmp_path / "docs" / "research" / "lifecycle.md"
+    report.write_text(
+        "# Research report\n\nResearch Outcome: NEEDS MORE EVIDENCE\n",
+        encoding="utf-8",
+    )
+    review_root = tmp_path / "review-root"
+    review_report = review_root / "docs" / "research" / "lifecycle.md"
+    review_report.parent.mkdir(parents=True)
+    review_report.write_text(report.read_text(encoding="utf-8"), encoding="utf-8")
+
+    base_sha = "1" * 40
+    head_sha = "2" * 40
+    merge_sha = "3" * 40
+    branch = "research/199-supported-workflow"
+    diff_text = "diff --git a/docs/research/lifecycle.md b/docs/research/lifecycle.md\n"
+    body_sha = sha256_json({"body": RESEARCH_BODY})
+
+    class Runner:
+        def __init__(self) -> None:
+            self.project_writes = 0
+
+        def run(self, argv: Any, *, command_id: str, **_: Any) -> CommandResult:
+            command = tuple(str(item) for item in argv)
+            if command[:3] == ("git", "diff", "--quiet"):
+                return CommandResult(command_id, command, 1, "", "")
+            if command[:2] == ("git", "merge-base"):
+                return CommandResult(command_id, command, 0, f"{base_sha}\n", "")
+            if command[:2] == ("git", "diff") and "--name-only" in command:
+                return CommandResult(
+                    command_id,
+                    command,
+                    0,
+                    "docs/research/lifecycle.md\n",
+                    "",
+                )
+            if command[:2] == ("git", "diff"):
+                return CommandResult(command_id, command, 0, diff_text, "")
+            if command == ("git", "branch", "--show-current"):
+                return CommandResult(command_id, command, 0, f"{branch}\n", "")
+            if command == ("git", "rev-parse", "HEAD"):
+                return CommandResult(command_id, command, 0, f"{head_sha}\n", "")
+            if command == (
+                "git",
+                "status",
+                "--porcelain=v1",
+                "--untracked-files=all",
+            ):
+                return CommandResult(command_id, command, 0, "", "")
+            if command[:2] == ("git", "show"):
+                return CommandResult(
+                    command_id,
+                    command,
+                    0,
+                    "name: CI\non:\n  pull_request:\n    branches: [main]\njobs:\n  quality:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo ok\n",
+                    "",
+                )
+            if command[:3] == ("gh", "project", "item-edit"):
+                self.project_writes += 1
+                return CommandResult(command_id, command, 0, "", "")
+            if command[:3] == ("gh", "api", "graphql"):
+                query = next(item for item in command if item.startswith("query="))
+                assert "repository(owner:$owner, name:$name)" in query
+                return CommandResult(
+                    command_id,
+                    command,
+                    0,
+                    json.dumps(
+                        _project_field_query_payload(
+                            "NEEDS MORE EVIDENCE" if self.project_writes else None
+                        )
+                    ),
+                    "",
+                )
+            if command[:3] == ("gh", "issue", "view"):
+                raise AssertionError(
+                    "Research Outcome must use the Project GraphQL query"
+                )
+            raise AssertionError(f"unsupported lifecycle command: {command}")
+
+    runner = Runner()
+    root_project_items = lck_shared_facts._normalize_project_items(
+        {
+            "nodes": [
+                {
+                    "project": {
+                        "number": 1,
+                        "title": "Quant System Development",
+                        "owner": {"login": "owner"},
+                    },
+                    "content": {
+                        "number": 199,
+                        "repository": {"nameWithOwner": "owner/repo"},
+                    },
+                    "fieldValues": {
+                        "nodes": [
+                            {
+                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                "name": "Review",
+                                "field": {"name": "Status"},
+                            }
+                        ],
+                        "pageInfo": {"hasNextPage": False},
+                    },
+                }
+            ],
+            "pageInfo": {"hasNextPage": False},
+        }
+    )
+    issue = {
+        "number": 199,
+        "title": "[Research] supported workflow",
+        "state": "OPEN",
+        "labels": {"items": ["type:research", "codex:ready"]},
+        "project_status": "Review",
+        "project_items": root_project_items,
+        "body": RESEARCH_BODY,
+        "body_sha256": body_sha,
+        "research_contract": research_contract_snapshot(RESEARCH_BODY),
+    }
+    assert (
+        lck_shared_facts.canonical_project_field(
+            root_project_items,
+            repository="owner/repo",
+            issue_number=199,
+            field_name="Research Outcome",
+        )
+        is None
+    )
+    pr = {
+        "number": 299,
+        "state": "OPEN",
+        "isDraft": False,
+        "baseRefName": "main",
+        "baseRefOid": base_sha,
+        "headRefName": branch,
+        "headRefOid": head_sha,
+        "mergeable": "MERGEABLE",
+    }
+    state = lck_models.LiveState(
+        task_number=199,
+        repository="owner/repo",
+        issue=issue,
+        relationships={
+            "available": True,
+            "blocked_by": {"items": [], "count": 0, "truncated": False},
+        },
+        git={
+            "branch": branch,
+            "head_sha": head_sha,
+            "local_main_sha": base_sha,
+            "remote_main_sha": base_sha,
+            "clean": True,
+        },
+        target_branch=branch,
+        local_task_branch=branch,
+        local_task_head=head_sha,
+        remote_task_branch=branch,
+        remote_task_oid=head_sha,
+        open_pr=pr,
+        merged_pr_numbers=(),
+        merged=False,
+        checks={},
+        cleanup={},
+        task_contract={
+            "number": 199,
+            "title": issue["title"],
+            "body": RESEARCH_BODY,
+            "body_sha256": body_sha,
+            "research_contract": issue["research_contract"],
+        },
+    )
+    resolver = cast(
+        Any,
+        type("Resolver", (), {"repo_root": tmp_path, "runner": runner})(),
+    )
+    resolver.resolve = lambda _task_number: state
+
+    class Eligible:
+        def resolve(
+            self,
+            _state: lck_models.LiveState,
+            phase: lck_models.Phase,
+            **_: Any,
+        ) -> lck_eligibility.PhaseDecision:
+            return lck_eligibility.PhaseDecision(phase=phase, eligible=True)
+
+    class Commit:
+        def current_head_tree(self) -> str:
+            return "4" * 40
+
+        def verify_tree_unchanged(self, *_args: Any, **_kwargs: Any) -> None:
+            return None
+
+    class Remote:
+        def execute(self, *_args: Any, **_kwargs: Any) -> lck_models.EffectReceipt:
+            return lck_models.EffectReceipt(
+                "ensure_remote_branch", "synchronized", {"remote_oid": head_sha}
+            )
+
+    class PR:
+        def execute(self, *_args: Any, **_kwargs: Any) -> lck_models.EffectReceipt:
+            return lck_models.EffectReceipt(
+                "ensure_open_pr",
+                "already-open",
+                {"number": 299, "head_sha": head_sha, "base_sha": base_sha},
+            )
+
+    class Checks:
+        def observe(self, _snapshot: lck_models.OperationSnapshot) -> dict[str, Any]:
+            return {
+                "status": "observed",
+                "pr": {"number": 299, "head_sha": head_sha, "base_sha": base_sha},
+            }
+
+        def evaluate(self, _snapshot: lck_models.OperationSnapshot) -> dict[str, Any]:
+            return {
+                "status": "pass",
+                "pr": {"number": 299, "head_sha": head_sha, "base_sha": base_sha},
+            }
+
+    class Status:
+        def execute(self, *_args: Any, **_kwargs: Any) -> lck_models.EffectReceipt:
+            return lck_models.EffectReceipt("set_project_review", "already-review", {})
+
+    delivery = lck_delivery.DeliveryCompleter(
+        resolver,
+        eligibility=cast(Any, Eligible()),
+        formal_validation=cast(
+            Any, type("Validation", (), {"run": lambda *_: {"status": "pass"}})()
+        ),
+        commit_effect=cast(Any, Commit()),
+        remote_effect=cast(Any, Remote()),
+        pr_effect=cast(Any, PR()),
+        status_effect=cast(Any, Status()),
+        checks_gate=cast(Any, Checks()),
+        services=(ResearchValidationGate(resolver),),
+    )
+    delivery_result = delivery.complete(
+        199,
+        commit_message="test Research lifecycle",
+        summary="exercise the supported Research path",
+        operation_snapshot=lck_models.OperationSnapshot(
+            operation=lck_models.Phase.DELIVERY_COMPLETE.value,
+            state=state,
+        ),
+    )
+    assert delivery_result.status == "READY_FOR_REVIEW"
+    assert delivery_result.research_artifact["status"] == "pass"
+
+    binding = research_artifact_binding(
+        review_root,
+        task_number=199,
+        pr_number=299,
+        base_sha=base_sha,
+        head_sha=head_sha,
+        task_body_sha256=body_sha,
+        merge_base_sha=base_sha,
+        effective_diff_sha256=hashlib.sha256(diff_text.encode()).hexdigest(),
+        changed_files=("docs/research/lifecycle.md",),
+    )
+    identity = lck_review_workspace.ReviewIdentity(
+        task_number=199,
+        pr_number=299,
+        base_sha=base_sha,
+        head_sha=head_sha,
+        task_body_sha256=body_sha,
+        merge_base_sha=base_sha,
+        effective_diff_sha256=hashlib.sha256(diff_text.encode()).hexdigest(),
+        changed_files=("docs/research/lifecycle.md",),
+        research_artifact=binding,
+    )
+    monkeypatch.setattr(
+        lck_review, "_review_identity", lambda *_args, **_kwargs: identity
+    )
+    review_store = lck_review_workspace.ReviewInvocationStore(tmp_path)
+    review_id = "e" * 32
+    review_store.write_guard(
+        review_id,
+        {
+            "task_number": 199,
+            "identity": identity.to_dict(),
+            "review_root": str(review_root),
+            "validation": {"status": "pass"},
+            "checks": {"status": "observed"},
+            "snapshot": {"operation": "review-prepare"},
+        },
+    )
+    review_result = lck_review.ReviewCompleter(
+        resolver,
+        eligibility=cast(Any, Eligible()),
+        checks_gate=cast(Any, Checks()),
+        store=review_store,
+        workspace=cast(Any, FakeReviewWorkspace(review_root)),
+    ).complete(199, review_id, verdict="PASS")
+    assert review_result.status == "READY_FOR_MERGE_PREFLIGHT"
+    review_record = review_store.read_record(199, review_id)
+    assert review_record["research_outcome"] == "NEEDS MORE EVIDENCE"
+
+    merge_result = lck_review.MergePreflight(
+        resolver,
+        review_gate=cast(
+            Any,
+            type("ReviewGate", (), {"run": lambda *_: {"status": "pass"}})(),
+        ),
+        checks_gate=cast(Any, Checks()),
+    ).run(199)
+    assert merge_result.status == "READY_FOR_HUMAN_MERGE"
+
+    closed_issue = dict(issue)
+    closed_issue["state"] = "CLOSED"
+    merged_pr = dict(pr)
+    merged_pr.update(
+        {
+            "state": "MERGED",
+            "mergeCommit": {"oid": merge_sha},
+            "mergedAt": "2026-08-30T00:00:00Z",
+            "closingIssuesReferences": [{"number": 199}],
+        }
+    )
+    closeout_state = replace(
+        state,
+        issue=closed_issue,
+        open_pr=None,
+        merged=True,
+        merged_pr=merged_pr,
+        merged_pr_numbers=(299,),
+    )
+    resolver.resolve = lambda _task_number: closeout_state
+
+    class FixedEffect:
+        def __init__(self, effect: str, action: str) -> None:
+            self.receipt = lck_models.EffectReceipt(effect, action, {})
+
+        def execute(self, *_args: Any, **_kwargs: Any) -> lck_models.EffectReceipt:
+            return self.receipt
+
+    closeout = lck_closeout.CloseoutCompleter(
+        resolver,
+        main_effect=cast(Any, FixedEffect("synchronize_main", "synchronized")),
+        metadata_effect=cast(
+            Any, FixedEffect("converge_task_metadata", "already-converged")
+        ),
+        cleanup_effect=cast(Any, FixedEffect("cleanup_task_refs", "already-clean")),
+        review_store=review_store,
+    )
+    closeout._validate_merged_identity = lambda _state: (head_sha, merge_sha)
+    closeout._validate_reviewed_identity = lambda _state, _pr: review_record
+    closeout_result = closeout.complete(199)
+    assert closeout_result.status == "BUSINESS_DELIVERY_COMPLETE"
+    assert closeout_result.business_delivery == "COMPLETE"
+    assert closeout_result.cleanup == "COMPLETE"
+    assert closeout_result.research_outcome == "NEEDS MORE EVIDENCE"
+    assert runner.project_writes == 1
+
+    blocker_gate = _formal_blockers_gate(
+        {
+            "available": True,
+            "blocked_by": {
+                "items": [
+                    {
+                        "number": 198,
+                        "state": "CLOSED",
+                        "labels": ["type:research"],
+                        "labels_complete": True,
+                        "research_contract": research_contract_snapshot(RESEARCH_BODY),
+                        "research_outcome": "IMPLEMENT",
+                    }
+                ],
+                "count": 1,
+                "truncated": False,
+            },
+        },
+        downstream_profile=issue_profiles.TASK_PROFILE,
+    )
+    assert blocker_gate["status"] == "pass"
+
+
+@pytest.mark.parametrize("outcome", ("IMPLEMENT", "DO NOT IMPLEMENT"))
+def test_research_completion_accepts_typed_outcomes_and_rejects_artifact_divergence(
+    tmp_path: Path, outcome: str
+) -> None:
+    artifact_path = tmp_path / "docs" / "research" / "report.md"
+    artifact_path.parent.mkdir(parents=True)
+    artifact_path.write_text(
+        f"# Research report\n\nResearch Outcome: {outcome}\n",
+        encoding="utf-8",
+    )
+    body_sha = sha256_json({"body": RESEARCH_BODY})
+    head_sha = "c" * 40
+    binding = research_artifact_binding(
+        tmp_path,
+        task_number=199,
+        pr_number=299,
+        base_sha=SHA,
+        head_sha=head_sha,
+        task_body_sha256=body_sha,
+        merge_base_sha=SHA,
+        effective_diff_sha256=DIGEST,
+        changed_files=("docs/research/report.md",),
+    )
+    identity = {
+        "task_number": 199,
+        "pr_number": 299,
+        "base_sha": SHA,
+        "head_sha": head_sha,
+        "task_body_sha256": body_sha,
+        "merge_base_sha": SHA,
+        "effective_diff_sha256": DIGEST,
+        "changed_files": ["docs/research/report.md"],
+        "research_artifact": binding,
+    }
+    issue = {
+        "number": 199,
+        "body_sha256": body_sha,
+        "research_contract": research_contract_snapshot(RESEARCH_BODY),
+    }
+    completion_input = {
+        "task_number": 199,
+        "repository": "owner/repo",
+        "merged_pr": {
+            "number": 299,
+            "baseRefOid": SHA,
+            "headRefOid": head_sha,
+        },
+        "review_record": {
+            "identity": identity,
+            "research_artifact": binding,
+        },
+    }
+
+    result = validate_profile_completion(
+        issue_profiles.RESEARCH_PROFILE,
+        issue,
+        completion_input,
+    )
+    assert result.effect is not None
+    assert result.effect.parameters["value"] == outcome
+
+    tampered = dict(binding)
+    tampered["artifact_sha256"] = "f" * 64
+    tampered_input = {
+        **completion_input,
+        "review_record": {
+            "identity": identity,
+            "research_artifact": tampered,
+        },
+    }
+    with pytest.raises(
+        lck_models.LckStopError,
+        match="diverges from the reviewed identity",
+    ):
+        validate_profile_completion(
+            issue_profiles.RESEARCH_PROFILE,
+            issue,
+            tampered_input,
+        )
+
+
+def test_closeout_rejects_missing_review_artifact_before_any_effect(
+    tmp_path: Path,
+) -> None:
+    body_sha = sha256_json({"body": RESEARCH_BODY})
+    issue = {
+        "number": 199,
+        "title": "[Research] supported workflow",
+        "state": "CLOSED",
+        "labels": {"items": ["type:research", "codex:ready"]},
+        "project_status": "Review",
+        "body_sha256": body_sha,
+        "research_contract": research_contract_snapshot(RESEARCH_BODY),
+    }
+    state = lck_models.LiveState(
+        issue_number=199,
+        repository="owner/repo",
+        issue=issue,
+        leaf_contract={
+            "number": 199,
+            "title": issue["title"],
+            "body": RESEARCH_BODY,
+            "body_sha256": body_sha,
+            "research_contract": issue["research_contract"],
+        },
+        relationships={
+            "available": True,
+            "blocked_by": {"items": [], "count": 0, "truncated": False},
+        },
+        merged_pr={"number": 299},
+    )
+    resolver = cast(
+        Any,
+        type(
+            "Resolver",
+            (),
+            {
+                "repo_root": tmp_path,
+                "resolve": lambda _self, _task_number: state,
+            },
+        )(),
+    )
+
+    class Eligible:
+        def resolve(
+            self,
+            _state: lck_models.LiveState,
+            phase: lck_models.Phase,
+        ) -> lck_eligibility.PhaseDecision:
+            return lck_eligibility.PhaseDecision(phase=phase, eligible=True)
+
+    class ForbiddenEffect:
+        def execute(self, *_args: Any, **_kwargs: Any) -> lck_models.EffectReceipt:
+            raise AssertionError("Closeout effect ran before completion validation")
+
+    handler = lck_closeout.CloseoutCompleter(
+        resolver,
+        eligibility=cast(Any, Eligible()),
+        main_effect=cast(Any, ForbiddenEffect()),
+    )
+    handler._validate_merged_identity = lambda _state: ("2" * 40, "3" * 40)
+    handler._validate_reviewed_identity = lambda _state, _pr: {
+        "identity": {
+            "task_number": 199,
+            "pr_number": 299,
+            "base_sha": "1" * 40,
+            "head_sha": "2" * 40,
+            "task_body_sha256": body_sha,
+        }
+    }
+
+    with pytest.raises(
+        lck_models.LckStopError,
+        match="reviewed artifact binding",
+    ):
+        handler.complete(199)
+
+    assert handler.last_effects == []
+
+
+def test_research_blocker_uses_only_the_canonical_project_outcome() -> None:
+    class Runner:
+        def run(self, argv: Any, *, command_id: str, **_: Any) -> CommandResult:
+            assert tuple(argv[:3]) == ("gh", "api", "graphql")
+            return CommandResult(
+                command_id,
+                tuple(str(item) for item in argv),
+                0,
+                json.dumps(
+                    {
+                        "data": {
+                            "repository": {
+                                "issue": {
+                                    "number": 300,
+                                    "title": "Research dependency",
+                                    "state": "OPEN",
+                                    "blockedBy": {
+                                        "nodes": [
+                                            {
+                                                "number": 198,
+                                                "title": "Research decision",
+                                                "state": "CLOSED",
+                                                "body": RESEARCH_BODY,
+                                                "labels": {
+                                                    "nodes": [
+                                                        {"name": "type:research"}
+                                                    ],
+                                                    "pageInfo": {"hasNextPage": False},
+                                                },
+                                                "projectItems": {
+                                                    "nodes": [
+                                                        {
+                                                            "project": {
+                                                                "number": 17,
+                                                                "title": "Other",
+                                                                "owner": {
+                                                                    "login": "owner"
+                                                                },
+                                                            },
+                                                            "content": {
+                                                                "number": 198,
+                                                                "repository": {
+                                                                    "nameWithOwner": "owner/repo"
+                                                                },
+                                                            },
+                                                            "fieldValues": {
+                                                                "nodes": [
+                                                                    {
+                                                                        "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                                                        "name": "IMPLEMENT",
+                                                                        "field": {
+                                                                            "name": "Research Outcome"
+                                                                        },
+                                                                    }
+                                                                ],
+                                                                "pageInfo": {
+                                                                    "hasNextPage": False
+                                                                },
+                                                            },
+                                                        },
+                                                        {
+                                                            "project": {
+                                                                "number": 1,
+                                                                "title": "Quant System Development",
+                                                                "owner": {
+                                                                    "login": "owner"
+                                                                },
+                                                            },
+                                                            "content": {
+                                                                "number": 198,
+                                                                "repository": {
+                                                                    "nameWithOwner": "owner/repo"
+                                                                },
+                                                            },
+                                                            "fieldValues": {
+                                                                "nodes": [
+                                                                    {
+                                                                        "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                                                        "name": "DO NOT IMPLEMENT",
+                                                                        "field": {
+                                                                            "name": "Research Outcome"
+                                                                        },
+                                                                    }
+                                                                ],
+                                                                "pageInfo": {
+                                                                    "hasNextPage": False
+                                                                },
+                                                            },
+                                                        },
+                                                    ],
+                                                    "pageInfo": {"hasNextPage": False},
+                                                },
+                                            }
+                                        ],
+                                        "pageInfo": {"hasNextPage": False},
+                                    },
+                                    "blocking": {
+                                        "nodes": [],
+                                        "pageInfo": {"hasNextPage": False},
+                                    },
+                                    "subIssues": {
+                                        "nodes": [],
+                                        "pageInfo": {"hasNextPage": False},
+                                    },
+                                    "issueType": None,
+                                    "parent": None,
+                                }
+                            }
+                        }
+                    }
+                ),
+                "",
+            )
+
+    relationships = _relationship_snapshot(Runner(), "owner/repo", 300, [])
+    blocker = relationships["blocked_by"]["items"][0]
+
+    assert blocker["research_outcome"] == "DO NOT IMPLEMENT"
+    assert blocker["research_outcome_is_canonical"] is True
+    assert (
+        _formal_blockers_gate(
+            relationships, downstream_profile=issue_profiles.TASK_PROFILE
+        )["status"]
+        == "fail"
+    )
+
+
+def test_research_outcome_postcondition_fails_closed_on_incomplete_pagination() -> None:
+    class Runner:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, ...]] = []
+
+        def run(self, argv: Any, *, command_id: str, **_: Any) -> CommandResult:
+            command = tuple(str(item) for item in argv)
+            self.calls.append(command)
+            query = next(item for item in command if item.startswith("query="))
+            assert "repository(owner:$owner, name:$name)" in query
+            assert "user(login:$owner)" not in query
+            assert "organization(login:$owner)" not in query
+            payload = _project_field_query_payload(
+                "IMPLEMENT", project_has_next_page=True
+            )
+            return CommandResult(command_id, command, 0, json.dumps(payload), "")
+
+    runner = Runner()
+    resolver = type("Resolver", (), {"runner": runner})()
+
+    from tools.lck.profile_policies import ResearchOutcomeEffect
+
+    outcome = ResearchOutcomeEffect(cast(Any, resolver))._query_outcome(
+        "owner/repo", 199
+    )
+
+    assert outcome is None
+    assert len(runner.calls) == 1
+
+
+@pytest.mark.parametrize(
+    "defect",
+    (
+        "wrong-issue",
+        "wrong-repository",
+        "wrong-project",
+        "wrong-owner",
+        "missing-field",
+        "project-pagination",
+        "field-pagination",
+        "duplicate-item",
+    ),
+)
+def test_project_field_fresh_read_rejects_incomplete_or_wrong_identity(
+    defect: str,
+) -> None:
+    payload = _project_field_query_payload("IMPLEMENT")
+    issue = payload["data"]["repository"]["issue"]
+    project_items = issue["projectItems"]
+    project_item = project_items["nodes"][0]
+    if defect == "wrong-issue":
+        issue["number"] = 200
+    elif defect == "wrong-repository":
+        project_item["content"]["repository"]["nameWithOwner"] = "owner/other"
+    elif defect == "wrong-project":
+        project_item["project"]["number"] = 2
+    elif defect == "wrong-owner":
+        project_item["project"]["owner"]["login"] = "someone-else"
+    elif defect == "missing-field":
+        project_item["fieldValues"]["nodes"] = []
+    elif defect == "project-pagination":
+        project_items["pageInfo"]["hasNextPage"] = True
+    elif defect == "field-pagination":
+        project_item["fieldValues"]["pageInfo"]["hasNextPage"] = True
+    elif defect == "duplicate-item":
+        project_items["nodes"].append(json.loads(json.dumps(project_item)))
+
+    class Runner:
+        def run(self, argv: Any, *, command_id: str, **_: Any) -> CommandResult:
+            command = tuple(str(item) for item in argv)
+            return CommandResult(command_id, command, 0, json.dumps(payload), "")
+
+    assert (
+        lck_shared_facts.query_project_single_select_field(
+            Runner(),
+            repository="owner/repo",
+            issue_number=199,
+            project_number=1,
+            field_name="Research Outcome",
+            command_id="test-project-field-query",
+        )
+        is None
+    )
+
+
+def test_project_field_fresh_read_rejects_graphql_partial_error() -> None:
+    class Runner:
+        def run(self, argv: Any, *, command_id: str, **_: Any) -> CommandResult:
+            command = tuple(str(item) for item in argv)
+            payload = _project_field_query_payload("IMPLEMENT")
+            payload["errors"] = [{"type": "NOT_FOUND", "message": "query failed"}]
+            return CommandResult(command_id, command, 1, json.dumps(payload), "")
+
+    assert (
+        lck_shared_facts.query_project_single_select_field(
+            Runner(),
+            repository="owner/repo",
+            issue_number=199,
+            project_number=1,
+            field_name="Research Outcome",
+            command_id="test-project-field-query",
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize("owner_type", ("User", "Organization"))
+def test_research_outcome_effect_uses_owner_safe_read_for_idempotency(
+    owner_type: str,
+) -> None:
+    class Runner:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, ...]] = []
+
+        def run(self, argv: Any, *, command_id: str, **_: Any) -> CommandResult:
+            command = tuple(str(item) for item in argv)
+            self.calls.append(command)
+            if command[:3] != ("gh", "api", "graphql"):
+                raise AssertionError(f"unexpected Project write: {command}")
+            query = next(item for item in command if item.startswith("query="))
+            assert "repository(owner:$owner, name:$name)" in query
+            assert "user(login:$owner)" not in query
+            assert "organization(login:$owner)" not in query
+            return CommandResult(
+                command_id,
+                command,
+                0,
+                json.dumps(
+                    _project_field_query_payload("IMPLEMENT", owner_type=owner_type)
+                ),
+                "",
+            )
+
+    descriptor = ProfileEffectDescriptor(
+        effect_kind="project.single_select.set.v1",
+        schema_version=1,
+        parameters={
+            "repository": "owner/repo",
+            "task_number": 199,
+            "project_number": 1,
+            "field": "Research Outcome",
+            "value": "IMPLEMENT",
+        },
+        postcondition={
+            "kind": "project.single_select.equals",
+            "repository": "owner/repo",
+            "task_number": 199,
+            "project_number": 1,
+            "field": "Research Outcome",
+            "value": "IMPLEMENT",
+        },
+        receipt={"outcome": "IMPLEMENT"},
+    )
+    runner = Runner()
+    resolver = type("Resolver", (), {"runner": runner})()
+    state = type(
+        "State",
+        (),
+        {
+            "repository": "owner/repo",
+            "task_number": 199,
+            "issue": {"research_outcome": "DO NOT IMPLEMENT"},
+        },
+    )()
+
+    receipt = lck_effects.DEFAULT_EFFECT_EXECUTOR_REGISTRY.execute(
+        descriptor,
+        resolver=cast(Any, resolver),
+        state=cast(Any, state),
+    )
+
+    assert receipt.action == "already-set"
+    assert len(runner.calls) == 1
+
+
+@pytest.mark.parametrize("owner_type", ("User", "Organization"))
+def test_research_outcome_effect_write_then_owner_safe_fresh_read(
+    monkeypatch: pytest.MonkeyPatch, owner_type: str
+) -> None:
+    class Runner:
+        def __init__(self) -> None:
+            self.queries = 0
+
+        def run(self, argv: Any, *, command_id: str, **_: Any) -> CommandResult:
+            command = tuple(str(item) for item in argv)
+            assert command[:3] == ("gh", "api", "graphql")
+            query = next(item for item in command if item.startswith("query="))
+            assert "repository(owner:$owner, name:$name)" in query
+            assert "user(login:$owner)" not in query
+            assert "organization(login:$owner)" not in query
+            self.queries += 1
+            outcome = "DO NOT IMPLEMENT" if self.queries == 1 else "IMPLEMENT"
+            return CommandResult(
+                command_id,
+                command,
+                0,
+                json.dumps(
+                    _project_field_query_payload(outcome, owner_type=owner_type)
+                ),
+                "",
+            )
+
+    descriptor = ProfileEffectDescriptor(
+        effect_kind="project.single_select.set.v1",
+        schema_version=1,
+        parameters={
+            "repository": "owner/repo",
+            "task_number": 199,
+            "project_number": 1,
+            "field": "Research Outcome",
+            "value": "IMPLEMENT",
+        },
+        postcondition={
+            "kind": "project.single_select.equals",
+            "repository": "owner/repo",
+            "task_number": 199,
+            "project_number": 1,
+            "field": "Research Outcome",
+            "value": "IMPLEMENT",
+        },
+        receipt={"outcome": "IMPLEMENT"},
+    )
+    writes: list[tuple[str, int, int, str, str]] = []
+    monkeypatch.setattr(
+        lck_effects,
+        "set_project_status_with_runner",
+        lambda _runner, repository, task_number, *, project_number, field, value: (
+            writes.append((repository, task_number, project_number, field, value))
+        ),
+    )
+    runner = Runner()
+    resolver = type("Resolver", (), {"runner": runner})()
+    state = type(
+        "State",
+        (),
+        {
+            "repository": "owner/repo",
+            "task_number": 199,
+            "issue": {"research_outcome": "IMPLEMENT"},
+        },
+    )()
+
+    receipt = lck_effects.DEFAULT_EFFECT_EXECUTOR_REGISTRY.execute(
+        descriptor,
+        resolver=cast(Any, resolver),
+        state=cast(Any, state),
+    )
+
+    assert receipt.action == "updated"
+    assert writes == [("owner/repo", 199, 1, "Research Outcome", "IMPLEMENT")]
+    assert runner.queries == 2
+
+
+def test_research_outcome_pending_receipt_preserves_descriptor_metadata() -> None:
+    class Runner:
+        def run(self, argv: Any, *, command_id: str, **_: Any) -> CommandResult:
+            command = tuple(str(item) for item in argv)
+            if command[:3] == ("gh", "project", "item-edit"):
+                return CommandResult(command_id, command, 0, "", "")
+            if command[:3] == ("gh", "api", "graphql"):
+                return CommandResult(
+                    command_id,
+                    command,
+                    0,
+                    json.dumps(
+                        {
+                            "data": {
+                                "user": None,
+                                "organization": None,
+                            }
+                        }
+                    ),
+                    "",
+                )
+            raise AssertionError(f"unexpected command: {command}")
+
+    descriptor = ProfileEffectDescriptor(
+        effect_kind="project.single_select.set.v1",
+        schema_version=1,
+        parameters={
+            "repository": "owner/repo",
+            "task_number": 199,
+            "project_number": 1,
+            "field": "Research Outcome",
+            "value": "IMPLEMENT",
+        },
+        postcondition={
+            "kind": "project.single_select.equals",
+            "repository": "owner/repo",
+            "task_number": 199,
+            "project_number": 1,
+            "field": "Research Outcome",
+            "value": "IMPLEMENT",
+        },
+        receipt={"outcome": "IMPLEMENT"},
+    )
+    resolver = type("Resolver", (), {"runner": Runner()})()
+    state = type(
+        "State",
+        (),
+        {
+            "repository": "owner/repo",
+            "task_number": 199,
+            "issue": {},
+        },
+    )()
+
+    receipt = lck_effects.DEFAULT_EFFECT_EXECUTOR_REGISTRY.execute(
+        descriptor,
+        resolver=cast(Any, resolver),
+        state=cast(Any, state),
+    )
+
+    assert receipt.action == "pending"
+    assert receipt.details["outcome"] == "IMPLEMENT"
+
+
+def test_research_artifact_binding_rejects_non_utf8_as_policy_error(
+    tmp_path: Path,
+) -> None:
+    artifact = tmp_path / "docs" / "research" / "report.md"
+    artifact.parent.mkdir(parents=True)
+    artifact.write_bytes(b"Research Outcome: IMPLEMENT\n\xff")
+
+    with pytest.raises(ResearchPolicyError, match="artifact cannot be read"):
+        research_artifact_binding(
+            tmp_path,
+            task_number=199,
+            pr_number=299,
+            base_sha=SHA,
+            head_sha=SHA,
+            task_body_sha256=DIGEST,
+            merge_base_sha=SHA,
+            effective_diff_sha256=DIGEST,
+            changed_files=("docs/research/report.md",),
+        )
+
+
+def test_review_prepare_wraps_non_utf8_artifact_as_structured_stop(
+    tmp_path: Path,
+) -> None:
+    review_root = tmp_path / "review-root"
+    artifact = review_root / "docs" / "research" / "report.md"
+    artifact.parent.mkdir(parents=True)
+    artifact.write_bytes(b"Research Outcome: IMPLEMENT\n\xff")
+
+    body_sha = sha256_json({"body": RESEARCH_BODY})
+    state = lck_models.LiveState(
+        task_number=199,
+        repository="owner/repo",
+        issue={
+            "number": 199,
+            "title": "[Research] supported workflow",
+            "state": "OPEN",
+            "labels": {"items": ["type:research", "codex:ready"]},
+            "project_status": "Review",
+            "body": RESEARCH_BODY,
+            "body_sha256": body_sha,
+            "research_contract": research_contract_snapshot(RESEARCH_BODY),
+        },
+        relationships={
+            "available": True,
+            "blocked_by": {"items": [], "count": 0, "truncated": False},
+        },
+        git={"branch": "research/199-supported-workflow", "clean": True},
+        target_branch="research/199-supported-workflow",
+        local_task_branch="research/199-supported-workflow",
+        local_task_head=SHA,
+        remote_task_branch="research/199-supported-workflow",
+        remote_task_oid=SHA,
+        open_pr={
+            "number": 299,
+            "state": "OPEN",
+            "isDraft": False,
+            "baseRefOid": SHA,
+            "headRefOid": SHA,
+        },
+        merged_pr_numbers=(),
+        merged=False,
+        checks={},
+        cleanup={},
+        task_contract={
+            "number": 199,
+            "title": "[Research] supported workflow",
+            "body": RESEARCH_BODY,
+            "body_sha256": body_sha,
+        },
+    )
+
+    class Runner:
+        def run(self, argv: Any, *, command_id: str, **_: Any) -> CommandResult:
+            command = tuple(str(item) for item in argv)
+            if command[:2] == ("git", "merge-base"):
+                return CommandResult(command_id, command, 0, f"{SHA}\n", "")
+            if command[:2] == ("git", "diff") and "--name-only" in command:
+                return CommandResult(
+                    command_id,
+                    command,
+                    0,
+                    "docs/research/report.md\n",
+                    "",
+                )
+            if command[:2] == ("git", "diff"):
+                return CommandResult(command_id, command, 0, "diff\n", "")
+            raise AssertionError(f"unsupported review command: {command}")
+
+    class Resolver:
+        repo_root = tmp_path
+        runner = Runner()
+
+    class Snapshots:
+        def acquire(self, _task_number: int, *, operation: str) -> Any:
+            assert operation == "review-prepare"
+            return type("Snapshot", (), {"state": state})()
+
+    class Eligible:
+        def resolve(self, _state: Any, phase: lck_models.Phase, **_: Any) -> Any:
+            return lck_eligibility.PhaseDecision(phase=phase, eligible=True)
+
+    workspace = FakeReviewWorkspace(review_root)
+    preparer = lck_review.ReviewPreparer(
+        cast(Any, Resolver()),
+        eligibility=cast(Any, Eligible()),
+        validation=cast(Any, type("Validation", (), {})()),
+        checks_gate=cast(
+            Any,
+            type(
+                "Checks",
+                (),
+                {"observe": lambda self, _snapshot: {"status": "observed"}},
+            )(),
+        ),
+        workspace=cast(Any, workspace),
+        store=lck_review_workspace.ReviewInvocationStore(tmp_path),
+    )
+    preparer.snapshots = cast(Any, Snapshots())
+
+    with pytest.raises(
+        lck_models.LckStopError,
+        match="Research artifact policy rejected the Review target",
+    ):
+        preparer.prepare(199)
+
+    assert workspace.removed == [review_root]
+
+
+def test_research_policy_reclassifies_changes_outside_repository_artifacts() -> None:
+    result = evaluate_research_changes(
+        ("docs/research/report.md", "src/tracequant/runtime.py")
+    )
+
+    assert result.status.value == "reclassification_required"
+    assert result.artifact_files == ("docs/research/report.md",)
+    assert result.disallowed_files == ("src/tracequant/runtime.py",)
+
+
+@pytest.mark.parametrize("symlink_kind", ["file", "directory"])
+def test_research_policy_rejects_symlinked_artifacts(
+    tmp_path: Path,
+    symlink_kind: str,
+) -> None:
+    research_root = tmp_path / "docs" / "research"
+    research_root.mkdir(parents=True)
+    target_root = tmp_path / "src"
+    target_root.mkdir()
+    if symlink_kind == "file":
+        target = target_root / "runtime.md"
+        target.write_text("Research Outcome: IMPLEMENT\n", encoding="utf-8")
+        link = research_root / "report.md"
+        link.symlink_to(target)
+        changed_files = ("docs/research/report.md",)
+    else:
+        target = target_root / "reports"
+        target.mkdir()
+        (target / "report.md").write_text(
+            "Research Outcome: IMPLEMENT\n", encoding="utf-8"
+        )
+        link = research_root / "reports"
+        link.symlink_to(target, target_is_directory=True)
+        changed_files = ("docs/research/reports/report.md",)
+
+    result = evaluate_research_changes(changed_files, repo_root=tmp_path)
+
+    assert result.status.value == "reclassification_required"
+    assert result.disallowed_files == changed_files
+    assert "symlink" in result.detail
+
+    with pytest.raises(ResearchPolicyError, match="symlinks"):
+        research_artifact_binding(
+            tmp_path,
+            task_number=199,
+            pr_number=299,
+            base_sha=SHA,
+            head_sha=SHA,
+            task_body_sha256=DIGEST,
+            merge_base_sha=SHA,
+            effective_diff_sha256=DIGEST,
+            changed_files=changed_files,
+        )
+
+
+def test_research_contract_is_bound_to_the_issue_form() -> None:
+    template = research_template_contract(ROOT / ".github/ISSUE_TEMPLATE/research.yml")
+    assert template.field_ids == (
+        "question_decision",
+        "context",
+        "scope",
+        "non_goals",
+        "evidence_evaluation",
+        "expected_outcome_artifact",
+    )
+    assert template.section_labels == (
+        "Question / Decision Needed",
+        "Context",
+        "Scope",
+        "Non-goals",
+        "Evidence / Evaluation Criteria",
+        "Expected Outcome / Artifact",
+    )
+
+    contract = research_contract_snapshot(RESEARCH_BODY)
+    assert is_valid_research_contract(contract)
+    assert contract["status"] == "pass"
+
+    invalid = research_contract_snapshot(
+        RESEARCH_BODY.replace("- Repository-backed workflow behavior.\n", "")
+    )
+    assert invalid["status"] == "reclassification_required"
+    assert "empty sections" in invalid["detail"]
+
+
+def test_architecture_decision_requires_matching_downstream_contract() -> None:
+    research_decision = decision_contract_snapshot(RESEARCH_BODY, research=True)
+    downstream = {
+        "body": "### Decision Contract\n\nAdopt the repository-backed workflow contract and record the resulting ADR.\n",
+    }
+    assert research_decision["status"] == "pass"
+
+    assert architecture_decision_is_consistent(research_decision, downstream)
+    downstream_with_context = {
+        "body": """### Decision Contract
+
+Adopt the repository-backed workflow contract and record the resulting ADR.
+
+### Acceptance Criteria
+
+- The downstream issue records the implementation criteria.
+""",
+    }
+    assert architecture_decision_is_consistent(
+        research_decision, downstream_with_context
+    )
+    assert not architecture_decision_is_consistent(
+        research_decision,
+        {"body": "### Decision Contract\n\nAn unrelated decision.\n"},
+    )
+    assert not architecture_decision_is_consistent(research_decision, {})
+
+
+def test_research_artifact_rejects_conflicting_typed_outcomes(tmp_path: Path) -> None:
+    first = tmp_path / "docs" / "research" / "first.md"
+    second = tmp_path / "docs" / "research" / "second.md"
+    first.parent.mkdir(parents=True)
+    first.write_text("Research Outcome: IMPLEMENT\n", encoding="utf-8")
+    second.write_text("Research Outcome: NEEDS MORE EVIDENCE\n", encoding="utf-8")
+
+    with pytest.raises(ResearchPolicyError, match="conflicting outcomes"):
+        research_artifact_binding(
+            tmp_path,
+            task_number=199,
+            pr_number=299,
+            base_sha=SHA,
+            head_sha=SHA,
+            task_body_sha256=DIGEST,
+            merge_base_sha=SHA,
+            effective_diff_sha256=DIGEST,
+            changed_files=("docs/research/first.md", "docs/research/second.md"),
+        )
+
+
+@pytest.mark.parametrize(
+    ("outcome", "expected"),
+    [
+        ("IMPLEMENT", "pass"),
+        ("DO NOT IMPLEMENT", "fail"),
+        ("NEEDS MORE EVIDENCE", "fail"),
+    ],
+)
+def test_closed_research_blocker_requires_an_implementation_outcome(
+    outcome: str,
+    expected: str,
+) -> None:
+    result = _formal_blockers_gate(
+        {
+            "available": True,
+            "blocked_by": {
+                "items": [
+                    {
+                        "number": 198,
+                        "state": "CLOSED",
+                        "labels": ["type:research"],
+                        "research_contract": research_contract_snapshot(RESEARCH_BODY),
+                        "research_outcome": outcome,
+                    }
+                ],
+                "count": 1,
+                "truncated": False,
+            },
+        },
+        downstream_profile=issue_profiles.TASK_PROFILE,
+    )
+
+    assert result["status"] == expected
+
+
+def test_closed_architecture_decision_requires_consistent_contract() -> None:
+    research_decision = decision_contract_snapshot(RESEARCH_BODY, research=True)
+    blocker = {
+        "number": 198,
+        "state": "CLOSED",
+        "labels": ["type:research"],
+        "research_contract": research_contract_snapshot(RESEARCH_BODY),
+        "decision_contract": research_decision,
+        "research_outcome": "ARCHITECTURE DECISION",
+    }
+    relationships = {
+        "available": True,
+        "blocked_by": {"items": [blocker], "count": 1, "truncated": False},
+    }
+    assert _formal_blockers_gate(relationships)["status"] == "unknown"
+    assert (
+        _formal_blockers_gate(
+            relationships,
+            downstream_contract={
+                "body": "### Decision Contract\n\nAdopt the repository-backed workflow contract and record the resulting ADR.\n",
+            },
+            downstream_profile=issue_profiles.TASK_PROFILE,
+        )["status"]
+        == "pass"
+    )
+
+
+def test_incomplete_research_label_evidence_fails_closed() -> None:
+    result = _formal_blockers_gate(
+        {
+            "available": True,
+            "blocked_by": {
+                "items": [
+                    {
+                        "number": 198,
+                        "state": "CLOSED",
+                        "labels": [],
+                        "labels_complete": False,
+                        "research_outcome": "IMPLEMENT",
+                    }
+                ],
+                "count": 1,
+                "truncated": False,
+            },
+        }
+    )
+    assert result["status"] == "unknown"
+
+
+def test_closed_research_blocker_without_outcome_fails_closed() -> None:
+    result = _formal_blockers_gate(
+        {
+            "available": True,
+            "blocked_by": {
+                "items": [
+                    {
+                        "number": 198,
+                        "state": "CLOSED",
+                        "labels": ["type:research"],
+                        "research_contract": research_contract_snapshot(RESEARCH_BODY),
+                    }
+                ],
+                "count": 1,
+                "truncated": False,
+            },
+        }
+    )
+
+    assert result["status"] == "unknown"
+
+
+def test_closed_blocker_with_multiple_type_labels_fails_closed() -> None:
+    result = _formal_blockers_gate(
+        {
+            "available": True,
+            "blocked_by": {
+                "items": [
+                    {
+                        "number": 198,
+                        "state": "CLOSED",
+                        "labels": ["type:research", "type:task"],
+                        "research_contract": research_contract_snapshot(RESEARCH_BODY),
+                        "research_outcome": "IMPLEMENT",
+                    }
+                ],
+                "count": 1,
+                "truncated": False,
+            },
+        }
+    )
+
+    assert result["status"] == "unknown"
+    assert "unknown_state=1" in result["detail"]

--- a/tests/tools/lck/test_retrieval_v2_policy.py
+++ b/tests/tools/lck/test_retrieval_v2_policy.py
@@ -1,0 +1,56 @@
+"""Guard the isolated LCK context-retrieval policy."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+POLICY = ROOT / ".agents" / "policies" / "context-retrieval.md"
+
+
+def _policy() -> str:
+    return POLICY.read_text(encoding="utf-8")
+
+
+def test_leaf_issue_is_the_default_full_text_context() -> None:
+    text = _policy()
+    assert "current leaf Issue body" in text
+    assert "default full-text business input" in text
+
+
+def test_eager_hierarchy_and_comment_reads_are_excluded() -> None:
+    text = _policy()
+    for marker in ("Issue comments", "Parent Feature", "Epic bodies", "all ADRs"):
+        assert marker in text
+    assert "Do not eagerly load" in text
+
+
+def test_context_expansion_is_bounded_and_fail_closed() -> None:
+    text = _policy()
+    assert "Expansion is progressive" in text
+    assert "Unbounded recursive expansion" in text
+    assert "Human Gate" in text
+
+
+def test_deterministic_facts_do_not_imply_full_text_retrieval() -> None:
+    text = _policy()
+    for marker in ("labels", "blockers", "PR identity", "SHAs", "checks"):
+        assert marker in text
+    assert "without injecting the corresponding full text" in text
+
+
+def test_feature_audit_is_the_bounded_hierarchy_exception() -> None:
+    text = _policy()
+    assert "feature-completion-audit" in text
+    assert "bounded exception" in text
+
+
+def test_policy_is_owned_outside_product_code_and_docs() -> None:
+    agents = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
+    claude = (ROOT / "CLAUDE.md").read_text(encoding="utf-8")
+    assert ".agents/policies/context-retrieval.md" in agents
+    assert "AGENTS.md" in claude
+    assert not any(
+        "context-retrieval" in path.read_text(encoding="utf-8")
+        for path in (ROOT / "src" / "tracequant").rglob("*.py")
+    )

--- a/tests/tools/lck/test_review.py
+++ b/tests/tools/lck/test_review.py
@@ -1,0 +1,1188 @@
+# ruff: noqa: E402, I001
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import uuid
+from pathlib import Path
+from typing import (
+    Any,
+    cast,
+)
+
+import pytest
+
+AGENT_WORKFLOW = str(Path(__file__).parents[3] / "tools" / "agent_workflow")
+if AGENT_WORKFLOW not in sys.path:
+    sys.path.insert(0, AGENT_WORKFLOW)
+
+from tools.lck import (  # type: ignore[import-not-found]  # noqa: E402
+    eligibility as lck_eligibility,
+    models as lck_models,
+    receipts as lck_receipts,
+    review as lck_review,
+    review_workspace as lck_review_workspace,
+    state as lck_state,
+    structured_review_instructions as lck_structured_review_instructions,
+    validation_gates as lck_validation,
+)
+from tools.lck.common import (  # type: ignore[import-not-found]  # noqa: E402
+    CommandResult,
+    CommandRunner,
+    print_json,
+)
+from .support import (  # noqa: E402
+    FakeRunner,
+    FakeReviewChecks,
+    FakeReviewValidation,
+    FakeReviewWorkspace,
+    FakeWorkspaceRunner,
+    StaticResolver,
+    SHA,
+    _install_facts,
+    _issue,
+    _open_pr,
+    _relationships,
+    _resolver,
+    _review_guard,
+    _review_identity_value,
+    _review_state,
+    _task_contract,
+    _write_required_checks_workflow,
+)
+
+
+def test_review_prepare_rejects_draft_open_pr(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    branch = "task/159-lck-core-live-state-resolution"
+    fake = FakeRunner(
+        branch=branch, local_branches={branch}, remote_branches={branch: SHA}
+    )
+    issue = _issue()
+    issue["project_status"] = "Review"
+    _install_facts(
+        monkeypatch,
+        fake,
+        issue=issue,
+        open_pr=_open_pr(branch, is_draft=True),
+    )
+
+    state = _resolver(fake).resolve(159)
+    decision = lck_eligibility.PhaseEligibilityResolver().resolve(
+        state,
+        lck_models.Phase.REVIEW_PREPARE,
+    )
+
+    assert not decision.eligible
+    assert any("non-Draft" in reason for reason in decision.reasons)
+
+
+def test_delivery_complete_allows_review_status_for_partial_effect_recovery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    branch = "task/159-lck-core-live-state-resolution"
+    fake = FakeRunner(
+        branch=branch,
+        local_branches={branch},
+        remote_branches={branch: SHA},
+    )
+    issue = _issue()
+    issue["project_status"] = "Review"
+    _install_facts(
+        monkeypatch,
+        fake,
+        issue=issue,
+        open_pr=_open_pr(branch),
+    )
+
+    state = _resolver(fake).resolve(159)
+    decision = lck_eligibility.PhaseEligibilityResolver().resolve(
+        state,
+        lck_models.Phase.DELIVERY_COMPLETE,
+    )
+
+    assert decision.eligible
+
+
+def test_review_prepare_builds_context_only_from_live_resolution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = _review_state()
+    resolver = cast(Any, StaticResolver(tmp_path, state))
+    identity = _review_identity_value()
+    monkeypatch.setattr(
+        lck_review, "_review_identity", lambda *_args, **_kwargs: identity
+    )
+    workspace = FakeReviewWorkspace(tmp_path / "review-root")
+    checks = FakeReviewChecks()
+    store = lck_review_workspace.ReviewInvocationStore(tmp_path)
+
+    context = lck_review.ReviewPreparer(
+        resolver,
+        validation=cast(Any, FakeReviewValidation()),
+        checks_gate=cast(Any, checks),
+        workspace=cast(Any, workspace),
+        store=store,
+    ).prepare(159)
+
+    value = context.to_dict()
+    assert value["review_target"]["head_sha"] == SHA
+    assert value["review_target"]["base_sha"] == SHA
+    assert value["task_contract"]["body"] == "Task Contract"
+    assert value["workspace_mode"] == "implementation-read-only"
+    assert value["mechanical_authority"].startswith("live Git/GitHub")
+    assert workspace.sealed == [tmp_path / "review-root"]
+    assert store.guard_path(context.review_id).is_file()
+    inflight = json.loads(
+        store.review_prepare_inflight_path(159).read_text(encoding="utf-8")
+    )
+    assert inflight["state"] == "handed-off"
+    assert inflight["review_id"] == context.review_id
+    assert checks.calls == 1
+
+
+def test_standard_review_path_provides_canonical_structured_review_instructions(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The normal Review Prepare handoff carries owner-provided guidance only."""
+    state = _review_state()
+    resolver = cast(Any, StaticResolver(tmp_path, state))
+    identity = _review_identity_value()
+    monkeypatch.setattr(
+        lck_review, "_review_identity", lambda *_args, **_kwargs: identity
+    )
+    calls = 0
+    owner = lck_structured_review_instructions
+    original_provider = owner.canonical_structured_review_instructions
+    expected = original_provider()
+
+    def provide_instructions() -> dict[str, Any]:
+        nonlocal calls
+        calls += 1
+        return cast(dict[str, Any], original_provider())
+
+    monkeypatch.setattr(
+        owner, "canonical_structured_review_instructions", provide_instructions
+    )
+    context = lck_review.ReviewPreparer(
+        resolver,
+        validation=cast(Any, FakeReviewValidation()),
+        checks_gate=cast(Any, FakeReviewChecks()),
+        workspace=cast(Any, FakeReviewWorkspace(tmp_path / "review-root")),
+        store=lck_review_workspace.ReviewInvocationStore(tmp_path),
+    ).prepare(159)
+
+    value = context.to_dict()
+    handoff = value["structured_review_instructions"]
+    assert calls == 1
+    assert handoff == expected
+    assert [item["obligation_id"] for item in handoff["obligations"]] == [
+        "contract-critical-outcome",
+        "functional-invariants",
+        "boundary-conversion-error",
+        "state-persistence-compatibility",
+        "tests-vs-claims",
+        "adversarial-residual-sweep",
+    ]
+    assert any("blocker" in item for item in handoff["review_sequence"])
+    assert any("residual sweep" in item for item in handoff["review_sequence"])
+
+    agent_view = lck_receipts._agent_view_for_result(context)
+    assert agent_view["structured_review_instructions"] == expected
+    assert agent_view["workspace_mode"] == "implementation-read-only"
+    assert agent_view["mechanical_authority"].startswith("live Git/GitHub")
+
+
+def test_review_prepare_allows_pending_checks_for_parallel_semantic_review(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = _review_state()
+    resolver = cast(Any, StaticResolver(tmp_path, state))
+    identity = _review_identity_value()
+    monkeypatch.setattr(
+        lck_review, "_review_identity", lambda *_args, **_kwargs: identity
+    )
+
+    class PendingChecks(FakeReviewChecks):
+        def evaluate(self, _snapshot: lck_models.OperationSnapshot) -> dict[str, Any]:
+            raise AssertionError("Review Prepare must not require passing checks")
+
+    checks = PendingChecks()
+    context = lck_review.ReviewPreparer(
+        resolver,
+        validation=cast(Any, FakeReviewValidation()),
+        checks_gate=cast(Any, checks),
+        workspace=cast(Any, FakeReviewWorkspace(tmp_path / "review-root")),
+        store=lck_review_workspace.ReviewInvocationStore(tmp_path),
+    ).prepare(159)
+
+    assert context.checks["status"] == "observed"
+    assert context.checks["check_state"] == "pending"
+    assert checks.calls == 1
+
+
+def test_review_prepare_emits_bounded_progress_without_changing_final_result(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    state = _review_state()
+    resolver = cast(Any, StaticResolver(tmp_path, state))
+    identity = _review_identity_value()
+    monkeypatch.setattr(
+        lck_review, "_review_identity", lambda *_args, **_kwargs: identity
+    )
+    store = lck_review_workspace.ReviewInvocationStore(tmp_path)
+    context = lck_review.ReviewPreparer(
+        resolver,
+        validation=cast(Any, FakeReviewValidation()),
+        checks_gate=cast(Any, FakeReviewChecks()),
+        workspace=cast(Any, FakeReviewWorkspace(tmp_path / "review-root")),
+        store=store,
+    ).prepare(159)
+
+    print_json(context.to_dict())
+    captured = capsys.readouterr()
+    final_result = json.loads(captured.out)
+    progress = [json.loads(line) for line in captured.err.splitlines() if line.strip()]
+
+    assert final_result == context.to_dict()
+    assert progress
+    assert progress[0]["event"] == "started"
+    assert any(item["event"] == "completed" for item in progress)
+    assert {item["operation"] for item in progress} == {"review-prepare"}
+    assert {item["stage"] for item in progress} >= {
+        "initializing",
+        "formal-validation",
+        "handoff",
+    }
+    assert all(
+        item["kind"] == "workflow-progress"
+        and item["authority"] == "non-authoritative observability only"
+        for item in progress
+    )
+    assert all("Task Contract" not in line for line in captured.err.splitlines())
+    assert all(
+        "snapshot" not in line and "diff" not in line
+        for line in captured.err.splitlines()
+    )
+
+
+def test_review_prepare_freezes_authority_before_validation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = _review_state()
+    resolver = cast(Any, StaticResolver(tmp_path, state))
+    identity = _review_identity_value()
+    monkeypatch.setattr(
+        lck_review, "_review_identity", lambda *_args, **_kwargs: identity
+    )
+
+    class DraftingValidation(FakeReviewValidation):
+        def run(self, _root: Path, _base: str, _head: str) -> dict[str, Any]:
+            assert state.open_pr is not None
+            state.open_pr["isDraft"] = True
+            return super().run(_root, _base, _head)
+
+    workspace = FakeReviewWorkspace(tmp_path / "review-root")
+    context = lck_review.ReviewPreparer(
+        resolver,
+        validation=cast(Any, DraftingValidation()),
+        checks_gate=cast(Any, FakeReviewChecks()),
+        workspace=cast(Any, workspace),
+        store=lck_review_workspace.ReviewInvocationStore(tmp_path),
+    ).prepare(159)
+
+    assert context.identity == identity
+    assert workspace.sealed == [tmp_path / "review-root"]
+
+
+def test_review_complete_acquires_one_fresh_snapshot_and_accepts_unchanged_target(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    identity = _review_identity_value()
+    resolver = cast(Any, StaticResolver(tmp_path, _review_state()))
+    monkeypatch.setattr(
+        lck_review, "_review_identity", lambda *_args, **_kwargs: identity
+    )
+    store = lck_review_workspace.ReviewInvocationStore(tmp_path)
+    review_id = store.new_id()
+    review_root = tmp_path / "review-root"
+    review_root.mkdir()
+    store.write_guard(
+        review_id,
+        _review_guard(identity, review_root=review_root),
+    )
+    workspace = FakeReviewWorkspace(review_root)
+
+    result = lck_review.ReviewCompleter(
+        resolver,
+        checks_gate=cast(Any, FakeReviewChecks()),
+        store=store,
+        workspace=cast(Any, workspace),
+    ).complete(159, review_id, verdict="PASS")
+
+    assert result.status == "READY_FOR_MERGE_PREFLIGHT"
+    assert result.identity == identity
+    assert resolver.calls == 1
+    record = store.read_record(159, review_id)
+    assert record["review_snapshot"]["operation"] == "review-prepare"
+    assert record["completion_snapshot"]["operation"] == "review-complete"
+    assert "fresh Review Complete snapshot matched" in record["authority_note"]
+    assert workspace.ready_checked == [review_root]
+    assert workspace.removed == [review_root]
+
+
+def test_review_complete_rejects_research_outcome_for_task_profile(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    identity = _review_identity_value()
+    resolver = cast(Any, StaticResolver(tmp_path, _review_state()))
+    monkeypatch.setattr(
+        lck_review, "_review_identity", lambda *_args, **_kwargs: identity
+    )
+    store = lck_review_workspace.ReviewInvocationStore(tmp_path)
+    review_id = store.new_id()
+    review_root = tmp_path / "review-root"
+    review_root.mkdir()
+    store.write_guard(review_id, _review_guard(identity, review_root=review_root))
+
+    with pytest.raises(
+        lck_models.LckStopError,
+        match="--research-outcome is supported only for Research Issues",
+    ):
+        lck_review.ReviewCompleter(
+            resolver,
+            checks_gate=cast(Any, FakeReviewChecks()),
+            store=store,
+            workspace=cast(Any, FakeReviewWorkspace(review_root)),
+        ).complete(
+            159,
+            review_id,
+            verdict="PASS",
+            research_outcome="IMPLEMENT",
+        )
+
+    assert not store.record_path(159, review_id).exists()
+
+
+def test_review_complete_acquires_only_review_complete_fact_profile(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    branch = "task/159-lck-core-live-state-resolution"
+    issue = _issue()
+    issue.update({"project_status": "Review", "body_sha256": "d" * 64})
+    contract = _task_contract(issue)
+    contract["body_sha256"] = "d" * 64
+    pr = _open_pr(branch)
+    pr["statusCheckRollup"] = [{"name": "quality", "conclusion": "SUCCESS"}]
+    observations: dict[str, list[Any]] = {
+        "issue": [],
+        "branches": [],
+        "pr": [],
+    }
+
+    monkeypatch.setattr(lck_state, "_repository_slug", lambda *_args: "owner/repo")
+
+    def issue_query(*args: Any) -> tuple[dict[str, Any], dict[str, Any]]:
+        observations["issue"].append(tuple(args[-3:]))
+        return issue, contract
+
+    def task_branches(
+        _self: Any,
+        _task: int,
+        _warnings: list[dict[str, Any]],
+        *,
+        include_local: bool,
+        include_remote: bool,
+    ) -> tuple[set[str], dict[str, str], bool]:
+        observations["branches"].append((include_local, include_remote))
+        return set(), {branch: SHA}, True
+
+    def open_pr_query(*args: Any) -> dict[str, Any]:
+        observations["pr"].append(tuple(args[-3:]))
+        return pr
+
+    monkeypatch.setattr(lck_state, "_issue_view_with_contract", issue_query)
+    monkeypatch.setattr(
+        lck_state, "_relationship_snapshot", lambda *_args: _relationships()
+    )
+    monkeypatch.setattr(lck_state.LiveStateResolver, "_task_branches", task_branches)
+    monkeypatch.setattr(lck_state, "resolve_open_pr", open_pr_query)
+    monkeypatch.setattr(
+        lck_state,
+        "list_matching_prs",
+        lambda *_args, **_kwargs: pytest.fail("Review Complete queried PR history"),
+    )
+    monkeypatch.setattr(
+        lck_state,
+        "_git_snapshot",
+        lambda *_args, **_kwargs: pytest.fail(
+            "Review Complete queried source workspace Git facts"
+        ),
+    )
+
+    snapshot = lck_state.OperationSnapshotBuilder(
+        lck_state.LiveStateResolver(tmp_path, runner=cast(Any, FakeRunner()))
+    ).acquire(159, operation="review-complete")
+
+    assert snapshot.state.status is lck_models.ResolutionStatus.RESOLVED
+    assert snapshot.fact_profile == "review-complete"
+    assert observations == {
+        "issue": [(False, False, True)],
+        "branches": [(False, True)],
+        "pr": [(True, False, False)],
+    }
+    assert "task_contract" in snapshot.acquired_facts
+    assert "checks" in snapshot.acquired_facts
+    assert {
+        "comments",
+        "issue_closure",
+        "git",
+        "workspace_inventory",
+        "local_task_branches",
+        "pr_history",
+    }.isdisjoint(snapshot.acquired_facts)
+
+
+def test_review_complete_can_retry_after_transient_live_resolution_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    identity = _review_identity_value()
+    state = _review_state()
+
+    class FlakyResolver(StaticResolver):
+        def resolve(self, task_number: int) -> lck_models.LiveState:
+            self.calls += 1
+            if self.calls == 1:
+                raise lck_models.LckStopError("transient live-state resolution failure")
+            return self.state
+
+    resolver = cast(Any, FlakyResolver(tmp_path, state))
+    monkeypatch.setattr(
+        lck_review, "_review_identity", lambda *_args, **_kwargs: identity
+    )
+    store = lck_review_workspace.ReviewInvocationStore(tmp_path)
+    review_id = store.new_id()
+    review_root = tmp_path / "review-root"
+    review_root.mkdir()
+    store.write_guard(review_id, _review_guard(identity, review_root=review_root))
+    store.review_prepare_inflight_path(159).parent.mkdir(parents=True, exist_ok=True)
+    store.review_prepare_inflight_path(159).write_text(
+        json.dumps(
+            {
+                "task_number": 159,
+                "operation_id": store.new_id(),
+                "pid": 1,
+                "state": "handed-off",
+                "review_id": review_id,
+                "review_root": str(review_root),
+            }
+        ),
+        encoding="utf-8",
+    )
+    workspace = FakeReviewWorkspace(review_root)
+    completer = lck_review.ReviewCompleter(
+        resolver,
+        checks_gate=cast(Any, FakeReviewChecks()),
+        store=store,
+        workspace=cast(Any, workspace),
+    )
+
+    with pytest.raises(
+        lck_models.LckStopError, match="transient live-state resolution"
+    ):
+        completer.complete(159, review_id, verdict="PASS")
+
+    assert resolver.calls == 1
+    assert workspace.removed == []
+    assert store.guard_path(review_id).is_file()
+    assert store.review_prepare_inflight_path(159).is_file()
+
+    result = completer.complete(159, review_id, verdict="PASS")
+
+    assert result.status == "READY_FOR_MERGE_PREFLIGHT"
+    assert resolver.calls == 2
+    assert workspace.removed == [review_root]
+    assert not store.guard_path(review_id).exists()
+    assert not store.review_prepare_inflight_path(159).exists()
+
+
+def test_review_pass_stops_at_merge_preflight_boundary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    identity = _review_identity_value()
+    resolver = cast(Any, StaticResolver(tmp_path, _review_state()))
+    monkeypatch.setattr(
+        lck_review, "_review_identity", lambda *_args, **_kwargs: identity
+    )
+    store = lck_review_workspace.ReviewInvocationStore(tmp_path)
+    review_id = store.new_id()
+    review_root = tmp_path / "review-root"
+    review_root.mkdir()
+    store.write_guard(review_id, _review_guard(identity, review_root=review_root))
+
+    result = lck_review.ReviewCompleter(
+        resolver,
+        checks_gate=cast(Any, FakeReviewChecks()),
+        store=store,
+        workspace=cast(Any, FakeReviewWorkspace(review_root)),
+    ).complete(159, review_id, verdict="PASS")
+
+    assert result.status == "READY_FOR_MERGE_PREFLIGHT"
+    assert "Merge Preflight" in result.to_dict()["human_boundary"]
+    assert resolver.calls == 1
+
+
+@pytest.mark.parametrize(
+    ("code", "current_identity"),
+    [
+        (
+            "REVIEW_STALE_PR",
+            lck_review_workspace.ReviewIdentity(
+                task_number=159,
+                pr_number=201,
+                base_sha=SHA,
+                head_sha=SHA,
+                task_body_sha256="d" * 64,
+                merge_base_sha=SHA,
+                effective_diff_sha256="e" * 64,
+                changed_files=("tools/lck/__main__.py",),
+            ),
+        ),
+        ("REVIEW_STALE_HEAD", _review_identity_value(head="b" * 40)),
+        ("REVIEW_STALE_BASE", _review_identity_value(base="b" * 40)),
+        (
+            "REVIEW_STALE_TASK",
+            lck_review_workspace.ReviewIdentity(
+                task_number=159,
+                pr_number=200,
+                base_sha=SHA,
+                head_sha=SHA,
+                task_body_sha256="f" * 64,
+                merge_base_sha=SHA,
+                effective_diff_sha256="e" * 64,
+                changed_files=("tools/lck/__main__.py",),
+            ),
+        ),
+        (
+            "REVIEW_STALE_DIFF",
+            lck_review_workspace.ReviewIdentity(
+                task_number=159,
+                pr_number=200,
+                base_sha=SHA,
+                head_sha=SHA,
+                task_body_sha256="d" * 64,
+                merge_base_sha=SHA,
+                effective_diff_sha256="f" * 64,
+                changed_files=("tools/lck/__main__.py",),
+            ),
+        ),
+    ],
+)
+def test_review_complete_rejects_stale_target_from_one_fresh_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    code: str,
+    current_identity: lck_review_workspace.ReviewIdentity,
+) -> None:
+    reviewed = _review_identity_value()
+    resolver = cast(Any, StaticResolver(tmp_path, _review_state()))
+    monkeypatch.setattr(
+        lck_review, "_review_identity", lambda *_args, **_kwargs: current_identity
+    )
+    store = lck_review_workspace.ReviewInvocationStore(tmp_path)
+    review_id = store.new_id()
+    review_root = tmp_path / "review-root"
+    review_root.mkdir()
+    store.write_guard(review_id, _review_guard(reviewed, review_root=review_root))
+
+    with pytest.raises(lck_models.ReviewStaleError, match=code):
+        lck_review.ReviewCompleter(
+            resolver,
+            checks_gate=cast(Any, FakeReviewChecks()),
+            store=store,
+            workspace=cast(Any, FakeReviewWorkspace(review_root)),
+        ).complete(159, review_id, verdict="PASS")
+
+    assert resolver.calls == 1
+    assert store.read_latest_review(159) is None
+    assert not store.record_path(159, review_id).exists()
+
+
+def test_review_complete_reports_changed_remote_head_before_local_diff_probe(
+    tmp_path: Path,
+) -> None:
+    reviewed = _review_identity_value()
+    resolver = cast(Any, StaticResolver(tmp_path, _review_state(head="b" * 40)))
+    store = lck_review_workspace.ReviewInvocationStore(tmp_path)
+    review_id = store.new_id()
+    review_root = tmp_path / "review-root"
+    review_root.mkdir()
+    store.write_guard(review_id, _review_guard(reviewed, review_root=review_root))
+
+    with pytest.raises(lck_models.ReviewStaleError, match="REVIEW_STALE_HEAD"):
+        lck_review.ReviewCompleter(
+            resolver,
+            checks_gate=cast(Any, FakeReviewChecks()),
+            store=store,
+            workspace=cast(Any, FakeReviewWorkspace(review_root)),
+        ).complete(159, review_id, verdict="PASS")
+
+    assert resolver.calls == 1
+    assert not any("merge-base" in command for command in resolver.runner.commands)
+    assert not any("diff" in command for command in resolver.runner.commands)
+
+
+def test_review_complete_revalidates_current_checks(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    identity = _review_identity_value()
+    resolver = cast(Any, StaticResolver(tmp_path, _review_state()))
+    monkeypatch.setattr(
+        lck_review, "_review_identity", lambda *_args, **_kwargs: identity
+    )
+    store = lck_review_workspace.ReviewInvocationStore(tmp_path)
+    review_id = store.new_id()
+    review_root = tmp_path / "review-root"
+    review_root.mkdir()
+    store.write_guard(review_id, _review_guard(identity, review_root=review_root))
+
+    class CurrentChecksFail:
+        def evaluate(self, _snapshot: lck_models.OperationSnapshot) -> dict[str, Any]:
+            raise lck_models.LckStopError("PR checks are pending")
+
+    with pytest.raises(lck_models.LckStopError, match="PR checks are pending"):
+        lck_review.ReviewCompleter(
+            resolver,
+            checks_gate=cast(Any, CurrentChecksFail()),
+            store=store,
+            workspace=cast(Any, FakeReviewWorkspace(review_root)),
+        ).complete(159, review_id, verdict="PASS")
+
+    assert resolver.calls == 1
+    assert store.read_latest_review(159) is None
+
+
+def test_review_fail_is_not_delayed_by_pending_checks(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    identity = _review_identity_value()
+    resolver = cast(Any, StaticResolver(tmp_path, _review_state()))
+    monkeypatch.setattr(
+        lck_review, "_review_identity", lambda *_args, **_kwargs: identity
+    )
+    store = lck_review_workspace.ReviewInvocationStore(tmp_path)
+    review_id = store.new_id()
+    review_root = tmp_path / "review-root"
+    review_root.mkdir()
+    store.write_guard(review_id, _review_guard(identity, review_root=review_root))
+    findings = tmp_path / "findings.txt"
+    findings.write_text(
+        "[F1][Medium] CI-independent semantic finding.\n", encoding="utf-8"
+    )
+
+    class PendingChecks(FakeReviewChecks):
+        def evaluate(self, _snapshot: lck_models.OperationSnapshot) -> dict[str, Any]:
+            raise lck_models.LckStopError("PR checks are pending")
+
+    result = lck_review.ReviewCompleter(
+        resolver,
+        checks_gate=cast(Any, PendingChecks()),
+        store=store,
+        workspace=cast(Any, FakeReviewWorkspace(review_root)),
+    ).complete(159, review_id, verdict="FAIL", findings_file=findings)
+
+    assert result.status == "STOP_REQUIRED"
+
+
+def test_review_workspace_seal_removes_write_bits(tmp_path: Path) -> None:
+    root = tmp_path / "review"
+    nested = root / "pkg"
+    nested.mkdir(parents=True)
+    target = nested / "file.py"
+    target.write_text("print('read only')\n", encoding="utf-8")
+    executable = nested / "tool.py"
+    executable.write_text("#!/usr/bin/env python3\n", encoding="utf-8")
+    executable.chmod(0o755)
+
+    lck_review_workspace.ReviewWorkspaceManager.seal_read_only(root)
+
+    assert root.stat().st_mode & 0o222 == 0
+    assert nested.stat().st_mode & 0o222 == 0
+    assert target.stat().st_mode & 0o222 == 0
+    assert executable.stat().st_mode & 0o222 == 0
+    assert executable.stat().st_mode & 0o111 != 0
+    lck_review_workspace.ReviewWorkspaceManager._make_removable(root)
+
+
+def test_review_workspace_seal_preserves_clean_status_and_rejects_mutation(
+    tmp_path: Path,
+) -> None:
+    with tempfile.TemporaryDirectory(prefix="tracequant-lck-review-") as raw:
+        root = Path(raw)
+        (root / ".git").mkdir()
+        (root / "tracked.py").write_text("print('review')\n", encoding="utf-8")
+        resolver = cast(Any, StaticResolver(tmp_path, _review_state()))
+        runner = FakeWorkspaceRunner(root)
+        resolver.runner = runner
+        manager = lck_review_workspace.ReviewWorkspaceManager(resolver)
+        manager._write_owner(
+            root,
+            task_number=159,
+            base_sha=SHA,
+            head_sha=SHA,
+        )
+
+        manager.seal_for_review(root, SHA)
+
+        assert root.stat().st_mode & 0o222 == 0
+        assert (root / "tracked.py").stat().st_mode & 0o222 == 0
+        manager.assert_ready_for_completion(root, SHA)
+
+        runner.status_output = " M tracked.py\n"
+        with pytest.raises(lck_models.LckStopError, match="changed the isolated clone"):
+            manager.assert_ready_for_completion(root, SHA)
+        manager._make_removable(root)
+
+
+def test_review_prepare_materializes_missing_pr_head_before_deriving_diff(
+    tmp_path: Path,
+) -> None:
+    """A fresh remote PR head need not already exist in the source object store."""
+    if shutil.which("git") is None:
+        pytest.skip("git is required for Review clone integration test")
+
+    remote = tmp_path / "remote.git"
+    subprocess.run(
+        ["git", "init", "--bare", str(remote)],
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    producer = tmp_path / "producer"
+    subprocess.run(
+        ["git", "clone", str(remote), str(producer)],
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+
+    def git(
+        cwd: Path, *args: str, check: bool = True
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            check=check,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+
+    git(producer, "config", "user.name", "TraceQuant Test")
+    git(producer, "config", "user.email", "tracequant-test@example.invalid")
+    (producer / "tracked.py").write_text("base\n", encoding="utf-8")
+    _write_required_checks_workflow(producer)
+    git(producer, "add", "tracked.py", ".github/workflows/ci.yml")
+    git(producer, "commit", "-m", "base")
+    git(producer, "branch", "-M", "main")
+    git(producer, "push", "origin", "main")
+    base_sha = git(producer, "rev-parse", "HEAD").stdout.strip()
+
+    source = tmp_path / "source"
+    subprocess.run(
+        ["git", "clone", "--branch", "main", str(remote), str(source)],
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    _write_required_checks_workflow(source)
+
+    git(producer, "checkout", "-b", "task/159-lck-core-live-state-resolution")
+    (producer / "tracked.py").write_text("base\nhead\n", encoding="utf-8")
+    git(producer, "add", "tracked.py")
+    git(producer, "commit", "-m", "head")
+    git(producer, "push", "origin", "HEAD")
+    head_sha = git(producer, "rev-parse", "HEAD").stdout.strip()
+
+    missing = git(source, "cat-file", "-e", f"{head_sha}^{{commit}}", check=False)
+    assert missing.returncode != 0
+
+    state = _review_state(head=head_sha, base=base_sha)
+    resolver = cast(Any, StaticResolver(source, state))
+    resolver.runner = CommandRunner(source)
+    store = lck_review_workspace.ReviewInvocationStore(source)
+    workspace = lck_review_workspace.ReviewWorkspaceManager(resolver)
+
+    context = lck_review.ReviewPreparer(
+        resolver,
+        validation=cast(Any, FakeReviewValidation()),
+        checks_gate=cast(Any, FakeReviewChecks()),
+        workspace=workspace,
+        store=store,
+    ).prepare(159)
+
+    try:
+        assert context.identity.base_sha == base_sha
+        assert context.identity.head_sha == head_sha
+        assert context.identity.merge_base_sha == base_sha
+        assert context.identity.changed_files == ("tracked.py",)
+        assert (
+            git(
+                source, "cat-file", "-e", f"{head_sha}^{{commit}}", check=False
+            ).returncode
+            != 0
+        )
+        assert (
+            git(
+                context.review_root, "cat-file", "-e", f"{head_sha}^{{commit}}"
+            ).returncode
+            == 0
+        )
+    finally:
+        workspace.remove(context.review_root)
+        store.delete_guard(context.review_id)
+        store.release_review_prepare(159, context.review_id)
+
+
+def test_review_workspace_uses_standalone_clone_without_source_git_mutation(
+    tmp_path: Path,
+) -> None:
+    if shutil.which("git") is None:
+        pytest.skip("git is required for Review clone integration test")
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    def git(*args: str, cwd: Path = repo) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            check=True,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+
+    git("init")
+    git("config", "user.name", "TraceQuant Test")
+    git("config", "user.email", "tracequant-test@example.invalid")
+    git("remote", "add", "origin", "https://example.invalid/tracequant.git")
+    tracked = repo / "tracked.py"
+    tracked.write_text("print('review')\n", encoding="utf-8")
+    executable = repo / "tool.py"
+    executable.write_text("#!/usr/bin/env python3\n", encoding="utf-8")
+    executable.chmod(0o755)
+    git("add", "tracked.py", "tool.py")
+    git("commit", "-m", "initial")
+    head_sha = git("rev-parse", "HEAD").stdout.strip()
+
+    source_worktrees_before = git("worktree", "list", "--porcelain").stdout
+    source_head_before = git("rev-parse", "HEAD").stdout.strip()
+    source_status_before = git("status", "--porcelain=v1").stdout
+    source_git_modes_before = {
+        path.relative_to(repo / ".git"): path.stat().st_mode
+        for path in (repo / ".git").rglob("*")
+        if not path.is_symlink()
+    }
+    source_object = repo / ".git" / "objects" / head_sha[:2] / head_sha[2:]
+    assert source_object.is_file()
+
+    resolver = cast(Any, StaticResolver(repo, _review_state()))
+    resolver.runner = CommandRunner(repo)
+    manager = lck_review_workspace.ReviewWorkspaceManager(resolver)
+    review_root = manager.create(159, head_sha, head_sha)
+
+    try:
+        assert git("rev-parse", "HEAD", cwd=review_root).stdout.strip() == head_sha
+        assert git("branch", "--show-current", cwd=review_root).stdout.strip() == ""
+        assert git("status", "--porcelain=v1", cwd=review_root).stdout.strip() == ""
+        assert (
+            git("remote", "get-url", "origin", cwd=review_root).stdout.strip()
+            == "https://example.invalid/tracequant.git"
+        )
+        clone_object = review_root / ".git" / "objects" / head_sha[:2] / head_sha[2:]
+        assert clone_object.is_file()
+        assert clone_object.stat().st_ino != source_object.stat().st_ino
+
+        manager.seal_for_review(review_root, head_sha)
+        manager.assert_ready_for_completion(review_root, head_sha)
+        assert review_root.stat().st_mode & 0o222 == 0
+        assert (review_root / "tracked.py").stat().st_mode & 0o222 == 0
+        sealed_executable = review_root / "tool.py"
+        assert sealed_executable.stat().st_mode & 0o222 == 0
+        assert sealed_executable.stat().st_mode & 0o111 != 0
+
+        assert git("rev-parse", "HEAD").stdout.strip() == source_head_before
+        assert git("status", "--porcelain=v1").stdout == source_status_before
+        assert git("worktree", "list", "--porcelain").stdout == source_worktrees_before
+        source_git_modes_after = {
+            path.relative_to(repo / ".git"): path.stat().st_mode
+            for path in (repo / ".git").rglob("*")
+            if not path.is_symlink()
+        }
+        assert source_git_modes_after == source_git_modes_before
+    finally:
+        manager.remove(review_root)
+
+    assert not review_root.exists()
+    assert git("worktree", "list", "--porcelain").stdout == source_worktrees_before
+
+
+def test_review_workspace_remove_rejects_unvalidated_path(tmp_path: Path) -> None:
+    resolver = cast(Any, StaticResolver(tmp_path, _review_state()))
+    manager = lck_review_workspace.ReviewWorkspaceManager(resolver)
+
+    with pytest.raises(lck_models.LckStopError, match="cleanup path"):
+        manager.remove(tmp_path / "not-an-lck-workspace")
+
+
+def test_review_workspace_recovered_partial_clone_cleanup_is_path_local(
+    tmp_path: Path,
+) -> None:
+    resolver = cast(Any, StaticResolver(tmp_path, _review_state()))
+    manager = lck_review_workspace.ReviewWorkspaceManager(resolver)
+    review_root = manager.path_for(159, uuid.uuid4().hex)
+    review_root.mkdir()
+    partial_git = review_root / ".git"
+    partial_git.mkdir()
+    (partial_git / "partial").write_text("interrupted clone\n", encoding="utf-8")
+    manager.seal_read_only(review_root)
+
+    manager.remove_recovered(review_root)
+
+    assert not review_root.exists()
+
+
+def test_review_validation_artifacts_are_preserved_outside_review_clone(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    source_agents = repo_root / ".agents"
+    source_agents.mkdir()
+    review_root = tmp_path / "review-root"
+    tool = review_root / "tools" / "lck" / "validation_runner.py"
+    tool.parent.mkdir(parents=True)
+    tool.write_text("# validation stub\n", encoding="utf-8")
+    output_dir = review_root / ".agents" / "validation.local" / "run"
+    output_dir.mkdir(parents=True)
+    (output_dir / "pytest.log").write_text("pass\n", encoding="utf-8")
+
+    class ValidationRunner:
+        def run(self, argv: Any, *, command_id: str, **_: Any) -> CommandResult:
+            payload = {
+                "status": "pass",
+                "output_dir": ".agents/validation.local/run",
+                "commands": [
+                    {
+                        "status": "pass",
+                        "log_path": ".agents/validation.local/run/pytest.log",
+                    }
+                ],
+            }
+            return CommandResult(
+                command_id=command_id,
+                argv=tuple(str(item) for item in argv),
+                returncode=0,
+                stdout=json.dumps(payload),
+                stderr="",
+            )
+
+    resolver = cast(Any, StaticResolver(repo_root, _review_state()))
+    resolver.runner = ValidationRunner()
+    validation = lck_validation.ReviewValidationGate(resolver).run(
+        review_root, SHA, SHA
+    )
+
+    durable_output = repo_root / validation["output_dir"]
+    durable_log = repo_root / validation["commands"][0]["log_path"]
+    assert validation["output_dir"].startswith(
+        ".workflow.local/lck/review-validation/lck-review-"
+    )
+    assert validation["evidence_path"] == validation["output_dir"]
+    assert validation["validated_base_sha"] == SHA
+    assert validation["validated_head_sha"] == SHA
+    assert durable_output.is_dir()
+    assert durable_log.read_text(encoding="utf-8") == "pass\n"
+    evidence_file = repo_root / validation["evidence_file"]
+    evidence = json.loads(evidence_file.read_text(encoding="utf-8"))
+    assert evidence["validated_base_sha"] == SHA
+    assert evidence["commands"][0]["status"] == "pass"
+    assert not (source_agents / "validation.local").exists()
+
+
+def test_review_validation_failure_is_persisted_before_prepare_stops(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    review_root = tmp_path / "review-root"
+    tool = review_root / "tools" / "lck" / "validation_runner.py"
+    tool.parent.mkdir(parents=True)
+    tool.write_text("# validation stub\n", encoding="utf-8")
+    output_dir = review_root / ".agents" / "validation.local" / "run"
+    output_dir.mkdir(parents=True)
+    (output_dir / "ruff-check.log").write_text("format mismatch\n", encoding="utf-8")
+
+    class ValidationRunner:
+        def run(self, argv: Any, *, command_id: str, **_: Any) -> CommandResult:
+            payload = {
+                "status": "fail",
+                "output_dir": ".agents/validation.local/run",
+                "commands": [
+                    {
+                        "command_id": "ruff-check",
+                        "status": "fail",
+                        "exit_code": 1,
+                        "diagnostic": "format mismatch",
+                        "log_path": ".agents/validation.local/run/ruff-check.log",
+                    }
+                ],
+            }
+            return CommandResult(
+                command_id=command_id,
+                argv=tuple(str(item) for item in argv),
+                returncode=1,
+                stdout=json.dumps(payload),
+                stderr="",
+            )
+
+    resolver = cast(Any, StaticResolver(repo_root, _review_state()))
+    resolver.runner = ValidationRunner()
+    validation = lck_validation.ReviewValidationGate(resolver).run(
+        review_root, SHA, "b" * 40
+    )
+
+    assert validation["status"] == "fail"
+    assert validation["validated_base_sha"] == SHA
+    assert validation["validated_head_sha"] == "b" * 40
+    assert validation["commands"][0]["command_id"] == "ruff-check"
+    assert validation["commands"][0]["exit_code"] == 1
+    evidence = repo_root / validation["evidence_path"]
+    assert evidence.is_dir()
+    assert (evidence / "ruff-check.log").read_text(encoding="utf-8") == (
+        "format mismatch\n"
+    )
+    stored = json.loads(
+        (repo_root / validation["evidence_file"]).read_text(encoding="utf-8")
+    )
+    assert stored["commands"][0]["command_id"] == "ruff-check"
+    assert stored["commands"][0]["exit_code"] == 1
+    assert stored["commands"][0]["diagnostic"] == "format mismatch"
+    assert stored["validated_head_sha"] == "b" * 40
+
+
+def test_review_prepare_claims_operation_before_validation_and_has_no_review_id_on_fail(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = _review_state()
+    resolver = cast(Any, StaticResolver(tmp_path, state))
+    identity = _review_identity_value()
+    store = lck_review_workspace.ReviewInvocationStore(tmp_path)
+    monkeypatch.setattr(
+        lck_review, "_review_identity", lambda *_args, **_kwargs: identity
+    )
+
+    class FailingValidation:
+        def run(self, _root: Path, base: str, head: str) -> dict[str, Any]:
+            assert store.review_prepare_inflight_path(159).is_file()
+            return {
+                "status": "fail",
+                "validated_base_sha": base,
+                "validated_head_sha": head,
+                "commands": [
+                    {
+                        "command_id": "ruff-check",
+                        "status": "fail",
+                        "exit_code": 1,
+                        "diagnostic": "format mismatch",
+                    }
+                ],
+                "evidence_path": ".workflow.local/lck/review-validation/lck-review-failure",
+            }
+
+    workspace = FakeReviewWorkspace(tmp_path / "review-root")
+    with pytest.raises(
+        lck_models.LckStopError,
+        match="failed command ruff-check.*evidence",
+    ) as exc_info:
+        lck_review.ReviewPreparer(
+            resolver,
+            validation=cast(Any, FailingValidation()),
+            checks_gate=cast(Any, FakeReviewChecks()),
+            workspace=cast(Any, workspace),
+            store=store,
+        ).prepare(159)
+
+    assert "validated base" in str(exc_info.value)
+    assert workspace.removed == [tmp_path / "review-root"]
+    assert not (store.root / "review-invocations").exists()
+    assert not store.review_prepare_inflight_path(159).exists()
+
+
+def test_review_prepare_inflight_guard_blocks_second_operation(tmp_path: Path) -> None:
+    store = lck_review_workspace.ReviewInvocationStore(tmp_path)
+    first = store.begin_review_prepare(159)
+    try:
+        with pytest.raises(lck_models.LckStopError, match="already in flight"):
+            store.begin_review_prepare(159)
+    finally:
+        first.finish()
+
+    assert not store.review_prepare_inflight_path(159).exists()
+
+
+def test_review_prepare_handoff_keeps_explicit_ownership_until_cleanup(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = lck_review_workspace.ReviewInvocationStore(tmp_path)
+    review_id = store.new_id()
+    review_root = tmp_path / "tracequant-lck-review-159-handoff"
+    review_root.mkdir()
+    store.write_guard(review_id, {"review_id": review_id})
+    store.review_prepare_inflight_path(159).parent.mkdir(parents=True, exist_ok=True)
+    store.review_prepare_inflight_path(159).write_text(
+        json.dumps(
+            {
+                "task_number": 159,
+                "pid": 1,
+                "operation_id": store.new_id(),
+                "state": "handed-off",
+                "review_id": review_id,
+                "review_root": str(review_root),
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        lck_review_workspace.ReviewInvocationStore,
+        "_pid_is_alive",
+        staticmethod(lambda _pid: False),
+    )
+
+    with pytest.raises(lck_models.LckStopError, match="handoff is still owned"):
+        store.begin_review_prepare(159)
+
+    assert store.review_prepare_inflight_path(159).is_file()

--- a/tests/tools/lck/test_review_models.py
+++ b/tests/tools/lck/test_review_models.py
@@ -1,0 +1,248 @@
+"""Critical Outcome tests for the canonical Review vNext contracts."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tools.lck.review_models import (
+    ALWAYS_ON_SURFACES,
+    AssuranceObligation,
+    AssuranceResult,
+    AssuranceStatus,
+    CandidateFinding,
+    ChangeMapEntry,
+    EvidenceReference,
+    FindingBlockingStatus,
+    FindingSeverity,
+    FindingVerificationStatus,
+    ReviewAuthorityIdentity,
+    ReviewAuthorityKind,
+    ReviewContractError,
+    ReviewEvidencePackage,
+    ReviewRiskProfile,
+    ReviewRunReceipt,
+    ReviewSurface,
+    ReviewSurfacePlan,
+    RunProvenance,
+    TokenUsage,
+    VerifiedFinding,
+)
+
+
+def _authority(*, head: str = "b" * 40) -> ReviewAuthorityIdentity:
+    return ReviewAuthorityIdentity(
+        authority_kind=ReviewAuthorityKind.LIVE,
+        repository="PhoenixSss/tracequant",
+        task_number=254,
+        pull_request_number=300,
+        base_sha="a" * 40,
+        head_sha=head,
+        diff_sha256="c" * 64,
+    )
+
+
+def _surface_plan() -> ReviewSurfacePlan:
+    risk_surface = ReviewSurface.SECURITY
+    required = (*ALWAYS_ON_SURFACES, risk_surface)
+    return ReviewSurfacePlan(
+        required=required,
+        covered=required,
+        risk_triggered=(risk_surface,),
+        semantic_escalation_requests=(),
+    )
+
+
+def _provenance(run_id: str) -> RunProvenance:
+    return RunProvenance(
+        run_id=run_id,
+        authority=_authority(),
+        harness_id="review-harness.v1",
+        protocol_id="review-protocol.v1",
+    )
+
+
+def _candidate() -> CandidateFinding:
+    return CandidateFinding(
+        finding_id="finding-1",
+        surface=ReviewSurface.ERROR_FAILURE_PATHS,
+        claim="The failure path can leave an operation unresolved.",
+        affected_locations=("src/tracequant/contracts/review.py:1",),
+        contract_invariant="Unknown state must not be retried without reconciliation.",
+        failure_scenario="A transport error occurs after the side effect but before acknowledgement.",
+        evidence_refs=("deterministic-1",),
+        originating_runs=(_provenance("run-1"), _provenance("run-2")),
+    )
+
+
+def test_review_vnext_canonical_contracts_round_trip_without_profile_specific_fields() -> (
+    None
+):
+    """Exercise every canonical representation through JSON-compatible data."""
+    risk = ReviewRiskProfile(
+        deterministic_facts={
+            "changed_runtime_boundary": True,
+            "credential_path": False,
+        },
+        triggered_surfaces=(ReviewSurface.SECURITY,),
+    )
+    evidence = EvidenceReference(
+        reference_id="deterministic-1",
+        kind="validation-result",
+        locator=".workflow.local/lck/review-validation/result.json",
+        summary="Bounded deterministic validation result.",
+        digest_sha256="d" * 64,
+    )
+    package = ReviewEvidencePackage(
+        summary="Compact Review facts with retrieval pointers.",
+        authority=_authority(),
+        task_contract={
+            "number": 254,
+            "body_sha256": "e" * 64,
+            "acceptance_count": 7,
+            "labels": ("type:task",),
+        },
+        change_map=(
+            ChangeMapEntry(
+                path="src/tracequant/contracts/review.py",
+                change_kind="added",
+                locations=("ReviewEvidencePackage", "ReviewRunReceipt"),
+                summary="Adds canonical Review value contracts.",
+            ),
+        ),
+        deterministic_evidence=(evidence,),
+        risk_profile=risk,
+        surface_plan=_surface_plan(),
+        targeted_retrieval_references=(
+            EvidenceReference(
+                reference_id="source-1",
+                kind="source-location",
+                locator="docs/architecture/repository-structure.md",
+                summary="Repository boundary reference.",
+            ),
+        ),
+    )
+    candidate = _candidate()
+    verified = VerifiedFinding.from_candidate(
+        candidate,
+        verification_status=FindingVerificationStatus.CONFIRMED,
+        verification_evidence_refs=("deterministic-1",),
+        severity=FindingSeverity.HIGH,
+        blocking_status=FindingBlockingStatus.NON_BLOCKING,
+    )
+    receipt = ReviewRunReceipt(
+        run_id="run-1",
+        authority=_authority(),
+        harness_config={"subject_only": True},
+        protocol_config={"sequence": ("Inspect", "Reason", "Judge", "Report")},
+        model_config={"temperature": 0},
+        coverage=_surface_plan(),
+        candidate_findings=(candidate,),
+        verified_findings=(verified,),
+        token_usage=TokenUsage(input_tokens=120, output_tokens=30, total_tokens=150),
+        wall_clock_ms=250,
+        assurance_obligations=(
+            AssuranceObligation(
+                obligation_id="coverage",
+                description="All required surfaces are covered.",
+                required_surfaces=(*ALWAYS_ON_SURFACES, ReviewSurface.SECURITY),
+            ),
+        ),
+        assurance_results=(
+            AssuranceResult(
+                obligation_id="coverage",
+                status=AssuranceStatus.PASS,
+                evidence_refs=("deterministic-1",),
+                summary="Required surfaces are covered.",
+            ),
+        ),
+    )
+
+    for model in (package, candidate, verified, receipt):
+        payload = model.to_dict()
+        assert payload["kind"]
+        assert payload["schema_version"]
+        assert json.loads(json.dumps(payload, allow_nan=False)) == payload
+
+    assert ReviewEvidencePackage.from_json(package.to_json()) == package
+    assert CandidateFinding.from_dict(candidate.to_dict()) == candidate
+    assert VerifiedFinding.from_dict(verified.to_dict()) == verified
+    assert ReviewRunReceipt.from_json(receipt.to_json()) == receipt
+    assert receipt.review_complete is True
+    assert "severity" not in candidate.to_dict()
+    assert "blocking_status" not in candidate.to_dict()
+    assert len(candidate.originating_runs) == 2
+    serialized = package.to_json()
+    assert "provider" not in serialized
+    assert "openai" not in serialized
+
+
+def test_surface_plan_does_not_hide_uncovered_required_surfaces() -> None:
+    plan = ReviewSurfacePlan(
+        covered=ALWAYS_ON_SURFACES[:-1],
+        skipped_with_reason={
+            ReviewSurface.TESTS_VS_CLAIMS.value: "No test claim was available in this fixture."
+        },
+    )
+
+    assert plan.is_complete is False
+    assert plan.coverage_status == "incomplete"
+    assert plan.missing_required == (ReviewSurface.TESTS_VS_CLAIMS,)
+    with pytest.raises(ReviewContractError, match="risk-triggered"):
+        ReviewSurfacePlan(
+            required=ALWAYS_ON_SURFACES,
+            risk_triggered=(ReviewSurface.SECURITY,),
+        )
+
+
+def test_review_completion_requires_obligation_surfaces_in_coverage() -> None:
+    receipt = ReviewRunReceipt(
+        run_id="run-1",
+        authority=_authority(),
+        harness_config={"subject_only": True},
+        protocol_config={"sequence": ("Inspect", "Reason", "Judge", "Report")},
+        model_config={"temperature": 0},
+        coverage=ReviewSurfacePlan(
+            required=ALWAYS_ON_SURFACES,
+            covered=ALWAYS_ON_SURFACES,
+        ),
+        candidate_findings=(),
+        verified_findings=(),
+        token_usage=TokenUsage(input_tokens=1, output_tokens=1, total_tokens=2),
+        wall_clock_ms=1,
+        assurance_obligations=(
+            AssuranceObligation(
+                obligation_id="security",
+                description="Security must be reviewed.",
+                required_surfaces=(ReviewSurface.SECURITY,),
+            ),
+        ),
+        assurance_results=(
+            AssuranceResult(
+                obligation_id="security",
+                status=AssuranceStatus.PASS,
+                evidence_refs=(),
+                summary="Security review passed.",
+            ),
+        ),
+    )
+
+    assert receipt.review_complete is False
+    assert receipt.review_status == "incomplete"
+    assert ReviewRunReceipt.from_json(receipt.to_json()) == receipt
+
+
+def test_candidate_severity_cannot_become_a_verified_blocker_implicitly() -> None:
+    candidate = _candidate()
+
+    assert not hasattr(candidate, "severity")
+    assert not hasattr(candidate, "blocking_status")
+    with pytest.raises(ReviewContractError, match="confirmed"):
+        VerifiedFinding.from_candidate(
+            candidate,
+            verification_status=FindingVerificationStatus.INCONCLUSIVE,
+            verification_evidence_refs=("deterministic-1",),
+            severity=FindingSeverity.CRITICAL,
+            blocking_status=FindingBlockingStatus.BLOCKING,
+        )

--- a/tests/tools/lck/test_runtime_telemetry_removed.py
+++ b/tests/tools/lck/test_runtime_telemetry_removed.py
@@ -1,0 +1,37 @@
+"""Ensure historical workflow telemetry is not restored as runtime authority."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_no_runtime_telemetry_module_or_command_exists() -> None:
+    assert not (ROOT / "tools" / "lck" / "telemetry.py").exists()
+    assert not any(
+        path.name.startswith("test_telemetry") for path in ROOT.rglob("*.py")
+    )
+
+
+def test_active_lck_code_has_no_runtime_telemetry_module_or_command() -> None:
+    source = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in (ROOT / "tools" / "lck").glob("*.py")
+    ).casefold()
+    assert "from .telemetry" not in source
+    assert (
+        '"telemetry"'
+        not in (ROOT / "tools" / "lck" / "cli.py")
+        .read_text(encoding="utf-8")
+        .casefold()
+    )
+
+
+def test_external_analysis_boundary_is_documented_in_lck_policy() -> None:
+    policy = (ROOT / ".agents" / "policies" / "context-retrieval.md").read_text(
+        encoding="utf-8"
+    )
+    assert "outside this repository" in policy
+    assert "must not be committed" in policy
+    assert "never change permissions" in policy

--- a/tests/tools/lck/test_state.py
+++ b/tests/tools/lck/test_state.py
@@ -1,0 +1,756 @@
+# ruff: noqa: E402, I001
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import (
+    Any,
+    cast,
+)
+
+import pytest
+
+AGENT_WORKFLOW = str(Path(__file__).parents[3] / "tools" / "agent_workflow")
+if AGENT_WORKFLOW not in sys.path:
+    sys.path.insert(0, AGENT_WORKFLOW)
+
+from tools.lck import (  # type: ignore[import-not-found]  # noqa: E402
+    delivery as lck_delivery,
+    eligibility as lck_eligibility,
+    models as lck_models,
+    state as lck_state,
+)
+from tools.lck.github_prs import (  # type: ignore[import-not-found]  # noqa: E402
+    PrResolveError,
+    list_matching_prs,
+)
+from tools.lck.common import (  # type: ignore[import-not-found]  # noqa: E402
+    CommandResult,
+)
+from tools.lck.feature_audit import (  # type: ignore[import-not-found]  # noqa: E402
+    _git_snapshot as workflow_git_snapshot,
+)
+from .support import (  # noqa: E402
+    FakeRunner,
+    SHA,
+    _git_snapshot,
+    _install_facts,
+    _issue,
+    _open_pr,
+    _relationships,
+    _review_state,
+    _resolver,
+    _task_contract,
+)
+
+
+def test_closed_pr_does_not_block_current_open_pr(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    branch = "task/159-lck-core-live-state-resolution"
+    fake = FakeRunner(
+        branch=branch,
+        local_branches={branch},
+        remote_branches={branch: SHA},
+    )
+    open_pr = {
+        "number": 200,
+        "state": "OPEN",
+        "isDraft": False,
+        "baseRefName": "main",
+        "baseRefOid": SHA,
+        "headRefName": branch,
+        "headRefOid": SHA,
+        "url": "https://github.com/owner/repo/pull/200",
+        "statusCheckRollup": [],
+    }
+    _install_facts(
+        monkeypatch,
+        fake,
+        open_pr=open_pr,
+        history=[
+            {"number": 199, "state": "CLOSED"},
+            {"number": 200, "state": "OPEN"},
+        ],
+    )
+
+    state = _resolver(fake).resolve(159)
+
+    assert state.status is lck_models.ResolutionStatus.RESOLVED
+    assert state.open_pr is not None
+    assert state.open_pr["number"] == 200
+    assert state.merged_pr_numbers == ()
+
+
+def test_live_state_resolver_reads_non_empty_pr_checks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    branch = "task/159-lck-core-live-state-resolution"
+    open_pr = {
+        "number": 200,
+        "state": "OPEN",
+        "isDraft": False,
+        "baseRefName": "main",
+        "baseRefOid": SHA,
+        "headRefName": branch,
+        "headRefOid": SHA,
+        "url": "https://github.com/owner/repo/pull/200",
+        "statusCheckRollup": [
+            {"name": "quality", "conclusion": "SUCCESS"},
+        ],
+    }
+    fake = FakeRunner(
+        branch=branch,
+        local_branches={branch},
+        remote_branches={branch: SHA},
+        open_pr=open_pr,
+    )
+    monkeypatch.setattr(lck_state, "_repository_slug", lambda *_args: "owner/repo")
+    monkeypatch.setattr(
+        lck_state,
+        "_issue_view_with_contract",
+        lambda *_args: (_issue(), _task_contract()),
+    )
+    monkeypatch.setattr(
+        lck_state, "_relationship_snapshot", lambda *_args: _relationships()
+    )
+    monkeypatch.setattr(
+        lck_state,
+        "_git_snapshot",
+        lambda *_args, **_kwargs: _git_snapshot(fake),
+    )
+
+    state = _resolver(fake).resolve(159)
+
+    assert state.status is lck_models.ResolutionStatus.RESOLVED
+    assert state.checks["count"] == 1
+    assert state.checks["success"] == 1
+    view_commands = [
+        command for command in fake.commands if command[:3] == ("gh", "pr", "view")
+    ]
+    assert len(view_commands) == 1
+    fields = view_commands[0][view_commands[0].index("--json") + 1].split(",")
+    assert "statusCheckRollup" in fields
+
+
+def test_live_git_snapshot_separates_remote_main_from_tracking_cache() -> None:
+    class ReadOnlyGitRunner:
+        def __init__(self) -> None:
+            self.commands: list[tuple[str, ...]] = []
+
+        def run(
+            self,
+            argv: list[str] | tuple[str, ...],
+            *,
+            command_id: str,
+            **_: Any,
+        ) -> CommandResult:
+            command = tuple(str(item) for item in argv)
+            self.commands.append(command)
+            outputs = {
+                ("git", "branch", "--show-current"): "task/159-live",
+                ("git", "rev-parse", "HEAD"): SHA,
+                ("git", "rev-parse", "refs/heads/main"): SHA,
+                ("git", "rev-parse", "refs/remotes/origin/main"): "b" * 40,
+                (
+                    "git",
+                    "ls-remote",
+                    "origin",
+                    "refs/heads/main",
+                ): f"{SHA}\trefs/heads/main",
+                (
+                    "git",
+                    "status",
+                    "--short",
+                    "--untracked-files=all",
+                ): "",
+                ("git", "diff", "--cached", "--name-only"): "",
+                ("git", "diff", "--name-only"): "",
+                ("git", "worktree", "list", "--porcelain"): "worktree /repo\n",
+            }
+            if command == ("git", "fetch", "--prune", "origin"):
+                return CommandResult(command_id, command, 1, "", "fetch forbidden")
+            return CommandResult(
+                command_id,
+                command,
+                0 if command in outputs else 1,
+                outputs.get(command, ""),
+                "" if command in outputs else "unsupported",
+            )
+
+    runner = ReadOnlyGitRunner()
+    warnings: list[dict[str, Any]] = []
+    snapshot = workflow_git_snapshot(
+        cast(Any, runner), warnings, read_only_local_refs=True
+    )
+
+    assert snapshot["local_main_sha"] == SHA
+    assert snapshot["tracking_main_sha"] == "b" * 40
+    assert snapshot["remote_main_sha"] == SHA
+    assert snapshot["tracking_main_stale"] is True
+    assert not any(
+        command[1:4] == ("fetch", "--prune", "origin") for command in runner.commands
+    )
+
+
+def test_ambiguous_open_pr_stops_phase_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    branch = "task/159-lck-core-live-state-resolution"
+    fake = FakeRunner(branch=branch, local_branches={branch})
+    _install_facts(monkeypatch, fake)
+
+    def ambiguous(*_args: Any) -> dict[str, Any] | None:
+        raise PrResolveError("multiple OPEN PRs for the Task branch")
+
+    monkeypatch.setattr(lck_state, "resolve_open_pr", ambiguous)
+    state = _resolver(fake).resolve(159)
+    decision = lck_eligibility.PhaseEligibilityResolver().resolve(
+        state, lck_models.Phase.DELIVERY_PREPARE
+    )
+
+    assert state.status is lck_models.ResolutionStatus.STOP
+    assert not decision.eligible
+    assert any("multiple OPEN PRs" in reason for reason in decision.reasons)
+
+
+def test_multiple_merged_prs_stop_before_workspace_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = FakeRunner(branch="main")
+    _install_facts(
+        monkeypatch,
+        fake,
+        history=[
+            {"number": 200, "state": "MERGED"},
+            {"number": 201, "state": "MERGED"},
+        ],
+    )
+
+    with pytest.raises(lck_models.LckStopError, match="multiple merged PRs"):
+        lck_delivery.DeliveryPreparer(_resolver(fake)).prepare(159)
+
+    assert fake.branch == "main"
+    assert not any(command[:2] == ("git", "switch") for command in fake.commands)
+
+
+def test_open_pr_without_task_branch_stops_before_workspace_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    branch = "task/159-lck-core-live-state-resolution"
+    fake = FakeRunner(branch="main")
+    _install_facts(monkeypatch, fake, open_pr=_open_pr(branch))
+
+    with pytest.raises(
+        lck_models.LckStopError,
+        match="current OPEN PR has no local or remote Task branch",
+    ):
+        lck_delivery.DeliveryPreparer(_resolver(fake)).prepare(159)
+
+    assert fake.branch == "main"
+    assert not any(command[:2] == ("git", "switch") for command in fake.commands)
+
+
+def test_open_pr_head_mismatch_stops_before_workspace_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    branch = "task/159-lck-core-live-state-resolution"
+    fake = FakeRunner(
+        branch="main",
+        local_branches={branch},
+        remote_branches={branch: SHA},
+    )
+    open_pr = _open_pr(branch)
+    open_pr["headRefOid"] = "b" * 40
+    _install_facts(monkeypatch, fake, open_pr=open_pr)
+
+    with pytest.raises(
+        lck_models.LckStopError,
+        match="current OPEN PR head OID differs",
+    ):
+        lck_delivery.DeliveryPreparer(_resolver(fake)).prepare(159)
+
+    assert fake.branch == "main"
+    assert not any(command[:2] == ("git", "switch") for command in fake.commands)
+
+
+def test_optional_git_snapshot_warning_does_not_stop_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = FakeRunner(branch="main")
+    _install_facts(monkeypatch, fake)
+
+    def unavailable_git_snapshot(
+        _runner: Any,
+        warnings: list[dict[str, Any]],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        warnings.append(
+            {
+                "command_id": "git-status",
+                "exit_code": 1,
+                "error": "git status unavailable",
+            }
+        )
+        return _git_snapshot(fake)
+
+    monkeypatch.setattr(lck_state, "_git_snapshot", unavailable_git_snapshot)
+
+    state = _resolver(fake).resolve(159)
+
+    assert state.status is lck_models.ResolutionStatus.RESOLVED
+
+
+def test_legacy_origin_main_only_stops_before_workspace_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = FakeRunner(branch="main")
+    _install_facts(monkeypatch, fake)
+
+    def unavailable_remote_main(
+        _runner: Any,
+        _warnings: list[dict[str, Any]],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        value = _git_snapshot(fake)
+        value["origin_main_sha"] = "b" * 40
+        value["remote_main_query"] = "unknown"
+        value.pop("remote_main_sha", None)
+        return value
+
+    legacy_only = unavailable_remote_main(fake, [])
+    assert legacy_only["origin_main_sha"] == "b" * 40
+    assert "remote_main_sha" not in legacy_only
+    monkeypatch.setattr(lck_state, "_git_snapshot", unavailable_remote_main)
+
+    with pytest.raises(lck_models.LckStopError, match="remote main query failed"):
+        lck_delivery.DeliveryPreparer(_resolver(fake)).prepare(159)
+
+    assert fake.branch == "main"
+    assert not any(command[:2] == ("git", "switch") for command in fake.commands)
+
+
+def test_task_branch_inventory_warning_stops_before_workspace_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = FakeRunner(branch="main")
+    _install_facts(monkeypatch, fake)
+
+    def unavailable_task_branches(
+        _resolver: Any,
+        _task_number: int,
+        warnings: list[dict[str, Any]],
+    ) -> tuple[set[str], dict[str, str], bool]:
+        warnings.append(
+            {
+                "command_id": "lck-local-task-branches",
+                "exit_code": 1,
+                "error": "local branch inventory unavailable",
+            }
+        )
+        return set(), {}, True
+
+    monkeypatch.setattr(
+        lck_state.LiveStateResolver,
+        "_task_branches",
+        unavailable_task_branches,
+    )
+
+    with pytest.raises(lck_models.LckStopError, match="Task branch inventory"):
+        lck_delivery.DeliveryPreparer(_resolver(fake)).prepare(159)
+
+    assert fake.branch == "main"
+    assert not any(command[:2] == ("git", "switch") for command in fake.commands)
+
+
+@pytest.mark.parametrize(
+    ("operation", "expected"),
+    [
+        (
+            "Delivery Prepare",
+            {
+                "issue": (False, False, True),
+                "git": {
+                    "read_only_local_refs": True,
+                    "include_workspace_inventory": False,
+                },
+                "branches": (True, True),
+                "pr": (False, False, False),
+                "history": {
+                    "include_checks": False,
+                    "include_mergeability": False,
+                    "include_history_details": False,
+                },
+                "included": {
+                    "task_contract",
+                    "git",
+                    "pr_history",
+                },
+                "excluded": {
+                    "comments",
+                    "issue_closure",
+                    "workspace_inventory",
+                    "checks",
+                },
+            },
+        ),
+        (
+            "Delivery Complete",
+            {
+                "issue": (False, False, True),
+                "git": {
+                    "read_only_local_refs": True,
+                    "include_workspace_inventory": False,
+                },
+                "branches": (True, True),
+                "pr": (True, False, False),
+                "history": {
+                    "include_checks": False,
+                    "include_mergeability": False,
+                    "include_history_details": False,
+                },
+                "included": {"task_contract", "git", "checks", "pr_history"},
+                "excluded": {"comments", "issue_closure", "workspace_inventory"},
+            },
+        ),
+        (
+            "review-prepare",
+            {
+                "issue": (False, False, True),
+                "git": None,
+                "branches": (False, True),
+                "pr": (True, False, False),
+                "history": None,
+                "included": {
+                    "task_contract",
+                    "remote_task_branches",
+                    "open_pr",
+                    "checks",
+                },
+                "excluded": {
+                    "comments",
+                    "issue_closure",
+                    "git",
+                    "workspace_inventory",
+                    "local_task_branches",
+                    "pr_history",
+                },
+            },
+        ),
+        (
+            "Remediation Prepare",
+            {
+                "issue": (False, False, True),
+                "git": {
+                    "read_only_local_refs": True,
+                    "include_workspace_inventory": False,
+                },
+                "branches": (True, True),
+                "pr": (False, False, False),
+                "history": None,
+                "included": {
+                    "task_contract",
+                    "git",
+                    "local_task_branches",
+                    "remote_task_branches",
+                    "open_pr",
+                },
+                "excluded": {
+                    "comments",
+                    "issue_closure",
+                    "workspace_inventory",
+                    "checks",
+                    "pr_history",
+                },
+            },
+        ),
+        (
+            "Remediation No Change",
+            {
+                "issue": (False, False, True),
+                "git": {
+                    "read_only_local_refs": True,
+                    "include_workspace_inventory": False,
+                },
+                "branches": (True, True),
+                "pr": (False, False, False),
+                "history": None,
+                "included": {
+                    "git",
+                    "local_task_branches",
+                    "remote_task_branches",
+                    "open_pr",
+                },
+                "excluded": {
+                    "comments",
+                    "issue_closure",
+                    "workspace_inventory",
+                    "checks",
+                    "pr_history",
+                },
+            },
+        ),
+        (
+            "merge-preflight",
+            {
+                "issue": (False, False, True),
+                "git": None,
+                "branches": (False, True),
+                "pr": (True, True, False),
+                "history": None,
+                "included": {
+                    "task_contract",
+                    "remote_task_branches",
+                    "open_pr",
+                    "checks",
+                    "mergeability",
+                },
+                "excluded": {
+                    "comments",
+                    "issue_closure",
+                    "git",
+                    "workspace_inventory",
+                    "local_task_branches",
+                    "pr_history",
+                },
+            },
+        ),
+        (
+            "closeout",
+            {
+                "issue": (False, True, True),
+                "git": {
+                    "read_only_local_refs": True,
+                    "include_workspace_inventory": False,
+                },
+                "branches": (True, True),
+                "pr": (False, False, False),
+                "history": {
+                    "include_checks": False,
+                    "include_mergeability": False,
+                    "include_history_details": True,
+                },
+                "included": {
+                    "issue_closure",
+                    "git",
+                    "pr_history",
+                },
+                "excluded": {
+                    "comments",
+                    "workspace_inventory",
+                    "checks",
+                },
+            },
+        ),
+    ],
+)
+def test_authoritative_operation_resolver_queries_only_its_fact_profile(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    operation: str,
+    expected: dict[str, Any],
+) -> None:
+    branch = "task/159-lck-core-live-state-resolution"
+    issue = _issue()
+    contract = _task_contract(issue)
+    pr = _open_pr(branch)
+    pr["statusCheckRollup"] = [{"name": "quality", "conclusion": "SUCCESS"}]
+    observations: dict[str, list[Any]] = {
+        "issue": [],
+        "relationships": [],
+        "git": [],
+        "branches": [],
+        "pr": [],
+        "history": [],
+    }
+
+    monkeypatch.setattr(lck_state, "_repository_slug", lambda *_args: "owner/repo")
+
+    def issue_query(*args: Any) -> tuple[dict[str, Any], dict[str, Any]]:
+        observations["issue"].append(tuple(args[-3:]))
+        return issue, contract
+
+    def relationship_query(*_args: Any) -> dict[str, Any]:
+        observations["relationships"].append(True)
+        return _relationships()
+
+    def git_query(*_args: Any, **kwargs: Any) -> dict[str, Any]:
+        if expected["git"] is None:
+            pytest.fail(f"{operation} queried source workspace Git facts")
+        if operation in {"Delivery Prepare", "closeout"} and (
+            kwargs.get("include_workspace_inventory") is not False
+        ):
+            pytest.fail(
+                f"{operation} queried forbidden staged/changed/worktree inventory"
+            )
+        observations["git"].append(kwargs)
+        return _git_snapshot(FakeRunner(branch=branch))
+
+    def task_branches(
+        _self: Any,
+        _task: int,
+        _warnings: list[dict[str, Any]],
+        *,
+        include_local: bool = True,
+        include_remote: bool = True,
+    ) -> tuple[set[str], dict[str, str], bool]:
+        observations["branches"].append((include_local, include_remote))
+        return set(), {branch: SHA} if include_remote else {}, True
+
+    def open_pr_query(*args: Any) -> dict[str, Any]:
+        observations["pr"].append(tuple(args[-3:]))
+        return pr
+
+    def history_query(*_args: Any, **kwargs: Any) -> list[dict[str, Any]]:
+        if expected["history"] is None:
+            pytest.fail(f"{operation} queried PR history")
+        observations["history"].append(kwargs)
+        return []
+
+    monkeypatch.setattr(lck_state, "_issue_view_with_contract", issue_query)
+    monkeypatch.setattr(lck_state, "_relationship_snapshot", relationship_query)
+    monkeypatch.setattr(lck_state, "_git_snapshot", git_query)
+    monkeypatch.setattr(lck_state.LiveStateResolver, "_task_branches", task_branches)
+    monkeypatch.setattr(lck_state, "resolve_open_pr", open_pr_query)
+    monkeypatch.setattr(lck_state, "list_matching_prs", history_query)
+
+    snapshot = lck_state.OperationSnapshotBuilder(
+        lck_state.LiveStateResolver(tmp_path, runner=cast(Any, FakeRunner()))
+    ).acquire(159, operation=operation)
+
+    assert snapshot.state.status is lck_models.ResolutionStatus.RESOLVED
+    assert observations["issue"] == [expected["issue"]]
+    assert observations["relationships"] == [True]
+    assert observations["git"] == ([] if expected["git"] is None else [expected["git"]])
+    assert observations["branches"] == [expected["branches"]]
+    assert observations["pr"] == [expected["pr"]]
+    assert observations["history"] == (
+        [] if expected["history"] is None else [expected["history"]]
+    )
+    facts = set(snapshot.acquired_facts)
+    assert expected["included"] <= facts
+    assert expected["excluded"].isdisjoint(facts)
+
+
+@pytest.mark.parametrize(
+    ("operation", "included", "excluded"),
+    [
+        (
+            "Delivery Prepare",
+            {"task_contract", "git", "pr_history"},
+            {"comments", "issue_closure", "workspace_inventory", "checks"},
+        ),
+        (
+            "Delivery Complete",
+            {"task_contract", "git", "checks", "pr_history"},
+            {"comments", "issue_closure", "workspace_inventory"},
+        ),
+        (
+            "review-prepare",
+            {"task_contract", "remote_task_branches", "open_pr", "checks"},
+            {"comments", "issue_closure", "git", "pr_history"},
+        ),
+        (
+            "review-complete",
+            {"task_contract", "remote_task_branches", "open_pr", "checks"},
+            {"comments", "issue_closure", "git", "pr_history"},
+        ),
+        (
+            "Remediation Prepare",
+            {"task_contract", "git", "local_task_branches", "open_pr"},
+            {"comments", "issue_closure", "checks", "pr_history"},
+        ),
+        (
+            "Remediation No Change",
+            {"git", "local_task_branches", "open_pr"},
+            {"comments", "issue_closure", "checks", "pr_history"},
+        ),
+        (
+            "Remediation Complete",
+            {"task_contract", "git", "local_task_branches", "checks"},
+            {"comments", "issue_closure", "workspace_inventory", "pr_history"},
+        ),
+        (
+            "merge-preflight",
+            {"task_contract", "remote_task_branches", "checks", "mergeability"},
+            {"comments", "issue_closure", "git", "pr_history"},
+        ),
+        (
+            "closeout",
+            {"issue_closure", "git", "pr_history"},
+            {"comments", "workspace_inventory", "checks"},
+        ),
+    ],
+)
+def test_authoritative_operations_bind_stable_fact_profiles(
+    operation: str,
+    included: set[str],
+    excluded: set[str],
+) -> None:
+    facts = set(lck_models.fact_profile_for_operation(operation).facts())
+
+    assert included <= facts
+    assert excluded.isdisjoint(facts)
+
+
+def test_delivery_history_query_requests_only_merged_detection_fields() -> None:
+    fake = FakeRunner()
+
+    assert (
+        list_matching_prs(
+            cast(Any, fake),
+            "owner/repo",
+            "task/159-lck-core-live-state-resolution",
+            "main",
+            [],
+            include_checks=False,
+            include_mergeability=False,
+            include_history_details=False,
+        )
+        == []
+    )
+
+    command = fake.commands[-1]
+    assert command[command.index("--json") + 1] == "number,state"
+
+
+def test_live_state_uses_neutral_storage_with_legacy_projections() -> None:
+    state = _review_state()
+    payload = state.to_dict()
+
+    assert state.issue_number == state.task_number == 159
+    assert state.local_issue_branch == state.local_task_branch
+    assert state.local_issue_head == state.local_task_head
+    assert state.remote_issue_branch == state.remote_task_branch
+    assert state.remote_issue_oid == state.remote_task_oid
+    assert state.leaf_contract == state.task_contract
+    assert "task_number" not in state.__dict__
+    assert "task_contract" not in state.__dict__
+    assert payload["issue_number"] == payload["task_number"] == 159
+    assert payload["leaf_contract"]["body"] == "Task Contract"
+    assert payload["task_contract"]["body_sha256"] == "d" * 64
+
+    restored = lck_models.LiveState.from_dict(payload)
+    assert restored == state
+    snapshot = lck_models.OperationSnapshot(operation="test", state=state)
+    restored_snapshot = lck_models.OperationSnapshot.from_dict(snapshot.to_dict())
+    assert restored_snapshot.issue_number == restored_snapshot.task_number == 159
+    assert restored_snapshot.leaf_contract == state.leaf_contract
+
+
+def test_live_state_compatibility_conflicts_fail_closed() -> None:
+    with pytest.raises(ValueError, match="issue_number/task_number"):
+        lck_models.LiveState(issue_number=1, task_number=2)
+
+    payload = _review_state().to_dict()
+    payload["remote_task_oid"] = "b" * 40
+    with pytest.raises(ValueError, match="remote_issue_oid/remote_task_oid"):
+        lck_models.LiveState.from_dict(payload)
+
+    payload = _review_state().to_dict()
+    legacy_contract = dict(cast(dict[str, Any], payload["task_contract"]))
+    legacy_contract["body_sha256"] = "f" * 64
+    payload["task_contract"] = legacy_contract
+    with pytest.raises(ValueError, match="leaf_contract/task_contract"):
+        lck_models.LiveState.from_dict(payload)

--- a/tests/tools/lck/test_structure.py
+++ b/tests/tools/lck/test_structure.py
@@ -1,0 +1,54 @@
+"""Structural guardrails for the isolated LCK package."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+CORE = ROOT / "tools" / "lck"
+
+
+def _symbols(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    return {
+        node.name
+        for node in tree.body
+        if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+
+
+def test_lck_decomposition_preserves_responsibility_boundaries() -> None:
+    owners = {
+        "state.py": {"LiveStateResolver", "OperationSnapshotBuilder"},
+        "eligibility.py": {"PhaseEligibilityResolver", "evaluate_shared_blockers"},
+        "validation_gates.py": {"FormalValidationGate", "DeliveryChecksGate"},
+        "effects.py": {"CommitCurrentTreeEffect", "EnsureRemoteBranchEffect"},
+        "delivery.py": {"DeliveryPreparer", "DeliveryCompleter"},
+        "review_workspace.py": {"ReviewWorkspaceManager", "ReviewInvocationStore"},
+        "review.py": {"ReviewPreparer", "ReviewCompleter", "MergePreflight"},
+        "remediation.py": {"RemediationPreparer", "RemediationCompleter"},
+        "closeout.py": {"CloseoutCompleter"},
+        "receipts.py": {"AuditReceiptStore"},
+    }
+    for filename, expected in owners.items():
+        assert expected <= _symbols(CORE / filename)
+
+
+def test_package_entrypoint_is_thin_and_stable() -> None:
+    entrypoint = (CORE / "__main__.py").read_text(encoding="utf-8")
+    assert "from .cli import main" in entrypoint
+    assert len(entrypoint.splitlines()) < 20
+    assert not (ROOT / "tools" / "agent_workflow").exists()
+
+
+def test_shared_modules_do_not_import_phase_orchestration() -> None:
+    forbidden = {"delivery", "review", "remediation", "closeout", "receipts"}
+    for filename in ("models.py", "state.py", "eligibility.py", "validation_gates.py"):
+        tree = ast.parse((CORE / filename).read_text(encoding="utf-8"))
+        imported = {
+            node.module.rsplit(".", 1)[-1]
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ImportFrom) and node.module
+        }
+        assert imported.isdisjoint(forbidden), (filename, imported & forbidden)

--- a/tests/tools/lck/test_typed_dependency_contracts.py
+++ b/tests/tools/lck/test_typed_dependency_contracts.py
@@ -1,0 +1,493 @@
+# ruff: noqa: E402, I001
+
+"""Regression coverage for complete typed dependency contracts."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+ROOT = Path(__file__).parents[3]
+AGENT_WORKFLOW = str(ROOT / "tools" / "agent_workflow")
+if AGENT_WORKFLOW not in sys.path:
+    sys.path.insert(0, AGENT_WORKFLOW)
+
+from tools.lck import eligibility, models, shared_facts  # type: ignore[import-not-found]  # noqa: E402
+from tools.lck.issue_profiles import resolve_leaf_issue_profile  # type: ignore[import-not-found]  # noqa: E402
+from tools.lck.profile_policies import validate_profile_contract  # type: ignore[import-not-found]  # noqa: E402
+from tools.lck.research_policy import (
+    decision_contract_snapshot,
+    research_contract_snapshot,
+)  # type: ignore[import-not-found]  # noqa: E402
+from tools.lck.common import CommandResult, bounded_list, sha256_json  # type: ignore[import-not-found]  # noqa: E402
+from tools.lck.feature_audit import (  # type: ignore[import-not-found]  # noqa: E402
+    _formal_blockers_gate as audit_formal_blockers_gate,
+    _relationship_snapshot as audit_relationship_snapshot,
+)
+
+
+BUG_BODY = (
+    """### Observed
+
+The long Bug contract remains readable.
+
+### Expected
+
+LCK should evaluate the complete Bug contract.
+
+### Reproduction / Evidence
+
+"""
+    + ("Evidence prefix. " * 45)
+    + """
+
+### Acceptance Criteria
+
+- The complete Bug contract is accepted.
+"""
+)
+
+DOCUMENTATION_BODY = (
+    """### Documentation Goal
+
+The long Documentation contract remains readable.
+
+### Requirements
+
+"""
+    + ("Document the supported behavior. " * 45)
+    + """
+
+### Acceptance Criteria
+
+- The complete Documentation contract is accepted.
+"""
+)
+
+RESEARCH_BODY = (
+    """### Question / Decision Needed
+
+Should the supported path be adopted?
+
+### Context
+
+The long Research contract remains readable.
+
+### Scope
+
+- Repository-backed workflow behavior.
+
+### Non-goals
+
+- No unrelated runtime changes.
+
+### Evidence / Evaluation Criteria
+
+"""
+    + ("Evaluate the repository-backed evidence. " * 45)
+    + """
+
+### Expected Outcome / Artifact
+
+Adopt the repository-backed workflow contract.
+"""
+)
+
+DEPENDENCY_PROJECT = {
+    "nodes": [
+        {
+            "project": {
+                "number": 1,
+                "title": "Quant System Development",
+                "owner": {"login": "owner"},
+            },
+            "content": {
+                "number": 191,
+                "repository": {"nameWithOwner": "owner/repo"},
+            },
+            "fieldValues": {
+                "nodes": [
+                    {
+                        "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                        "name": "ARCHITECTURE DECISION",
+                        "field": {"name": "Research Outcome"},
+                    }
+                ],
+                "pageInfo": {"hasNextPage": False},
+            },
+        }
+    ],
+    "pageInfo": {"hasNextPage": False},
+}
+
+
+def _raw_dependency(
+    *,
+    number: int,
+    label: str,
+    body: str,
+    project_items: Any = None,
+) -> dict[str, Any]:
+    return {
+        "number": number,
+        "title": f"[{label}] long dependency",
+        "state": "CLOSED",
+        "body": body,
+        "labels": {
+            "nodes": [{"name": label}],
+            "pageInfo": {"hasNextPage": False},
+        },
+        "projectItems": project_items
+        or {"nodes": [], "pageInfo": {"hasNextPage": False}},
+    }
+
+
+def _bounded_dependency(raw: dict[str, Any]) -> dict[str, Any]:
+    normalized = shared_facts._normalize_relationship_item(raw)
+    assert normalized is not None
+    value = bounded_list([normalized])
+    return cast(dict[str, Any], value["items"][0])
+
+
+def _relationship_payload(dependency: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "data": {
+            "repository": {
+                "issue": {
+                    "number": 300,
+                    "title": "Task with typed dependency",
+                    "state": "OPEN",
+                    "blockedBy": {
+                        "nodes": [dependency],
+                        "pageInfo": {"hasNextPage": False},
+                    },
+                    "blocking": {
+                        "nodes": [],
+                        "pageInfo": {"hasNextPage": False},
+                    },
+                    "subIssues": {
+                        "nodes": [],
+                        "pageInfo": {"hasNextPage": False},
+                    },
+                    "issueType": {"name": "Task"},
+                    "parent": None,
+                }
+            }
+        }
+    }
+
+
+class _GraphQLRunner:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.payload = payload
+
+    def run(self, argv: Any, *, command_id: str, **_: Any) -> CommandResult:
+        return CommandResult(
+            command_id,
+            tuple(str(item) for item in argv),
+            0,
+            json.dumps(self.payload),
+            "",
+        )
+
+
+@pytest.mark.parametrize(
+    ("label", "body", "contract_key"),
+    [
+        ("type:bug", BUG_BODY, "bug_contract"),
+        ("type:documentation", DOCUMENTATION_BODY, "documentation_contract"),
+        ("type:research", RESEARCH_BODY, "research_contract"),
+    ],
+)
+def test_lck_policy_uses_complete_dependency_contract(
+    label: str,
+    body: str,
+    contract_key: str,
+) -> None:
+    dependency = _bounded_dependency(
+        _raw_dependency(
+            number=191,
+            label=label,
+            body=body,
+            project_items=DEPENDENCY_PROJECT if label == "type:research" else None,
+        )
+    )
+    assert len(dependency["body"]) < len(body)
+    assert dependency["contract"]["body"] == body
+    assert dependency["contract"]["body_characters"] == len(body)
+
+    resolution = resolve_leaf_issue_profile({"labels": [label]})
+    assert resolution.resolved and resolution.profile is not None
+    check = validate_profile_contract(resolution.profile, dependency)
+    assert check.valid, check.detail
+    assert check.evidence is not None
+    assert check.evidence.payload["contract"]["status"] == "pass"
+    assert check.evidence.payload["contract"]["required_sections"]
+
+
+def test_lck_eligibility_accepts_long_research_architecture_dependency() -> None:
+    dependency = _bounded_dependency(
+        _raw_dependency(
+            number=191,
+            label="type:research",
+            body=RESEARCH_BODY,
+            project_items=DEPENDENCY_PROJECT,
+        )
+    )
+    downstream_body = (
+        "### Decision Contract\n\nAdopt the repository-backed workflow contract.\n"
+    )
+    target = {
+        "number": 239,
+        "title": "[Task] downstream",
+        "state": "OPEN",
+        "labels": ["type:task", "codex:ready"],
+    }
+    state = models.LiveState(
+        issue_number=239,
+        repository="owner/repo",
+        issue=target,
+        leaf_contract={
+            "number": 239,
+            "body": downstream_body,
+            "body_sha256": sha256_json({"body": downstream_body}),
+        },
+        relationships={
+            "available": True,
+            "blocked_by": {
+                "items": [dependency],
+                "count": 1,
+                "truncated": False,
+            },
+        },
+    )
+
+    reasons = eligibility.PhaseEligibilityResolver().blocker_reasons(
+        state, phase=models.Phase.REVIEW_PREPARE
+    )
+    assert reasons == ()
+
+
+def _research_dependency(outcome: str) -> dict[str, Any]:
+    dependency = _bounded_dependency(
+        _raw_dependency(number=191, label="type:research", body=RESEARCH_BODY)
+    )
+    dependency["research_outcome"] = outcome
+    dependency["decision_contract"] = decision_contract_snapshot(
+        RESEARCH_BODY, research=True
+    )
+    return dependency
+
+
+def _downstream_contract(label: str, *, matching_decision: bool) -> dict[str, Any]:
+    bodies = {
+        "type:task": "### Objective\n\nImplement the researched behavior.\n",
+        "type:bug": BUG_BODY,
+        "type:documentation": DOCUMENTATION_BODY,
+        "type:research": RESEARCH_BODY,
+    }
+    body = bodies[label]
+    if matching_decision:
+        body += (
+            "\n\n### Decision Contract\n\n"
+            "Adopt the repository-backed workflow contract.\n"
+        )
+    return {
+        "number": 300,
+        "body": body,
+        "body_sha256": sha256_json({"body": body}),
+    }
+
+
+@pytest.mark.parametrize(
+    ("downstream_label", "outcome", "matching_decision", "expected_code"),
+    [
+        ("type:research", "IMPLEMENT", False, None),
+        ("type:research", "DO NOT IMPLEMENT", False, None),
+        ("type:research", "NEEDS MORE EVIDENCE", False, None),
+        ("type:research", "ARCHITECTURE DECISION", False, None),
+        ("type:documentation", "IMPLEMENT", False, None),
+        ("type:documentation", "DO NOT IMPLEMENT", False, None),
+        ("type:documentation", "NEEDS MORE EVIDENCE", False, None),
+        ("type:documentation", "ARCHITECTURE DECISION", False, None),
+        ("type:task", "IMPLEMENT", False, None),
+        ("type:task", "DO NOT IMPLEMENT", False, "RESEARCH_OUTCOME_NOT_IMPLEMENTATION"),
+        (
+            "type:task",
+            "NEEDS MORE EVIDENCE",
+            False,
+            "RESEARCH_OUTCOME_NOT_IMPLEMENTATION",
+        ),
+        (
+            "type:task",
+            "ARCHITECTURE DECISION",
+            False,
+            "ARCHITECTURE_DECISION_UNMATCHED",
+        ),
+        ("type:task", "ARCHITECTURE DECISION", True, None),
+        ("type:bug", "IMPLEMENT", False, None),
+        ("type:bug", "DO NOT IMPLEMENT", False, "RESEARCH_OUTCOME_NOT_IMPLEMENTATION"),
+        (
+            "type:bug",
+            "NEEDS MORE EVIDENCE",
+            False,
+            "RESEARCH_OUTCOME_NOT_IMPLEMENTATION",
+        ),
+        ("type:bug", "ARCHITECTURE DECISION", False, "ARCHITECTURE_DECISION_UNMATCHED"),
+        ("type:bug", "ARCHITECTURE DECISION", True, None),
+    ],
+)
+def test_research_dependency_semantics_follow_downstream_profile(
+    downstream_label: str,
+    outcome: str,
+    matching_decision: bool,
+    expected_code: str | None,
+) -> None:
+    dependency = _research_dependency(outcome)
+    downstream = _downstream_contract(
+        downstream_label, matching_decision=matching_decision
+    )
+    issue = {
+        "number": 300,
+        "title": "Downstream leaf Issue",
+        "state": "OPEN",
+        "labels": [downstream_label],
+    }
+    resolution = resolve_leaf_issue_profile(issue)
+    assert resolution.resolved and resolution.profile is not None
+    relationships = {
+        "available": True,
+        "blocked_by": {"items": [dependency], "count": 1, "truncated": False},
+    }
+    state = models.LiveState(
+        issue_number=300,
+        repository="owner/repo",
+        issue=issue,
+        leaf_contract=downstream,
+        relationships=relationships,
+    )
+
+    reasons = eligibility.PhaseEligibilityResolver().blocker_reasons(
+        state, phase=models.Phase.REVIEW_PREPARE
+    )
+    audit_dependency = {
+        key: value for key, value in dependency.items() if key != "contract"
+    }
+    audit_dependency["research_contract"] = research_contract_snapshot(RESEARCH_BODY)
+    audit_result = audit_formal_blockers_gate(
+        {
+            **relationships,
+            "blocked_by": {
+                "items": [audit_dependency],
+                "count": 1,
+                "truncated": False,
+            },
+        },
+        downstream_contract=downstream,
+        downstream_profile=resolution.profile,
+    )
+
+    if expected_code is None:
+        assert reasons == ()
+        assert audit_result["status"] == "pass"
+    else:
+        assert any(f"[{expected_code}]" in reason for reason in reasons)
+        assert audit_result["status"] != "pass"
+
+
+def test_research_dependency_fails_closed_without_downstream_profile() -> None:
+    dependency = _research_dependency("IMPLEMENT")
+    state = models.LiveState(
+        issue_number=300,
+        repository="owner/repo",
+        issue={"number": 300, "state": "OPEN", "labels": ["type:unknown"]},
+        leaf_contract={"number": 300, "body": "Unknown profile"},
+        relationships={
+            "available": True,
+            "blocked_by": {"items": [dependency], "count": 1, "truncated": False},
+        },
+    )
+
+    reasons = eligibility.PhaseEligibilityResolver().blocker_reasons(
+        state, phase=models.Phase.REVIEW_PREPARE
+    )
+    assert any("[DOWNSTREAM_PROFILE_UNKNOWN]" in reason for reason in reasons)
+
+    audit_dependency = {
+        key: value for key, value in dependency.items() if key != "contract"
+    }
+    audit_dependency["research_contract"] = research_contract_snapshot(RESEARCH_BODY)
+    audit_result = audit_formal_blockers_gate(
+        {
+            "available": True,
+            "blocked_by": {
+                "items": [audit_dependency],
+                "count": 1,
+                "truncated": False,
+            },
+        }
+    )
+    assert audit_result["status"] == "unknown"
+    assert "downstream Issue profile is unavailable" in audit_result["detail"]
+
+
+@pytest.mark.parametrize(
+    ("label", "body", "contract_key"),
+    [
+        ("type:bug", BUG_BODY, "bug_contract"),
+        ("type:documentation", DOCUMENTATION_BODY, "documentation_contract"),
+        ("type:research", RESEARCH_BODY, "research_contract"),
+    ],
+)
+def test_feature_audit_parses_complete_typed_dependency_contract(
+    label: str,
+    body: str,
+    contract_key: str,
+) -> None:
+    raw = _raw_dependency(
+        number=191,
+        label=label,
+        body=body,
+        project_items=DEPENDENCY_PROJECT if label == "type:research" else None,
+    )
+    relationships = audit_relationship_snapshot(
+        _GraphQLRunner(_relationship_payload(raw)), "owner/repo", 300, []
+    )
+    dependency = relationships["blocked_by"]["items"][0]
+    assert len(dependency["body"]) < len(body)
+    assert dependency[contract_key]["status"] == "pass"
+    if label == "type:research":
+        assert dependency["research_outcome"] == "ARCHITECTURE DECISION"
+        assert dependency["research_outcome_is_canonical"] is True
+        assert dependency["decision_contract"]["status"] == "pass"
+    assert "contract" not in dependency
+
+
+def test_relationship_contract_fails_closed_on_truncation_and_identity_mismatch() -> (
+    None
+):
+    dependency = _bounded_dependency(
+        _raw_dependency(number=201, label="type:bug", body=BUG_BODY)
+    )
+    assert shared_facts.relationship_contract(dependency) is not None
+
+    invalid_body = dict(dependency["contract"])
+    invalid_body["body"] = BUG_BODY[:512]
+    dependency["contract"] = invalid_body
+    assert shared_facts.relationship_contract(dependency) is None
+    profile = resolve_leaf_issue_profile({"labels": ["type:bug"]}).profile
+    assert profile is not None
+    assert not validate_profile_contract(profile, dependency).valid
+
+    dependency = _bounded_dependency(
+        _raw_dependency(number=201, label="type:bug", body=BUG_BODY)
+    )
+    invalid_identity = dict(dependency["contract"])
+    invalid_identity["number"] = 999
+    dependency["contract"] = invalid_identity
+    assert shared_facts.relationship_contract(dependency) is None
+    assert not validate_profile_contract(profile, dependency).valid

--- a/tests/tools/lck/test_validation_runner.py
+++ b/tests/tools/lck/test_validation_runner.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).parents[3] / "tools" / "lck" / "validation_runner.py"
+PYTHON = os.environ.get("WORKFLOW_TEST_PYTHON", sys.executable)
+
+
+def _write_fake_tools(tmp_path: Path, *, fail: str | None = None) -> Path:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+
+    def add_windows_launcher(name: str) -> None:
+        if os.name != "nt":
+            return
+        launcher = bin_dir / f"{name}.cmd"
+        launcher.write_text(
+            f'@echo off\r\n"{PYTHON}" "{bin_dir / name}" %*\r\n',
+            encoding="utf-8",
+        )
+
+    uv = bin_dir / "uv"
+    uv.write_text(
+        f"""#!{PYTHON}
+import os, sys
+args=sys.argv[1:]
+key='-'.join(args)
+if os.environ.get('FAKE_PATH_OUTPUT'):
+    print(r'C:/Users/Maple/secret/file.txt /home/maple/private/file.txt')
+fail=os.environ.get('FAKE_VALIDATION_FAIL')
+if fail and fail in key:
+    print('very long failure marker ' + 'x'*5000)
+    sys.exit(1)
+if args[:2] == ['lock','--check']:
+    print('Resolved 3 packages')
+elif 'pytest' in args:
+    print('================ 12 passed in 0.10s ================')
+elif args[-3:] == ['ruff','check','.'] or ('ruff' in args and 'check' in args):
+    print('All checks passed!')
+elif 'format' in args:
+    print('8 files already formatted')
+elif 'mypy' in args:
+    print('Success: no issues found in 12 source files')
+else:
+    print('ok')
+""",
+        encoding="utf-8",
+    )
+    git = bin_dir / "git"
+    git.write_text(
+        f"""#!{PYTHON}
+import os, sys
+args=sys.argv[1:]
+if args[:2] == ['diff','--name-only']:
+    print(os.environ.get('FAKE_CHANGED_FILE', 'src/example.py'))
+elif args[:2] == ['diff','--check']:
+    sys.exit(0)
+else:
+    sys.exit(0)
+""",
+        encoding="utf-8",
+    )
+    uv.chmod(0o755)
+    git.chmod(0o755)
+    add_windows_launcher("uv")
+    add_windows_launcher("git")
+    return bin_dir
+
+
+def _write_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    (repo / "tests").mkdir(parents=True)
+    (repo / "src").mkdir()
+    (repo / ".agents" / "skills" / "task-delivery-runner").mkdir(parents=True)
+    (repo / ".gitignore").write_text(
+        ".agents/validation.local/\n.agents/evidence.local/\n",
+        encoding="utf-8",
+    )
+    (repo / "uv.lock").write_text("lock", encoding="utf-8")
+    (repo / "pyproject.toml").write_text(
+        "[tool.ruff]\ntarget-version='py311'\n[tool.mypy]\nstrict=true\n",
+        encoding="utf-8",
+    )
+    return repo
+
+
+def _run(
+    repo: Path, env: dict[str, str], *args: str
+) -> subprocess.CompletedProcess[str]:
+    env = env.copy()
+    env["PYTHONUTF8"] = "1"
+    env["PYTHONIOENCODING"] = "utf-8"
+    return subprocess.run(
+        [PYTHON, str(SCRIPT), "run", "--repo-root", str(repo), *args],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+    )
+
+
+def test_help() -> None:
+    result = subprocess.run(
+        [PYTHON, str(SCRIPT), "--help"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+    )
+    assert result.returncode == 0
+
+
+def test_success_output_is_compact_and_logs_are_ignored(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    bin_dir = _write_fake_tools(tmp_path)
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+    result = _run(repo, env, "--phase", "delivery")
+    assert result.returncode == 0, result.stderr
+    value = json.loads(result.stdout)
+    assert value["status"] == "pass"
+    assert value["command_count"] == 6
+    assert value["failed"] == 0
+    assert len(result.stdout) < 10000
+    assert "12 passed" in json.dumps(value)
+    for command in value["commands"]:
+        log = repo / command["log_path"]
+        assert log.is_file()
+        assert command["log_path"].startswith(".agents/validation.local/")
+
+
+def test_progress_is_bounded_stderr_and_does_not_change_final_result(
+    tmp_path: Path,
+) -> None:
+    repo = _write_repo(tmp_path)
+    bin_dir = _write_fake_tools(tmp_path)
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+
+    result = _run(repo, env, "--phase", "delivery")
+
+    assert result.returncode == 0, result.stderr
+    final_result = json.loads(result.stdout)
+    progress = [json.loads(line) for line in result.stderr.splitlines() if line.strip()]
+    assert final_result["status"] == "pass"
+    assert progress[0] == {
+        "authority": "non-authoritative observability only",
+        "event": "started",
+        "kind": "workflow-progress",
+        "operation": "workflow-validation",
+        "schema_version": 1,
+        "stage": "validation",
+    }
+    assert progress[-1]["event"] == "completed"
+    assert progress[-1]["stage"] == "validation"
+    assert all(len(line.encode("utf-8")) < 512 for line in result.stderr.splitlines())
+    assert all(
+        "commands" not in line
+        and "output_dir" not in line
+        and "Task Contract" not in line
+        for line in result.stderr.splitlines()
+    )
+
+
+def test_failure_has_bounded_diagnostic_and_nonzero_exit(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    bin_dir = _write_fake_tools(tmp_path)
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+    env["FAKE_VALIDATION_FAIL"] = "pytest"
+    result = _run(repo, env, "--phase", "review")
+    assert result.returncode == 1, result.stderr
+    value = json.loads(result.stdout)
+    assert value["status"] == "fail"
+    failed = [item for item in value["commands"] if item["status"] == "fail"]
+    assert len(failed) == 1
+    assert len(failed[0]["diagnostic"]) <= 2015
+    assert "<truncated>" in failed[0]["diagnostic"]
+
+
+def test_required_skill_validator_fails_closed_when_missing(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    bin_dir = _write_fake_tools(tmp_path)
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+    env["CODEX_SKILL_VALIDATOR"] = str(tmp_path / "missing_quick_validate.py")
+    result = _run(
+        repo,
+        env,
+        "--phase",
+        "feature-audit",
+        "--include-skill-validators",
+        "--require-skill-validator",
+    )
+    assert result.returncode == 2
+    assert "required but unavailable" in result.stderr
+
+
+def test_base_sha_detects_governance_change_and_runs_skill_validator(
+    tmp_path: Path,
+) -> None:
+    repo = _write_repo(tmp_path)
+    bin_dir = _write_fake_tools(tmp_path)
+    validator = tmp_path / "quick_validate.py"
+    validator.write_text("import sys\nprint('valid', sys.argv[1])\n", encoding="utf-8")
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+    env["FAKE_CHANGED_FILE"] = ".agents/skills/task-delivery-runner/SKILL.md"
+    result = _run(
+        repo,
+        env,
+        "--phase",
+        "review",
+        "--base-sha",
+        "a" * 40,
+        "--skill-validator",
+        str(validator),
+    )
+    assert result.returncode == 0, result.stderr
+    value = json.loads(result.stdout)
+    assert value["base_sha"] == "a" * 40
+    assert any(
+        item["command_id"] == "skill-task-delivery-runner" for item in value["commands"]
+    )
+
+
+def test_invalid_base_sha_fails_closed(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    bin_dir = _write_fake_tools(tmp_path)
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+    result = _run(repo, env, "--phase", "review", "--base-sha", "not-a-sha")
+    assert result.returncode == 2
+    assert "full commit SHA" in result.stderr
+
+
+def test_machine_absolute_paths_are_redacted_from_summary_and_log(
+    tmp_path: Path,
+) -> None:
+    repo = _write_repo(tmp_path)
+    bin_dir = _write_fake_tools(tmp_path)
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+    env["FAKE_PATH_OUTPUT"] = "1"
+    result = _run(repo, env, "--phase", "delivery")
+    assert result.returncode == 0, result.stderr
+    assert "C:/Users" not in result.stdout
+    assert "/home/maple" not in result.stdout
+    value = json.loads(result.stdout)
+    logs = [
+        (repo / command["log_path"]).read_text(encoding="utf-8")
+        for command in value["commands"]
+    ]
+    assert all("C:/Users" not in log and "/home/maple" not in log for log in logs)
+    assert any("<absolute-path-redacted>" in log for log in logs)

--- a/tests/tools/lck/test_workflow_common.py
+++ b/tests/tools/lck/test_workflow_common.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from tools.lck import common as workflow_common
+from tools.lck.common import (
+    CommandRunner,
+    build_workflow_env,
+    command_warning,
+)
+
+ROOT = Path(__file__).parents[3]
+
+
+def test_project_uv_config_redirects_canonical_launcher_cache() -> None:
+    uv = shutil.which("uv")
+    if uv is None:
+        pytest.skip("uv is not installed")
+
+    env = os.environ.copy()
+    env.pop("UV_CACHE_DIR", None)
+    result = subprocess.run(
+        [uv, "cache", "dir"],
+        cwd=ROOT,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (
+        Path(result.stdout.strip()).resolve()
+        == (ROOT / ".workflow.local" / "uv-cache").resolve()
+    )
+
+
+def test_build_workflow_env_defaults_to_repo_local_uv_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("UV_CACHE_DIR", raising=False)
+
+    env = build_workflow_env(tmp_path)
+
+    assert env["UV_CACHE_DIR"] == str(tmp_path / ".workflow.local" / "uv-cache")
+
+
+def test_build_workflow_env_preserves_explicit_uv_cache_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    custom_cache = "/some/custom/cache"
+    monkeypatch.setenv("UV_CACHE_DIR", custom_cache)
+
+    env = build_workflow_env(tmp_path)
+
+    assert env["UV_CACHE_DIR"] == custom_cache
+
+
+def test_command_runner_passes_repo_local_uv_cache_to_subprocess(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    marker = tmp_path / "uv-cache-env.txt"
+    uv = tmp_path / "uv"
+    uv.write_text(
+        f"#!{sys.executable}\n"
+        "import os\n"
+        "from pathlib import Path\n"
+        f"Path({str(marker)!r}).write_text(os.environ['UV_CACHE_DIR'], encoding='utf-8')\n",
+        encoding="utf-8",
+    )
+    uv.chmod(0o755)
+    monkeypatch.delenv("UV_CACHE_DIR", raising=False)
+    monkeypatch.setenv("PATH", f"{tmp_path}{os.pathsep}{os.environ['PATH']}")
+
+    result = CommandRunner(tmp_path).run(
+        ["uv", "run", "--frozen", "pytest"],
+        command_id="test-uv-cache-env",
+        validation=True,
+    )
+
+    assert result.returncode == 0
+    assert marker.read_text(encoding="utf-8") == str(
+        tmp_path / ".workflow.local" / "uv-cache"
+    )
+
+
+def test_command_runner_times_out_and_reports_bounded_diagnostic(
+    tmp_path: Path,
+) -> None:
+    result = CommandRunner(tmp_path).run(
+        [sys.executable, "-c", "import time; time.sleep(60)"],
+        command_id="test-timeout",
+        timeout_seconds=0.2,
+    )
+
+    assert result.returncode == 124
+    assert result.stdout == ""
+    assert result.timed_out is True
+    assert result.timeout_seconds == 0.2
+    warning = command_warning(result)
+    assert warning["timed_out"] is True
+    assert warning["timeout_seconds"] == 0.2
+    assert "timed out after 0.2 seconds" in warning["error"]
+
+
+def test_command_runner_returns_immediately_when_process_finishes_before_heartbeat(
+    tmp_path: Path,
+) -> None:
+    started = time.monotonic()
+    result = CommandRunner(tmp_path).run(
+        [sys.executable, "-c", "print('finished')"],
+        command_id="test-early-finish",
+        timeout_seconds=1.0,
+        progress=lambda: pytest.fail("early completion must not wait for heartbeat"),
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == "finished"
+    assert time.monotonic() - started < 0.8
+
+
+def test_command_runner_emits_low_frequency_heartbeat_without_changing_result(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(workflow_common, "PROGRESS_HEARTBEAT_INTERVAL_SECONDS", 0.02)
+    heartbeats: list[int] = []
+
+    result = CommandRunner(tmp_path).run(
+        [sys.executable, "-c", "import time; time.sleep(0.07); print('finished')"],
+        command_id="test-heartbeat",
+        timeout_seconds=1.0,
+        progress=lambda: heartbeats.append(1),
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == "finished"
+    assert heartbeats
+
+
+def test_command_runner_retries_only_when_requested(tmp_path: Path) -> None:
+    marker = tmp_path / "attempted"
+    flaky = tmp_path / "flaky-command"
+    flaky.write_text(
+        f"#!{sys.executable}\n"
+        "from pathlib import Path\n"
+        f"marker = Path({str(marker)!r})\n"
+        "if marker.exists():\n"
+        "    print('recovered')\n"
+        "else:\n"
+        "    marker.write_text('1', encoding='utf-8')\n"
+        "    raise SystemExit(1)\n",
+        encoding="utf-8",
+    )
+    flaky.chmod(0o755)
+
+    result = CommandRunner(tmp_path).run(
+        [str(flaky)],
+        command_id="test-retry",
+        retries=1,
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == "recovered"

--- a/tests/tools/lck/test_workflow_skills.py
+++ b/tests/tools/lck/test_workflow_skills.py
@@ -1,0 +1,69 @@
+"""Contracts exposed by the canonical LCK workflow Skills."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tools.lck.skill_audit import SKILLS, audit
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def _skill(name: str) -> str:
+    return (ROOT / ".agents" / "skills" / name / "SKILL.md").read_text(encoding="utf-8")
+
+
+def test_lifecycle_commands_use_the_locked_project_python() -> None:
+    combined = "\n".join(_skill(name) for name in SKILLS)
+    assert "uv run --frozen python -m tools.lck delivery prepare" in combined
+    assert "uv run --frozen python -m tools.lck review prepare" in combined
+    assert "uv run --frozen python -m tools.lck merge preflight" in combined
+    assert "tools/agent_workflow" not in combined
+
+
+def test_delivery_skill_delegates_git_and_github_effects_to_lck() -> None:
+    delivery = _skill("task-delivery-runner")
+    assert "delivery prepare" in delivery
+    assert "delivery complete" in delivery
+    assert "remediation prepare" in delivery
+    assert "remediation complete" in delivery
+    for direct in ("git commit", "git push", "gh pr create"):
+        assert direct not in delivery
+
+
+def test_review_skill_is_read_only_and_requires_fresh_review() -> None:
+    review = _skill("task-pr-review-runner")
+    assert "review prepare" in review
+    assert "review complete" in review
+    assert "implementation-read-only" in review
+    assert "Independent Review never modifies implementation" in review
+    assert "REVIEW_STALE_HEAD" in review
+    assert "REVIEW_STALE_BASE" in review
+
+
+def test_closeout_never_merges_and_feature_audit_is_separate() -> None:
+    closeout = _skill("task-closeout")
+    feature = _skill("feature-completion-audit")
+    assert "This Skill never merges" in closeout
+    assert "merge preflight" in closeout
+    assert "feature-audit-snapshot" in feature
+    assert "feature-audit-recheck" in feature
+
+
+def test_agent_permission_adapters_only_allow_the_stable_front_doors() -> None:
+    settings = json.loads((ROOT / ".claude" / "settings.json").read_text())
+    serialized = json.dumps(settings, sort_keys=True)
+    assert "python -m tools.lck" in serialized
+    assert "tools/agent_workflow" not in serialized
+
+    rules = (ROOT / ".codex/rules/tracequant-wsl-validation.rules").read_text(
+        encoding="utf-8"
+    )
+    assert "tools.lck.wsl2_validation_runner" in rules
+
+
+def test_path_audit_reports_clean_canonical_skills_and_adapters() -> None:
+    report, returncode = audit(ROOT)
+    assert returncode == 0, report["violations"]
+    assert report["status"] == "pass"

--- a/tests/tools/lck/test_wsl2_validation_rules.py
+++ b/tests/tools/lck/test_wsl2_validation_rules.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+ROOT = Path(__file__).parents[3]
+RULES = ROOT / ".codex" / "rules" / "tracequant-wsl-validation.rules"
+RUNNER_ARGV = [
+    "uv",
+    "run",
+    "--frozen",
+    "python",
+    "-m",
+    "tools.lck.wsl2_validation_runner",
+]
+
+
+def _execpolicy_decision(argv: list[str]) -> str:
+    codex = shutil.which("codex")
+    if codex is None:
+        pytest.skip("codex executable is required for real execpolicy checks")
+    result = subprocess.run(
+        [
+            codex,
+            "execpolicy",
+            "check",
+            "--pretty",
+            "--rules",
+            str(RULES),
+            "--",
+            *argv,
+        ],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    assert result.returncode == 0, result.stderr
+    payload_start = result.stdout.find("{")
+    assert payload_start >= 0, result.stdout
+    payload: dict[str, Any] = json.loads(result.stdout[payload_start:])
+    decision = payload.get("decision")
+    if decision is None:
+        return "unmatched"
+    assert isinstance(decision, str)
+    assert decision in {"allow", "prompt", "forbidden"}
+    return decision
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected"),
+    [
+        (RUNNER_ARGV + ["current-ci-equivalent"], "allow"),
+        (RUNNER_ARGV + ["targeted"], "allow"),
+        (RUNNER_ARGV + ["targeted:tools-tests"], "allow"),
+        (RUNNER_ARGV + ["targeted:workflow-tests"], "allow"),
+        (RUNNER_ARGV + ["post-merge"], "allow"),
+        (RUNNER_ARGV + ["workflow-delivery", "--base-sha", "a" * 40], "allow"),
+        (RUNNER_ARGV + ["workflow-review", "--base-sha", "a" * 40], "allow"),
+        (RUNNER_ARGV + ["workflow-closeout", "--base-sha", "a" * 40], "allow"),
+        (RUNNER_ARGV + ["targeted", "tests/tools"], "allow"),
+        (RUNNER_ARGV + ["targeted", "arbitrary-value"], "allow"),
+        (
+            ["uv", "run", "--frozen", "ruff", "format", "--check", "."],
+            "allow",
+        ),
+        (RUNNER_ARGV + ["targeted", "--command", "pytest"], "forbidden"),
+        (RUNNER_ARGV + ["targeted", "--shell", "bash"], "forbidden"),
+        (RUNNER_ARGV + ["targeted", "--exec", "anything"], "forbidden"),
+    ],
+)
+def test_execpolicy_runner_profile_matrix(argv: list[str], expected: str) -> None:
+    assert _execpolicy_decision(argv) == expected
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["uv", "run", "pytest"],
+        ["uv", "run", "--frozen", "pytest"],
+        ["python3", "tools/lck/wsl2_validation_runner.py", "targeted"],
+        ["python", "tools/lck/wsl2_validation_runner.py", "targeted"],
+        ["bash", "-c", "tools/lck/wsl2_validation_runner.py targeted"],
+        ["sh", "-c", "tools/lck/wsl2_validation_runner.py targeted"],
+    ],
+)
+def test_execpolicy_direct_interpreters_tools_and_shells_are_not_allowed(
+    argv: list[str],
+) -> None:
+    assert _execpolicy_decision(argv) != "allow"
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["git", "push"],
+        ["git", "reset", "--hard"],
+        ["git", "clean", "-fd"],
+        ["gh", "issue", "edit", "83", "--body", "x"],
+        ["gh", "pr", "edit", "101", "--body", "x"],
+        ["gh", "api", "graphql", "-f", "query=mutation { viewer { login } }"],
+    ],
+)
+def test_execpolicy_git_and_github_writes_do_not_allow(argv: list[str]) -> None:
+    assert _execpolicy_decision(argv) in {"prompt", "forbidden", "unmatched"}
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["uv", "lock", "--check"],
+        ["uv", "run", "--frozen", "pytest"],
+        ["uv", "run", "--frozen", "ruff", "check", "."],
+        ["uv", "run", "--frozen", "mypy", "src", "tests"],
+        ["git", "diff", "--check"],
+    ],
+)
+def test_validation_shapes_with_unsafe_prefix_semantics_remain_fail_closed(
+    argv: list[str],
+) -> None:
+    assert _execpolicy_decision(argv) != "allow"
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["uv", "run", "--frozen", "ruff", "format", "."],
+        ["uv", "run", "--frozen", "ruff", "check", "--fix", "."],
+        ["uv", "run", "--frozen", "mypy", "--install-types", "src", "tests"],
+        ["uv", "lock", "--check", "--upgrade"],
+    ],
+)
+def test_validation_mutation_shapes_do_not_become_allowed(
+    argv: list[str],
+) -> None:
+    assert _execpolicy_decision(argv) != "allow"
+
+
+def test_execpolicy_prefix_boundary_is_runner_enforced() -> None:
+    assert _execpolicy_decision(RUNNER_ARGV + ["targeted", "tests/tools"]) == "allow"
+    assert (
+        _execpolicy_decision(RUNNER_ARGV + ["targeted", "arbitrary-value"]) == "allow"
+    )
+
+
+def test_rules_do_not_reference_removed_trusted_runner() -> None:
+    text = RULES.read_text(encoding="utf-8")
+    assert "trusted_runner.py" not in text
+    assert "--trusted-sha" not in text

--- a/tests/tools/lck/test_wsl2_validation_runner.py
+++ b/tests/tools/lck/test_wsl2_validation_runner.py
@@ -1,0 +1,801 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).parents[3]
+SCRIPT = ROOT / "tools" / "lck" / "wsl2_validation_runner.py"
+SPEC = ROOT / "tools" / "lck" / "config" / "validation_profiles.json"
+RULES = ROOT / ".codex" / "rules" / "tracequant-wsl-validation.rules"
+WORKFLOW_VALIDATION = ROOT / "tools" / "lck" / "validation_runner.py"
+WORKFLOW_COMMON = ROOT / "tools" / "lck" / "common.py"
+PYTHON = os.environ.get("WORKFLOW_TEST_PYTHON", sys.executable)
+IDENTITY_RELATIVE_PATHS = (
+    "tools/lck/wsl2_validation_runner.py",
+    "tools/lck/config/validation_profiles.json",
+    ".codex/rules/tracequant-wsl-validation.rules",
+    "tools/lck/validation_runner.py",
+    "tools/lck/common.py",
+)
+REMOVED_TRUSTED_ENV_KEYS = (
+    "WORKFLOW_TRUSTED_RUNNER_SHA",
+    "WORKFLOW_TRUSTED_TOOL_CONTENT_SHA256",
+    "WORKFLOW_TRUSTED_BUNDLE_ROOT",
+    "WORKFLOW_TARGET_REPO_ROOT",
+)
+
+
+def _clean_test_env() -> dict[str, str]:
+    env = os.environ.copy()
+    for key in REMOVED_TRUSTED_ENV_KEYS:
+        env.pop(key, None)
+    env.pop("UV_CACHE_DIR", None)
+    return env
+
+
+def _snapshot_trusted_files(repo: Path) -> None:
+    snapshot_root = repo / ".fake-head"
+    if snapshot_root.exists():
+        shutil.rmtree(snapshot_root)
+    for relative_path in IDENTITY_RELATIVE_PATHS:
+        source = repo / relative_path
+        destination = snapshot_root / relative_path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
+
+
+def _copy_runner_repo(tmp_path: Path, *, name: str = "repo") -> Path:
+    repo = tmp_path / name
+    (repo / "tools" / "lck" / "config").mkdir(parents=True)
+    (repo / ".github" / "workflows").mkdir(parents=True)
+    (repo / ".codex" / "rules").mkdir(parents=True)
+    (repo / "tools" / "__init__.py").touch()
+    (repo / "tools" / "lck" / "__init__.py").touch()
+    shutil.copy2(SCRIPT, repo / "tools" / "lck" / SCRIPT.name)
+    shutil.copy2(SPEC, repo / "tools" / "lck" / "config" / SPEC.name)
+    shutil.copy2(RULES, repo / ".codex" / "rules" / RULES.name)
+    shutil.copy2(
+        WORKFLOW_VALIDATION,
+        repo / "tools" / "lck" / WORKFLOW_VALIDATION.name,
+    )
+    shutil.copy2(WORKFLOW_COMMON, repo / "tools" / "lck" / WORKFLOW_COMMON.name)
+    (repo / ".gitignore").write_text(
+        ".agents/validation.local/\n.agents/evidence.local/\n.workflow.local/\n",
+        encoding="utf-8",
+    )
+    (repo / "uv.lock").write_text("version = 1\n", encoding="utf-8")
+    (repo / "pyproject.toml").write_text(
+        "[tool.ruff]\nline-length = 88\n[tool.mypy]\npython_version = '3.11'\n",
+        encoding="utf-8",
+    )
+    (repo / "tests").mkdir()
+    for skill_dir in (".agents", ".claude"):
+        for skill in (
+            "task-delivery-runner",
+            "task-pr-review-runner",
+            "task-closeout",
+            "feature-completion-audit",
+        ):
+            target = repo / skill_dir / "skills" / skill
+            target.mkdir(parents=True, exist_ok=True)
+            (target / "SKILL.md").write_text(
+                f"---\nname: {skill}\n---\n", encoding="utf-8"
+            )
+    (repo / ".github" / "workflows" / "ci.yml").write_text(
+        """name: CI
+jobs:
+  quality:
+    steps:
+      - name: Sync locked dependencies
+        run: uv sync --locked --dev
+      - name: Validate lock file
+        run: uv lock --check
+      - name: Run tests
+        run: uv run --frozen pytest
+      - name: Run Ruff lint
+        run: uv run --frozen ruff check .
+      - name: Check Ruff formatting
+        run: uv run --frozen ruff format --check .
+      - name: Run mypy
+        run: uv run --frozen mypy src tools/lck tests
+""",
+        encoding="utf-8",
+    )
+    _snapshot_trusted_files(repo)
+    return repo
+
+
+def _write_fake_tools(
+    tmp_path: Path,
+    repo: Path,
+    *,
+    branch: str = "83-task",
+    dirty: bool = False,
+    fail_id: str | None = None,
+    sleep_id: str | None = None,
+    grandchild_marker: Path | None = None,
+    cache_marker: Path | None = None,
+) -> Path:
+    suffix = (
+        f"{branch}-{fail_id or 'pass'}-{sleep_id or 'nosleep'}-"
+        f"{dirty}-{grandchild_marker.name if grandchild_marker else 'nochild'}-"
+        f"{cache_marker.name if cache_marker else 'nocache'}"
+    )
+    bin_dir = tmp_path / f"bin-{repo.name}-{suffix}"
+    bin_dir.mkdir()
+    git = bin_dir / "git"
+    git.write_text(
+        f"""#!{PYTHON}
+from pathlib import Path
+import sys
+args = sys.argv[1:]
+repo = Path({str(repo)!r})
+branch = {branch!r}
+dirty = {dirty!r}
+fail = {fail_id!r}
+def snapshot(relative):
+    return repo / '.fake-head' / relative
+if args == ['rev-parse', '--show-toplevel']:
+    print(repo)
+elif args == ['branch', '--show-current']:
+    print(branch)
+elif args == ['rev-parse', 'HEAD']:
+    print('a' * 40)
+elif args in (
+    ['rev-parse', 'refs/remotes/origin/main'],
+    ['rev-parse', '--verify', 'refs/remotes/origin/main'],
+):
+    print('a' * 40)
+elif args[:2] == ['status', '--short']:
+    print(' M file.txt' if dirty else '')
+elif len(args) == 4 and args[:3] == ['diff', '--quiet', '--']:
+    relative = args[3]
+    current = repo / relative
+    expected = snapshot(relative)
+    if (
+        not expected.exists()
+        or not current.exists()
+        or current.read_bytes() != expected.read_bytes()
+    ):
+        sys.exit(1)
+elif len(args) == 5 and args[:4] == ['diff', '--cached', '--quiet', '--']:
+    relative = args[4]
+    current = repo / relative
+    expected = snapshot(relative)
+    if (
+        not expected.exists()
+        or not current.exists()
+        or current.read_bytes() != expected.read_bytes()
+    ):
+        sys.exit(1)
+elif len(args) == 2 and args[0] == 'show' and args[1].startswith('HEAD:'):
+    relative = args[1].split(':', 1)[1]
+    expected = snapshot(relative)
+    if not expected.exists():
+        sys.exit(128)
+    sys.stdout.buffer.write(expected.read_bytes())
+elif args == ['diff', '--check']:
+    if fail == 'git-diff-check':
+        print('diff failure ' + 'x' * 9000)
+        sys.exit(1)
+elif args[:2] == ['diff', '--name-only']:
+    print('tools/lck/wsl2_validation_runner.py')
+sys.exit(0)
+""",
+        encoding="utf-8",
+    )
+    uv = bin_dir / "uv"
+    uv.write_text(
+        f"""#!{PYTHON}
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+args = sys.argv[1:]
+key = '-'.join(args)
+fail = {fail_id!r}
+sleep = {sleep_id!r}
+marker = {str(grandchild_marker) if grandchild_marker else None!r}
+cache_marker = {str(cache_marker) if cache_marker else None!r}
+if cache_marker:
+    Path(cache_marker).write_text(os.environ.get('UV_CACHE_DIR', ''), encoding='utf-8')
+if sleep and sleep in key:
+    if marker:
+        child_code = (
+            "import signal, time; from pathlib import Path; "
+            + "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+            + "time.sleep(4); Path(" + repr(marker) + ").write_text('survived')"
+        )
+        subprocess.Popen([{PYTHON!r}, '-c', child_code])
+    time.sleep(30)
+if fail and fail in key:
+    print('failure stdout secret=top-secret-token ' + 'x' * 9000)
+    print('failure stderr ghp_' + 'a' * 25 + ' y' * 9000, file=sys.stderr)
+    sys.exit(1)
+if args == ['lock', '--check']:
+    print('Resolved 3 packages')
+elif args[:3] == ['run', '--frozen', 'pytest']:
+    print('================ 7 passed in 0.01s ================')
+elif args == ['run', '--frozen', 'ruff', 'check', '.']:
+    print('All checks passed!')
+elif args == ['run', '--frozen', 'ruff', 'format', '--check', '.']:
+    print('8 files already formatted')
+elif args == ['run', '--frozen', 'mypy', 'src', 'tests']:
+    print('Success: no issues found in 8 source files')
+else:
+    print('unexpected ' + key)
+sys.exit(0)
+""",
+        encoding="utf-8",
+    )
+    git.chmod(0o755)
+    uv.chmod(0o755)
+    env_file = bin_dir / "env.json"
+    env_file.write_text(
+        json.dumps({"fail_id": fail_id, "sleep_id": sleep_id}), encoding="utf-8"
+    )
+    return bin_dir
+
+
+def _fake_skill_validator(tmp_path: Path) -> Path:
+    validator = tmp_path / "quick_validate.py"
+    validator.write_text("import sys\nprint('valid', sys.argv[1])\n", encoding="utf-8")
+    return validator
+
+
+def _run(
+    repo: Path,
+    bin_dir: Path,
+    *args: str,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = _clean_test_env()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+    env["PYTHONUTF8"] = "1"
+    env["PYTHONIOENCODING"] = "utf-8"
+    env.pop("GITHUB_TOKEN", None)
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        [PYTHON, str(repo / "tools" / "lck" / SCRIPT.name), *args],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+    )
+
+
+def test_current_ci_equivalent_success_digest_and_logs(tmp_path: Path) -> None:
+    repo = _copy_runner_repo(tmp_path)
+    bin_dir = _write_fake_tools(tmp_path, repo)
+    result = _run(repo, bin_dir, "current-ci-equivalent")
+    assert result.returncode == 0, result.stderr
+    digest = json.loads(result.stdout)
+    assert digest["status"] == "pass"
+    assert digest["profile"] == "current-ci-equivalent"
+    assert digest["command_count"] == 6
+    assert "7 passed" not in result.stdout
+    result_path = repo / digest["result_path"]
+    stored = json.loads(result_path.read_text(encoding="utf-8"))
+    assert stored["commands"][0]["argv"] == ["uv", "lock", "--check"]
+    assert stored["commands"][-1]["id"] == "git-diff-check"
+    assert stored["integrity"]["rules_sha256"]
+
+
+def test_uv_subprocess_uses_repo_local_cache_by_default(tmp_path: Path) -> None:
+    repo = _copy_runner_repo(tmp_path)
+    cache_marker = tmp_path / "uv-cache-env.txt"
+    bin_dir = _write_fake_tools(tmp_path, repo, cache_marker=cache_marker)
+
+    result = _run(repo, bin_dir, "targeted")
+
+    assert result.returncode == 0, result.stderr
+    assert cache_marker.read_text(encoding="utf-8") == str(
+        repo / ".workflow.local" / "uv-cache"
+    )
+
+
+def test_targeted_profile_is_not_ci_equivalent(tmp_path: Path) -> None:
+    repo = _copy_runner_repo(tmp_path)
+    bin_dir = _write_fake_tools(tmp_path, repo)
+    result = _run(repo, bin_dir, "targeted")
+    assert result.returncode == 0, result.stderr
+    stored = json.loads((repo / json.loads(result.stdout)["result_path"]).read_text())
+    assert stored["profile_kind"] == "targeted"
+    assert stored["expected_command_count"] == 1
+
+
+def test_fixed_profile_test_paths_exist() -> None:
+    spec = json.loads(SPEC.read_text(encoding="utf-8"))
+    missing: list[str] = []
+    for profile in spec["profiles"].values():
+        for command in profile.get("commands", []):
+            for argument in command["argv"]:
+                if argument.startswith("tests/") and not (ROOT / argument).exists():
+                    missing.append(argument)
+    assert missing == []
+
+
+def test_post_merge_fails_closed_off_main_and_accepts_clean_main(
+    tmp_path: Path,
+) -> None:
+    repo = _copy_runner_repo(tmp_path)
+    off_main = _write_fake_tools(tmp_path, repo, branch="feature")
+    assert _run(repo, off_main, "post-merge").returncode == 2
+    main = _write_fake_tools(tmp_path, repo, branch="main")
+    assert _run(repo, main, "post-merge").returncode == 0
+
+
+def test_unknown_profile_unknown_argument_and_trailing_argument_fail(
+    tmp_path: Path,
+) -> None:
+    repo = _copy_runner_repo(tmp_path)
+    bin_dir = _write_fake_tools(tmp_path, repo)
+    assert _run(repo, bin_dir, "unknown").returncode == 2
+    assert _run(repo, bin_dir, "targeted", "--command", "pytest").returncode == 2
+    assert _run(repo, bin_dir, "targeted", "tests/tools").returncode == 2
+    assert _run(repo, bin_dir, "targeted", "arbitrary-value").returncode == 2
+    assert _run(repo, bin_dir, "targeted", "--unknown").returncode == 2
+    assert _run(repo, bin_dir, "targeted", "--", "tests/tools").returncode == 2
+    assert _run(repo, bin_dir, "targeted", ">").returncode == 2
+
+
+def test_trailing_arguments_fail_before_validation_side_effects(
+    tmp_path: Path,
+) -> None:
+    repo = _copy_runner_repo(tmp_path)
+    bin_dir = _write_fake_tools(tmp_path, repo)
+    canary = bin_dir / "validation-command-started"
+    for tool in ("uv", "git"):
+        tool_path = bin_dir / tool
+        original = tool_path.read_text(encoding="utf-8")
+        tool_path.write_text(
+            original.replace(
+                "import sys\n",
+                (
+                    "import sys\nfrom pathlib import Path\n"
+                    f"Path({str(canary)!r}).write_text({tool!r})\n"
+                ),
+                1,
+            ),
+            encoding="utf-8",
+        )
+
+    for extra in (
+        ("tests/tools",),
+        ("arbitrary-value",),
+        ("--unknown",),
+        ("--", "tests/tools"),
+        (">",),
+        ("$(id)",),
+    ):
+        result = _run(repo, bin_dir, "targeted", *extra)
+        assert result.returncode == 2, f"extra={extra!r}: {result.stderr}"
+        assert (
+            "trailing arguments are not accepted" in result.stderr
+            or "unrecognized arguments" in result.stderr
+            or "error: unrecognized" in result.stderr
+        )
+        assert result.stdout == ""
+        assert not canary.exists()
+        assert not (repo / ".agents" / "validation.local").exists()
+
+
+def test_failure_propagates_and_summaries_are_bounded_and_redacted(
+    tmp_path: Path,
+) -> None:
+    repo = _copy_runner_repo(tmp_path)
+    bin_dir = _write_fake_tools(tmp_path, repo)
+    bin_dir = _write_fake_tools(tmp_path, repo, fail_id="pytest")
+    result = _run(repo, bin_dir, "current-ci-equivalent")
+    assert result.returncode == 1, result.stderr
+    digest = json.loads(result.stdout)
+    assert digest["status"] == "fail"
+    failed = digest["failed_command"]
+    assert failed["id"] == "pytest"
+    assert failed["stdout_truncated"]
+    assert failed["stderr_truncated"]
+    assert "top-secret-token" not in result.stdout
+    assert "ghp_" not in result.stdout
+    stored = json.loads((repo / digest["result_path"]).read_text())
+    assert len(stored["commands"]) == 2
+
+
+def test_git_diff_failure_propagates(tmp_path: Path) -> None:
+    repo = _copy_runner_repo(tmp_path)
+    bin_dir = _write_fake_tools(tmp_path, repo)
+    bin_dir = _write_fake_tools(tmp_path, repo, fail_id="git-diff-check")
+    result = _run(repo, bin_dir, "current-ci-equivalent")
+    assert result.returncode == 1
+    assert json.loads(result.stdout)["failed_command"]["id"] == "git-diff-check"
+
+
+def test_timeout_and_sigint_are_explicit(tmp_path: Path) -> None:
+    repo = _copy_runner_repo(tmp_path)
+    spec = json.loads((repo / "tools/lck/config/validation_profiles.json").read_text())
+    spec["profiles"]["targeted"]["timeout_seconds"] = 1
+    (repo / "tools/lck/config/validation_profiles.json").write_text(
+        json.dumps(spec), encoding="utf-8"
+    )
+    _snapshot_trusted_files(repo)
+    marker = tmp_path / "grandchild-survived.txt"
+    bin_dir = _write_fake_tools(
+        tmp_path, repo, sleep_id="pytest", grandchild_marker=marker
+    )
+    timeout = _run(repo, bin_dir, "targeted")
+    assert timeout.returncode == 1
+    assert json.loads(timeout.stdout)["failed_command"]["timed_out"]
+    time.sleep(4.5)
+    assert not marker.exists(), "timed-out grandchild survived process-group kill"
+
+    proc_env = _clean_test_env()
+    proc_env["PATH"] = f"{bin_dir}{os.pathsep}{proc_env.get('PATH', '')}"
+    proc = subprocess.Popen(
+        [PYTHON, str(repo / "tools" / "lck" / SCRIPT.name), "targeted"],
+        cwd=repo,
+        env=proc_env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+    )
+    time.sleep(0.5)
+    proc.send_signal(signal.SIGINT)
+    stdout, _stderr = proc.communicate(timeout=10)
+    assert proc.returncode in {1, 130}
+    if stdout:
+        assert json.loads(stdout)["status"] in {"fail", "interrupted"}
+
+
+def test_repository_root_cwd_space_and_symlink_checks(tmp_path: Path) -> None:
+    repo = _copy_runner_repo(tmp_path, name="repo with space")
+    bin_dir = _write_fake_tools(tmp_path, repo)
+    assert _run(repo, bin_dir, "targeted").returncode == 0
+
+    subdir = repo / "subdir"
+    subdir.mkdir()
+    env = _clean_test_env()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+    wrong_cwd = subprocess.run(
+        [PYTHON, str(repo / "tools" / "lck" / SCRIPT.name), "targeted"],
+        cwd=subdir,
+        env=env,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+    )
+    assert wrong_cwd.returncode == 2
+
+    link = tmp_path / "runner-link.py"
+    link.symlink_to(repo / "tools" / "lck" / SCRIPT.name)
+    symlinked = subprocess.run(
+        [PYTHON, str(link), "targeted"],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+    )
+    assert symlinked.returncode == 2
+
+
+def test_current_content_is_hashed_and_canonical_drift_fails_closed(
+    tmp_path: Path,
+) -> None:
+    repo = _copy_runner_repo(tmp_path)
+    bin_dir = _write_fake_tools(tmp_path, repo)
+    first = _run(repo, bin_dir, "targeted")
+    assert first.returncode == 0
+    stored = json.loads((repo / json.loads(first.stdout)["result_path"]).read_text())
+    assert stored["integrity"]["verification"] == "current-worktree-content"
+    original_hash = stored["integrity"]["runner_sha256"]
+
+    runner_path = repo / "tools" / "lck" / SCRIPT.name
+    runner_path.write_text(
+        runner_path.read_text(encoding="utf-8") + "\n# current change\n",
+        encoding="utf-8",
+    )
+    changed_runner = _run(repo, bin_dir, "targeted")
+    assert changed_runner.returncode == 0, changed_runner.stderr
+    changed_stored = json.loads(
+        (repo / json.loads(changed_runner.stdout)["result_path"]).read_text()
+    )
+    assert changed_stored["integrity"]["runner_sha256"] != original_hash
+
+    spec_path = repo / "tools" / "lck" / "config" / SPEC.name
+    spec = json.loads(spec_path.read_text(encoding="utf-8"))
+    spec["profiles"]["targeted"]["commands"][0]["argv"] = [
+        "python3",
+        "-c",
+        "print('not canonical')",
+    ]
+    spec_path.write_text(json.dumps(spec), encoding="utf-8")
+    bad_spec = _run(repo, bin_dir, "targeted")
+    assert bad_spec.returncode == 2
+    assert "does not match canonical command" in bad_spec.stderr
+
+    shutil.copy2(SPEC, spec_path)
+    workflow = repo / ".github" / "workflows" / "ci.yml"
+    workflow.write_text(
+        workflow.read_text(encoding="utf-8").replace("pytest", "pytest -q")
+    )
+    drift = _run(repo, bin_dir, "targeted")
+    assert drift.returncode == 2
+    assert "drifted" in drift.stderr
+
+
+def test_invalid_or_duplicate_command_ids_fail_before_execution(tmp_path: Path) -> None:
+    repo = _copy_runner_repo(tmp_path)
+    bin_dir = _write_fake_tools(tmp_path, repo)
+    spec_path = repo / "tools" / "lck" / "config" / SPEC.name
+
+    spec = json.loads(spec_path.read_text(encoding="utf-8"))
+    spec["profiles"]["targeted"]["commands"][0]["id"] = "../../escape"
+    spec_path.write_text(json.dumps(spec), encoding="utf-8")
+    _snapshot_trusted_files(repo)
+    invalid = _run(repo, bin_dir, "targeted")
+    assert invalid.returncode == 2
+    assert "invalid profile command id" in invalid.stderr
+
+    shutil.copy2(SPEC, spec_path)
+    spec = json.loads(spec_path.read_text(encoding="utf-8"))
+    command = spec["profiles"]["targeted"]["commands"][0]
+    spec["profiles"]["targeted"]["commands"] = [command, command]
+    spec_path.write_text(json.dumps(spec), encoding="utf-8")
+    _snapshot_trusted_files(repo)
+    duplicate = _run(repo, bin_dir, "targeted")
+    assert duplicate.returncode == 2
+    assert "duplicate profile command id" in duplicate.stderr
+
+
+def test_result_write_failure_does_not_report_success(tmp_path: Path) -> None:
+    repo = _copy_runner_repo(tmp_path)
+    bin_dir = _write_fake_tools(tmp_path, repo)
+    blocked = repo / ".agents" / "validation.local"
+    blocked.parent.mkdir(parents=True, exist_ok=True)
+    blocked.write_text("not a directory", encoding="utf-8")
+    result = _run(repo, bin_dir, "targeted")
+    assert result.returncode == 2
+    assert result.stdout == ""
+
+
+def test_workflow_profiles_require_base_sha_and_run_one_bounded_command(
+    tmp_path: Path,
+) -> None:
+    repo = _copy_runner_repo(tmp_path)
+    bin_dir = _write_fake_tools(tmp_path, repo)
+    validator = _fake_skill_validator(tmp_path)
+    base_sha = "b" * 40
+    for profile in ("workflow-delivery", "workflow-review"):
+        missing = _run(repo, bin_dir, profile)
+        assert missing.returncode == 2
+        result = _run(
+            repo,
+            bin_dir,
+            profile,
+            "--base-sha",
+            base_sha,
+            extra_env={"CODEX_SKILL_VALIDATOR": str(validator)},
+        )
+        assert result.returncode == 0, result.stderr
+        digest = json.loads(result.stdout)
+        assert digest["profile"] == profile
+        assert digest["command_count"] == 1
+        stored = json.loads((repo / digest["result_path"]).read_text())
+        assert stored["commands"][0]["id"] == "workflow-validation"
+        assert stored["commands"][0]["exit_code"] == 0
+
+
+def test_workflow_closeout_requires_clean_synchronized_main(tmp_path: Path) -> None:
+    repo = _copy_runner_repo(tmp_path)
+    validator = _fake_skill_validator(tmp_path)
+    base_sha = "b" * 40
+    off_main = _write_fake_tools(tmp_path, repo, branch="feature")
+    result = _run(
+        repo,
+        off_main,
+        "workflow-closeout",
+        "--base-sha",
+        base_sha,
+        extra_env={"CODEX_SKILL_VALIDATOR": str(validator)},
+    )
+    assert result.returncode == 2
+    main = _write_fake_tools(tmp_path, repo, branch="main")
+    result = _run(
+        repo,
+        main,
+        "workflow-closeout",
+        "--base-sha",
+        base_sha,
+        extra_env={"CODEX_SKILL_VALIDATOR": str(validator)},
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_rules_file_contains_positive_and_negative_boundaries() -> None:
+    text = RULES.read_text(encoding="utf-8")
+    for allowed in (
+        "current-ci-equivalent",
+        "targeted",
+        "post-merge",
+        "workflow-delivery",
+        "workflow-review",
+        "workflow-closeout",
+    ):
+        assert allowed in text
+    for boundary in (
+        "generic Python, uv, shell wrappers",
+        "--command",
+        "--shell",
+        "gh",
+        "auth",
+        "token",
+        "push",
+        "reset",
+        "clean",
+    ):
+        assert boundary in text
+
+
+def test_workflow_delivery_and_review_require_clean_committed_head(
+    tmp_path: Path,
+) -> None:
+    repo = _copy_runner_repo(tmp_path)
+    validator = _fake_skill_validator(tmp_path)
+    dirty_tools = _write_fake_tools(tmp_path, repo, dirty=True)
+    for profile in ("workflow-delivery", "workflow-review"):
+        result = _run(
+            repo,
+            dirty_tools,
+            profile,
+            "--base-sha",
+            "b" * 40,
+            extra_env={"CODEX_SKILL_VALIDATOR": str(validator)},
+        )
+        assert result.returncode == 2
+        assert "clean working tree" in result.stderr
+
+
+def test_validation_runner_has_no_removed_trusted_version_interface() -> None:
+    text = SCRIPT.read_text(encoding="utf-8")
+    for fragment in (
+        "WORKFLOW_TRUSTED_RUNNER_SHA",
+        "WORKFLOW_TRUSTED_BUNDLE_ROOT",
+        "WORKFLOW_TARGET_REPO_ROOT",
+        "trusted-commit-bundle-pre-execution",
+    ):
+        assert fragment not in text
+
+
+# --- Skill identity tests ---
+
+
+def test_workflow_review_records_default_agents_skill_path(tmp_path: Path) -> None:
+    """Without --skill-path the validation runner falls back to .agents path."""
+    repo = _copy_runner_repo(tmp_path)
+    bin_dir = _write_fake_tools(tmp_path, repo)
+    validator = _fake_skill_validator(tmp_path)
+    result = _run(
+        repo,
+        bin_dir,
+        "workflow-review",
+        "--base-sha",
+        "b" * 40,
+        extra_env={"CODEX_SKILL_VALIDATOR": str(validator)},
+    )
+    assert result.returncode == 0, result.stderr
+    stored = json.loads((repo / json.loads(result.stdout)["result_path"]).read_text())
+    assert stored["integrity"]["skill"]["path"] == (
+        ".agents/skills/task-pr-review-runner/SKILL.md"
+    )
+    assert stored["integrity"]["skill"]["sha256"]
+
+
+def test_workflow_review_records_claude_skill_path_when_provided(
+    tmp_path: Path,
+) -> None:
+    """--skill-path .claude/... is recorded with actual content hash."""
+    repo = _copy_runner_repo(tmp_path)
+    bin_dir = _write_fake_tools(tmp_path, repo)
+    validator = _fake_skill_validator(tmp_path)
+    claude_skill = ".claude/skills/task-pr-review-runner/SKILL.md"
+    result = _run(
+        repo,
+        bin_dir,
+        "workflow-review",
+        "--base-sha",
+        "b" * 40,
+        "--skill-path",
+        claude_skill,
+        extra_env={"CODEX_SKILL_VALIDATOR": str(validator)},
+    )
+    assert result.returncode == 0, result.stderr
+    stored = json.loads((repo / json.loads(result.stdout)["result_path"]).read_text())
+    assert stored["integrity"]["skill"]["path"] == claude_skill
+    import hashlib
+
+    expected_hash = hashlib.sha256((repo / claude_skill).read_bytes()).hexdigest()
+    assert stored["integrity"]["skill"]["sha256"] == expected_hash
+
+
+def test_validation_skill_path_outside_allowed_roots_fails(tmp_path: Path) -> None:
+    """--skill-path outside .agents/skills/ or .claude/skills/ is rejected."""
+    repo = _copy_runner_repo(tmp_path)
+    bin_dir = _write_fake_tools(tmp_path, repo)
+    result = _run(
+        repo,
+        bin_dir,
+        "workflow-review",
+        "--base-sha",
+        "b" * 40,
+        "--skill-path",
+        "tools/lck/README.md",
+    )
+    assert result.returncode == 2
+
+
+def test_validation_skill_path_parent_traversal_fails(tmp_path: Path) -> None:
+    """--skill-path with .. is rejected."""
+    repo = _copy_runner_repo(tmp_path)
+    bin_dir = _write_fake_tools(tmp_path, repo)
+    result = _run(
+        repo,
+        bin_dir,
+        "workflow-review",
+        "--base-sha",
+        "b" * 40,
+        "--skill-path",
+        ".claude/skills/../../dangerous/SKILL.md",
+    )
+    assert result.returncode == 2
+
+
+def test_workflow_delivery_agents_skill_is_default(tmp_path: Path) -> None:
+    """workflow-delivery defaults to .agents task-delivery-runner path."""
+    repo = _copy_runner_repo(tmp_path)
+    bin_dir = _write_fake_tools(tmp_path, repo)
+    validator = _fake_skill_validator(tmp_path)
+    result = _run(
+        repo,
+        bin_dir,
+        "workflow-delivery",
+        "--base-sha",
+        "b" * 40,
+        extra_env={"CODEX_SKILL_VALIDATOR": str(validator)},
+    )
+    assert result.returncode == 0, result.stderr
+    stored = json.loads((repo / json.loads(result.stdout)["result_path"]).read_text())
+    assert ".agents/skills/task-delivery-runner/SKILL.md" in str(
+        stored["integrity"]["skill"]["path"]
+    )
+
+
+def test_workflow_closeout_agents_skill_is_default(tmp_path: Path) -> None:
+    """workflow-closeout defaults to .agents task-closeout path."""
+    repo = _copy_runner_repo(tmp_path)
+    validator = _fake_skill_validator(tmp_path)
+    main = _write_fake_tools(tmp_path, repo, branch="main")
+    result = _run(
+        repo,
+        main,
+        "workflow-closeout",
+        "--base-sha",
+        "b" * 40,
+        extra_env={"CODEX_SKILL_VALIDATOR": str(validator)},
+    )
+    assert result.returncode == 0, result.stderr
+    stored = json.loads((repo / json.loads(result.stdout)["result_path"]).read_text())
+    assert ".agents/skills/task-closeout/SKILL.md" in str(
+        stored["integrity"]["skill"]["path"]
+    )

--- a/tools/lck/__init__.py
+++ b/tools/lck/__init__.py
@@ -1,0 +1,1 @@
+"""Internal responsibility-owned implementation for the LCK CLI."""

--- a/tools/lck/__main__.py
+++ b/tools/lck/__main__.py
@@ -1,0 +1,8 @@
+"""Stable module entry point for the Local Control Kernel."""
+
+from __future__ import annotations
+
+from .cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lck/bug_policy.py
+++ b/tools/lck/bug_policy.py
@@ -1,0 +1,255 @@
+"""Repository-owned policy for Bug leaf contracts.
+
+The Bug Issue form is the authority for the minimum defect contract.  This
+module validates the rendered Markdown shape and records only bounded contract
+facts; it never interprets Issue content as a command or execution plan.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Any, Final
+
+from .issue_forms import (
+    IssueFormTemplateContract,
+    IssueFormTemplateError,
+    load_issue_form_template,
+    parse_issue_form_contract,
+)
+
+BUG_TEMPLATE_PATH: Final = Path(".github/ISSUE_TEMPLATE/bug.yml")
+BUG_POLICY_ID: Final = "repository-bug-defect-contract-v1"
+
+
+class BugPolicyStatus(StrEnum):
+    """Outcomes of validating a Bug Issue defect contract."""
+
+    PASS = "pass"
+    RECLASSIFICATION_REQUIRED = "reclassification_required"
+
+
+class BugTemplateError(IssueFormTemplateError):
+    """The repository-owned Bug Issue form is not usable."""
+
+
+BugTemplateContract = IssueFormTemplateContract
+
+
+@dataclass(frozen=True)
+class BugContract:
+    status: BugPolicyStatus
+    required_sections: tuple[str, ...] = ()
+    missing_sections: tuple[str, ...] = ()
+    duplicate_sections: tuple[str, ...] = ()
+    empty_sections: tuple[str, ...] = ()
+    insufficient_sections: tuple[str, ...] = ()
+    template_path: str = BUG_TEMPLATE_PATH.as_posix()
+    detail: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status.value,
+            "required_sections": list(self.required_sections),
+            "missing_sections": list(self.missing_sections),
+            "duplicate_sections": list(self.duplicate_sections),
+            "empty_sections": list(self.empty_sections),
+            "insufficient_sections": list(self.insufficient_sections),
+            "template_path": self.template_path,
+            **({"detail": self.detail} if self.detail else {}),
+        }
+
+
+_PLACEHOLDER_VALUES: Final = frozenset(
+    {
+        "...",
+        "-",
+        "n/a",
+        "na",
+        "none",
+        "not applicable",
+        "tbd",
+        "todo",
+        "unknown",
+        "无",
+        "未知",
+        "待定",
+    }
+)
+_VAGUE_VALUES: Final = frozenset(
+    {
+        "as expected",
+        "behave correctly",
+        "correct behavior",
+        "it works",
+        "it should work",
+        "正常",
+        "正常工作",
+        "应该正常",
+        "should work",
+        "works",
+        "works as expected",
+    }
+)
+_NON_REPRODUCIBLE_EVIDENCE_VALUES: Final = frozenset(
+    {
+        "cannot reproduce",
+        "cannot reproduce in current environment",
+        "not reproducible",
+        "not reproducible in current environment",
+        "unable to reproduce",
+        "无法复现",
+        "无法在当前环境复现",
+        "当前环境无法复现",
+        "暂时无法复现",
+        "暂时无法在当前环境复现",
+    }
+)
+_FORM_PLACEHOLDER_RE: Final = re.compile(
+    r"^(?:实际发生|正确行为应为|复现步骤或证据)\s*:\s*(?:[.…]+)?$",
+    re.IGNORECASE,
+)
+_CHECKBOX_PLACEHOLDER_RE: Final = re.compile(
+    r"^(?:[-*]\s*)?\[\s*(?:x| )?\s*\]\s*(?:[.…]+)?$",
+    re.IGNORECASE,
+)
+
+
+def _default_bug_template_path() -> Path:
+    return Path(__file__).resolve().parents[2] / BUG_TEMPLATE_PATH
+
+
+def bug_template_contract(
+    template_path: Path | None = None,
+) -> BugTemplateContract:
+    """Load required Bug fields from the formal Issue form."""
+
+    path = template_path or _default_bug_template_path()
+    return load_issue_form_template(
+        path,
+        form_name="Bug",
+        template_display_path=BUG_TEMPLATE_PATH.as_posix(),
+        error_type=BugTemplateError,
+    )
+
+
+def _is_placeholder(content: str) -> bool:
+    normalized = unicodedata.normalize("NFKC", " ".join(content.split())).casefold()
+    if normalized in _PLACEHOLDER_VALUES or normalized in _VAGUE_VALUES:
+        return True
+    if _FORM_PLACEHOLDER_RE.fullmatch(normalized):
+        return True
+    # Markdown checkboxes with no actual criterion are not acceptance evidence.
+    lines = [line.strip() for line in content.splitlines() if line.strip()]
+    return bool(lines) and all(
+        _CHECKBOX_PLACEHOLDER_RE.fullmatch(
+            unicodedata.normalize("NFKC", line).casefold()
+        )
+        for line in lines
+    )
+
+
+def _is_non_reproducible_evidence(content: str) -> bool:
+    """Reject evidence that only says the defect cannot currently be reproduced."""
+
+    normalized = unicodedata.normalize("NFKC", " ".join(content.split())).casefold()
+    if normalized in _NON_REPRODUCIBLE_EVIDENCE_VALUES:
+        return True
+    form_prefix = "复现步骤或证据:"
+    return (
+        normalized.startswith(form_prefix)
+        and normalized.removeprefix(form_prefix).strip()
+        in _NON_REPRODUCIBLE_EVIDENCE_VALUES
+    )
+
+
+def _insufficient_sections(
+    sections: tuple[tuple[str, str], ...],
+    required_labels: tuple[str, ...],
+) -> tuple[str, ...]:
+    """Reject required fields that contain no usable defect information."""
+
+    required_keys = {label.casefold(): label for label in required_labels}
+    insufficient: list[str] = []
+    for heading, content in sections:
+        label = required_keys.get(heading.casefold())
+        if label is not None and (
+            _is_placeholder(content)
+            or (
+                label.casefold() == "reproduction / evidence"
+                and _is_non_reproducible_evidence(content)
+            )
+        ):
+            insufficient.append(label)
+    return tuple(insufficient)
+
+
+def bug_contract_snapshot(
+    body: str | None,
+    *,
+    template_path: Path | None = None,
+) -> dict[str, Any]:
+    """Return a bounded typed snapshot of the Bug Issue defect contract."""
+
+    parsed = parse_issue_form_contract(
+        body,
+        template_path=template_path or _default_bug_template_path(),
+        form_name="Bug",
+        template_display_path=BUG_TEMPLATE_PATH.as_posix(),
+        error_type=BugTemplateError,
+        valid_status=BugPolicyStatus.PASS.value,
+        invalid_status=BugPolicyStatus.RECLASSIFICATION_REQUIRED.value,
+    )
+
+    if parsed.template is None:
+        return BugContract(
+            BugPolicyStatus.RECLASSIFICATION_REQUIRED,
+            detail=parsed.detail,
+        ).to_dict()
+
+    insufficient = _insufficient_sections(
+        parsed.sections, parsed.template.section_labels
+    )
+    if not parsed.structurally_valid or insufficient:
+        parts: list[str] = []
+        if parsed.detail:
+            parts.append(parsed.detail)
+        if insufficient:
+            parts.append("insufficient sections: " + ", ".join(insufficient))
+        return BugContract(
+            BugPolicyStatus.RECLASSIFICATION_REQUIRED,
+            required_sections=parsed.required_sections,
+            missing_sections=parsed.missing_sections,
+            duplicate_sections=parsed.duplicate_sections,
+            empty_sections=parsed.empty_sections,
+            insufficient_sections=insufficient,
+            detail="; ".join(parts),
+        ).to_dict()
+    return BugContract(
+        BugPolicyStatus.PASS,
+        required_sections=parsed.required_sections,
+    ).to_dict()
+
+
+def is_valid_bug_contract(value: object) -> bool:
+    """Validate the bounded Bug contract consumed by LCK eligibility."""
+
+    if not isinstance(value, Mapping):
+        return False
+    try:
+        template = bug_template_contract()
+    except BugTemplateError:
+        return False
+    return (
+        value.get("status") == BugPolicyStatus.PASS.value
+        and value.get("required_sections") == list(template.section_labels)
+        and value.get("missing_sections") == []
+        and value.get("duplicate_sections") == []
+        and value.get("empty_sections") == []
+        and value.get("insufficient_sections") == []
+        and value.get("template_path") == BUG_TEMPLATE_PATH.as_posix()
+    )

--- a/tools/lck/cli.py
+++ b/tools/lck/cli.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import argparse
+import uuid
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from .closeout import CloseoutCompleter
+from .common import WorkflowToolError, print_json
+from .delivery import DeliveryCompleter, DeliveryPreparer
+from .models import LckStopError, LiveState, ResolutionStatus, ReviewStaleError
+from .receipts import (
+    AuditReceiptStore,
+    _failure_fallback,
+    _result_operation_id,
+    _write_failure_receipt,
+    _write_success_receipt,
+)
+from .remediation import (
+    RemediationCompleter,
+    RemediationNoChangeCompleter,
+    RemediationPreparer,
+)
+from .review import MergePreflight, ReviewCompleter, ReviewPreparer
+from .state import LiveStateResolver
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="LCK v1 live state operations")
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--repository")
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    status = commands.add_parser("status")
+    status.add_argument("task", type=int)
+
+    delivery = commands.add_parser("delivery")
+    delivery_commands = delivery.add_subparsers(dest="delivery_command", required=True)
+    prepare = delivery_commands.add_parser("prepare")
+    prepare.add_argument("task", type=int)
+    complete = delivery_commands.add_parser("complete")
+    complete.add_argument("task", type=int)
+    complete.add_argument("--commit-message", required=True)
+    complete.add_argument("--summary", required=True)
+    complete.add_argument("--risks", default="")
+
+    review = commands.add_parser("review")
+    review_commands = review.add_subparsers(dest="review_command", required=True)
+    review_prepare = review_commands.add_parser("prepare")
+    review_prepare.add_argument("task", type=int)
+    review_complete = review_commands.add_parser("complete")
+    review_complete.add_argument("task", type=int)
+    review_complete.add_argument("--review-id", required=True)
+    review_complete.add_argument("--verdict", required=True, choices=("PASS", "FAIL"))
+    review_complete.add_argument("--findings-file", type=Path)
+    review_complete.add_argument("--research-outcome")
+
+    remediation = commands.add_parser("remediation")
+    remediation_commands = remediation.add_subparsers(
+        dest="remediation_command", required=True
+    )
+    remediation_prepare = remediation_commands.add_parser("prepare")
+    remediation_prepare.add_argument("task", type=int)
+    remediation_prepare.add_argument("--review-id", required=True)
+    remediation_prepare.add_argument("--findings-file", type=Path)
+    remediation_no_change = remediation_commands.add_parser("no-change")
+    remediation_no_change.add_argument("task", type=int)
+    remediation_no_change.add_argument("--review-id", required=True)
+    remediation_no_change.add_argument("--summary", required=True)
+    remediation_complete = remediation_commands.add_parser("complete")
+    remediation_complete.add_argument("task", type=int)
+    remediation_complete.add_argument("--review-id", required=True)
+    remediation_complete.add_argument("--commit-message", required=True)
+    remediation_complete.add_argument("--summary", required=True)
+    remediation_complete.add_argument("--risks", default="")
+
+    merge = commands.add_parser("merge")
+    merge_commands = merge.add_subparsers(dest="merge_command", required=True)
+    merge_preflight = merge_commands.add_parser("preflight")
+    merge_preflight.add_argument("task", type=int)
+
+    merge_preflight_alias = commands.add_parser("merge-preflight")
+    merge_preflight_alias.add_argument("task", type=int)
+
+    closeout = commands.add_parser("closeout")
+    closeout.add_argument("task", type=int)
+    return parser
+
+
+def _cli_operation(args: argparse.Namespace) -> str:
+    if args.command == "status":
+        return "status"
+    if args.command == "delivery":
+        return f"delivery-{args.delivery_command}"
+    if args.command == "review":
+        return f"review-{args.review_command}"
+    if args.command == "remediation":
+        return f"remediation-{args.remediation_command}"
+    if args.command in {"merge", "merge-preflight"}:
+        return "merge-preflight"
+    if args.command == "closeout":
+        return "closeout"
+    return "unknown"
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    resolver = LiveStateResolver(
+        args.repo_root,
+        repository=args.repository,
+    )
+    operation = _cli_operation(args)
+    task_number = args.task
+    operation_id = uuid.uuid4().hex
+    receipt_store = AuditReceiptStore(resolver.repo_root)
+    handler: Any = resolver
+
+    def emit_success(value: Any) -> int:
+        nonlocal operation_id
+        operation_id = _result_operation_id(value, operation_id)
+        print_json(
+            _write_success_receipt(
+                value,
+                operation=operation,
+                task_number=task_number,
+                operation_id=operation_id,
+                store=receipt_store,
+            ),
+            pretty=True,
+        )
+        if isinstance(value, LiveState) and value.status is ResolutionStatus.STOP:
+            return 2
+        return 0
+
+    try:
+        if args.command == "status":
+            return emit_success(resolver.resolve(task_number))
+        if args.command == "delivery" and args.delivery_command == "prepare":
+            handler = DeliveryPreparer(resolver)
+            return emit_success(handler.prepare(task_number))
+        if args.command == "delivery" and args.delivery_command == "complete":
+            handler = DeliveryCompleter(resolver)
+            return emit_success(
+                handler.complete(
+                    task_number,
+                    commit_message=args.commit_message,
+                    summary=args.summary,
+                    risks=args.risks,
+                )
+            )
+        if args.command == "review" and args.review_command == "prepare":
+            handler = ReviewPreparer(resolver)
+            return emit_success(handler.prepare(task_number))
+        if args.command == "review" and args.review_command == "complete":
+            handler = ReviewCompleter(resolver)
+            return emit_success(
+                handler.complete(
+                    task_number,
+                    args.review_id,
+                    verdict=args.verdict,
+                    findings_file=args.findings_file,
+                    research_outcome=args.research_outcome,
+                )
+            )
+        if args.command == "remediation" and args.remediation_command == "prepare":
+            handler = RemediationPreparer(resolver)
+            return emit_success(
+                handler.prepare(
+                    task_number,
+                    args.review_id,
+                    findings_file=args.findings_file,
+                )
+            )
+        if args.command == "remediation" and args.remediation_command == "no-change":
+            handler = RemediationNoChangeCompleter(resolver)
+            return emit_success(
+                handler.complete(
+                    task_number,
+                    args.review_id,
+                    summary=args.summary,
+                )
+            )
+        if args.command == "remediation" and args.remediation_command == "complete":
+            handler = RemediationCompleter(resolver)
+            return emit_success(
+                handler.complete(
+                    task_number,
+                    args.review_id,
+                    commit_message=args.commit_message,
+                    summary=args.summary,
+                    risks=args.risks,
+                )
+            )
+        if (
+            args.command == "merge" and args.merge_command == "preflight"
+        ) or args.command == "merge-preflight":
+            handler = MergePreflight(resolver)
+            return emit_success(handler.run(task_number))
+        if args.command == "closeout":
+            handler = CloseoutCompleter(resolver)
+            return emit_success(handler.complete(task_number))
+        raise LckStopError("unsupported LCK command")
+    except ReviewStaleError as exc:
+        try:
+            payload = _write_failure_receipt(
+                operation=operation,
+                task_number=task_number,
+                operation_id=operation_id,
+                status="stale",
+                code=exc.code,
+                error=str(exc),
+                handler=handler,
+                store=receipt_store,
+            )
+        except WorkflowToolError as receipt_error:
+            payload = _failure_fallback(
+                operation=operation,
+                task_number=task_number,
+                operation_id=operation_id,
+                status="stale",
+                code=exc.code,
+                error=str(exc),
+                receipt_error=receipt_error,
+                store=receipt_store,
+            )
+        print_json(payload)
+        return 3
+    except WorkflowToolError as exc:
+        try:
+            payload = _write_failure_receipt(
+                operation=operation,
+                task_number=task_number,
+                operation_id=operation_id,
+                status="stop",
+                code=getattr(exc, "code", None),
+                error=str(exc),
+                handler=handler,
+                store=receipt_store,
+            )
+        except WorkflowToolError as receipt_error:
+            payload = _failure_fallback(
+                operation=operation,
+                task_number=task_number,
+                operation_id=operation_id,
+                status="stop",
+                code=getattr(exc, "code", None),
+                error=str(exc),
+                receipt_error=receipt_error,
+                store=receipt_store,
+            )
+        print_json(payload)
+        return 2

--- a/tools/lck/closeout.py
+++ b/tools/lck/closeout.py
@@ -1,0 +1,736 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from .common import WorkflowToolError, is_sha, read_json_text, safe_text
+from .effects import DEFAULT_EFFECT_EXECUTOR_REGISTRY, EffectExecutorRegistry
+from .eligibility import PhaseEligibilityResolver
+from .github_projects import set_project_status_with_runner
+from .issue_profiles import resolve_leaf_issue_profile
+from .models import (
+    BASE_BRANCH,
+    LCK_SCHEMA_VERSION,
+    EffectReceipt,
+    LckStopError,
+    LiveState,
+    OperationSnapshot,
+    Phase,
+    _jsonable,
+    _merge_commit_sha,
+    _pr_base_sha,
+    _pr_head_sha,
+    _remote_refs,
+    branch_matches_profile,
+)
+from .profile_policies import (
+    DEFAULT_PROFILE_POLICY_REGISTRY,
+    PolicyContext,
+    ProfileEvidenceEnvelope,
+    ProfilePolicyError,
+    ProfilePolicyRegistry,
+    ProfileResolver,
+    profile_cleanup_label,
+    resolve_issue_policy,
+    validate_profile_completion,
+)
+from .review_workspace import ReviewInvocationStore, _identity_from_mapping
+from .shared_facts import _find_project_status
+from .state import (
+    LiveStateResolver,
+    OperationSnapshotBuilder,
+    _policy_issue_from_state,
+)
+
+
+def _label_names(issue: Mapping[str, Any] | None) -> set[str]:
+    if not isinstance(issue, Mapping):
+        return set()
+    raw = issue.get("labels")
+    if isinstance(raw, Mapping):
+        raw = raw.get("items")
+    if not isinstance(raw, list):
+        return set()
+    return {item for item in raw if isinstance(item, str)}
+
+
+def _pending_receipt(
+    effect: str,
+    action: str,
+    *,
+    reason: str,
+    details: Mapping[str, Any] | None = None,
+) -> EffectReceipt:
+    payload = {"reason": reason}
+    if details:
+        payload.update(details)
+    return EffectReceipt(effect=effect, action=action, details=payload)
+
+
+class MainSynchronizationEffect:
+    """Fast-forward the local main to origin/main and prove merge reachability."""
+
+    def __init__(self, resolver: LiveStateResolver) -> None:
+        self.resolver = resolver
+
+    def execute(
+        self,
+        state: LiveState,
+        *,
+        merge_sha: str | None,
+    ) -> EffectReceipt:
+        if not is_sha(merge_sha):
+            return _pending_receipt(
+                "synchronize_main",
+                "pending",
+                reason="merged PR merge commit identity is unavailable",
+            )
+        if state.git.get("clean") is not True:
+            return _pending_receipt(
+                "synchronize_main",
+                "pending",
+                reason="current worktree is not clean",
+            )
+        if state.git.get("branch") != BASE_BRANCH:
+            switched = self.resolver.runner.run(
+                ["git", "switch", BASE_BRANCH],
+                command_id="lck-closeout-switch-main",
+            )
+            if switched.returncode != 0:
+                return _pending_receipt(
+                    "synchronize_main",
+                    "pending",
+                    reason="cannot switch to main",
+                )
+        fetched = self.resolver.runner.run(
+            ["git", "fetch", "--prune", "origin"],
+            command_id="lck-closeout-fetch-origin",
+        )
+        if fetched.returncode != 0:
+            return _pending_receipt(
+                "synchronize_main",
+                "pending",
+                reason="cannot refresh origin/main",
+            )
+        merged = self.resolver.runner.run(
+            ["git", "merge", "--ff-only", f"refs/remotes/origin/{BASE_BRANCH}"],
+            command_id="lck-closeout-fast-forward-main",
+        )
+        if merged.returncode != 0:
+            return _pending_receipt(
+                "synchronize_main",
+                "pending",
+                reason="local main cannot fast-forward to origin/main",
+            )
+        head = self.resolver.runner.run(
+            ["git", "rev-parse", "HEAD"],
+            command_id="lck-closeout-main-head",
+        )
+        origin = self.resolver.runner.run(
+            ["git", "rev-parse", f"refs/remotes/origin/{BASE_BRANCH}"],
+            command_id="lck-closeout-origin-main-head",
+        )
+        ancestry = self.resolver.runner.run(
+            [
+                "git",
+                "merge-base",
+                "--is-ancestor",
+                merge_sha,
+                f"refs/remotes/origin/{BASE_BRANCH}",
+            ],
+            command_id="lck-closeout-merge-reachable",
+        )
+        if (
+            head.returncode != 0
+            or origin.returncode != 0
+            or not is_sha(head.stdout.strip())
+            or head.stdout.strip() != origin.stdout.strip()
+            or ancestry.returncode != 0
+        ):
+            return _pending_receipt(
+                "synchronize_main",
+                "pending",
+                reason="main synchronization postcondition is not proven",
+            )
+        return EffectReceipt(
+            effect="synchronize_main",
+            action="synchronized",
+            details={"main_sha": head.stdout.strip(), "merge_sha": merge_sha},
+        )
+
+
+class CloseoutMetadataEffect:
+    """Converge only the exact closed Task's Project status and lifecycle labels."""
+
+    def __init__(self, resolver: LiveStateResolver) -> None:
+        self.resolver = resolver
+
+    def _query_metadata(
+        self, repository: str, task_number: int
+    ) -> tuple[str | None, str | None, set[str]]:
+        result = self.resolver.runner.run(
+            [
+                "gh",
+                "issue",
+                "view",
+                str(task_number),
+                "--repo",
+                repository,
+                "--json",
+                "state,labels,projectItems",
+            ],
+            command_id="lck-closeout-metadata-postcondition",
+        )
+        if result.returncode != 0 or not result.stdout.strip():
+            return None, None, set()
+        value = read_json_text(
+            result.stdout, field="lck-closeout-metadata-postcondition"
+        )
+        if not isinstance(value, Mapping):
+            return None, None, set()
+        raw_labels = value.get("labels")
+        labels: set[str] = set()
+        if isinstance(raw_labels, list):
+            for item in raw_labels:
+                if isinstance(item, Mapping) and isinstance(item.get("name"), str):
+                    labels.add(str(item["name"]))
+                elif isinstance(item, str):
+                    labels.add(item)
+        return (
+            safe_text(value.get("state")),
+            _find_project_status(value.get("projectItems")),
+            labels,
+        )
+
+    def execute(self, state: LiveState) -> EffectReceipt:
+        if state.issue_state != "CLOSED":
+            return _pending_receipt(
+                "converge_task_metadata",
+                "pending",
+                reason="Issue is not closed by authoritative GitHub state",
+            )
+        if state.repository is None:
+            return _pending_receipt(
+                "converge_task_metadata",
+                "pending",
+                reason="repository identity is unavailable",
+            )
+        actions: list[str] = []
+        try:
+            if state.project_status != "Done":
+                set_project_status_with_runner(
+                    self.resolver.runner,
+                    state.repository,
+                    state.issue_number,
+                    value="Done",
+                )
+                actions.append("project-status-done")
+            labels = _label_names(state.issue)
+            if "codex:ready" not in labels or "codex:blocked" in labels:
+                label_result = self.resolver.runner.run(
+                    [
+                        "gh",
+                        "issue",
+                        "edit",
+                        str(state.issue_number),
+                        "--repo",
+                        state.repository,
+                        "--add-label",
+                        "codex:ready",
+                        "--remove-label",
+                        "codex:blocked",
+                    ],
+                    command_id="lck-closeout-lifecycle-labels",
+                )
+                if label_result.returncode != 0:
+                    return _pending_receipt(
+                        "converge_task_metadata",
+                        "pending",
+                        reason="lifecycle label convergence failed",
+                        details={"actions": actions},
+                    )
+                actions.append("lifecycle-labels-converged")
+        except WorkflowToolError:
+            return _pending_receipt(
+                "converge_task_metadata",
+                "pending",
+                reason="Project Status convergence failed",
+                details={"actions": actions},
+            )
+        final_state, final_project_status, final_labels = self._query_metadata(
+            state.repository, state.issue_number
+        )
+        if (
+            str(final_state or "").upper() != "CLOSED"
+            or final_project_status != "Done"
+            or "codex:ready" not in final_labels
+            or "codex:blocked" in final_labels
+        ):
+            return _pending_receipt(
+                "converge_task_metadata",
+                "pending",
+                reason="metadata convergence postcondition is not proven",
+                details={"actions": actions},
+            )
+        return EffectReceipt(
+            effect="converge_task_metadata",
+            action="already-converged" if not actions else "updated",
+            details={"actions": actions},
+        )
+
+
+class CleanupTaskRefsEffect:
+    """Clean only the verified Task branch and recognize GitHub auto-deletion."""
+
+    def __init__(self, resolver: LiveStateResolver) -> None:
+        self.resolver = resolver
+
+    def execute(
+        self,
+        state: LiveState,
+        *,
+        expected_head_sha: str | None,
+        merge_sha: str | None,
+    ) -> EffectReceipt:
+        branch = state.target_branch
+        profile = resolve_leaf_issue_profile(state.issue).profile
+        if (
+            branch == BASE_BRANCH
+            or profile is None
+            or not branch_matches_profile(branch, state.issue_number, profile)
+        ):
+            label = (
+                profile_cleanup_label(profile) if profile is not None else "leaf Issue"
+            )
+            raise LckStopError(f"Cleanup target is not the verified {label} branch")
+        worktrees = self.resolver.runner.run(
+            ["git", "worktree", "list", "--porcelain"],
+            command_id="lck-closeout-worktree-precondition",
+        )
+        if worktrees.returncode != 0:
+            return _pending_receipt(
+                "cleanup_task_refs",
+                "pending",
+                reason="current worktree ownership cannot be verified",
+            )
+        worktree_branches = {
+            line.removeprefix("branch refs/heads/")
+            for line in worktrees.stdout.splitlines()
+            if line.startswith("branch refs/heads/")
+        }
+        if branch in worktree_branches:
+            return _pending_receipt(
+                "cleanup_task_refs",
+                "pending",
+                reason="verified Task branch is still used by a worktree",
+            )
+
+        if not is_sha(expected_head_sha) or not is_sha(merge_sha):
+            raise LckStopError(
+                "Cleanup STOP: merged PR head and squash merge identities are required"
+            )
+        tree_result = self.resolver.runner.run(
+            ["git", "diff", "--quiet", expected_head_sha, merge_sha],
+            command_id="lck-closeout-squash-tree-equality",
+        )
+        if tree_result.returncode != 0:
+            raise LckStopError(
+                "Cleanup STOP: PR head tree does not equal squash merge tree"
+            )
+
+        if state.local_issue_branch is None and state.remote_issue_branch is None:
+            return EffectReceipt(
+                effect="cleanup_task_refs",
+                action="already-clean",
+                details={"branch": branch, "remote_branch": "already-deleted"},
+            )
+        if state.local_issue_branch is not None:
+            local_result = self.resolver.runner.run(
+                ["git", "rev-parse", f"refs/heads/{branch}"],
+                command_id="lck-closeout-local-branch-tip",
+            )
+            local_tip = local_result.stdout.strip()
+            if local_result.returncode != 0 or local_tip != expected_head_sha:
+                raise LckStopError(
+                    "Cleanup STOP: local Task branch diverges from merged PR head"
+                )
+            deleted = self.resolver.runner.run(
+                ["git", "branch", "-d", branch],
+                command_id="lck-closeout-local-branch-delete",
+            )
+            if deleted.returncode != 0:
+                deleted = self.resolver.runner.run(
+                    ["git", "branch", "-D", branch],
+                    command_id="lck-closeout-local-branch-force-delete-after-proof",
+                )
+            if deleted.returncode != 0:
+                return _pending_receipt(
+                    "cleanup_task_refs",
+                    "pending",
+                    reason="verified local Task branch could not be deleted",
+                )
+        if state.remote_issue_branch is not None:
+            if state.remote_issue_oid != expected_head_sha:
+                raise LckStopError(
+                    "Cleanup STOP: remote Task branch diverges from merged PR head"
+                )
+            remote_ref = self.resolver.runner.run(
+                ["git", "ls-remote", "--heads", "origin", branch],
+                command_id="lck-closeout-remote-branch-precondition",
+            )
+            if remote_ref.returncode != 0:
+                return _pending_receipt(
+                    "cleanup_task_refs",
+                    "pending",
+                    reason="remote Task branch precondition could not be verified",
+                )
+            remote_refs = _remote_refs(remote_ref.stdout)
+            observed_remote_oid = remote_refs.get(branch)
+            if observed_remote_oid is None:
+                if remote_ref.stdout.strip():
+                    raise LckStopError(
+                        "Cleanup STOP: remote Task branch identity is malformed"
+                    )
+                return EffectReceipt(
+                    effect="cleanup_task_refs",
+                    action="already-clean",
+                    details={"branch": branch, "remote_branch": "already-deleted"},
+                )
+            if observed_remote_oid != expected_head_sha:
+                raise LckStopError(
+                    "Cleanup STOP: remote Task branch diverges from merged PR head"
+                )
+            removed = self.resolver.runner.run(
+                [
+                    "git",
+                    "push",
+                    "origin",
+                    "--delete",
+                    branch,
+                ],
+                command_id="lck-closeout-remote-branch-delete",
+            )
+            if removed.returncode != 0:
+                return _pending_receipt(
+                    "cleanup_task_refs",
+                    "pending",
+                    reason="verified remote Task branch could not be deleted",
+                )
+            verified = self.resolver.runner.run(
+                ["git", "ls-remote", "--heads", "origin", branch],
+                command_id="lck-closeout-remote-branch-verify",
+            )
+            if verified.returncode != 0 or verified.stdout.strip():
+                return _pending_receipt(
+                    "cleanup_task_refs",
+                    "pending",
+                    reason="remote Task branch deletion postcondition is not proven",
+                )
+        return EffectReceipt(
+            effect="cleanup_task_refs",
+            action="cleaned",
+            details={"branch": branch, "expected_head_sha": expected_head_sha},
+        )
+
+
+@dataclass(frozen=True)
+class CloseoutResult:
+    task_number: int
+    status: str
+    business_delivery: str
+    cleanup: str
+    effects: tuple[EffectReceipt, ...]
+    operation_snapshot: OperationSnapshot
+    research_outcome: str | None = None
+    profile_evidence: ProfileEvidenceEnvelope | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": LCK_SCHEMA_VERSION,
+            "operation": "closeout",
+            "task_number": self.task_number,
+            "status": self.status,
+            "issue_profile": _jsonable(self.operation_snapshot.state.issue_profile),
+            "business_delivery": self.business_delivery,
+            "cleanup": self.cleanup,
+            "research_outcome": self.research_outcome,
+            "profile_evidence": (
+                self.profile_evidence.to_dict() if self.profile_evidence else None
+            ),
+            "effects": [item.to_dict() for item in self.effects],
+            "operation_snapshot": self.operation_snapshot.to_dict(),
+            "automatic_merge": False,
+            "manual_issue_close": False,
+        }
+
+
+class CloseoutCompleter:
+    """Resolve and converge post-merge state without trusting prior snapshots."""
+
+    def __init__(
+        self,
+        resolver: LiveStateResolver,
+        *,
+        eligibility: PhaseEligibilityResolver | None = None,
+        main_effect: MainSynchronizationEffect | None = None,
+        metadata_effect: CloseoutMetadataEffect | None = None,
+        cleanup_effect: CleanupTaskRefsEffect | None = None,
+        review_store: ReviewInvocationStore | None = None,
+        effect_registry: EffectExecutorRegistry | None = None,
+        policy_registry: ProfilePolicyRegistry | None = None,
+        profile_resolver: ProfileResolver | None = None,
+    ) -> None:
+        self.resolver = resolver
+        self.snapshots = OperationSnapshotBuilder(resolver)
+        self.policy_registry = policy_registry or DEFAULT_PROFILE_POLICY_REGISTRY
+        self.profile_resolver = (
+            profile_resolver
+            or getattr(eligibility, "profile_resolver", None)
+            or resolve_leaf_issue_profile
+        )
+        self.eligibility = eligibility or PhaseEligibilityResolver(
+            registry=self.policy_registry,
+            profile_resolver=self.profile_resolver,
+        )
+        self.main_effect = main_effect or MainSynchronizationEffect(resolver)
+        self.metadata_effect = metadata_effect or CloseoutMetadataEffect(resolver)
+        self.cleanup_effect = cleanup_effect or CleanupTaskRefsEffect(resolver)
+        self.effect_registry = effect_registry or DEFAULT_EFFECT_EXECUTOR_REGISTRY
+        self.review_store = review_store or ReviewInvocationStore(resolver.repo_root)
+        self.last_snapshot: OperationSnapshot | None = None
+        self.last_effects: list[EffectReceipt] = []
+        self.last_profile_evidence: ProfileEvidenceEnvelope | None = None
+
+    @staticmethod
+    def _validate_merged_identity(state: LiveState) -> tuple[str, str]:
+        pr = state.merged_pr
+        if not isinstance(pr, Mapping):
+            raise LckStopError("Closeout STOP: merged PR identity is unavailable")
+        if str(pr.get("state", "")).upper() != "MERGED":
+            raise LckStopError("Closeout STOP: merged PR state is not MERGED")
+        number = pr.get("number")
+        if not isinstance(number, int) or isinstance(number, bool) or number <= 0:
+            raise LckStopError("Closeout STOP: merged PR number is unavailable")
+        if pr.get("baseRefName") != BASE_BRANCH:
+            raise LckStopError("Closeout STOP: merged PR base branch is not main")
+        if pr.get("headRefName") != state.target_branch:
+            raise LckStopError(
+                "Closeout STOP: merged PR head branch is not the resolved Task branch"
+            )
+        expected_head = _pr_head_sha(pr)
+        base_sha = _pr_base_sha(pr)
+        merge_sha = _merge_commit_sha(pr)
+        merged_at = pr.get("mergedAt", pr.get("merged_at"))
+        if (
+            expected_head is None
+            or base_sha is None
+            or merge_sha is None
+            or not isinstance(merged_at, str)
+            or not merged_at
+        ):
+            raise LckStopError("Closeout STOP: merged PR identity is incomplete")
+        closing = pr.get("closingIssuesReferences")
+        if not isinstance(closing, list):
+            raise LckStopError(
+                "Closeout STOP: merged PR closing-Task linkage is unavailable"
+            )
+        closing_numbers = [
+            item.get("number")
+            for item in closing
+            if isinstance(item, Mapping) and isinstance(item.get("number"), int)
+        ]
+        if len(closing_numbers) != 1 or closing_numbers[0] != state.issue_number:
+            raise LckStopError(
+                "Closeout STOP: merged PR does not close exactly this Task"
+            )
+        if state.issue_state == "CLOSED":
+            closure = (
+                state.issue.get("issue_closure")
+                if isinstance(state.issue, Mapping)
+                else None
+            )
+            if (
+                not isinstance(closure, Mapping)
+                or closure.get("evidence_status") != "complete"
+                or closure.get("status") != "closed-by-pr"
+                or closure.get("closer_repository") != state.repository
+                or closure.get("closer_number") != number
+            ):
+                raise LckStopError(
+                    "Closeout STOP: closed Task is not proven closed by the merged PR"
+                )
+        if (
+            state.local_issue_head is not None
+            and state.local_issue_head != expected_head
+        ):
+            raise LckStopError(
+                "Closeout STOP: local Task branch diverges from merged PR head"
+            )
+        if (
+            state.remote_issue_oid is not None
+            and state.remote_issue_oid != expected_head
+        ):
+            raise LckStopError(
+                "Closeout STOP: remote Task branch diverges from merged PR head"
+            )
+        return expected_head, merge_sha
+
+    def _validate_reviewed_identity(
+        self, state: LiveState, merged_pr: Mapping[str, Any]
+    ) -> Mapping[str, Any]:
+        latest = self.review_store.read_latest_review(state.issue_number)
+        if not isinstance(latest, Mapping) or latest.get("verdict") != "PASS":
+            raise LckStopError(
+                "Closeout STOP: latest Independent Review PASS is unavailable"
+            )
+        review_id = latest.get("review_id")
+        if not isinstance(review_id, str):
+            raise LckStopError("Closeout STOP: latest Review PASS has no review id")
+        record = self.review_store.read_record(state.issue_number, review_id)
+        if (
+            record.get("task_number") != state.issue_number
+            or record.get("review_id") != review_id
+            or record.get("verdict") != "PASS"
+            or record.get("status") != "READY_FOR_MERGE_PREFLIGHT"
+        ):
+            raise LckStopError("Closeout STOP: latest Review PASS record is invalid")
+        raw_identity = record.get("identity")
+        if not isinstance(raw_identity, Mapping):
+            raise LckStopError("Closeout STOP: Review PASS identity is unavailable")
+        reviewed = _identity_from_mapping(raw_identity)
+        current_contract = state.leaf_contract
+        current_body_sha256 = (
+            current_contract.get("body_sha256")
+            if isinstance(current_contract, Mapping)
+            else None
+        )
+        if current_body_sha256 != reviewed.task_body_sha256:
+            raise LckStopError(
+                "Closeout STOP: Review PASS is stale: Task Contract changed"
+            )
+        if (
+            reviewed.task_number != state.issue_number
+            or reviewed.pr_number != merged_pr.get("number")
+            or reviewed.base_sha != _pr_base_sha(merged_pr)
+            or reviewed.head_sha != _pr_head_sha(merged_pr)
+        ):
+            raise LckStopError(
+                "Closeout STOP: merged PR/head does not match the latest Review PASS"
+            )
+        return record
+
+    def complete(self, task_number: int) -> CloseoutResult:
+        effects: list[EffectReceipt] = []
+        # Keep the same list object while effects run so any effect failure
+        # still leaves already-completed effects visible to the failure path.
+        self.last_effects = effects
+        self.last_profile_evidence = None
+        snapshot = self.snapshots.acquire(task_number, operation="closeout")
+        self.last_snapshot = snapshot
+        state = snapshot.state
+        decision = self.eligibility.resolve(state, Phase.CLOSEOUT)
+        if not decision.eligible:
+            raise LckStopError(
+                f"Closeout STOP for Task #{task_number}: " + "; ".join(decision.reasons)
+            )
+        expected_head, merge_sha = self._validate_merged_identity(state)
+        if not isinstance(state.merged_pr, Mapping):
+            raise LckStopError("Closeout STOP: merged PR identity is unavailable")
+        review_record = self._validate_reviewed_identity(state, state.merged_pr)
+        try:
+            profile, _policy = resolve_issue_policy(
+                _policy_issue_from_state(state),
+                registry=self.policy_registry,
+                profile_resolver=self.profile_resolver or resolve_leaf_issue_profile,
+            )
+            raw_envelope = review_record.get("profile_evidence")
+            review_evidence = (
+                raw_envelope.get("review")
+                if isinstance(raw_envelope, Mapping)
+                else None
+            )
+            completion = validate_profile_completion(
+                profile,
+                _policy_issue_from_state(state),
+                {
+                    "task_number": state.issue_number,
+                    "repository": state.repository,
+                    "merged_pr": state.merged_pr,
+                    "review_record": review_record,
+                    "review_evidence": review_evidence,
+                },
+                registry=self.policy_registry,
+                context=PolicyContext(
+                    profile=profile,
+                    phase="completion",
+                    issue=_policy_issue_from_state(state),
+                    review_record=review_record,
+                    merged_pr=state.merged_pr,
+                ),
+            )
+        except (ProfilePolicyError, TypeError, ValueError) as exc:
+            raise LckStopError(
+                f"profile completion capability rejected the merge: {exc}"
+            ) from exc
+
+        self.last_profile_evidence = completion.profile_evidence
+        # Validate the exact Review/artifact binding and bounded completion
+        # descriptor before any Closeout effect. Execution still follows the
+        # established main -> metadata -> profile completion -> cleanup order.
+        main = self.main_effect.execute(state, merge_sha=merge_sha)
+        effects.append(main)
+
+        metadata = self.metadata_effect.execute(state)
+        effects.append(metadata)
+
+        completion_effect: EffectReceipt | None = None
+        if completion.effect is not None:
+            if main.action in {"synchronized", "already-synced"}:
+                completion_effect = self.effect_registry.execute(
+                    completion.effect,
+                    resolver=self.resolver,
+                    state=state,
+                )
+            else:
+                completion_effect = _pending_receipt(
+                    completion.effect.effect_kind,
+                    "pending",
+                    reason="main synchronization is incomplete",
+                    details=completion.effect.receipt,
+                )
+            effects.append(completion_effect)
+
+        if main.action in {"synchronized", "already-synced"}:
+            cleanup = self.cleanup_effect.execute(
+                state,
+                expected_head_sha=expected_head,
+                merge_sha=merge_sha,
+            )
+        else:
+            cleanup = _pending_receipt(
+                "cleanup_task_refs",
+                "pending",
+                reason="main synchronization is incomplete",
+            )
+        effects.append(cleanup)
+        cleanup_complete = (
+            main.action in {"synchronized", "already-synced"}
+            and metadata.action in {"updated", "already-converged"}
+            and cleanup.action in {"cleaned", "already-clean"}
+        )
+        completion_complete = completion_effect is None or completion_effect.is_complete
+        return CloseoutResult(
+            task_number=task_number,
+            status="BUSINESS_DELIVERY_COMPLETE",
+            business_delivery="COMPLETE" if completion_complete else "PENDING",
+            cleanup="COMPLETE" if cleanup_complete else "PENDING",
+            effects=tuple(effects),
+            operation_snapshot=snapshot,
+            research_outcome=(
+                completion_effect.details.get("outcome")
+                if completion_effect is not None
+                else None
+            ),
+            profile_evidence=completion.profile_evidence,
+        )

--- a/tools/lck/common.py
+++ b/tools/lck/common.py
@@ -1,0 +1,528 @@
+#!/usr/bin/env python3
+"""Shared helpers for local workflow evidence and validation tools."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shutil
+import signal
+import subprocess
+import sys
+import threading
+import time
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Final, TypeGuard
+
+MAX_STRING: Final = 512
+MAX_LIST_ITEMS: Final = 50
+MAX_STDERR_TAIL: Final = 2000
+MAX_LOG_BYTES: Final = 1_000_000
+DEFAULT_COMMAND_TIMEOUT_SECONDS: Final = 30.0
+NETWORK_COMMAND_TIMEOUT_SECONDS: Final = 60.0
+VALIDATION_COMMAND_TIMEOUT_SECONDS: Final = 1200.0
+PROCESS_TERM_GRACE_SECONDS: Final = 2.0
+RETRY_DELAY_SECONDS: Final = 0.5
+PROGRESS_HEARTBEAT_INTERVAL_SECONDS: Final = 30.0
+TIMEOUT_EXIT_CODE: Final = 124
+SHA_PATTERN: Final = re.compile(r"^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$")
+WINDOWS_ABSOLUTE_PATH: Final = re.compile(r"^[A-Za-z]:[\\/]")
+WINDOWS_ABSOLUTE_PATH_IN_TEXT: Final = re.compile(
+    r"(?<![A-Za-z0-9])[A-Za-z]:[\\/][^\s\"']+"
+)
+POSIX_ABSOLUTE_PATH_IN_TEXT: Final = re.compile(r"(?<![:/A-Za-z0-9])/(?!/)[^\s\"']+")
+SENSITIVE_VALUE_PATTERNS: Final = (
+    re.compile(r"gh[pousr]_[A-Za-z0-9]{20,}"),
+    re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._~-]{16,}"),
+    re.compile(r"-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----"),
+    re.compile(
+        r"(?i)(authorization|cookie|api[_-]?key|token|password|secret)\s*[:=]\s*\S+"
+    ),
+)
+
+
+class WorkflowToolError(RuntimeError):
+    """Expected user-facing workflow tooling error."""
+
+
+ProgressCallback = Callable[[], None]
+
+
+class ProgressReporter:
+    """Write bounded, non-authoritative workflow progress to stderr."""
+
+    _EVENTS: Final = frozenset(
+        {"started", "running", "heartbeat", "completed", "failed"}
+    )
+
+    def __init__(self, operation: str) -> None:
+        self.operation = operation
+        self._enabled = True
+        self._last_stage = "initializing"
+
+    @staticmethod
+    def _value(value: str) -> str:
+        # Progress values are internal identifiers, but keep the output safe if
+        # a future caller derives one from a command or error path.
+        normalized = " ".join(value.replace("\x00", "").split())
+        return safe_text(normalized, limit=96) or "unknown"
+
+    def emit(
+        self,
+        event: str,
+        stage: str,
+        *,
+        command_id: str | None = None,
+    ) -> None:
+        """Emit one small JSONL event without affecting lifecycle execution."""
+        if not self._enabled or event not in self._EVENTS:
+            return
+        if event != "failed":
+            self._last_stage = stage
+        payload: dict[str, str | int] = {
+            "schema_version": 1,
+            "kind": "workflow-progress",
+            "operation": self._value(self.operation),
+            "stage": self._value(stage),
+            "event": event,
+            "authority": "non-authoritative observability only",
+        }
+        if command_id is not None:
+            payload["command_id"] = self._value(command_id)
+        try:
+            print(json_dumps(payload), end="", file=sys.stderr, flush=True)
+        except Exception:
+            # Progress is deliberately outside the lifecycle result contract.
+            # A closed or unavailable diagnostic stream must not change the
+            # command's exit status or suppress its final machine result.
+            self._enabled = False
+
+    def started(self, stage: str) -> None:
+        self.emit("started", stage)
+
+    def running(self, stage: str, *, command_id: str | None = None) -> None:
+        self.emit("running", stage, command_id=command_id)
+
+    def heartbeat(self, stage: str, *, command_id: str | None = None) -> None:
+        self.emit("heartbeat", stage, command_id=command_id)
+
+    def completed(self, stage: str) -> None:
+        self.emit("completed", stage)
+
+    def failed(self, stage: str | None = None) -> None:
+        self.emit("failed", stage or self._last_stage)
+
+
+def build_workflow_env(repo_root: Path) -> dict[str, str]:
+    """Build the shared environment for Workflow-owned subprocesses.
+
+    Workflow runtime state belongs under the repository, not in a user HOME
+    cache that may be unavailable in a sandbox. An explicit caller override
+    remains authoritative.
+    """
+    env = os.environ.copy()
+    env.setdefault(
+        "UV_CACHE_DIR",
+        str(repo_root.resolve() / ".workflow.local" / "uv-cache"),
+    )
+    return env
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    command_id: str
+    argv: tuple[str, ...]
+    returncode: int
+    stdout: str
+    stderr: str
+    timed_out: bool = False
+    timeout_seconds: float | None = None
+
+
+def _command_timeout(
+    argv: Sequence[str], *, executable: str, validation: bool
+) -> float:
+    """Choose a bounded timeout appropriate for the command class."""
+    if validation:
+        return VALIDATION_COMMAND_TIMEOUT_SECONDS
+    if executable in {"gh", "gh.exe", "gh.cmd"}:
+        return DEFAULT_COMMAND_TIMEOUT_SECONDS
+    if executable in {"git", "git.exe", "git.cmd"} and any(
+        item in {"fetch", "ls-remote", "push", "pull", "clone"} for item in argv[1:]
+    ):
+        return NETWORK_COMMAND_TIMEOUT_SECONDS
+    return DEFAULT_COMMAND_TIMEOUT_SECONDS
+
+
+def _signal_process_group(process: subprocess.Popen[str], sig: signal.Signals) -> None:
+    """Terminate a bounded command and its descendants when possible."""
+    try:
+        if os.name == "posix":
+            os.killpg(process.pid, sig)
+        else:
+            process.send_signal(sig)
+    except ProcessLookupError:
+        pass
+
+
+def _run_process(
+    resolved_argv: Sequence[str],
+    *,
+    cwd: Path,
+    env: Mapping[str, str],
+    timeout_seconds: float,
+    on_heartbeat: ProgressCallback | None = None,
+) -> tuple[int, str, str, bool]:
+    """Run one command with a timeout and bounded heartbeat cadence."""
+    process = subprocess.Popen(
+        resolved_argv,
+        cwd=cwd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=env,
+        start_new_session=os.name == "posix",
+    )
+
+    stdout_parts: list[str] = []
+    stderr_parts: list[str] = []
+
+    def drain(pipe: Any, parts: list[str]) -> None:
+        try:
+            value = pipe.read()
+            if value:
+                parts.append(value)
+        finally:
+            pipe.close()
+
+    readers = (
+        threading.Thread(
+            target=drain,
+            args=(process.stdout, stdout_parts),
+            daemon=True,
+        ),
+        threading.Thread(
+            target=drain,
+            args=(process.stderr, stderr_parts),
+            daemon=True,
+        ),
+    )
+    for reader in readers:
+        reader.start()
+
+    timed_out = False
+    deadline = time.monotonic() + timeout_seconds
+    while process.poll() is None:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            timed_out = True
+            break
+        wait_window = min(remaining, PROGRESS_HEARTBEAT_INTERVAL_SECONDS)
+        try:
+            process.wait(timeout=wait_window)
+        except subprocess.TimeoutExpired:
+            if on_heartbeat is not None:
+                try:
+                    on_heartbeat()
+                except Exception:
+                    # The progress channel is not allowed to affect command
+                    # execution or its final result.
+                    pass
+
+    if timed_out:
+        _signal_process_group(process, signal.SIGTERM)
+        try:
+            process.wait(timeout=PROCESS_TERM_GRACE_SECONDS)
+        except subprocess.TimeoutExpired:
+            _signal_process_group(process, signal.SIGKILL)
+            process.wait()
+        timeout_message = f"command timed out after {timeout_seconds:g} seconds"
+        stderr_parts.append(timeout_message)
+
+    for reader in readers:
+        reader.join()
+    return (
+        TIMEOUT_EXIT_CODE if timed_out else int(process.returncode),
+        "".join(stdout_parts),
+        "\n".join(stderr_parts),
+        timed_out,
+    )
+
+
+class CommandRunner:
+    """Run commands without echoing raw output to the caller."""
+
+    def __init__(self, repo_root: Path) -> None:
+        self.repo_root = repo_root
+        self.tool_calls = 0
+        self.git_commands = 0
+        self.github_queries = 0
+        self.validation_commands = 0
+
+    def run(
+        self,
+        argv: Sequence[str],
+        *,
+        command_id: str,
+        cwd: Path | None = None,
+        validation: bool = False,
+        env: Mapping[str, str] | None = None,
+        timeout_seconds: float | None = None,
+        retries: int = 0,
+        progress: ProgressCallback | None = None,
+    ) -> CommandResult:
+        if not argv:
+            raise WorkflowToolError("command argv cannot be empty")
+        if retries < 0 or retries > 2:
+            raise WorkflowToolError("command retries must be between 0 and 2")
+        process_env = build_workflow_env(self.repo_root)
+        process_env.setdefault("PYTHONUTF8", "1")
+        process_env.setdefault("PYTHONIOENCODING", "utf-8")
+        if env:
+            process_env.update(env)
+        executable_path = shutil.which(str(argv[0]), path=process_env.get("PATH"))
+        resolved_argv = [
+            executable_path or str(argv[0]),
+            *[str(arg) for arg in argv[1:]],
+        ]
+        executable = Path(resolved_argv[0]).name.lower()
+        self.tool_calls += 1
+        if executable in {"git", "git.exe", "git.cmd"}:
+            self.git_commands += 1
+        if executable in {"gh", "gh.exe", "gh.cmd"}:
+            self.github_queries += 1
+        if validation:
+            self.validation_commands += 1
+        effective_timeout = (
+            _command_timeout(
+                resolved_argv,
+                executable=executable,
+                validation=validation,
+            )
+            if timeout_seconds is None
+            else timeout_seconds
+        )
+        if effective_timeout <= 0:
+            raise WorkflowToolError("command timeout must be positive")
+        for attempt in range(retries + 1):
+            try:
+                returncode, stdout, stderr, timed_out = _run_process(
+                    resolved_argv,
+                    cwd=cwd or self.repo_root,
+                    env=process_env,
+                    timeout_seconds=effective_timeout,
+                    on_heartbeat=progress,
+                )
+            except FileNotFoundError:
+                return CommandResult(
+                    command_id=command_id,
+                    argv=tuple(resolved_argv),
+                    returncode=127,
+                    stdout="",
+                    stderr=f"executable not found: {Path(argv[0]).name}",
+                )
+            if returncode == 0 or returncode == 127 or attempt == retries:
+                break
+            time.sleep(RETRY_DELAY_SECONDS)
+        return CommandResult(
+            command_id=command_id,
+            argv=tuple(resolved_argv),
+            returncode=returncode,
+            stdout=stdout,
+            stderr=stderr,
+            timed_out=timed_out,
+            timeout_seconds=effective_timeout if timed_out else None,
+        )
+
+    def counters(self) -> dict[str, int]:
+        return {
+            "tool_calls": self.tool_calls,
+            "git_commands": self.git_commands,
+            "github_queries": self.github_queries,
+            "validation_commands": self.validation_commands,
+        }
+
+
+def json_dumps(value: Any, *, pretty: bool = False) -> str:
+    if pretty:
+        return json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    return (
+        json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        + "\n"
+    )
+
+
+def print_json(value: Mapping[str, Any], *, pretty: bool = False) -> None:
+    print(json_dumps(value, pretty=pretty), end="")
+
+
+def read_json_text(text: str, *, field: str) -> Any:
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise WorkflowToolError(f"invalid JSON from {field}: {exc}") from exc
+
+
+def read_json_file(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise WorkflowToolError(f"required file is missing: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise WorkflowToolError(f"invalid JSON in {path}: {exc}") from exc
+
+
+def atomic_write_json(path: Path, value: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    temp.write_text(json_dumps(value, pretty=True), encoding="utf-8", newline="\n")
+    os.replace(temp, path)
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def sha256_json(value: Any) -> str:
+    payload = json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return sha256_bytes(payload)
+
+
+def is_sha(value: Any) -> TypeGuard[str]:
+    return isinstance(value, str) and SHA_PATTERN.fullmatch(value) is not None
+
+
+def safe_text(value: Any, *, limit: int = MAX_STRING) -> str | None:
+    if value is None:
+        return None
+    text = str(value).replace("\x00", "")
+    text = redact_machine_paths(redact_sensitive(text))
+    if WINDOWS_ABSOLUTE_PATH.match(text) or (
+        text.startswith("/") and not text.startswith("//")
+    ):
+        return "<absolute-path-redacted>"
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 16)] + "…<truncated>"
+
+
+def redact_sensitive(text: str) -> str:
+    result = text
+    for pattern in SENSITIVE_VALUE_PATTERNS:
+        result = pattern.sub("<redacted>", result)
+    return result
+
+
+def redact_machine_paths(text: str) -> str:
+    value = WINDOWS_ABSOLUTE_PATH_IN_TEXT.sub("<absolute-path-redacted>", text)
+    return POSIX_ABSOLUTE_PATH_IN_TEXT.sub("<absolute-path-redacted>", value)
+
+
+def stderr_tail(text: str, *, limit: int = MAX_STDERR_TAIL) -> str:
+    value = redact_machine_paths(redact_sensitive(text.strip()))
+    if len(value) <= limit:
+        return value
+    return "<truncated>…" + value[-limit:]
+
+
+def bounded_list(
+    values: Sequence[Any],
+    *,
+    item_limit: int = MAX_LIST_ITEMS,
+    string_limit: int = MAX_STRING,
+) -> dict[str, Any]:
+    bounded: list[Any] = []
+    for item in values[:item_limit]:
+        if isinstance(item, str):
+            bounded.append(safe_text(item, limit=string_limit))
+        elif isinstance(item, Mapping):
+            bounded.append(
+                {
+                    str(key): safe_text(value, limit=string_limit)
+                    if isinstance(value, str)
+                    else value
+                    for key, value in item.items()
+                }
+            )
+        else:
+            bounded.append(item)
+    return {
+        "items": bounded,
+        "count": len(values),
+        "truncated": len(values) > item_limit,
+    }
+
+
+def normalize_repo_relative(path: Path, repo_root: Path) -> str:
+    resolved = path.resolve()
+    root = repo_root.resolve()
+    try:
+        relative = resolved.relative_to(root)
+    except ValueError as exc:
+        raise WorkflowToolError("path must remain inside repository root") from exc
+    return relative.as_posix()
+
+
+def exact_gitignore_patterns(repo_root: Path) -> set[str]:
+    ignore = repo_root / ".gitignore"
+    if not ignore.exists():
+        return set()
+    patterns: set[str] = set()
+    for raw in ignore.read_text(encoding="utf-8-sig").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or line.startswith("!"):
+            continue
+        patterns.add(line.removeprefix("./"))
+    return patterns
+
+
+def require_exact_ignored_directory(repo_root: Path, relative: str) -> Path:
+    normalized = relative.strip().removeprefix("./").rstrip("/") + "/"
+    if normalized not in exact_gitignore_patterns(repo_root):
+        raise WorkflowToolError(
+            f"local output directory is not covered by an exact .gitignore rule: {normalized}"
+        )
+    path = repo_root / normalized.rstrip("/")
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def parse_repository_slug(remote: str) -> str | None:
+    value = remote.strip()
+    if not value:
+        return None
+    value = re.sub(r"^[a-z]+://[^/@]+@", "", value, flags=re.IGNORECASE)
+    value = re.sub(r"^[a-z]+://", "", value, flags=re.IGNORECASE)
+    value = value.removeprefix("git@")
+    value = value.replace(":", "/", 1) if value.startswith("github.com:") else value
+    if "github.com/" in value:
+        value = value.split("github.com/", 1)[1]
+    elif value.startswith("github.com/"):
+        value = value[len("github.com/") :]
+    value = value.removesuffix(".git").strip("/")
+    if re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", value):
+        return value
+    return None
+
+
+def command_warning(result: CommandResult) -> dict[str, Any]:
+    warning: dict[str, Any] = {
+        "command_id": result.command_id,
+        "exit_code": result.returncode,
+        "error": stderr_tail(result.stderr or result.stdout),
+    }
+    if result.timed_out:
+        warning["timed_out"] = True
+        warning["timeout_seconds"] = result.timeout_seconds
+    return warning

--- a/tools/lck/config/validation_profiles.json
+++ b/tools/lck/config/validation_profiles.json
@@ -1,0 +1,283 @@
+{
+  "schema_version": 1,
+  "runner_version": "1.2.0",
+  "ci_workflow": ".github/workflows/ci.yml",
+  "ci_validation_commands": [
+    [
+      "uv",
+      "lock",
+      "--check"
+    ],
+    [
+      "uv",
+      "run",
+      "--frozen",
+      "pytest"
+    ],
+    [
+      "uv",
+      "run",
+      "--frozen",
+      "ruff",
+      "check",
+      "."
+    ],
+    [
+      "uv",
+      "run",
+      "--frozen",
+      "ruff",
+      "format",
+      "--check",
+      "."
+    ],
+    [
+      "uv",
+      "run",
+      "--frozen",
+      "mypy",
+      "src",
+      "tools/lck",
+      "tests"
+    ]
+  ],
+  "profiles": {
+    "current-ci-equivalent": {
+      "kind": "ci-equivalent",
+      "description": "Current CI validation commands plus local whitespace validation.",
+      "timeout_seconds": 900,
+      "requires_clean_worktree": false,
+      "requires_main_branch": false,
+      "commands": [
+        {
+          "id": "uv-lock-check",
+          "argv": [
+            "uv",
+            "lock",
+            "--check"
+          ]
+        },
+        {
+          "id": "pytest",
+          "argv": [
+            "uv",
+            "run",
+            "--frozen",
+            "pytest"
+          ]
+        },
+        {
+          "id": "ruff-check",
+          "argv": [
+            "uv",
+            "run",
+            "--frozen",
+            "ruff",
+            "check",
+            "."
+          ]
+        },
+        {
+          "id": "ruff-format-check",
+          "argv": [
+            "uv",
+            "run",
+            "--frozen",
+            "ruff",
+            "format",
+            "--check",
+            "."
+          ]
+        },
+        {
+          "id": "mypy",
+          "argv": [
+            "uv",
+            "run",
+            "--frozen",
+            "mypy",
+            "src",
+            "tools/lck",
+            "tests"
+          ]
+        },
+        {
+          "id": "git-diff-check",
+          "argv": [
+            "git",
+            "diff",
+            "--check"
+          ]
+        }
+      ]
+    },
+    "targeted": {
+      "kind": "targeted",
+      "description": "Fixed workflow-tool test preset. This is not CI-equivalent.",
+      "timeout_seconds": 300,
+      "requires_clean_worktree": false,
+      "requires_main_branch": false,
+      "commands": [
+        {
+          "id": "pytest-tools",
+          "argv": [
+            "uv",
+            "run",
+            "--frozen",
+            "pytest",
+            "tests/tools"
+          ]
+        }
+      ]
+    },
+    "targeted:tools-tests": {
+      "kind": "targeted",
+      "description": "Fixed tools test preset. This is not CI-equivalent.",
+      "timeout_seconds": 300,
+      "requires_clean_worktree": false,
+      "requires_main_branch": false,
+      "commands": [
+        {
+          "id": "pytest-tools",
+          "argv": [
+            "uv",
+            "run",
+            "--frozen",
+            "pytest",
+            "tests/tools"
+          ]
+        }
+      ]
+    },
+    "targeted:workflow-tests": {
+      "kind": "targeted",
+      "description": "Fixed workflow runner test preset. This is not CI-equivalent.",
+      "timeout_seconds": 300,
+      "requires_clean_worktree": false,
+      "requires_main_branch": false,
+      "commands": [
+        {
+          "id": "pytest-workflow",
+          "argv": [
+            "uv",
+            "run",
+            "--frozen",
+            "pytest",
+            "tests/tools/lck/test_workflow_skills.py",
+            "tests/tools/lck/test_validation_runner.py",
+            "tests/tools/lck/test_feature_audit.py",
+            "tests/tools/lck/test_wsl2_validation_runner.py",
+            "tests/tools/lck/test_wsl2_validation_rules.py",
+            "tests/tools/lck/test_acceptance.py"
+          ]
+        }
+      ]
+    },
+    "post-merge": {
+      "kind": "post-merge",
+      "description": "Post-merge validation for synchronized main only.",
+      "timeout_seconds": 900,
+      "requires_clean_worktree": true,
+      "requires_main_branch": true,
+      "requires_origin_main_identity": true,
+      "commands": [
+        {
+          "id": "uv-lock-check",
+          "argv": [
+            "uv",
+            "lock",
+            "--check"
+          ]
+        },
+        {
+          "id": "pytest",
+          "argv": [
+            "uv",
+            "run",
+            "--frozen",
+            "pytest"
+          ]
+        },
+        {
+          "id": "ruff-check",
+          "argv": [
+            "uv",
+            "run",
+            "--frozen",
+            "ruff",
+            "check",
+            "."
+          ]
+        },
+        {
+          "id": "ruff-format-check",
+          "argv": [
+            "uv",
+            "run",
+            "--frozen",
+            "ruff",
+            "format",
+            "--check",
+            "."
+          ]
+        },
+        {
+          "id": "mypy",
+          "argv": [
+            "uv",
+            "run",
+            "--frozen",
+            "mypy",
+            "src",
+            "tools/lck",
+            "tests"
+          ]
+        },
+        {
+          "id": "git-diff-check",
+          "argv": [
+            "git",
+            "diff",
+            "--check"
+          ]
+        }
+      ]
+    },
+    "workflow-delivery": {
+      "kind": "workflow-phase",
+      "description": "Delivery-phase CI-equivalent validation plus required Skill validators.",
+      "phase": "delivery",
+      "requires_base_sha": true,
+      "include_skill_validators": true,
+      "require_skill_validator": true,
+      "timeout_seconds": 1200,
+      "requires_clean_worktree": true,
+      "requires_main_branch": false,
+      "requires_origin_main_identity": false
+    },
+    "workflow-review": {
+      "kind": "workflow-phase",
+      "description": "Independent review validation for the locked reviewed head.",
+      "phase": "review",
+      "requires_base_sha": true,
+      "include_skill_validators": true,
+      "require_skill_validator": true,
+      "timeout_seconds": 1200,
+      "requires_clean_worktree": true,
+      "requires_main_branch": false,
+      "requires_origin_main_identity": false
+    },
+    "workflow-closeout": {
+      "kind": "workflow-phase",
+      "description": "Post-merge validation on synchronized clean main with required Skill validators.",
+      "phase": "closeout",
+      "requires_base_sha": true,
+      "include_skill_validators": true,
+      "require_skill_validator": true,
+      "timeout_seconds": 1200,
+      "requires_clean_worktree": true,
+      "requires_main_branch": true,
+      "requires_origin_main_identity": true
+    }
+  }
+}

--- a/tools/lck/critical_outcome.py
+++ b/tools/lck/critical_outcome.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Task Critical Outcome contract parsing and deterministic verification.
+
+The Issue body owns the semantic contract.  Execution is intentionally bounded:
+the contract may name one repository pytest node id, but it cannot inject an
+arbitrary command line into the workflow runtime.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Final
+
+from .common import CommandRunner, ProgressReporter, safe_text
+from .markdown_sections import extract_markdown_sections
+
+_FIELD_LINE: Final = re.compile(
+    r"^\s*(?:[-*+]\s*)?(?:\*\*)?"
+    r"(?P<key>Caller|Capability|Observable result|Verification test)"
+    r"(?:\*\*)?\s*:\s*(?:\*\*)?\s*(?P<value>.+?)\s*$",
+    re.IGNORECASE,
+)
+_NODE_ID: Final = re.compile(
+    r"^tests/(?:[A-Za-z0-9_.-]+/)*test_[A-Za-z0-9_.-]+\.py::test_[A-Za-z0-9_]+$"
+)
+_REQUIRED_KEYS: Final = (
+    "caller",
+    "capability",
+    "observable_result",
+    "verification_test",
+)
+
+
+class CriticalOutcomeError(ValueError):
+    """The Task Critical Outcome contract is missing, malformed, or unsafe."""
+
+
+@dataclass(frozen=True)
+class CriticalOutcomeContract:
+    caller: str
+    capability: str
+    observable_result: str
+    verification_test: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "caller": self.caller,
+            "capability": self.capability,
+            "observable_result": self.observable_result,
+            "verification_test": self.verification_test,
+        }
+
+
+@dataclass(frozen=True)
+class CriticalOutcomeResult:
+    status: str
+    contract: CriticalOutcomeContract
+    exit_code: int
+    summary: str | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "contract": self.contract.to_dict(),
+            "exit_code": self.exit_code,
+            "summary": self.summary,
+        }
+
+
+def _normalize_key(value: str) -> str:
+    return value.casefold().replace(" ", "_")
+
+
+def parse_critical_outcome(body: str | None) -> CriticalOutcomeContract:
+    """Parse the single required Markdown ``Critical Outcome`` section.
+
+    The section uses four one-line fields so the semantic contract remains
+    human-readable while the verification target stays machine-checkable.
+    """
+    if not isinstance(body, str) or not body.strip():
+        raise CriticalOutcomeError("Task body is unavailable")
+
+    sections = tuple(
+        section
+        for section in extract_markdown_sections(
+            body, canonical_names=("Critical Outcome",)
+        )
+        if section.name.casefold() == "critical outcome"
+    )
+    if len(sections) != 1:
+        raise CriticalOutcomeError(
+            "Task body must contain exactly one level 1-6 'Critical Outcome' section"
+        )
+
+    values: dict[str, str] = {}
+    for raw in sections[0].content.splitlines():
+        match = _FIELD_LINE.fullmatch(raw)
+        if match is None:
+            continue
+        key = _normalize_key(match.group("key"))
+        if key in values:
+            raise CriticalOutcomeError(f"Critical Outcome field is duplicated: {key}")
+        value = match.group("value").strip().strip("`").strip()
+        if not value:
+            raise CriticalOutcomeError(f"Critical Outcome field is empty: {key}")
+        values[key] = value
+
+    missing = [key for key in _REQUIRED_KEYS if not values.get(key)]
+    if missing:
+        raise CriticalOutcomeError(
+            "Critical Outcome is missing required fields: " + ", ".join(missing)
+        )
+
+    verification_test = values["verification_test"]
+    if _NODE_ID.fullmatch(verification_test) is None:
+        raise CriticalOutcomeError(
+            "Verification test must be one pytest node id under tests/: "
+            "tests/.../test_*.py::test_*"
+        )
+
+    return CriticalOutcomeContract(
+        caller=values["caller"],
+        capability=values["capability"],
+        observable_result=values["observable_result"],
+        verification_test=verification_test,
+    )
+
+
+def critical_outcome_snapshot(body: str | None) -> dict[str, Any]:
+    """Return a compact structured contract without exposing the full Issue body."""
+    try:
+        contract = parse_critical_outcome(body)
+    except CriticalOutcomeError as exc:
+        return {"status": "invalid", "detail": str(exc)}
+    return {"status": "valid", "contract": contract.to_dict()}
+
+
+def contract_from_snapshot(value: Any) -> CriticalOutcomeContract:
+    if not isinstance(value, Mapping) or value.get("status") != "valid":
+        detail = value.get("detail") if isinstance(value, Mapping) else None
+        raise CriticalOutcomeError(
+            str(detail or "Critical Outcome contract is invalid")
+        )
+    contract = value.get("contract")
+    if not isinstance(contract, Mapping):
+        raise CriticalOutcomeError("Critical Outcome contract payload is unavailable")
+    data = {key: contract.get(key) for key in _REQUIRED_KEYS}
+    if not all(isinstance(item, str) and item for item in data.values()):
+        raise CriticalOutcomeError("Critical Outcome contract payload is malformed")
+    verification_test = str(data["verification_test"])
+    if _NODE_ID.fullmatch(verification_test) is None:
+        raise CriticalOutcomeError("Critical Outcome verification target is unsafe")
+    return CriticalOutcomeContract(
+        caller=str(data["caller"]),
+        capability=str(data["capability"]),
+        observable_result=str(data["observable_result"]),
+        verification_test=verification_test,
+    )
+
+
+def verify_critical_outcome(
+    repo_root: Path,
+    runner: CommandRunner,
+    contract: CriticalOutcomeContract,
+    *,
+    progress: ProgressReporter | None = None,
+) -> CriticalOutcomeResult:
+    """Run the bounded Task-specific Critical Outcome verifier."""
+    file_part = contract.verification_test.split("::", 1)[0]
+    target = (repo_root / file_part).resolve()
+    try:
+        target.relative_to(repo_root.resolve())
+    except ValueError as exc:
+        raise CriticalOutcomeError(
+            "Critical Outcome target escapes repository root"
+        ) from exc
+    if not target.is_file():
+        raise CriticalOutcomeError(
+            f"Critical Outcome verification test does not exist: {file_part}"
+        )
+
+    reporter = progress or ProgressReporter("critical-outcome")
+    reporter.started("critical-outcome")
+    try:
+        result = runner.run(
+            [
+                "uv",
+                "run",
+                "--frozen",
+                "pytest",
+                "-q",
+                contract.verification_test,
+            ],
+            command_id="lck-critical-outcome",
+            validation=True,
+            progress=lambda: reporter.heartbeat(
+                "critical-outcome", command_id="lck-critical-outcome"
+            ),
+        )
+    except BaseException:
+        reporter.failed("critical-outcome")
+        raise
+    if result.returncode != 0:
+        reporter.failed("critical-outcome")
+    else:
+        reporter.completed("critical-outcome")
+    combined = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    summary = safe_text(combined[-1], limit=240) if combined else None
+    return CriticalOutcomeResult(
+        status="pass" if result.returncode == 0 else "fail",
+        contract=contract,
+        exit_code=result.returncode,
+        summary=summary,
+    )

--- a/tools/lck/delivery.py
+++ b/tools/lck/delivery.py
@@ -1,0 +1,674 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from .common import ProgressReporter, is_sha
+from .effects import (
+    CommitCurrentTreeEffect,
+    EnsureOpenPrEffect,
+    EnsureRemoteBranchEffect,
+    ReuseExistingOpenPrEffect,
+    SetInProgressStatusEffect,
+    SetReviewStatusEffect,
+)
+from .eligibility import PhaseDecision, PhaseEligibilityResolver
+from .issue_profiles import resolve_leaf_issue_profile
+from .models import (
+    BASE_BRANCH,
+    LCK_SCHEMA_VERSION,
+    EffectReceipt,
+    LckStopError,
+    LiveState,
+    OperationSnapshot,
+    Phase,
+    _is_clean_current_main,
+    _jsonable,
+    _remote_main_sha,
+)
+from .profile_policies import (
+    DEFAULT_PROFILE_POLICY_REGISTRY,
+    ProfileEvidenceEnvelope,
+    ProfileGateFailure,
+    ProfilePolicyRegistry,
+    ProfileResolver,
+    resolve_issue_policy,
+    run_profile_delivery_gates,
+)
+from .state import (
+    LiveStateResolver,
+    OperationSnapshotBuilder,
+    _leaf_contract_from_state,
+    _policy_issue_from_state,
+)
+from .validation_gates import (
+    DeliveryChecksGate,
+    FormalValidationGate,
+)
+
+
+@dataclass(frozen=True)
+class DeliveryContext:
+    task_number: int
+    repository: str | None
+    branch: str
+    base_sha: str | None
+    action: str
+    operation_snapshot: OperationSnapshot
+    eligibility: PhaseDecision
+    effects: tuple[EffectReceipt, ...] = ()
+
+    @property
+    def state(self) -> LiveState:
+        return self.operation_snapshot.state
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": LCK_SCHEMA_VERSION,
+            "operation": "delivery-prepare",
+            "task_number": self.task_number,
+            "repository": self.repository,
+            "branch": self.branch,
+            "base_sha": self.base_sha,
+            "action": self.action,
+            "issue_profile": _jsonable(self.state.issue_profile),
+            "task_contract": _jsonable(_leaf_contract_from_state(self.state)),
+            "operation_snapshot": self.operation_snapshot.to_dict(),
+            "eligibility": self.eligibility.to_dict(),
+            "effects": [item.to_dict() for item in self.effects],
+        }
+
+
+class DeliveryPreparer:
+    """Prepare or restore one local Task workspace with bounded Git effects."""
+
+    def __init__(
+        self,
+        resolver: LiveStateResolver,
+        *,
+        eligibility: PhaseEligibilityResolver | None = None,
+        profile_resolver: ProfileResolver | None = None,
+        status_effect: SetInProgressStatusEffect | None = None,
+    ) -> None:
+        self.resolver = resolver
+        self.snapshots = OperationSnapshotBuilder(resolver)
+        self.profile_resolver = (
+            profile_resolver
+            or getattr(eligibility, "profile_resolver", None)
+            or resolve_leaf_issue_profile
+        )
+        self.eligibility = eligibility or PhaseEligibilityResolver(
+            profile_resolver=self.profile_resolver
+        )
+        self.status_effect = status_effect or SetInProgressStatusEffect(resolver)
+        self.last_snapshot: OperationSnapshot | None = None
+        self.last_effects: list[EffectReceipt] = []
+
+    def _run_git(self, args: Sequence[str], command_id: str) -> None:
+        result = self.resolver.runner.run(
+            ["git", *args],
+            command_id=command_id,
+        )
+        if result.returncode != 0:
+            raise LckStopError(
+                f"{command_id} failed with exit code {result.returncode}: "
+                f"{result.stderr.strip() or result.stdout.strip()}"
+            )
+
+    def _verify_workspace(self, branch: str, expected_head: str | None) -> None:
+        current = self.resolver.runner.run(
+            ["git", "branch", "--show-current"],
+            command_id="lck-delivery-prepare-post-branch",
+        )
+        head = self.resolver.runner.run(
+            ["git", "rev-parse", "HEAD"],
+            command_id="lck-delivery-prepare-post-head",
+        )
+        if (
+            current.returncode != 0
+            or current.stdout.strip() != branch
+            or head.returncode != 0
+            or not is_sha(head.stdout.strip())
+            or (expected_head is not None and head.stdout.strip() != expected_head)
+        ):
+            raise LckStopError(
+                "workspace postcondition failed: selected branch/head is not the "
+                "operation snapshot target"
+            )
+
+    def prepare(self, task_number: int) -> DeliveryContext:
+        self.last_effects = []
+        snapshot = self.snapshots.acquire(
+            task_number,
+            operation=Phase.DELIVERY_PREPARE.value,
+        )
+        self.last_snapshot = snapshot
+        state = snapshot.state
+        decision = self.eligibility.resolve(state, Phase.DELIVERY_PREPARE)
+        if not decision.eligible:
+            raise LckStopError(
+                f"Delivery Prepare STOP for Task #{task_number}: "
+                + "; ".join(decision.reasons)
+            )
+
+        branch = state.target_branch
+        current_branch = state.git.get("branch")
+        clean = state.git.get("clean") is True
+        base_sha = state.git.get("local_main_sha")
+        if not is_sha(base_sha):
+            raise LckStopError("current local main identity is unavailable")
+        action = "already-prepared"
+        local_exists = state.local_issue_branch is not None
+
+        if local_exists:
+            if current_branch != branch:
+                if not clean:
+                    raise LckStopError(
+                        "cannot switch to Task branch with a dirty unrelated worktree"
+                    )
+                self._run_git(
+                    ["switch", branch],
+                    "lck-select-existing-task-branch",
+                )
+                action = "selected-existing"
+        elif state.remote_issue_branch is not None:
+            if current_branch != BASE_BRANCH or not clean:
+                raise LckStopError(
+                    "restoring a remote Task branch requires a clean main worktree"
+                )
+            self._run_git(
+                ["switch", "--track", "-c", branch, f"origin/{branch}"],
+                "lck-restore-remote-task-branch",
+            )
+            action = "restored-from-remote"
+        else:
+            if not _is_clean_current_main(state.git):
+                raise LckStopError(
+                    "new Task workspace requires clean main with "
+                    "HEAD == local main == origin/main"
+                )
+            self._run_git(
+                ["switch", "-c", branch, base_sha],
+                "lck-create-task-branch",
+            )
+            action = "created-from-main"
+
+        expected_head = (
+            state.local_issue_head
+            if local_exists
+            else state.remote_issue_oid
+            if state.remote_issue_branch is not None
+            else base_sha
+        )
+        self._verify_workspace(branch, expected_head)
+        status_receipt = self.status_effect.execute(state)
+        self.last_effects.append(status_receipt)
+        return DeliveryContext(
+            task_number=task_number,
+            repository=state.repository,
+            branch=branch,
+            base_sha=base_sha if isinstance(base_sha, str) else None,
+            action=action,
+            operation_snapshot=snapshot,
+            eligibility=decision,
+            effects=tuple(self.last_effects),
+        )
+
+
+@dataclass(frozen=True)
+class DeliveryCompletionResult:
+    task_number: int
+    status: str
+    branch: str
+    head_sha: str
+    critical_outcome: Mapping[str, Any] | None
+    validation: Mapping[str, Any]
+    checks: Mapping[str, Any]
+    effects: tuple[EffectReceipt, ...]
+    operation_snapshot: OperationSnapshot
+    research_artifact: Mapping[str, Any] | None = None
+    profile_evidence: ProfileEvidenceEnvelope | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": LCK_SCHEMA_VERSION,
+            "operation": "delivery-complete",
+            "task_number": self.task_number,
+            "status": self.status,
+            "branch": self.branch,
+            "head_sha": self.head_sha,
+            "issue_profile": _jsonable(self.operation_snapshot.state.issue_profile),
+            "critical_outcome": _jsonable(self.critical_outcome),
+            "validation": _jsonable(self.validation),
+            "checks": _jsonable(self.checks),
+            "research_artifact": _jsonable(self.research_artifact),
+            "profile_evidence": (
+                self.profile_evidence.to_dict() if self.profile_evidence else None
+            ),
+            "effects": [item.to_dict() for item in self.effects],
+            "operation_snapshot": self.operation_snapshot.to_dict(),
+            "human_boundary": "Independent Review must be started separately",
+        }
+
+
+class DeliveryCompleter:
+    """Complete Delivery from one immutable operation-start snapshot.
+
+    Lifecycle authority is acquired once.  Local/remote/PR/metadata mutations
+    then prove only their own exact postconditions.  Asynchronous PR checks are
+    observed without blocking Delivery; pending checks are reported while the
+    operation continues through Project Status and final identity verification.
+    Strict check evaluation remains owned by Review Complete and Merge Preflight.
+    """
+
+    def __init__(
+        self,
+        resolver: LiveStateResolver,
+        *,
+        eligibility: PhaseEligibilityResolver | None = None,
+        formal_validation: FormalValidationGate | None = None,
+        commit_effect: CommitCurrentTreeEffect | None = None,
+        remote_effect: EnsureRemoteBranchEffect | None = None,
+        pr_effect: EnsureOpenPrEffect | ReuseExistingOpenPrEffect | None = None,
+        status_effect: SetReviewStatusEffect | None = None,
+        checks_gate: DeliveryChecksGate | None = None,
+        policy_registry: ProfilePolicyRegistry | None = None,
+        profile_resolver: ProfileResolver | None = None,
+        require_existing_open_pr: bool = False,
+        candidate_recorder: Callable[[str, str], None] | None = None,
+        services: Sequence[Any] = (),
+    ) -> None:
+        self.resolver = resolver
+        self.snapshots = OperationSnapshotBuilder(resolver)
+        self.policy_registry = policy_registry or DEFAULT_PROFILE_POLICY_REGISTRY
+        self.profile_resolver = (
+            profile_resolver
+            or getattr(eligibility, "profile_resolver", None)
+            or resolve_leaf_issue_profile
+        )
+        self.eligibility = eligibility or PhaseEligibilityResolver(
+            registry=self.policy_registry,
+            profile_resolver=self.profile_resolver,
+        )
+        self.formal_validation = formal_validation or FormalValidationGate(resolver)
+        self.commit_effect = commit_effect or CommitCurrentTreeEffect(resolver)
+        self.remote_effect = remote_effect or EnsureRemoteBranchEffect(resolver)
+        self.pr_effect = pr_effect or EnsureOpenPrEffect(resolver)
+        self.status_effect = status_effect or SetReviewStatusEffect(resolver)
+        self.checks_gate = checks_gate or DeliveryChecksGate(resolver)
+        self.services = tuple(services)
+        self.require_existing_open_pr = require_existing_open_pr
+        self.candidate_recorder = candidate_recorder
+        self.last_snapshot: OperationSnapshot | None = None
+        self.last_critical_outcome: dict[str, Any] | None = None
+        self.last_documentation_validation: dict[str, Any] | None = None
+        self.last_research_validation: dict[str, Any] | None = None
+        self.last_profile_evidence: ProfileEvidenceEnvelope | None = None
+        self.last_validation: dict[str, Any] | None = None
+        self.last_checks: dict[str, Any] | None = None
+        self.last_effects: list[EffectReceipt] = []
+
+    def _capture_checks_from_gate(self) -> None:
+        """Retain a check gate's result before a later failure is reported."""
+        for attribute in ("last_result", "last_checks"):
+            value = getattr(self.checks_gate, attribute, None)
+            if isinstance(value, Mapping):
+                self.last_checks = dict(value)
+                return
+
+    def _run_formal_validation(self, base_sha: str) -> dict[str, Any]:
+        """Retain a parsed validation payload when the gate rejects it."""
+        try:
+            validation = self.formal_validation.run(base_sha)
+        except BaseException:
+            payload = getattr(self.formal_validation, "last_payload", None)
+            if isinstance(payload, dict):
+                self.last_validation = payload
+            raise
+        self.last_validation = validation
+        return validation
+
+    def _run_profile_gates(
+        self,
+        state: LiveState,
+        base_sha: str,
+        *,
+        progress: ProgressReporter,
+        include_index: bool = False,
+        head_sha: str | None = None,
+    ) -> dict[str, Any] | None:
+        policy_issue = _policy_issue_from_state(state)
+        if not policy_issue:
+            raise LckStopError("current leaf Issue workflow profile is unavailable")
+        try:
+            profile, _policy = resolve_issue_policy(
+                policy_issue,
+                registry=self.policy_registry,
+                profile_resolver=self.profile_resolver,
+            )
+        except (TypeError, ValueError) as exc:
+            raise LckStopError(
+                f"current leaf Issue workflow profile is unavailable: {exc}"
+            ) from exc
+        self.last_documentation_validation = None
+        self.last_research_validation = None
+        self.last_profile_evidence = None
+        try:
+            results = run_profile_delivery_gates(
+                profile,
+                base_sha=base_sha,
+                head_sha=head_sha,
+                include_index=include_index,
+                progress=progress,
+                issue=policy_issue,
+                registry=self.policy_registry,
+                repo_root=self.resolver.repo_root,
+                runner=self.resolver.runner,
+                services=self.services,
+            )
+        except ProfileGateFailure as exc:
+            self.last_profile_evidence = exc.profile_evidence
+            for field, value in exc.legacy_results.items():
+                target = f"last_{field}"
+                if isinstance(field, str) and hasattr(self, target):
+                    setattr(self, target, value)
+            raise
+        except LckStopError:
+            raise
+        self.last_documentation_validation = results.documentation_validation
+        self.last_research_validation = results.research_validation
+        self.last_critical_outcome = results.critical_outcome
+        self.last_profile_evidence = results.profile_evidence
+        return results.critical_outcome
+
+    def _has_task_diff(self, base_sha: str) -> bool:
+        result = self.resolver.runner.run(
+            ["git", "diff", "--quiet", f"{base_sha}...HEAD"],
+            command_id="lck-task-diff-present",
+        )
+        if result.returncode == 1:
+            return True
+        if result.returncode == 0:
+            return False
+        raise LckStopError("unable to verify Task diff against operation base")
+
+    def _verify_local_completion(self, branch: str, head_sha: str) -> None:
+        branch_result = self.resolver.runner.run(
+            ["git", "branch", "--show-current"],
+            command_id="lck-delivery-final-branch",
+        )
+        head_result = self.resolver.runner.run(
+            ["git", "rev-parse", "HEAD"],
+            command_id="lck-delivery-final-head",
+        )
+        status = self.resolver.runner.run(
+            ["git", "status", "--porcelain=v1", "--untracked-files=all"],
+            command_id="lck-delivery-final-status",
+        )
+        if (
+            branch_result.returncode != 0
+            or branch_result.stdout.strip() != branch
+            or head_result.returncode != 0
+            or head_result.stdout.strip() != head_sha
+            or status.returncode != 0
+            or status.stdout.strip()
+        ):
+            raise LckStopError(
+                "Delivery local postcondition failed: branch/head/worktree is not "
+                "the validated operation result"
+            )
+
+    @staticmethod
+    def _receipt_pr_identity(receipt: EffectReceipt) -> dict[str, Any]:
+        return {
+            "number": receipt.details.get("number"),
+            "head_sha": receipt.details.get("head_sha"),
+            "base_sha": receipt.details.get("base_sha"),
+        }
+
+    def _complete_from_snapshot(
+        self,
+        snapshot: OperationSnapshot,
+        *,
+        phase: Phase,
+        owned_remediation_candidate: bool = False,
+        commit_message: str,
+        summary: str,
+        risks: str,
+        progress: ProgressReporter,
+    ) -> DeliveryCompletionResult:
+        state = snapshot.state
+        task_number = state.issue_number
+        effects: list[EffectReceipt] = []
+        self.last_effects = effects
+        self.last_critical_outcome = None
+        self.last_documentation_validation = None
+        self.last_profile_evidence = None
+        self.last_validation = None
+        self.last_checks = None
+        decision = self.eligibility.resolve(
+            state,
+            phase,
+            owned_remediation_candidate=owned_remediation_candidate,
+        )
+        if not decision.eligible:
+            raise LckStopError(
+                f"{phase.value} STOP for Task #{task_number}: "
+                + "; ".join(decision.reasons)
+            )
+        base_sha_value = _remote_main_sha(state.git)
+        if not is_sha(base_sha_value):
+            raise LckStopError("current remote main identity is unavailable")
+        base_sha = str(base_sha_value)
+        issue = state.issue
+        body_sha256 = issue.get("body_sha256") if isinstance(issue, Mapping) else None
+        if not isinstance(body_sha256, str) or not body_sha256:
+            raise LckStopError("current Task body identity is unavailable")
+        branch = state.target_branch
+        if self.require_existing_open_pr:
+            pr = state.open_pr
+            if (
+                not isinstance(pr, Mapping)
+                or pr.get("isDraft") is not False
+                or pr.get("baseRefOid") != base_sha
+                or pr.get("headRefName") != branch
+            ):
+                raise LckStopError(
+                    "Remediation requires the snapshot's existing OPEN PR on the "
+                    "resolved Task branch/base"
+                )
+
+        if state.git.get("clean") is True:
+            progress.running("revalidating-candidate")
+            if not self._has_task_diff(base_sha):
+                raise LckStopError(
+                    "Delivery Complete found no Task diff against operation base"
+                )
+            validated_tree = self.commit_effect.current_head_tree()
+            critical = self._run_profile_gates(
+                state,
+                base_sha,
+                progress=progress,
+                head_sha=state.local_issue_head,
+            )
+            progress.running("formal-validation")
+            validation = self._run_formal_validation(base_sha)
+            if self.last_documentation_validation is not None:
+                validation = dict(validation)
+                validation["documentation_policy"] = self.last_documentation_validation
+                self.last_validation = validation
+            validated_head = state.local_issue_head
+            if not is_sha(validated_head):
+                raise LckStopError("current Task head is unavailable")
+            self.commit_effect.verify_tree_unchanged(
+                validated_tree,
+                expected_head_sha=validated_head,
+            )
+            head = validated_head
+            effects.append(
+                EffectReceipt(
+                    effect="commit_current_tree",
+                    action="already-committed-revalidated",
+                    details={"head_sha": head, "tree_oid": validated_tree},
+                )
+            )
+        else:
+            progress.running("staging-candidate")
+            validated_tree = self.commit_effect.stage_candidate_tree()
+            critical = self._run_profile_gates(
+                state,
+                base_sha,
+                progress=progress,
+                include_index=True,
+                head_sha=state.local_issue_head,
+            )
+            progress.running("formal-validation")
+            validation = self._run_formal_validation(base_sha)
+            if self.last_documentation_validation is not None:
+                validation = dict(validation)
+                validation["documentation_policy"] = self.last_documentation_validation
+                self.last_validation = validation
+            self.commit_effect.verify_tree_unchanged(
+                validated_tree,
+                expected_head_sha=state.local_issue_head,
+            )
+            commit = self.commit_effect.execute(
+                validated_tree,
+                commit_message,
+                expected_parent_sha=state.local_issue_head,
+            )
+            effects.append(commit)
+            committed_head = commit.details.get("head_sha")
+            if not is_sha(committed_head):
+                raise LckStopError("commit receipt did not contain a valid head SHA")
+            head = committed_head
+
+        if self.candidate_recorder is not None:
+            self.candidate_recorder(str(head), validated_tree)
+
+        progress.running("remote-branch")
+        remote = self.remote_effect.execute(branch, expected_head_sha=str(head))
+        effects.append(remote)
+        if remote.details.get("remote_oid") != head:
+            raise LckStopError("remote branch effect did not prove the validated head")
+
+        progress.running("open-pr")
+        pr_receipt = self.pr_effect.execute(
+            state,
+            head_sha=str(head),
+            summary=summary,
+            risks=risks,
+            critical_outcome=critical,
+            validation=validation,
+            expected_base_sha=base_sha,
+            expected_body_sha256=body_sha256,
+        )
+        effects.append(pr_receipt)
+        pr_identity = self._receipt_pr_identity(pr_receipt)
+        pr_number = pr_identity.get("number")
+        if (
+            not isinstance(pr_number, int)
+            or pr_identity.get("head_sha") != head
+            or pr_identity.get("base_sha") != base_sha
+        ):
+            raise LckStopError("PR effect did not prove the validated head/base")
+
+        progress.running("checks")
+        snapshot_pr = state.open_pr
+        try:
+            if (
+                isinstance(snapshot_pr, Mapping)
+                and snapshot_pr.get("number") == pr_number
+                and snapshot_pr.get("headRefOid") == head
+                and snapshot_pr.get("baseRefOid") == base_sha
+            ):
+                checks = self.checks_gate.observe(snapshot)
+            else:
+                if not isinstance(state.repository, str):
+                    raise LckStopError(
+                        "repository identity is unavailable for PR checks"
+                    )
+                checks = self.checks_gate.observe_exact_pr(
+                    state.repository,
+                    pr_number,
+                    expected_head_sha=str(head),
+                    expected_base_sha=base_sha,
+                )
+        except BaseException:
+            self._capture_checks_from_gate()
+            raise
+        self.last_checks = dict(checks)
+
+        checks_pr = checks.get("pr")
+        if not isinstance(checks_pr, Mapping):
+            raise LckStopError("checks result did not contain PR identity")
+        progress.running("project-status")
+        status_receipt = self.status_effect.execute(
+            state,
+            expected_pr=checks_pr,
+            checks_result=checks,
+        )
+        effects.append(status_receipt)
+        if status_receipt.action not in {"updated", "already-review"}:
+            raise LckStopError("Project Status effect did not reach Review")
+
+        self._verify_local_completion(branch, str(head))
+        return DeliveryCompletionResult(
+            task_number=task_number,
+            status="READY_FOR_REVIEW",
+            branch=branch,
+            head_sha=str(head),
+            critical_outcome=critical,
+            validation=validation,
+            checks=checks,
+            effects=tuple(effects),
+            operation_snapshot=snapshot,
+            research_artifact=self.last_research_validation,
+            profile_evidence=self.last_profile_evidence,
+        )
+
+    def complete(
+        self,
+        task_number: int,
+        *,
+        commit_message: str,
+        summary: str,
+        risks: str = "",
+        operation_snapshot: OperationSnapshot | None = None,
+        phase: Phase = Phase.DELIVERY_COMPLETE,
+        owned_remediation_candidate: bool = False,
+    ) -> DeliveryCompletionResult:
+        self.last_checks = None
+        if not summary.strip():
+            raise LckStopError("Delivery summary must be non-empty")
+        operation = (
+            "remediation-complete"
+            if phase is Phase.REMEDIATION_COMPLETE
+            else "delivery-complete"
+        )
+        progress = ProgressReporter(operation)
+        progress.started("initializing")
+        try:
+            progress.running("resolving-live-state")
+            snapshot = operation_snapshot or self.snapshots.acquire(
+                task_number,
+                operation=phase.value,
+            )
+            self.last_snapshot = snapshot
+            if snapshot.state.issue_number != task_number:
+                raise LckStopError("operation snapshot belongs to another Task")
+            result = self._complete_from_snapshot(
+                snapshot,
+                phase=phase,
+                owned_remediation_candidate=owned_remediation_candidate,
+                commit_message=commit_message,
+                summary=summary,
+                risks=risks,
+                progress=progress,
+            )
+        except BaseException:
+            progress.failed()
+            raise
+        progress.completed("handoff")
+        return result

--- a/tools/lck/documentation_policy.py
+++ b/tools/lck/documentation_policy.py
@@ -1,0 +1,212 @@
+"""Repository-owned policy for Documentation leaf contracts and changes.
+
+The policy is intentionally data-driven and side-effect free.  In particular,
+Issue-provided documentation context is never interpreted as a command plan.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Any, Final
+
+from .issue_forms import (
+    IssueFormTemplateContract,
+    IssueFormTemplateError,
+    load_issue_form_template,
+    parse_issue_form_contract,
+)
+
+
+class DocumentationPolicyStatus(StrEnum):
+    PASS = "pass"
+    RECLASSIFICATION_REQUIRED = "reclassification_required"
+
+
+DOCUMENTATION_POLICY_ID: Final = "repository-documentation-safe-v1"
+DOCUMENTATION_TEMPLATE_PATH: Final = Path(".github/ISSUE_TEMPLATE/documentation.yml")
+# Documentation deliberately has a narrow path allow-list.  Workflow and
+# development-policy prose is excluded because changing it changes the
+# repository's control contract even when the file happens to end in .md.
+_ALLOWED_EXACT_FILES: Final = frozenset({"README.md"})
+_ALLOWED_PREFIXES: Final = ("docs/",)
+_EXCLUDED_AGENT_CONTROL_BASENAMES: Final = frozenset({"agents.md", "claude.md"})
+_EXCLUDED_PREFIXES: Final = (
+    ".agents/",
+    ".claude/",
+    ".github/",
+    "docs/development/",
+    "docs/workflows/",
+    "src/",
+    "tests/",
+    "tools/",
+)
+
+
+@dataclass(frozen=True)
+class DocumentationContract:
+    status: DocumentationPolicyStatus
+    required_sections: tuple[str, ...] = ()
+    missing_sections: tuple[str, ...] = ()
+    duplicate_sections: tuple[str, ...] = ()
+    empty_sections: tuple[str, ...] = ()
+    template_path: str = DOCUMENTATION_TEMPLATE_PATH.as_posix()
+    detail: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status.value,
+            "required_sections": list(self.required_sections),
+            "missing_sections": list(self.missing_sections),
+            "duplicate_sections": list(self.duplicate_sections),
+            "empty_sections": list(self.empty_sections),
+            "template_path": self.template_path,
+            **({"detail": self.detail} if self.detail else {}),
+        }
+
+
+DocumentationTemplateContract = IssueFormTemplateContract
+
+
+class DocumentationTemplateError(IssueFormTemplateError):
+    """The repository-owned Documentation Issue form is not usable."""
+
+
+@dataclass(frozen=True)
+class DocumentationChangeResult:
+    status: DocumentationPolicyStatus
+    policy_id: str
+    changed_files: tuple[str, ...]
+    disallowed_files: tuple[str, ...] = ()
+    detail: str = ""
+
+    @property
+    def passed(self) -> bool:
+        return self.status is DocumentationPolicyStatus.PASS
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status.value,
+            "policy_id": self.policy_id,
+            "changed_files": list(self.changed_files),
+            "disallowed_files": list(self.disallowed_files),
+            **({"detail": self.detail} if self.detail else {}),
+        }
+
+
+def _default_template_path() -> Path:
+    return Path(__file__).resolve().parents[2] / DOCUMENTATION_TEMPLATE_PATH
+
+
+def documentation_template_contract(
+    template_path: Path | None = None,
+) -> DocumentationTemplateContract:
+    """Load required Documentation fields from the formal Issue form."""
+
+    path = template_path or _default_template_path()
+    return load_issue_form_template(
+        path,
+        form_name="Documentation",
+        template_display_path=DOCUMENTATION_TEMPLATE_PATH.as_posix(),
+        error_type=DocumentationTemplateError,
+    )
+
+
+def documentation_contract_snapshot(
+    body: str | None,
+    *,
+    template_path: Path | None = None,
+) -> dict[str, Any]:
+    """Return a bounded typed snapshot of the Documentation Issue contract."""
+
+    parsed = parse_issue_form_contract(
+        body,
+        template_path=template_path or _default_template_path(),
+        form_name="Documentation",
+        template_display_path=DOCUMENTATION_TEMPLATE_PATH.as_posix(),
+        error_type=DocumentationTemplateError,
+        valid_status=DocumentationPolicyStatus.PASS.value,
+        invalid_status=DocumentationPolicyStatus.RECLASSIFICATION_REQUIRED.value,
+    )
+    return DocumentationContract(
+        DocumentationPolicyStatus(parsed.status),
+        required_sections=parsed.required_sections,
+        missing_sections=parsed.missing_sections,
+        duplicate_sections=parsed.duplicate_sections,
+        empty_sections=parsed.empty_sections,
+        template_path=parsed.template_path,
+        detail=parsed.detail,
+    ).to_dict()
+
+
+def is_valid_documentation_contract(value: object) -> bool:
+    """Validate the bounded shape consumed by LCK eligibility."""
+
+    if not isinstance(value, Mapping):
+        return False
+    try:
+        template = documentation_template_contract()
+    except DocumentationTemplateError:
+        return False
+    return (
+        value.get("status") == DocumentationPolicyStatus.PASS.value
+        and value.get("required_sections") == list(template.section_labels)
+        and value.get("missing_sections") == []
+        and value.get("duplicate_sections") == []
+        and value.get("empty_sections") == []
+        and value.get("template_path") == DOCUMENTATION_TEMPLATE_PATH.as_posix()
+    )
+
+
+def _is_allowed_path(path: str) -> bool:
+    if (
+        not path
+        or path.startswith("/")
+        or "\\" in path
+        or any(part in {"", ".", ".."} for part in path.split("/"))
+    ):
+        return False
+    if path.rsplit("/", 1)[-1].casefold() in _EXCLUDED_AGENT_CONTROL_BASENAMES:
+        return False
+    if any(path.startswith(prefix) for prefix in _EXCLUDED_PREFIXES):
+        return False
+    return path in _ALLOWED_EXACT_FILES or (
+        path.startswith("docs/")
+        and path != "docs/"
+        and any(path.startswith(prefix) for prefix in _ALLOWED_PREFIXES)
+    )
+
+
+def evaluate_documentation_changes(
+    changed_files: Iterable[str],
+) -> DocumentationChangeResult:
+    """Evaluate a candidate against the fixed Documentation safe-change policy."""
+
+    normalized = tuple(sorted({path.strip() for path in changed_files if path.strip()}))
+    disallowed = tuple(path for path in normalized if not _is_allowed_path(path))
+    if disallowed:
+        return DocumentationChangeResult(
+            DocumentationPolicyStatus.RECLASSIFICATION_REQUIRED,
+            DOCUMENTATION_POLICY_ID,
+            normalized,
+            disallowed,
+            detail=(
+                "Documentation candidate exceeds the repository-owned safe-change "
+                "policy; reclassification or split required for: "
+                + ", ".join(disallowed)
+            ),
+        )
+    if not normalized:
+        return DocumentationChangeResult(
+            DocumentationPolicyStatus.RECLASSIFICATION_REQUIRED,
+            DOCUMENTATION_POLICY_ID,
+            normalized,
+            detail="Documentation candidate contains no changed files",
+        )
+    return DocumentationChangeResult(
+        DocumentationPolicyStatus.PASS,
+        DOCUMENTATION_POLICY_ID,
+        normalized,
+    )

--- a/tools/lck/effective_diff.py
+++ b/tools/lck/effective_diff.py
@@ -1,0 +1,89 @@
+"""Authoritative effective-diff calculations shared by LCK phases."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .common import is_sha
+from .models import LckStopError
+
+
+@dataclass(frozen=True)
+class EffectiveDiff:
+    """The file scope and patch identity for one effective candidate diff."""
+
+    merge_base_sha: str
+    effective_diff_sha256: str
+    changed_files: tuple[str, ...]
+
+
+def calculate_effective_diff(
+    runner: Any,
+    *,
+    base_sha: str,
+    head_ref: str,
+    command_id_prefix: str,
+    cwd: Path | None = None,
+    include_index: bool = False,
+) -> EffectiveDiff:
+    """Calculate one effective diff for Review or a staged Delivery candidate.
+
+    Review compares ``base...head``.  Delivery stages its candidate first, so
+    it compares the same merge base to the index (whose tree contains both the
+    committed HEAD and staged candidate content).
+    """
+
+    if not is_sha(base_sha):
+        raise LckStopError("effective-diff base SHA is unavailable")
+    if not include_index and not is_sha(head_ref):
+        raise LckStopError("effective-diff head SHA is unavailable")
+
+    merge_base = runner.run(
+        ["git", "merge-base", base_sha, head_ref],
+        command_id=f"{command_id_prefix}-merge-base",
+        cwd=cwd,
+    )
+    merge_base_sha = merge_base.stdout.strip()
+    if merge_base.returncode != 0 or not is_sha(merge_base_sha):
+        raise LckStopError("effective-diff merge base is unavailable")
+
+    diff_ref = merge_base_sha if include_index else f"{base_sha}...{head_ref}"
+    diff_args = ["git", "diff"]
+    if include_index:
+        diff_args.append("--cached")
+    diff_args.extend(
+        ["--binary", "--full-index", "--no-ext-diff", "--no-textconv", diff_ref]
+    )
+    diff = runner.run(
+        diff_args,
+        command_id=f"{command_id_prefix}-effective-diff",
+        cwd=cwd,
+    )
+    if diff.returncode != 0:
+        raise LckStopError(
+            "effective diff is unavailable: "
+            + (diff.stderr.strip() or f"exit {diff.returncode}")
+        )
+
+    names_args = ["git", "diff"]
+    if include_index:
+        names_args.append("--cached")
+    names_args.extend(["--name-only", diff_ref])
+    names = runner.run(
+        names_args,
+        command_id=f"{command_id_prefix}-changed-files",
+        cwd=cwd,
+    )
+    if names.returncode != 0:
+        raise LckStopError("effective-diff changed-file inventory is unavailable")
+
+    return EffectiveDiff(
+        merge_base_sha=merge_base_sha,
+        effective_diff_sha256=hashlib.sha256(
+            diff.stdout.encode("utf-8", errors="replace")
+        ).hexdigest(),
+        changed_files=tuple(line for line in names.stdout.splitlines() if line),
+    )

--- a/tools/lck/effects.py
+++ b/tools/lck/effects.py
@@ -1,0 +1,944 @@
+from __future__ import annotations
+
+import tempfile
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Final
+
+from .common import (
+    CommandResult,
+    WorkflowToolError,
+    is_sha,
+    read_json_text,
+    stderr_tail,
+)
+from .github_projects import set_project_status_with_runner
+from .github_prs import PrResolveError, resolve_or_create_pr
+from .models import (
+    BASE_BRANCH,
+    EffectReceipt,
+    LckStopError,
+    LiveState,
+    _issue_number_from_state,
+    _remote_main_sha,
+    _remote_refs,
+)
+from .profile_policies import ProfileEffectDescriptor
+from .shared_facts import _find_project_status, query_project_single_select_field
+from .state import LiveStateResolver
+
+
+class EffectExecutorRegistry:
+    """Immutable kernel allowlist for policy-declared effect kinds."""
+
+    def __init__(self, executors: Mapping[str, Any]) -> None:
+        selected: dict[str, Any] = {}
+        for kind, executor in executors.items():
+            if not isinstance(kind, str) or not kind or not callable(executor):
+                raise ValueError("effect executor registry entry is malformed")
+            if kind in selected:
+                raise ValueError(f"duplicate effect executor: {kind}")
+            selected[kind] = executor
+        self._executors = MappingProxyType(selected)
+
+    @property
+    def executors(self) -> Mapping[str, Any]:
+        return self._executors
+
+    def execute(
+        self,
+        descriptor: ProfileEffectDescriptor,
+        *,
+        resolver: LiveStateResolver,
+        state: LiveState,
+    ) -> EffectReceipt:
+        if not isinstance(descriptor, ProfileEffectDescriptor):
+            raise LckStopError("completion effect descriptor is malformed")
+        try:
+            executor = self._executors[descriptor.effect_kind]
+        except KeyError as exc:
+            raise LckStopError(
+                f"unknown completion effect kind: {descriptor.effect_kind}"
+            ) from exc
+        try:
+            receipt = executor(descriptor, resolver=resolver, state=state)
+            if not isinstance(receipt, EffectReceipt):
+                raise LckStopError("completion effect executor returned no receipt")
+            if receipt.effect != descriptor.effect_kind:
+                raise LckStopError(
+                    "completion effect receipt does not match its descriptor"
+                )
+            return receipt
+        except LckStopError:
+            raise
+        except Exception as exc:
+            raise LckStopError(f"completion effect execution failed: {exc}") from exc
+
+
+def _pending_effect(
+    effect: str, *, reason: str, details: Mapping[str, Any]
+) -> EffectReceipt:
+    payload = {"reason": reason, **dict(details)}
+    return EffectReceipt(effect=effect, action="pending", details=payload)
+
+
+class ProjectSingleSelectEffectExecutor:
+    """Execute the one generic Project single-select effect kind."""
+
+    effect_kind = "project.single_select.set.v1"
+    schema_version = 1
+
+    @staticmethod
+    def _parameters(descriptor: ProfileEffectDescriptor) -> dict[str, Any]:
+        params = dict(descriptor.parameters)
+        required = {"repository", "task_number", "project_number", "field", "value"}
+        if set(params) != required:
+            raise LckStopError("project field effect parameters are invalid")
+        if (
+            not isinstance(params["repository"], str)
+            or not params["repository"]
+            or not isinstance(params["task_number"], int)
+            or isinstance(params["task_number"], bool)
+            or params["task_number"] <= 0
+            or not isinstance(params["project_number"], int)
+            or isinstance(params["project_number"], bool)
+            or params["project_number"] <= 0
+            or not isinstance(params["field"], str)
+            or not params["field"]
+            or not isinstance(params["value"], str)
+            or not params["value"]
+        ):
+            raise LckStopError("project field effect parameters are invalid")
+        return params
+
+    @classmethod
+    def _validate(cls, descriptor: ProfileEffectDescriptor) -> dict[str, Any]:
+        if (
+            descriptor.effect_kind != cls.effect_kind
+            or descriptor.schema_version != cls.schema_version
+        ):
+            raise LckStopError("unsupported project field effect schema")
+        params = cls._parameters(descriptor)
+        expected_postcondition = {
+            "kind": "project.single_select.equals",
+            **params,
+        }
+        if dict(descriptor.postcondition) != expected_postcondition:
+            raise LckStopError("project field effect postcondition is invalid")
+        return params
+
+    @staticmethod
+    def _query(
+        resolver: LiveStateResolver,
+        *,
+        repository: str,
+        project_number: int,
+        task_number: int,
+        field: str,
+    ) -> str | None:
+        return query_project_single_select_field(
+            resolver.runner,
+            repository=repository,
+            issue_number=task_number,
+            project_number=project_number,
+            field_name=field,
+            command_id="lck-profile-effect-postcondition",
+        )
+
+    @classmethod
+    def execute(
+        cls,
+        descriptor: ProfileEffectDescriptor,
+        *,
+        resolver: LiveStateResolver,
+        state: LiveState,
+    ) -> EffectReceipt:
+        params = cls._validate(descriptor)
+        if (
+            state.repository != params["repository"]
+            or _issue_number_from_state(state) != params["task_number"]
+        ):
+            raise LckStopError(
+                "project field effect identity does not match live state"
+            )
+        observed = cls._query(
+            resolver,
+            repository=params["repository"],
+            project_number=params["project_number"],
+            task_number=params["task_number"],
+            field=params["field"],
+        )
+        action = "already-set" if observed == params["value"] else "updated"
+        if action == "updated":
+            try:
+                set_project_status_with_runner(
+                    resolver.runner,
+                    params["repository"],
+                    params["task_number"],
+                    project_number=params["project_number"],
+                    field=params["field"],
+                    value=params["value"],
+                )
+            except WorkflowToolError as exc:
+                raise LckStopError(f"project field effect write failed: {exc}") from exc
+            observed = cls._query(
+                resolver,
+                repository=params["repository"],
+                project_number=params["project_number"],
+                task_number=params["task_number"],
+                field=params["field"],
+            )
+        if observed != params["value"]:
+            return _pending_effect(
+                cls.effect_kind,
+                reason="project field effect postcondition is not proven",
+                details={
+                    "field": params["field"],
+                    "value": params["value"],
+                    "effect_kind": descriptor.effect_kind,
+                    **dict(descriptor.receipt),
+                },
+            )
+        details = {
+            "field": params["field"],
+            "value": params["value"],
+            "effect_kind": descriptor.effect_kind,
+            **dict(descriptor.receipt),
+        }
+        return EffectReceipt(
+            effect=cls.effect_kind,
+            action=action,
+            details=details,
+        )
+
+
+DEFAULT_EFFECT_EXECUTOR_REGISTRY: Final = EffectExecutorRegistry(
+    {
+        ProjectSingleSelectEffectExecutor.effect_kind: ProjectSingleSelectEffectExecutor.execute
+    }
+)
+PROFILE_EFFECT_EXECUTOR_REGISTRY: Final = DEFAULT_EFFECT_EXECUTOR_REGISTRY
+ProfileEffectExecutorRegistry = EffectExecutorRegistry
+
+
+class CommitCurrentTreeEffect:
+    """Commit exactly the staged tree that passed Critical Outcome + validation."""
+
+    def __init__(self, resolver: LiveStateResolver) -> None:
+        self.resolver = resolver
+
+    def _run(self, argv: Sequence[str], command_id: str) -> CommandResult:
+        result = self.resolver.runner.run(argv, command_id=command_id)
+        if result.returncode != 0:
+            raise LckStopError(
+                f"{command_id} failed with exit code {result.returncode}: "
+                f"{result.stderr.strip() or result.stdout.strip()}"
+            )
+        return result
+
+    def stage_candidate_tree(self) -> str:
+        status = self._run(
+            ["git", "status", "--porcelain=v1", "--untracked-files=all"],
+            "lck-delivery-status-before-stage",
+        )
+        if not status.stdout.strip():
+            raise LckStopError("Delivery Complete found no uncommitted Task changes")
+        self._run(["git", "add", "-A", "--", ":/"], "lck-stage-current-tree")
+        cached = self.resolver.runner.run(
+            ["git", "diff", "--cached", "--quiet"],
+            command_id="lck-staged-diff-present",
+        )
+        if cached.returncode == 0:
+            raise LckStopError("Delivery candidate contains no staged changes")
+        if cached.returncode not in {0, 1}:
+            raise LckStopError("unable to determine staged Delivery diff")
+        check = self.resolver.runner.run(
+            ["git", "diff", "--cached", "--check"],
+            command_id="lck-staged-diff-check",
+        )
+        if check.returncode != 0:
+            raise LckStopError(
+                "staged Delivery diff failed git diff --check: "
+                + (check.stderr.strip() or check.stdout.strip())
+            )
+        tree = self._run(
+            ["git", "write-tree"], "lck-write-candidate-tree"
+        ).stdout.strip()
+        if not is_sha(tree):
+            raise LckStopError("candidate tree OID is unavailable")
+        return tree
+
+    def current_head_tree(self) -> str:
+        tree = self._run(
+            ["git", "rev-parse", "HEAD^{tree}"],
+            "lck-current-head-tree",
+        ).stdout.strip()
+        if not is_sha(tree):
+            raise LckStopError("current HEAD tree OID is unavailable")
+        return tree
+
+    def verify_tree_unchanged(
+        self,
+        expected_tree: str,
+        *,
+        expected_head_sha: str | None = None,
+    ) -> None:
+        unstaged = self.resolver.runner.run(
+            ["git", "diff", "--quiet"],
+            command_id="lck-post-validation-unstaged-check",
+        )
+        if unstaged.returncode != 0:
+            if unstaged.returncode == 1:
+                raise LckStopError("working tree changed during formal validation")
+            raise LckStopError("unable to verify post-validation working tree")
+        status = self._run(
+            ["git", "status", "--porcelain=v1", "--untracked-files=all"],
+            "lck-post-validation-status",
+        )
+        # Staged entries are expected. Any untracked/unstaged entry makes status
+        # contain a line not represented by the staged tree; git diff --quiet
+        # already rejects tracked unstaged changes, and untracked paths start '??'.
+        if any(line.startswith("??") for line in status.stdout.splitlines()):
+            raise LckStopError("untracked files appeared during formal validation")
+        current_tree = self._run(
+            ["git", "write-tree"], "lck-write-tree-post-validation"
+        ).stdout.strip()
+        if current_tree != expected_tree:
+            raise LckStopError("validated candidate tree changed before commit")
+        if expected_head_sha is not None:
+            current_head = self._run(
+                ["git", "rev-parse", "HEAD"],
+                "lck-post-validation-head",
+            ).stdout.strip()
+            if current_head != expected_head_sha:
+                raise LckStopError("local Task HEAD changed during formal validation")
+
+    def execute(
+        self,
+        expected_tree: str,
+        message: str,
+        *,
+        expected_parent_sha: str | None = None,
+    ) -> EffectReceipt:
+        if not message.strip() or "\x00" in message or len(message) > 240:
+            raise LckStopError("commit message must be non-empty and <= 240 characters")
+        current_tree = self._run(
+            ["git", "write-tree"], "lck-write-tree-pre-commit"
+        ).stdout.strip()
+        if current_tree != expected_tree:
+            raise LckStopError(
+                "commit precondition failed: staged tree is not validated tree"
+            )
+        if expected_parent_sha is not None:
+            current_parent = self._run(
+                ["git", "rev-parse", "HEAD"],
+                "lck-commit-parent-head",
+            ).stdout.strip()
+            if current_parent != expected_parent_sha:
+                raise LckStopError(
+                    "commit precondition failed: local Task HEAD changed"
+                )
+        self._run(["git", "commit", "-m", message], "lck-commit-current-tree")
+        head = self._run(
+            ["git", "rev-parse", "HEAD"], "lck-head-after-commit"
+        ).stdout.strip()
+        if expected_parent_sha is not None:
+            parent = self._run(
+                ["git", "rev-parse", "HEAD^"],
+                "lck-parent-after-commit",
+            ).stdout.strip()
+            if parent != expected_parent_sha:
+                raise LckStopError(
+                    "commit postcondition failed: commit parent HEAD changed"
+                )
+        tree = self._run(
+            ["git", "rev-parse", "HEAD^{tree}"], "lck-tree-after-commit"
+        ).stdout.strip()
+        if not is_sha(head) or tree != expected_tree:
+            raise LckStopError(
+                "commit postcondition failed: committed tree != validated tree"
+            )
+        status = self._run(
+            ["git", "status", "--porcelain=v1", "--untracked-files=all"],
+            "lck-status-after-commit",
+        )
+        if status.stdout.strip():
+            raise LckStopError("commit postcondition failed: worktree is not clean")
+        return EffectReceipt(
+            effect="commit_current_tree",
+            action="committed",
+            details={"head_sha": head, "tree_oid": tree},
+        )
+
+
+class EnsureRemoteBranchEffect:
+    """Ensure origin Task branch equals current local HEAD without force push."""
+
+    def __init__(self, resolver: LiveStateResolver) -> None:
+        self.resolver = resolver
+
+    def _identity(
+        self,
+        branch: str,
+        *,
+        expected_head_sha: str | None = None,
+    ) -> tuple[str, str | None]:
+        branch_result = self.resolver.runner.run(
+            ["git", "branch", "--show-current"], command_id="lck-push-current-branch"
+        )
+        head_result = self.resolver.runner.run(
+            ["git", "rev-parse", "HEAD"], command_id="lck-push-current-head"
+        )
+        if branch_result.returncode != 0 or head_result.returncode != 0:
+            raise LckStopError("cannot resolve local branch identity before push")
+        current_branch = branch_result.stdout.strip()
+        head = head_result.stdout.strip()
+        if current_branch != branch or not is_sha(head):
+            raise LckStopError("push precondition failed: local Task identity changed")
+        if expected_head_sha is not None and head != expected_head_sha:
+            raise LckStopError(
+                "push precondition failed: validated local Task HEAD changed"
+            )
+        remote_result = self.resolver.runner.run(
+            ["git", "ls-remote", "--heads", "origin", f"refs/heads/{branch}"],
+            command_id="lck-push-remote-head",
+        )
+        if remote_result.returncode != 0:
+            raise LckStopError("cannot resolve remote Task branch before push")
+        refs = _remote_refs(remote_result.stdout)
+        remote_oid = refs.get(branch)
+        return head, remote_oid
+
+    def _ensure_upstream(self, branch: str) -> str:
+        expected = f"origin/{branch}"
+        upstream = self.resolver.runner.run(
+            [
+                "git",
+                "rev-parse",
+                "--abbrev-ref",
+                "--symbolic-full-name",
+                "@{upstream}",
+            ],
+            command_id="lck-task-branch-upstream",
+        )
+        current = upstream.stdout.strip() if upstream.returncode == 0 else ""
+        if current != expected:
+            set_upstream = self.resolver.runner.run(
+                [
+                    "git",
+                    "branch",
+                    "--set-upstream-to",
+                    expected,
+                    branch,
+                ],
+                command_id="lck-set-task-branch-upstream",
+            )
+            if set_upstream.returncode != 0:
+                raise LckStopError(
+                    "cannot establish Task branch upstream: "
+                    + (
+                        set_upstream.stderr.strip()
+                        or set_upstream.stdout.strip()
+                        or f"exit {set_upstream.returncode}"
+                    )
+                )
+            upstream = self.resolver.runner.run(
+                [
+                    "git",
+                    "rev-parse",
+                    "--abbrev-ref",
+                    "--symbolic-full-name",
+                    "@{upstream}",
+                ],
+                command_id="lck-verify-task-branch-upstream",
+            )
+            current = upstream.stdout.strip() if upstream.returncode == 0 else ""
+        if current != expected:
+            raise LckStopError(
+                "Task branch upstream postcondition failed: "
+                f"expected {expected!r}, observed {current or 'unavailable'!r}"
+            )
+        return current
+
+    def execute(
+        self,
+        branch: str,
+        *,
+        expected_head_sha: str | None = None,
+    ) -> EffectReceipt:
+        head, remote_oid = self._identity(
+            branch,
+            expected_head_sha=expected_head_sha,
+        )
+        if remote_oid == head:
+            upstream = self._ensure_upstream(branch)
+            return EffectReceipt(
+                effect="ensure_remote_branch",
+                action="already-synced",
+                details={
+                    "head_sha": head,
+                    "remote_oid": remote_oid,
+                    "upstream": upstream,
+                },
+            )
+        if remote_oid is not None:
+            remote_ref = f"refs/heads/{branch}"
+            available = self.resolver.runner.run(
+                ["git", "cat-file", "-e", f"{remote_oid}^{{commit}}"],
+                command_id="lck-observed-remote-object-available",
+            )
+            local_object_available = available.returncode == 0
+            if not local_object_available:
+                fetch = self.resolver.runner.run(
+                    ["git", "fetch", "--no-tags", "origin", remote_ref],
+                    command_id="lck-fetch-observed-remote-task-branch",
+                )
+                if fetch.returncode != 0:
+                    diagnostic = stderr_tail(fetch.stderr or fetch.stdout, limit=1200)
+                    raise LckStopError(
+                        "REMOTE_HEAD_FETCH_FAILED: "
+                        f"remote_ref={remote_ref}; observed_remote_oid={remote_oid}; "
+                        f"candidate_oid={head}; local_object_available=false; "
+                        f"git_exit_code={fetch.returncode}; stderr={diagnostic or 'empty'}"
+                    )
+                fetched = self.resolver.runner.run(
+                    ["git", "rev-parse", "FETCH_HEAD"],
+                    command_id="lck-fetched-remote-task-head",
+                )
+                if fetched.returncode != 0 or fetched.stdout.strip() != remote_oid:
+                    observed = (
+                        fetched.stdout.strip()
+                        if fetched.returncode == 0
+                        else "unavailable"
+                    )
+                    raise LckStopError(
+                        "REMOTE_HEAD_CHANGED: "
+                        f"remote_ref={remote_ref}; observed_remote_oid={remote_oid}; "
+                        f"materialized_oid={observed}; candidate_oid={head}"
+                    )
+            ancestor = self.resolver.runner.run(
+                ["git", "merge-base", "--is-ancestor", remote_oid, head],
+                command_id="lck-remote-fast-forward-check",
+            )
+            if ancestor.returncode != 0:
+                raise LckStopError(
+                    "REMOTE_BRANCH_DIVERGED: "
+                    f"remote_oid={remote_oid}; candidate_oid={head}; "
+                    "LCK will not rebase or force push"
+                )
+            action = "fast-forwarded"
+        else:
+            action = "created"
+
+        push = self.resolver.runner.run(
+            [
+                "git",
+                "push",
+                "-u",
+                "origin",
+                f"{head}:refs/heads/{branch}",
+            ],
+            command_id="lck-push-task-branch",
+        )
+        if push.returncode != 0:
+            diagnostic = stderr_tail(push.stderr or push.stdout, limit=1200)
+            raise LckStopError(
+                "REMOTE_PUSH_REJECTED: "
+                f"remote_ref=refs/heads/{branch}; candidate_oid={head}; "
+                f"git_exit_code={push.returncode}; stderr={diagnostic or 'empty'}"
+            )
+        final_head, final_remote = self._identity(
+            branch,
+            expected_head_sha=expected_head_sha,
+        )
+        if final_head != head or final_remote != head:
+            raise LckStopError(
+                "REMOTE_HEAD_CHANGED: push postcondition failed: "
+                f"candidate_oid={head}; local_oid={final_head}; remote_oid={final_remote}"
+            )
+        upstream = self._ensure_upstream(branch)
+        return EffectReceipt(
+            effect="ensure_remote_branch",
+            action=action,
+            details={
+                "head_sha": head,
+                "remote_oid": final_remote,
+                "upstream": upstream,
+            },
+        )
+
+
+class EnsureOpenPrEffect:
+    """Ensure one OPEN PR using only operation-snapshot authority.
+
+    The PR helper may query/create the exact PR as the bounded effect itself,
+    but it never re-runs lifecycle resolution.
+    """
+
+    def __init__(self, resolver: LiveStateResolver) -> None:
+        self.resolver = resolver
+
+    def execute(
+        self,
+        state: LiveState,
+        *,
+        head_sha: str,
+        summary: str,
+        risks: str,
+        critical_outcome: Mapping[str, Any] | None,
+        validation: Mapping[str, Any],
+        expected_base_sha: str,
+        expected_body_sha256: str,
+    ) -> EffectReceipt:
+        repository = state.repository
+        base = _remote_main_sha(state.git)
+        issue = state.issue
+        if (
+            not isinstance(repository, str)
+            or not is_sha(head_sha)
+            or not is_sha(base)
+            or not isinstance(issue, Mapping)
+        ):
+            raise LckStopError("OPEN PR snapshot preconditions are incomplete")
+        if state.merged is not False:
+            raise LckStopError(
+                "OPEN PR precondition failed: Task merge state is unavailable "
+                "or already merged"
+            )
+        if state.target_branch == BASE_BRANCH:
+            raise LckStopError("OPEN PR precondition failed: Task branch is invalid")
+        if base != expected_base_sha:
+            raise LckStopError("OPEN PR precondition failed: snapshot base mismatch")
+        if issue.get("body_sha256") != expected_body_sha256:
+            raise LckStopError(
+                "OPEN PR precondition failed: snapshot Task body mismatch"
+            )
+        title = issue.get("title")
+        if not isinstance(title, str) or not title.strip():
+            raise LckStopError("Task title is unavailable for PR creation")
+        validation_lines = [f"- Formal Delivery validation: {validation.get('status')}"]
+        if critical_outcome is not None:
+            validation_lines.insert(
+                0,
+                f"- Critical Outcome: {critical_outcome.get('status')}",
+            )
+        body = (
+            f"Closes #{state.issue_number}\n\n"
+            "## Summary\n"
+            f"{summary.strip()}\n\n"
+            "## Validation\n" + "\n".join(validation_lines) + "\n\n"
+            "## Risks / limitations\n"
+            f"{risks.strip() or 'None identified.'}\n"
+        )
+        warnings: list[dict[str, Any]] = []
+        with tempfile.TemporaryDirectory(prefix="lck-pr-") as temp_dir:
+            body_file = Path(temp_dir) / "body.md"
+            body_file.write_text(body, encoding="utf-8", newline="\n")
+            try:
+                result = resolve_or_create_pr(
+                    self.resolver.runner,
+                    repository,
+                    state.target_branch,
+                    BASE_BRANCH,
+                    title,
+                    body_file,
+                    head_sha,
+                    expected_base_sha,
+                    warnings,
+                )
+            except PrResolveError as exc:
+                raise LckStopError(str(exc)) from exc
+        if (
+            result.get("head_sha") != head_sha
+            or result.get("base_sha") != expected_base_sha
+            or not isinstance(result.get("number"), int)
+        ):
+            raise LckStopError("OPEN PR postcondition returned an unexpected identity")
+        return EffectReceipt(
+            effect="ensure_open_pr",
+            action=str(result.get("action")),
+            details={
+                "number": result.get("number"),
+                "url": result.get("url"),
+                "head_sha": result.get("head_sha"),
+                "base_sha": result.get("base_sha"),
+                "warnings": warnings,
+            },
+        )
+
+
+class ReuseExistingOpenPrEffect:
+    """Verify the pushed repair is attached to the snapshot's existing OPEN PR."""
+
+    PR_IDENTITY_FIELDS: Final = (
+        "number,url,state,isDraft,baseRefName,baseRefOid,headRefName,headRefOid"
+    )
+
+    def __init__(self, resolver: LiveStateResolver) -> None:
+        self.resolver = resolver
+
+    def execute(
+        self,
+        state: LiveState,
+        *,
+        head_sha: str,
+        summary: str,
+        risks: str,
+        critical_outcome: Mapping[str, Any] | None,
+        validation: Mapping[str, Any],
+        expected_base_sha: str,
+        expected_body_sha256: str,
+    ) -> EffectReceipt:
+        del summary, risks, critical_outcome, validation
+        pr = state.open_pr
+        issue = state.issue
+        repository = state.repository
+        if (
+            not isinstance(pr, Mapping)
+            or pr.get("isDraft") is not False
+            or not isinstance(repository, str)
+        ):
+            raise LckStopError("Remediation requires the existing non-Draft OPEN PR")
+        if _remote_main_sha(state.git) != expected_base_sha:
+            raise LckStopError(
+                "Remediation PR precondition failed: snapshot base mismatch"
+            )
+        if (
+            not isinstance(issue, Mapping)
+            or issue.get("body_sha256") != expected_body_sha256
+        ):
+            raise LckStopError(
+                "Remediation PR precondition failed: snapshot Task body mismatch"
+            )
+        pr_number = pr.get("number")
+        if not isinstance(pr_number, int) or isinstance(pr_number, bool):
+            raise LckStopError("Remediation PR number is unavailable")
+        result = self.resolver.runner.run(
+            [
+                "gh",
+                "pr",
+                "view",
+                str(pr_number),
+                "--repo",
+                repository,
+                "--json",
+                self.PR_IDENTITY_FIELDS,
+            ],
+            command_id="lck-remediation-pr-postcondition",
+        )
+        if result.returncode != 0 or not result.stdout.strip():
+            raise LckStopError("Remediation PR postcondition cannot be queried")
+        current = read_json_text(
+            result.stdout, field="lck-remediation-pr-postcondition"
+        )
+        if not isinstance(current, Mapping):
+            raise LckStopError("Remediation PR postcondition is malformed")
+        if (
+            current.get("number") != pr_number
+            or str(current.get("state", "")).upper() != "OPEN"
+            or current.get("isDraft") is not False
+            or current.get("headRefOid") != head_sha
+            or current.get("baseRefOid") != expected_base_sha
+            or current.get("headRefName") != state.target_branch
+            or current.get("baseRefName") != BASE_BRANCH
+        ):
+            raise LckStopError(
+                "Remediation PR postcondition failed: existing PR is not on the pushed head"
+            )
+        return EffectReceipt(
+            effect="reuse_open_pr",
+            action="reused-current-open-pr",
+            details={
+                "number": pr_number,
+                "url": current.get("url"),
+                "head_sha": head_sha,
+                "base_sha": expected_base_sha,
+            },
+        )
+
+
+def _query_issue_project_status(
+    resolver: LiveStateResolver,
+    repository: str,
+    task_number: int,
+    *,
+    command_id: str,
+) -> str | None:
+    result = resolver.runner.run(
+        [
+            "gh",
+            "issue",
+            "view",
+            str(task_number),
+            "--repo",
+            repository,
+            "--json",
+            "projectItems",
+        ],
+        command_id=command_id,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+    value = read_json_text(result.stdout, field=command_id)
+    if not isinstance(value, Mapping):
+        return None
+    return _find_project_status(value.get("projectItems"))
+
+
+class SetInProgressStatusEffect:
+    """Move Delivery Prepare to In Progress after workspace verification."""
+
+    def __init__(self, resolver: LiveStateResolver) -> None:
+        self.resolver = resolver
+
+    def execute(self, state: LiveState) -> EffectReceipt:
+        if state.repository is None:
+            raise LckStopError(
+                "cannot set In Progress status without repository identity"
+            )
+        observed = _query_issue_project_status(
+            self.resolver,
+            state.repository,
+            state.issue_number,
+            command_id="lck-in-progress-status-precondition",
+        )
+        if observed == "In Progress":
+            return EffectReceipt(
+                effect="set_in_progress_status",
+                action="already-in-progress",
+                details={"status": "In Progress", "postcondition": "verified"},
+            )
+        if observed != "Ready":
+            raise LckStopError(
+                "Project Status precondition failed: Delivery Prepare requires "
+                "live Ready or In Progress"
+            )
+        try:
+            set_project_status_with_runner(
+                self.resolver.runner,
+                state.repository,
+                state.issue_number,
+                value="In Progress",
+            )
+        except WorkflowToolError as exc:
+            raise LckStopError(
+                f"Project Status In Progress write failed: {exc}"
+            ) from exc
+        observed = _query_issue_project_status(
+            self.resolver,
+            state.repository,
+            state.issue_number,
+            command_id="lck-in-progress-status-postcondition",
+        )
+        if observed != "In Progress":
+            raise LckStopError(
+                "Project Status In Progress postcondition failed: live status "
+                "was not In Progress"
+            )
+        return EffectReceipt(
+            effect="set_in_progress_status",
+            action="updated",
+            details={
+                "previous_status": "Ready",
+                "status": "In Progress",
+                "postcondition": "verified",
+            },
+        )
+
+
+class SetReviewStatusEffect:
+    """Move the Task to Review and verify only that metadata effect."""
+
+    def __init__(self, resolver: LiveStateResolver) -> None:
+        self.resolver = resolver
+
+    def _query_project_status(self, repository: str, task_number: int) -> str | None:
+        return _query_issue_project_status(
+            self.resolver,
+            repository,
+            task_number,
+            command_id="lck-review-status-postcondition",
+        )
+
+    def execute(
+        self,
+        state: LiveState,
+        *,
+        expected_pr: Mapping[str, Any] | None = None,
+        checks_result: Mapping[str, Any] | None = None,
+    ) -> EffectReceipt:
+        if state.repository is None:
+            raise LckStopError("cannot set Review status without repository identity")
+        if expected_pr is None or checks_result is None:
+            raise LckStopError(
+                "Project Status Review requires the exact PR checks observation"
+            )
+        gated_pr = checks_result.get("pr")
+        expected_identity = {
+            "number": expected_pr.get("number"),
+            "head_sha": expected_pr.get("head_sha"),
+            "base_sha": expected_pr.get("base_sha"),
+        }
+        if (
+            not isinstance(gated_pr, Mapping)
+            or {
+                "number": gated_pr.get("number"),
+                "head_sha": gated_pr.get("head_sha"),
+                "base_sha": gated_pr.get("base_sha"),
+            }
+            != expected_identity
+        ):
+            raise LckStopError(
+                "Project Status precondition failed: checks receipt PR identity mismatch"
+            )
+        if checks_result.get("status") not in {"pass", "observed"}:
+            raise LckStopError(
+                "Project Status precondition failed: PR checks receipt is invalid"
+            )
+        if state.project_status == "Review":
+            return EffectReceipt(
+                effect="set_review_status", action="already-review", details={}
+            )
+        previous_status = state.project_status
+        if previous_status != "In Progress":
+            raise LckStopError(
+                "Project Status precondition failed: Delivery Complete requires "
+                "In Progress before Review"
+            )
+        set_project_status_with_runner(
+            self.resolver.runner,
+            state.repository,
+            state.issue_number,
+            value="Review",
+        )
+        observed = self._query_project_status(state.repository, state.issue_number)
+        if observed == "Review":
+            return EffectReceipt(
+                effect="set_review_status",
+                action="updated",
+                details={"status": "Review"},
+            )
+
+        try:
+            set_project_status_with_runner(
+                self.resolver.runner,
+                state.repository,
+                state.issue_number,
+                value=previous_status,
+            )
+        except Exception as restore_exc:
+            raise LckStopError(
+                "Project Status postcondition failed and compensation could not "
+                f"restore {previous_status!r}"
+            ) from restore_exc
+        restored = self._query_project_status(state.repository, state.issue_number)
+        if restored != previous_status:
+            raise LckStopError(
+                "Project Status postcondition failed and compensation did not "
+                f"restore {previous_status!r}"
+            )
+        raise LckStopError(
+            "Project Status postcondition failed; restored Project Status to "
+            f"{previous_status!r}"
+        )

--- a/tools/lck/eligibility.py
+++ b/tools/lck/eligibility.py
@@ -1,0 +1,450 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from .common import is_sha
+from .issue_profiles import resolve_leaf_issue_profile
+from .models import (
+    LiveState,
+    Phase,
+    ResolutionStatus,
+    _is_clean_current_main,
+    _items,
+    _remote_main_sha,
+)
+from .profile_policies import (
+    DEFAULT_PROFILE_POLICY_REGISTRY,
+    PolicyContext,
+    ProfilePolicyRegistry,
+    ProfileResolver,
+    evaluate_profile_blockers,
+    resolve_profile_policy,
+    validate_profile_contract,
+)
+from .shared_facts import gate
+
+
+def evaluate_shared_blockers(relationships: Mapping[str, Any]) -> dict[str, Any]:
+    """Evaluate generic lifecycle blockers from normalized relationship facts."""
+    if relationships.get("available") is not True:
+        return gate("unknown", "Relationship facts unavailable")
+    blocked_by = relationships.get("blocked_by")
+    if not isinstance(blocked_by, Mapping):
+        return gate("unknown", "Blocked-by metadata unavailable")
+    items = blocked_by.get("items")
+    count = blocked_by.get("count")
+    truncated = blocked_by.get("truncated")
+    if (
+        not isinstance(items, list)
+        or not isinstance(count, int)
+        or isinstance(count, bool)
+        or count < 0
+        or not isinstance(truncated, bool)
+    ):
+        return gate("unknown", "Blocked-by metadata is malformed")
+    open_numbers: list[int] = []
+    unresolved = unknown_state = 0
+    for item in items:
+        if not isinstance(item, Mapping):
+            unknown_state += 1
+            continue
+        state = item.get("state")
+        normalized_state = state.upper() if isinstance(state, str) else ""
+        if normalized_state == "OPEN":
+            unresolved += 1
+            if isinstance(item.get("number"), int) and not isinstance(
+                item.get("number"), bool
+            ):
+                open_numbers.append(item["number"])
+        elif normalized_state != "CLOSED":
+            unknown_state += 1
+    if unresolved:
+        return gate("fail", f"unresolved={unresolved}, open={open_numbers[:10]}")
+    if truncated:
+        return gate("unknown", f"blocked-by list truncated; observed={len(items)}")
+    if count != len(items):
+        return gate(
+            "unknown",
+            f"blocked-by count mismatch: count={count}, observed={len(items)}",
+        )
+    if unknown_state:
+        return gate("unknown", f"unknown_state={unknown_state}, total={count}")
+    return gate("pass", f"unresolved=0, total={count}")
+
+
+@dataclass(frozen=True)
+class PhaseDecision:
+    phase: Phase
+    eligible: bool
+    reasons: tuple[str, ...] = ()
+    capabilities: tuple[str, ...] = ()
+    issue_profile: Mapping[str, Any] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "phase": self.phase.value,
+            "eligible": self.eligible,
+            "reasons": list(self.reasons),
+            "capabilities": list(self.capabilities),
+            "issue_profile": self.issue_profile,
+        }
+
+
+class PhaseEligibilityResolver:
+    """Apply static phase capabilities to current live preconditions."""
+
+    def __init__(
+        self,
+        *,
+        registry: ProfilePolicyRegistry | None = None,
+        profile_resolver: ProfileResolver | None = None,
+    ) -> None:
+        self.registry = registry or DEFAULT_PROFILE_POLICY_REGISTRY
+        self.profile_resolver = profile_resolver or resolve_leaf_issue_profile
+
+    def blocker_reasons(
+        self,
+        state: LiveState,
+        *,
+        phase: Phase,
+    ) -> tuple[str, ...]:
+        """Aggregate generic relationship and registered policy blockers."""
+        reasons: list[str] = []
+        shared_gate = evaluate_shared_blockers(state.relationships)
+        if shared_gate.get("status") != "pass":
+            detail = shared_gate.get("detail") or "shared blocker gate did not pass"
+            # Keep the established diagnostic prefix while making ownership
+            # explicit: this is the generic aggregate, not profile semantics.
+            reasons.append(f"formal blocker gate: {detail}")
+
+        issue = state.issue
+        profile_resolution = self.profile_resolver(
+            issue if isinstance(issue, Mapping) else None
+        )
+        profile = profile_resolution.profile if profile_resolution.resolved else None
+        target_contract: Mapping[str, Any] | None = None
+        if isinstance(issue, Mapping):
+            target_contract = dict(issue)
+            if isinstance(state.leaf_contract, Mapping):
+                target_contract.update(state.leaf_contract)
+        downstream_contract = (
+            state.leaf_contract if isinstance(state.leaf_contract, Mapping) else issue
+        )
+        if profile is not None and isinstance(target_contract, Mapping):
+            try:
+                contract_check = validate_profile_contract(
+                    profile, target_contract, registry=self.registry
+                )
+                if not contract_check.valid:
+                    # Contract validity remains a lifecycle gate for entry
+                    # phases and typed profiles.  Review/Closeout snapshots
+                    # intentionally do not reacquire a Task contract, but a
+                    # registered policy with usable contract evidence still
+                    # receives the same blocker dispatch below.
+                    if profile.contract_policy is not None or phase in {
+                        Phase.DELIVERY_PREPARE,
+                        Phase.DELIVERY_COMPLETE,
+                        Phase.REMEDIATION_PREPARE,
+                        Phase.REMEDIATION_COMPLETE,
+                    }:
+                        reasons.append(contract_check.failure_reason)
+                else:
+                    policy_blockers = evaluate_profile_blockers(
+                        profile,
+                        target_contract,
+                        contract_evidence=contract_check.evidence,
+                        registry=self.registry,
+                        context=PolicyContext(
+                            profile=profile,
+                            phase=phase.value,
+                            issue=target_contract,
+                            relationships=state.relationships,
+                            repository=state.repository,
+                            downstream_contract=downstream_contract,
+                            downstream_profile=profile,
+                            blocker_subject="target",
+                        ),
+                    )
+                    reasons.extend(
+                        f"policy blocker [{blocker.code}]: {blocker.detail}"
+                        for blocker in policy_blockers
+                    )
+            except ValueError as exc:
+                reasons.append(f"profile blocker evaluation failed: {exc}")
+
+        blocked_by = state.relationships.get("blocked_by")
+        dependency_items = (
+            blocked_by.get("items") if isinstance(blocked_by, Mapping) else None
+        )
+        if isinstance(dependency_items, list):
+            for dependency in dependency_items:
+                if not isinstance(dependency, Mapping):
+                    continue
+                if str(dependency.get("state", "")).upper() != "CLOSED":
+                    continue
+                labels = dependency.get("labels")
+                labels_complete = dependency.get("labels_complete")
+                if labels_complete is not None and labels_complete is not True:
+                    reasons.append(
+                        "formal blocker gate: closed dependency labels are incomplete"
+                    )
+                    continue
+                if not isinstance(labels, list):
+                    reasons.append(
+                        "formal blocker gate: closed dependency labels are unavailable"
+                    )
+                    continue
+                dependency_resolution = self.profile_resolver(dependency)
+                dependency_profile = dependency_resolution.profile
+                # Task Critical Outcome is a leaf-entry contract.  It is not a
+                # dependency blocker policy; typed dependency semantics are
+                # supplied only by the registered profile capability.
+                if not dependency_resolution.resolved or dependency_profile is None:
+                    reasons.append(
+                        "formal blocker gate: closed dependency profile is unavailable"
+                    )
+                    continue
+                try:
+                    contract_check = validate_profile_contract(
+                        dependency_profile,
+                        dependency,
+                        registry=self.registry,
+                    )
+                    if not contract_check.valid:
+                        if dependency_profile.contract_policy is not None:
+                            reasons.append(contract_check.failure_reason)
+                        continue
+                    dependency_blockers = evaluate_profile_blockers(
+                        dependency_profile,
+                        dependency,
+                        contract_evidence=contract_check.evidence,
+                        registry=self.registry,
+                        context=PolicyContext(
+                            profile=dependency_profile,
+                            phase=phase.value,
+                            issue=dependency,
+                            relationships=state.relationships,
+                            repository=state.repository,
+                            downstream_contract=downstream_contract,
+                            downstream_profile=profile,
+                            blocker_subject="dependency",
+                        ),
+                    )
+                except ValueError as exc:
+                    reasons.append(f"profile blocker evaluation failed: {exc}")
+                else:
+                    reasons.extend(
+                        f"policy blocker [{blocker.code}]: {blocker.detail}"
+                        for blocker in dependency_blockers
+                    )
+        return tuple(dict.fromkeys(reasons))
+
+    def resolve(
+        self,
+        state: LiveState,
+        phase: Phase,
+        *,
+        owned_remediation_candidate: bool = False,
+    ) -> PhaseDecision:
+        reasons = list(state.stop_reasons)
+        issue = state.issue
+        profile_resolution = self.profile_resolver(
+            issue if isinstance(issue, Mapping) else None
+        )
+        issue_profile = profile_resolution.to_dict()
+        if state.status is not ResolutionStatus.RESOLVED:
+            reasons.append("live state resolution stopped")
+        if state.repository is None:
+            reasons.append("repository identity is unavailable")
+        if not isinstance(issue, Mapping):
+            reasons.append("Task metadata is unavailable")
+        else:
+            profile = profile_resolution.profile
+            if not profile_resolution.resolved:
+                reasons.append(profile_resolution.error_message)
+            elif profile is not None and not profile.lifecycle_enabled:
+                reasons.append(profile_resolution.error_message)
+            elif profile is not None:
+                try:
+                    resolve_profile_policy(profile, registry=self.registry)
+                except ValueError as exc:
+                    reasons.append(f"profile policy resolution failed: {exc}")
+            issue_state = str(issue.get("state", "")).upper()
+            if phase is not Phase.CLOSEOUT and issue_state != "OPEN":
+                reasons.append("Task is not OPEN")
+            if phase is not Phase.CLOSEOUT:
+                labels = set(_items(issue.get("labels")))
+                lifecycle_labels = labels & {
+                    "codex:needs-spec",
+                    "codex:ready",
+                    "codex:blocked",
+                }
+                if lifecycle_labels != {"codex:ready"}:
+                    reasons.append(
+                        "lifecycle labels must be exactly ['codex:ready']: "
+                        f"{sorted(lifecycle_labels) or 'none'}"
+                    )
+            project = issue.get("project_status")
+            allowed_projects = {
+                Phase.DELIVERY_PREPARE: {"Ready", "In Progress"},
+                # A prior status write may have moved the Task to Review before
+                # a later final verification stopped.  Allow the same LCK
+                # Delivery Complete path to reacquire and safely finish that
+                # partial invocation.
+                Phase.DELIVERY_COMPLETE: {"In Progress", "Review"},
+                Phase.REVIEW_PREPARE: {"Review", "In Progress"},
+                Phase.REVIEW_COMPLETE: {"Review", "In Progress"},
+                Phase.REMEDIATION_PREPARE: {"Review"},
+                Phase.REMEDIATION_NO_CHANGE: {"Review"},
+                Phase.REMEDIATION_COMPLETE: {"Review"},
+                Phase.CLOSEOUT: {
+                    "Inbox",
+                    "Specifying",
+                    "Ready",
+                    "In Progress",
+                    "Review",
+                    "Blocked",
+                    "Done",
+                },
+            }[phase]
+            if phase is Phase.DELIVERY_COMPLETE and project == "Ready":
+                reasons.append(
+                    "Delivery Complete requires Project Status In Progress; "
+                    "run Delivery Prepare first"
+                )
+            elif project not in allowed_projects:
+                reasons.append("Project Status is unavailable or unknown")
+
+        reasons.extend(self.blocker_reasons(state, phase=phase))
+
+        capabilities: tuple[str, ...] = ()
+        if phase is Phase.DELIVERY_PREPARE:
+            if state.merged is True:
+                reasons.append("Task already has a merged PR")
+            if (
+                state.local_issue_branch is not None
+                and state.git.get("branch") == state.local_issue_branch
+                and state.git.get("clean") is not True
+            ):
+                reasons.append("existing Task branch reuse requires a clean worktree")
+            if state.local_issue_head and state.remote_issue_oid:
+                if state.local_issue_head != state.remote_issue_oid:
+                    reasons.append("Task branch has divergent local and remote tips")
+            if state.open_pr is not None and state.local_issue_head is not None:
+                pr_head = state.open_pr.get("headRefOid")
+                if is_sha(pr_head) and state.local_issue_head != pr_head:
+                    reasons.append(
+                        "current OPEN PR head OID differs from local Task branch tip"
+                    )
+            if not state.local_issue_branch and not state.remote_issue_branch:
+                if not _is_clean_current_main(state.git):
+                    reasons.append(
+                        "new workspace bootstrap requires clean main with "
+                        "HEAD == local main == origin/main"
+                    )
+            capabilities = ("prepare_task_workspace",)
+        elif phase is Phase.DELIVERY_COMPLETE:
+            if state.merged is True:
+                reasons.append("Task already has a merged PR")
+            if state.local_issue_branch is None:
+                reasons.append("Delivery Complete requires a local Task branch")
+            if state.git.get("branch") != state.target_branch:
+                reasons.append(
+                    "Delivery Complete requires the resolved Task branch selected"
+                )
+            if not is_sha(state.local_issue_head):
+                reasons.append("Delivery Complete requires a current local Task head")
+            if state.open_pr is not None and state.open_pr.get("isDraft") is not False:
+                reasons.append("Delivery Complete cannot continue with a Draft OPEN PR")
+            candidate_capability = (
+                profile_resolution.profile.candidate_capability
+                if profile_resolution.profile is not None
+                else "verify_critical_outcome"
+            )
+            capabilities = (
+                candidate_capability,
+                "run_formal_validation",
+                "commit_current_tree",
+                "ensure_remote_branch",
+                "ensure_open_pr",
+                "set_review_status",
+            )
+        elif phase in {Phase.REVIEW_PREPARE, Phase.REVIEW_COMPLETE}:
+            if state.open_pr is None:
+                reasons.append("no current OPEN PR")
+            elif state.open_pr.get("isDraft") is not False:
+                reasons.append(f"{phase.value} requires a non-Draft OPEN PR")
+            if state.project_status not in {"Review", "In Progress"}:
+                reasons.append(f"Task is not eligible for {phase.value}")
+            capabilities = (
+                ("prepare_read_only_review_context",)
+                if phase is Phase.REVIEW_PREPARE
+                else ("accept_semantic_review_verdict",)
+            )
+        elif phase in {
+            Phase.REMEDIATION_PREPARE,
+            Phase.REMEDIATION_NO_CHANGE,
+            Phase.REMEDIATION_COMPLETE,
+        }:
+            if state.open_pr is None:
+                reasons.append("no current OPEN PR")
+            elif state.open_pr.get("isDraft") is not False:
+                reasons.append("Remediation requires a non-Draft OPEN PR")
+            if state.project_status != "Review":
+                reasons.append("Remediation requires Project Status Review")
+            pr_head = state.open_pr.get("headRefOid") if state.open_pr else None
+            if not is_sha(pr_head):
+                reasons.append("current OPEN PR head OID is unavailable")
+            pr_base = state.open_pr.get("baseRefOid") if state.open_pr else None
+            remote_main = _remote_main_sha(state.git)
+            if not is_sha(pr_base) or not is_sha(remote_main) or pr_base != remote_main:
+                reasons.append("current OPEN PR base must match current origin/main")
+            if state.remote_issue_oid != pr_head:
+                reasons.append("remote Task branch must match current OPEN PR head")
+            if (
+                state.local_issue_head is not None
+                and state.local_issue_head != pr_head
+                and not (
+                    phase is Phase.REMEDIATION_COMPLETE and owned_remediation_candidate
+                )
+            ):
+                reasons.append("local Task branch must match current OPEN PR head")
+            if phase is Phase.REMEDIATION_PREPARE:
+                capabilities = ("prepare_task_workspace", "load_review_findings")
+            else:
+                if state.local_issue_branch is None:
+                    reasons.append(f"{phase.value} requires a local Task branch")
+                if state.git.get("branch") != state.target_branch:
+                    reasons.append(
+                        f"{phase.value} requires the resolved Task branch selected"
+                    )
+                if phase is Phase.REMEDIATION_NO_CHANGE:
+                    capabilities = ("close_no_change_remediation",)
+                else:
+                    candidate_capability = (
+                        profile_resolution.profile.candidate_capability
+                        if profile_resolution.profile is not None
+                        else "verify_critical_outcome"
+                    )
+                    capabilities = (
+                        candidate_capability,
+                        "run_formal_validation",
+                        "commit_current_tree",
+                        "ensure_remote_branch",
+                        "reuse_open_pr",
+                    )
+        else:
+            if state.merged is not True:
+                reasons.append("Closeout requires one current merged PR")
+            if state.open_pr is not None:
+                reasons.append("Closeout cannot proceed while an OPEN PR exists")
+            capabilities = ("resolve_cleanup_state",)
+        return PhaseDecision(
+            phase=phase,
+            eligible=not reasons,
+            reasons=tuple(dict.fromkeys(reasons)),
+            capabilities=capabilities,
+            issue_profile=issue_profile,
+        )

--- a/tools/lck/feature_audit.py
+++ b/tools/lck/feature_audit.py
@@ -1,0 +1,902 @@
+#!/usr/bin/env python3
+"""Feature-audit evidence over the shared LCK fact-acquisition adapter.
+
+Task lifecycle control belongs exclusively to ``lck.py``. This module retains
+only audit-oriented Feature snapshot/recheck behavior; authoritative
+profile-neutral Git/GitHub facts are owned by ``tools.lck.shared_facts`` and
+consumed here through adapters. It does not expose Delivery, Review,
+Remediation, Merge, or Closeout control commands.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+if __package__ in {None, ""}:  # Support the documented direct-file fallback.
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+    __package__ = "tools.lck"
+
+from . import shared_facts
+from .bug_policy import BUG_TEMPLATE_PATH, bug_contract_snapshot
+from .common import (
+    CommandRunner,
+    WorkflowToolError,
+    atomic_write_json,
+    bounded_list,
+    command_warning,
+    is_sha,
+    print_json,
+    read_json_file,
+    read_json_text,
+    require_exact_ignored_directory,
+    safe_text,
+    sha256_bytes,
+    sha256_json,
+)
+from .critical_outcome import critical_outcome_snapshot
+from .documentation_policy import (
+    DOCUMENTATION_TEMPLATE_PATH,
+    documentation_contract_snapshot,
+)
+from .eligibility import evaluate_shared_blockers
+from .issue_profiles import LeafIssueWorkflowProfile, resolve_leaf_issue_profile
+from .profile_policies import (
+    DEFAULT_PROFILE_POLICY_REGISTRY,
+    PolicyContext,
+    evaluate_profile_blockers,
+    validate_profile_contract,
+)
+from .research_policy import (
+    RESEARCH_OUTCOME_FIELD,
+    RESEARCH_TEMPLATE_PATH,
+    decision_contract_snapshot,
+    research_contract_snapshot,
+)
+
+SCHEMA_VERSION: Final = 1
+EVIDENCE_ROOT: Final = ".agents/evidence.local"
+SNAPSHOT_SUBDIR: Final = "snapshots"
+MAX_CHILDREN: Final = 50
+MAX_FILES: Final = 100
+
+
+def _pr_view(
+    runner: CommandRunner,
+    repository: str,
+    number: int,
+    warnings: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    fields = (
+        "number,title,body,state,isDraft,url,baseRefName,baseRefOid,headRefName,headRefOid,"
+        "mergeCommit,mergedAt,mergeable,reviewDecision,files,commits,statusCheckRollup,"
+        "reviews,closingIssuesReferences,headRepository"
+    )
+    result = runner.run(
+        ["gh", "pr", "view", str(number), "--repo", repository, "--json", fields],
+        command_id=f"gh-pr-view-{number}",
+    )
+    if result.returncode != 0:
+        warnings.append(command_warning(result))
+        return None
+    value = read_json_text(result.stdout, field=f"PR #{number}")
+    if not isinstance(value, dict):
+        warnings.append(
+            {
+                "command_id": result.command_id,
+                "exit_code": 0,
+                "error": "PR response is not an object",
+            }
+        )
+        return None
+    files: list[str] = []
+    raw_files = value.get("files", [])
+    if isinstance(raw_files, list):
+        for item in raw_files:
+            if isinstance(item, dict) and isinstance(item.get("path"), str):
+                files.append(str(item["path"]))
+    commits: list[dict[str, Any]] = []
+    raw_commits = value.get("commits", [])
+    if isinstance(raw_commits, list):
+        for item in raw_commits:
+            if not isinstance(item, dict):
+                continue
+            commits.append(
+                {
+                    "oid": safe_text(item.get("oid"), limit=64),
+                    "headline": safe_text(item.get("messageHeadline"), limit=160),
+                }
+            )
+    closing_issues: list[int] = []
+    raw_closing = value.get("closingIssuesReferences", [])
+    if isinstance(raw_closing, list):
+        closing_issues = [
+            item["number"]
+            for item in raw_closing
+            if isinstance(item, dict) and isinstance(item.get("number"), int)
+        ]
+    reviews: list[dict[str, Any]] = []
+    raw_reviews = value.get("reviews", [])
+    if isinstance(raw_reviews, list):
+        for item in raw_reviews:
+            if not isinstance(item, dict):
+                continue
+            author = item.get("author")
+            reviews.append(
+                {
+                    "state": safe_text(item.get("state")),
+                    "author": safe_text(author.get("login"))
+                    if isinstance(author, dict)
+                    else None,
+                    "submitted_at": safe_text(item.get("submittedAt")),
+                }
+            )
+    checks = _normalize_checks(value.get("statusCheckRollup"))
+    merge_commit = value.get("mergeCommit")
+    head_repo = value.get("headRepository")
+    return {
+        "number": value.get("number"),
+        "title": safe_text(value.get("title")),
+        "content_sha256": sha256_json(
+            {"body": value.get("body") if isinstance(value.get("body"), str) else None}
+        ),
+        "body_characters": len(value["body"])
+        if isinstance(value.get("body"), str)
+        else None,
+        "state": safe_text(value.get("state")),
+        "is_draft": value.get("isDraft"),
+        "url": safe_text(value.get("url")),
+        "base_branch": safe_text(value.get("baseRefName")),
+        "base_sha": value.get("baseRefOid")
+        if is_sha(value.get("baseRefOid"))
+        else None,
+        "head_branch": safe_text(value.get("headRefName")),
+        "head_sha": value.get("headRefOid")
+        if is_sha(value.get("headRefOid"))
+        else None,
+        "merge_commit_sha": merge_commit.get("oid")
+        if isinstance(merge_commit, dict) and is_sha(merge_commit.get("oid"))
+        else None,
+        "merged_at": safe_text(value.get("mergedAt")),
+        "mergeable": safe_text(value.get("mergeable")),
+        "review_decision": safe_text(value.get("reviewDecision")),
+        "changed_files": bounded_list(files, item_limit=MAX_FILES),
+        "commits": bounded_list(commits),
+        "closing_issues": bounded_list(sorted(closing_issues)),
+        "checks": checks,
+        "reviews": bounded_list(reviews),
+        "head_repository": safe_text(head_repo.get("nameWithOwner"))
+        if isinstance(head_repo, dict)
+        else None,
+    }
+
+
+def _audit_issue_view_with_contract(
+    runner: CommandRunner,
+    repository: str,
+    number: int,
+    warnings: list[dict[str, Any]],
+    include_comments: bool = True,
+    include_closure: bool = True,
+    include_contract: bool = True,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    """Adapt shared Issue facts with profile semantics for Feature audit."""
+    issue, contract = shared_facts._issue_view_with_contract(
+        runner,
+        repository,
+        number,
+        warnings,
+        include_comments,
+        include_closure,
+        include_contract,
+    )
+    if issue is None:
+        return None, contract
+    result = copy.deepcopy(issue)
+    body = contract.get("body") if isinstance(contract, Mapping) else None
+    labels = result.get("labels")
+    if isinstance(labels, Mapping):
+        labels = labels.get("items")
+    labels = labels if isinstance(labels, list) else []
+    resolution = resolve_leaf_issue_profile({"labels": labels})
+    profile = resolution.profile if resolution.resolved else None
+    root = getattr(runner, "repo_root", None)
+    bug_template = root / BUG_TEMPLATE_PATH if isinstance(root, Path) else None
+    documentation_template = (
+        root / DOCUMENTATION_TEMPLATE_PATH if isinstance(root, Path) else None
+    )
+    research_template = (
+        root / RESEARCH_TEMPLATE_PATH if isinstance(root, Path) else None
+    )
+    result["critical_outcome"] = (
+        critical_outcome_snapshot(body)
+        if profile is not None and profile.requires_critical_outcome
+        else None
+    )
+    result["bug_contract"] = (
+        bug_contract_snapshot(body, template_path=bug_template)
+        if profile is not None and profile.contract_policy == "bug"
+        else None
+    )
+    result["documentation_contract"] = (
+        documentation_contract_snapshot(body, template_path=documentation_template)
+        if profile is not None and profile.contract_policy == "documentation"
+        else None
+    )
+    is_research = profile is not None and profile.supports_research_outcome
+    result["research_contract"] = (
+        research_contract_snapshot(body, template_path=research_template)
+        if is_research
+        else None
+    )
+    result["research_outcome"] = (
+        shared_facts.canonical_project_field(
+            result.get("project_items"),
+            repository=repository,
+            issue_number=result.get("number"),
+            field_name=RESEARCH_OUTCOME_FIELD,
+        )
+        if is_research
+        else None
+    )
+    if isinstance(contract, Mapping):
+        enriched_contract = dict(contract)
+        for field in (
+            "critical_outcome",
+            "bug_contract",
+            "documentation_contract",
+            "research_contract",
+            "research_outcome",
+        ):
+            enriched_contract[field] = result[field]
+        contract = enriched_contract
+    return result, contract
+
+
+def _audit_relationship_snapshot(
+    runner: CommandRunner,
+    repository: str,
+    number: int,
+    warnings: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Adapt shared relationship facts with audit-only profile projections."""
+    result = copy.deepcopy(
+        shared_facts._relationship_snapshot(runner, repository, number, warnings)
+    )
+    for connection_name in ("sub_issues", "blocked_by", "blocking"):
+        connection = result.get(connection_name)
+        items = connection.get("items") if isinstance(connection, Mapping) else None
+        if not isinstance(items, list):
+            continue
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            labels = item.get("labels") if isinstance(item.get("labels"), list) else []
+            resolution = resolve_leaf_issue_profile({"labels": labels})
+            profile = resolution.profile if resolution.resolved else None
+            complete_contract = shared_facts.relationship_contract(item)
+            if "contract" in item:
+                body = (
+                    complete_contract.get("body")
+                    if isinstance(complete_contract, Mapping)
+                    else None
+                )
+            else:
+                # Compatibility for already-normalized historical callers.
+                body = item.get("body") if isinstance(item.get("body"), str) else None
+            is_bug = profile is not None and profile.contract_policy == "bug"
+            is_documentation = (
+                profile is not None and profile.contract_policy == "documentation"
+            )
+            is_research = profile is not None and profile.supports_research_outcome
+            item["research_contract"] = (
+                research_contract_snapshot(body) if is_research else None
+            )
+            item["bug_contract"] = bug_contract_snapshot(body) if is_bug else None
+            item["documentation_contract"] = (
+                documentation_contract_snapshot(body) if is_documentation else None
+            )
+            item["decision_contract"] = (
+                decision_contract_snapshot(body, research=True) if is_research else None
+            )
+            item["research_outcome"] = (
+                shared_facts.canonical_project_field(
+                    item.get("project_items"),
+                    repository=repository,
+                    issue_number=item.get("number"),
+                    field_name=RESEARCH_OUTCOME_FIELD,
+                )
+                if is_research
+                else None
+            )
+            item["research_outcome_is_canonical"] = (
+                item["research_outcome"] is not None if is_research else None
+            )
+            # The audit projection retains bounded metadata and typed contract
+            # snapshots, not the raw full Issue body used to derive them.
+            item.pop("contract", None)
+    return result
+
+
+# The public names below are retained as audit adapters for existing Feature
+# snapshot consumers.  LCK imports the owner module directly and therefore
+# cannot accidentally acquire lifecycle facts through this audit module.
+_normalize_title = shared_facts.normalize_title
+_gate = shared_facts.gate
+_git_value = shared_facts._git_value
+_git_snapshot = shared_facts._git_snapshot
+_repository_slug = shared_facts._repository_slug
+_issue_view_with_contract = _audit_issue_view_with_contract
+
+
+def _issue_view(
+    runner: CommandRunner,
+    repository: str,
+    number: int,
+    warnings: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    return _audit_issue_view_with_contract(runner, repository, number, warnings)[0]
+
+
+_find_project_status = shared_facts._find_project_status
+_find_project_field = shared_facts._find_project_field
+_relationship_snapshot = _audit_relationship_snapshot
+_normalize_checks = shared_facts._normalize_checks
+
+
+def _runner_source(
+    runner: CommandRunner,
+    warnings: list[dict[str, Any]],
+) -> dict[str, Any]:
+    script = Path(__file__).resolve()
+    digest = sha256_bytes(script.read_bytes())
+    commit = _git_value(
+        runner,
+        [
+            "log",
+            "-1",
+            "--format=%H",
+            "--",
+            "tools/lck/feature_audit.py",
+        ],
+        command_id="git-runner-source-sha",
+        warnings=warnings,
+    )
+    return {
+        "path": "tools/lck/feature_audit.py",
+        "source_sha": commit if is_sha(commit) else None,
+        "content_sha256": digest,
+    }
+
+
+def _issue_gates(
+    issue: Mapping[str, Any] | None,
+    relationships: Mapping[str, Any],
+    *,
+    expected_title: str | None,
+    expected_state: str | None,
+    required_label: str | None,
+    forbidden_label: str | None,
+    expected_type_label: str | None,
+) -> dict[str, Any]:
+    gates: dict[str, Any] = {}
+    if issue is None:
+        return {"issue_available": _gate("unknown", "Issue metadata unavailable")}
+    gates["issue_available"] = _gate("pass")
+    actual_title = issue.get("title")
+    if expected_title is None:
+        gates["title"] = _gate("pass")
+    elif isinstance(actual_title, str) and _normalize_title(
+        actual_title
+    ) == _normalize_title(expected_title):
+        gates["title"] = _gate("pass")
+    else:
+        gates["title"] = _gate("fail", "supplied and canonical titles differ")
+    if expected_state is None:
+        gates["issue_state"] = _gate("pass")
+    elif str(issue.get("state", "")).upper() == expected_state.upper():
+        gates["issue_state"] = _gate("pass")
+    else:
+        gates["issue_state"] = _gate("fail", f"expected {expected_state}")
+    labels = set(issue.get("labels", {}).get("items", []))
+    if required_label:
+        gates[f"label:{required_label}"] = _gate(
+            "pass" if required_label in labels else "fail"
+        )
+    if forbidden_label:
+        gates[f"label-not:{forbidden_label}"] = _gate(
+            "pass" if forbidden_label not in labels else "fail"
+        )
+    if expected_type_label:
+        issue_type = relationships.get("issue_type")
+        matches_type = expected_type_label in labels or (
+            isinstance(issue_type, str)
+            and issue_type.casefold()
+            == expected_type_label.removeprefix("type:").casefold()
+        )
+        gates["issue_type"] = _gate(
+            "pass" if matches_type else "unknown", expected_type_label
+        )
+    downstream_resolution = resolve_leaf_issue_profile(issue)
+    gates["formal_blockers"] = _formal_blockers_gate(
+        relationships,
+        downstream_profile=(
+            downstream_resolution.profile if downstream_resolution.resolved else None
+        ),
+    )
+    return gates
+
+
+def _audit_formal_blockers_gate(
+    relationships: Mapping[str, Any],
+    *,
+    downstream_contract: Mapping[str, Any] | None = None,
+    downstream_profile: LeafIssueWorkflowProfile | None = None,
+) -> dict[str, Any]:
+    """Audit adapter for the shared gate and registered profile capabilities."""
+    shared_gate = evaluate_shared_blockers(relationships)
+    if shared_gate.get("status") == "fail":
+        return shared_gate
+    if shared_gate.get("status") != "pass":
+        return shared_gate
+    blocked_by = relationships.get("blocked_by")
+    items = blocked_by.get("items") if isinstance(blocked_by, Mapping) else None
+    if not isinstance(items, list):
+        return shared_facts.gate("unknown", "Blocked-by metadata unavailable")
+    profile_blockers: list[tuple[str, str]] = []
+    resolved = 0
+    for item in items:
+        if (
+            not isinstance(item, Mapping)
+            or str(item.get("state", "")).upper() != "CLOSED"
+        ):
+            continue
+        labels = item.get("labels")
+        if not isinstance(labels, list):
+            return shared_facts.gate("unknown", "closed dependency labels unavailable")
+        if item.get("labels_complete") is False:
+            return shared_facts.gate(
+                "unknown", "closed dependency labels are incomplete"
+            )
+        resolution = resolve_leaf_issue_profile({"labels": labels})
+        profile = resolution.profile if resolution.resolved else None
+        if profile is None:
+            return shared_facts.gate(
+                "unknown",
+                "unknown_state=1, closed dependency profile is unavailable",
+            )
+        if profile.contract_policy is None:
+            resolved += 1
+            continue
+        try:
+            contract_check = validate_profile_contract(
+                profile, item, registry=DEFAULT_PROFILE_POLICY_REGISTRY
+            )
+            if not contract_check.valid:
+                profile_blockers.append(("unknown", contract_check.failure_reason))
+                continue
+            blockers = evaluate_profile_blockers(
+                profile,
+                item,
+                contract_evidence=contract_check.evidence,
+                registry=DEFAULT_PROFILE_POLICY_REGISTRY,
+                context=PolicyContext(
+                    profile=profile,
+                    phase="audit",
+                    issue=item,
+                    repository=relationships.get("repository")
+                    if isinstance(relationships.get("repository"), str)
+                    else None,
+                    downstream_contract=downstream_contract,
+                    downstream_profile=downstream_profile,
+                    blocker_subject="dependency",
+                ),
+            )
+        except (TypeError, ValueError) as exc:
+            profile_blockers.append(("unknown", str(exc)))
+            continue
+        if blockers:
+            profile_blockers.extend(
+                (
+                    "unknown"
+                    if blocker.code
+                    in {
+                        "CONTRACT_INVALID",
+                        "RESEARCH_OUTCOME_UNKNOWN",
+                        "ARCHITECTURE_DECISION_UNMATCHED",
+                        "DOWNSTREAM_PROFILE_UNKNOWN",
+                    }
+                    else "fail",
+                    blocker.detail,
+                )
+                for blocker in blockers
+            )
+        else:
+            resolved += 1
+    if any(status == "fail" for status, _detail in profile_blockers):
+        details = "; ".join(
+            detail for status, detail in profile_blockers if status == "fail"
+        )
+        return shared_facts.gate("fail", details or "profile blocker rejected")
+    if profile_blockers:
+        details = "; ".join(detail for _status, detail in profile_blockers)
+        return shared_facts.gate(
+            "unknown", details or "profile blocker evidence unavailable"
+        )
+    return shared_facts.gate(
+        "pass", f"unresolved=0, resolved={resolved}, total={len(items)}"
+    )
+
+
+# Keep the historical audit helper available while routing all current LCK
+# decisions through ``PhaseEligibilityResolver.blocker_reasons``.
+_formal_blockers_gate = _audit_formal_blockers_gate
+
+
+def _sha_gate(actual: Any, expected: str | None, name: str) -> dict[str, Any]:
+    if expected is None:
+        return _gate("pass")
+    if actual == expected:
+        return _gate("pass")
+    if actual is None:
+        return _gate("unknown", f"{name} unavailable")
+    return _gate("fail", f"expected {expected}, observed {actual}")
+
+
+def _base_snapshot(
+    *,
+    operation: str,
+    subject: Mapping[str, Any],
+    repository: str | None,
+    observed: Mapping[str, Any],
+    execution_context: Mapping[str, Any],
+    gates: Mapping[str, Any],
+    warnings: Sequence[Mapping[str, Any]],
+    limitations: Sequence[str],
+    operations: Mapping[str, int],
+) -> dict[str, Any]:
+    warning_items = list(warnings[:50])
+    limitation_values = sorted(set(limitations))
+    core: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "operation": operation,
+        "subject": dict(subject),
+        "repository": repository,
+        "execution_context": dict(execution_context),
+        "observed": dict(observed),
+        "gates": dict(sorted(gates.items())),
+        "warnings": warning_items,
+        "warning_count": len(warnings),
+        "warnings_truncated": len(warnings) > len(warning_items),
+        "limitations": limitation_values[:50],
+        "limitation_count": len(limitation_values),
+        "limitations_truncated": len(limitation_values) > 50,
+        "operations": dict(operations),
+    }
+    snapshot_id = f"ev-{sha256_json(core)[:16]}"
+    return {**core, "snapshot_id": snapshot_id}
+
+
+def _store_snapshot(
+    repo_root: Path, snapshot: Mapping[str, Any], no_store: bool
+) -> str | None:
+    if no_store:
+        return None
+    root = require_exact_ignored_directory(repo_root, EVIDENCE_ROOT)
+    directory = root / SNAPSHOT_SUBDIR
+    directory.mkdir(parents=True, exist_ok=True)
+    snapshot_id = snapshot.get("snapshot_id")
+    if not isinstance(snapshot_id, str):
+        raise WorkflowToolError("snapshot_id is missing")
+    path = directory / f"{snapshot_id}.json"
+    atomic_write_json(path, snapshot)
+    return path.relative_to(repo_root).as_posix()
+
+
+def _snapshot_output(
+    repo_root: Path,
+    snapshot: dict[str, Any],
+    *,
+    no_store: bool,
+) -> dict[str, Any]:
+    details = _store_snapshot(repo_root, snapshot, no_store)
+    output = dict(snapshot)
+    output["details_path"] = details
+    return output
+
+
+def _feature_snapshot(args: argparse.Namespace, repo_root: Path) -> dict[str, Any]:
+    runner = CommandRunner(repo_root)
+    warnings: list[dict[str, Any]] = []
+    repository = _repository_slug(runner, args.repository, warnings)
+    limitations: list[str] = []
+    git = _git_snapshot(runner, warnings)
+    observed: dict[str, Any]
+    if repository is None:
+        limitations.append("repository identity unavailable")
+        observed = {
+            "git": git,
+            "feature": None,
+            "relationships": {},
+            "direct_children": bounded_list([]),
+        }
+        gates = {"repository": _gate("unknown")}
+    else:
+        feature = _issue_view(runner, repository, args.feature, warnings)
+        relationships = _relationship_snapshot(
+            runner, repository, args.feature, warnings
+        )
+        sub_issues = relationships.get("sub_issues")
+        child_items = (
+            sub_issues.get("items", []) if isinstance(sub_issues, dict) else []
+        )
+        children: list[dict[str, Any]] = []
+        for child in child_items[:MAX_CHILDREN]:
+            if not isinstance(child, dict) or not isinstance(child.get("number"), int):
+                continue
+            child_issue = _issue_view(runner, repository, child["number"], warnings)
+            if child_issue is not None:
+                child_relationships = _relationship_snapshot(
+                    runner, repository, child["number"], warnings
+                )
+                child_issue["relationship_evidence"] = {
+                    "available": child_relationships.get("available"),
+                    "issue_type": child_relationships.get("issue_type"),
+                    "parent": child_relationships.get("parent"),
+                    "blocked_by": child_relationships.get("blocked_by"),
+                    "blocking": child_relationships.get("blocking"),
+                }
+                pull_summaries: list[dict[str, Any]] = []
+                pull_items = child_issue.get("closing_pull_requests", {}).get(
+                    "items", []
+                )
+                if isinstance(pull_items, list):
+                    for pull_item in pull_items[:3]:
+                        if not isinstance(pull_item, dict) or not isinstance(
+                            pull_item.get("number"), int
+                        ):
+                            continue
+                        pull = _pr_view(
+                            runner, repository, pull_item["number"], warnings
+                        )
+                        if pull is None:
+                            continue
+                        raw_checks = pull.get("checks")
+                        checks: dict[str, Any] = (
+                            raw_checks if isinstance(raw_checks, dict) else {}
+                        )
+                        pull_summaries.append(
+                            {
+                                "number": pull.get("number"),
+                                "state": pull.get("state"),
+                                "merged_at": pull.get("merged_at"),
+                                "merge_commit_sha": pull.get("merge_commit_sha"),
+                                "base_sha": pull.get("base_sha"),
+                                "head_sha": pull.get("head_sha"),
+                                "checks_count": checks.get("count"),
+                                "checks_all_success": checks.get("all_success"),
+                                "closing_issues": pull.get("closing_issues"),
+                            }
+                        )
+                child_issue["pull_request_evidence"] = bounded_list(
+                    pull_summaries, item_limit=3
+                )
+                children.append(child_issue)
+        observed = {
+            "git": git,
+            "feature": feature,
+            "relationships": relationships,
+            "direct_children": bounded_list(children, item_limit=MAX_CHILDREN),
+        }
+        gates = _issue_gates(
+            feature,
+            relationships,
+            expected_title=args.expected_title,
+            expected_state="OPEN",
+            required_label=None,
+            forbidden_label=None,
+            expected_type_label="type:feature",
+        )
+        gates["repository"] = _gate("pass")
+        gates["origin_fetch"] = _gate(git.get("origin_fetch", "unknown"))
+        gates["audited_main_sha"] = _sha_gate(
+            git.get("remote_main_sha"), args.expected_main_sha, "remote main SHA"
+        )
+        gates["tracking_main"] = _gate(
+            "unknown" if git.get("tracking_main_sha") is None else "pass",
+            "local remote-tracking ref is unavailable"
+            if git.get("tracking_main_sha") is None
+            else None,
+        )
+        gates["direct_children_available"] = _gate(
+            "pass" if relationships.get("available") else "unknown"
+        )
+        gates["direct_children_complete"] = _gate(
+            "pass" if relationships.get("sub_issues_complete") is True else "unknown",
+            "direct-child inventory must be complete",
+        )
+    direct_children = observed.get("direct_children")
+    direct_children_items = (
+        direct_children.get("items", []) if isinstance(direct_children, dict) else []
+    )
+    relationships_value = observed.get("relationships")
+    relationships_digest_source = (
+        relationships_value if isinstance(relationships_value, dict) else {}
+    )
+    direct_numbers = [
+        child.get("number")
+        for child in direct_children_items
+        if isinstance(child, dict) and isinstance(child.get("number"), int)
+    ]
+    observed["direct_child_set_digest"] = relationships_digest_source.get(
+        "sub_issue_set_digest"
+    ) or sha256_json(sorted(direct_numbers))
+    observed["direct_child_evidence_digest"] = sha256_json(direct_children_items)
+    observed["relationships_digest"] = sha256_json(relationships_digest_source)
+    execution_context = {
+        "object_base_sha": git.get("remote_main_sha"),
+        "runner": _runner_source(runner, warnings),
+    }
+    return _base_snapshot(
+        operation="feature-audit-snapshot",
+        subject={"kind": "feature", "feature_number": args.feature},
+        repository=repository,
+        observed=observed,
+        execution_context=execution_context,
+        gates=gates,
+        warnings=warnings,
+        limitations=limitations,
+        operations=runner.counters(),
+    )
+
+
+def _snapshot_path(repo_root: Path, snapshot_id: str) -> Path:
+    if not snapshot_id.startswith("ev-") or len(snapshot_id) > 64:
+        raise WorkflowToolError("invalid snapshot ID")
+    root = require_exact_ignored_directory(repo_root, EVIDENCE_ROOT)
+    directory = root / SNAPSHOT_SUBDIR
+    directory.mkdir(parents=True, exist_ok=True)
+    return directory / f"{snapshot_id}.json"
+
+
+def _feature_stability_projection(snapshot: Mapping[str, Any]) -> dict[str, Any]:
+    """Return only Feature-audit facts whose change invalidates the audit."""
+
+    observed = snapshot.get("observed")
+    if not isinstance(observed, Mapping):
+        return {}
+    feature = observed.get("feature")
+    feature_facts: Mapping[str, Any] = feature if isinstance(feature, Mapping) else {}
+    git = observed.get("git")
+    git_facts: Mapping[str, Any] = git if isinstance(git, Mapping) else {}
+    return {
+        "repository": snapshot.get("repository"),
+        "subject": snapshot.get("subject"),
+        "feature_number": feature_facts.get("number"),
+        "feature_title": feature_facts.get("title"),
+        "feature_state": feature_facts.get("state"),
+        "feature_content_sha256": feature_facts.get("content_sha256"),
+        "feature_metadata_sha256": sha256_json(
+            {
+                "labels": feature_facts.get("labels"),
+                "project_status": feature_facts.get("project_status"),
+                "relationships": observed.get("relationships"),
+            }
+        ),
+        "remote_main_sha": git_facts.get("remote_main_sha"),
+        "tracking_main_sha": git_facts.get("tracking_main_sha"),
+        "direct_child_set_digest": observed.get("direct_child_set_digest"),
+        "direct_child_evidence_digest": observed.get("direct_child_evidence_digest"),
+        "relationships_digest": observed.get("relationships_digest"),
+    }
+
+
+def _feature_recheck(args: argparse.Namespace, repo_root: Path) -> dict[str, Any]:
+    path = _snapshot_path(repo_root, args.snapshot_id)
+    previous = read_json_file(path)
+    if not isinstance(previous, dict):
+        raise WorkflowToolError("snapshot is not an object")
+    if previous.get("operation") != "feature-audit-snapshot":
+        raise WorkflowToolError("only Feature audit snapshots support evidence recheck")
+
+    subject = previous.get("subject")
+    if not isinstance(subject, Mapping):
+        raise WorkflowToolError("snapshot subject is invalid")
+    feature_number = subject.get("feature_number")
+    if not isinstance(feature_number, int) or isinstance(feature_number, bool):
+        raise WorkflowToolError("snapshot Feature identity is invalid")
+
+    namespace = argparse.Namespace(
+        repository=previous.get("repository")
+        if isinstance(previous.get("repository"), str)
+        else None,
+        no_store=False,
+        expected_title=None,
+        expected_main_sha=None,
+        feature=feature_number,
+    )
+    current = _feature_snapshot(namespace, repo_root)
+    current["operation"] = "feature-audit-recheck"
+
+    before = _feature_stability_projection(previous)
+    after = _feature_stability_projection(current)
+    changed = sorted(
+        key for key in set(before) | set(after) if before.get(key) != after.get(key)
+    )
+    current["stability"] = {
+        "stable": not changed,
+        "changed_fields": bounded_list(changed),
+        "previous_snapshot_id": args.snapshot_id,
+        "previous_fingerprint": sha256_json(before),
+        "current_fingerprint": sha256_json(after),
+    }
+    current["gates"] = dict(current.get("gates", {}))
+    current["gates"]["feature_audit_stability"] = _gate(
+        "pass" if not changed else "fail", ", ".join(changed)
+    )
+    current["snapshot_id"] = (
+        "ev-"
+        + sha256_json(
+            {key: value for key, value in current.items() if key != "snapshot_id"}
+        )[:16]
+    )
+    return current
+
+
+def _common(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--repo-root", default=".", help="repository root")
+    parser.add_argument("--repository", help="GitHub owner/repository override")
+    parser.add_argument(
+        "--no-store", action="store_true", help="do not write ignored snapshot file"
+    )
+    parser.add_argument("--pretty", action="store_true", help="pretty-print JSON")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate compact Feature-audit evidence. "
+            "Task lifecycle commands are owned exclusively by LCK."
+        )
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    feature = sub.add_parser(
+        "feature-audit-snapshot", help="Feature inventory and locked-main snapshot"
+    )
+    _common(feature)
+    feature.add_argument("--feature", type=int, required=True)
+    feature.add_argument("--expected-title")
+    feature.add_argument("--expected-main-sha")
+
+    recheck = sub.add_parser(
+        "feature-audit-recheck", help="recollect and compare a Feature audit snapshot"
+    )
+    _common(recheck)
+    recheck.add_argument("--snapshot-id", required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    repo_root = Path(args.repo_root).resolve()
+    try:
+        if args.command == "feature-audit-snapshot":
+            snapshot = _feature_snapshot(args, repo_root)
+        else:
+            snapshot = _feature_recheck(args, repo_root)
+        output = _snapshot_output(repo_root, snapshot, no_store=args.no_store)
+        print_json(output, pretty=args.pretty)
+        return 0
+    except WorkflowToolError as exc:
+        print(f"workflow evidence error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lck/github_projects.py
+++ b/tools/lck/github_projects.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Deterministic project status helper for delivery Skills.
+
+Uses ``gh project item-edit`` with ``--url`` (not raw GraphQL) to update a
+project item's single-select field.  This avoids the GraphQL ``items(filter:)``
+compatibility problem and the manual ID-resolve dance.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from typing import Final
+
+if __package__ in {None, ""}:  # Support the documented direct-file fallback.
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+    __package__ = "tools.lck"
+
+from .common import CommandRunner, WorkflowToolError
+
+_REPO: Final = "PhoenixSss/tracequant"
+_ISSUE_URL_PREFIX: Final = f"https://github.com/{_REPO}/issues/"
+
+
+def set_project_status_with_runner(
+    runner: CommandRunner,
+    repository: str,
+    task: int,
+    *,
+    project_number: int = 1,
+    field: str = "Status",
+    value: str = "Review",
+) -> None:
+    """Update one Task Project field through the shared deterministic runner."""
+    if task <= 0:
+        raise WorkflowToolError("Task number must be positive")
+    owner, separator, _name = repository.partition("/")
+    if not separator or not owner:
+        raise WorkflowToolError("repository must be owner/name")
+    url = f"https://github.com/{repository}/issues/{task}"
+    result = runner.run(
+        [
+            "gh",
+            "project",
+            "item-edit",
+            str(project_number),
+            "--owner",
+            owner,
+            "--url",
+            url,
+            "--field",
+            field,
+            "--value",
+            value,
+        ],
+        command_id="lck-project-status",
+    )
+    if result.returncode != 0:
+        raise WorkflowToolError(
+            f"gh project item-edit failed (exit {result.returncode}): "
+            f"task={task}, field={field!r}, value={value!r}: "
+            f"{result.stderr.strip() or result.stdout.strip()}"
+        )
+
+
+def set_project_status(
+    task: int,
+    *,
+    project_number: int = 1,
+    owner: str = "PhoenixSss",
+    field: str = "Status",
+    value: str = "Review",
+) -> None:
+    """Update a Task project item's single-select field value.
+
+    Uses ``gh project item-edit --url``, which resolves the item by issue URL
+    and does not require GraphQL filter support.
+    """
+    url = f"{_ISSUE_URL_PREFIX}{task}"
+    result = subprocess.run(
+        [
+            "gh",
+            "project",
+            "item-edit",
+            str(project_number),
+            "--owner",
+            owner,
+            "--url",
+            url,
+            "--field",
+            field,
+            "--value",
+            value,
+        ],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"gh project item-edit failed (exit {result.returncode}): "
+            f"task={task}, field={field!r}, value={value!r}\n"
+            f"stderr: {result.stderr.strip()}\n"
+            f"stdout: {result.stdout.strip()}"
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point: set-project-status <task-number> [--value <status>]."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Set a Task project item Status field."
+    )
+    parser.add_argument("task", type=int, help="Task / Issue number")
+    parser.add_argument(
+        "--value",
+        default="Review",
+        help="Status value to set (default: Review)",
+    )
+    parser.add_argument(
+        "--field",
+        default="Status",
+        help="Field name (default: Status)",
+    )
+    parser.add_argument(
+        "--project-number",
+        type=int,
+        default=1,
+        help="Project number (default: 1)",
+    )
+    parser.add_argument(
+        "--owner",
+        default="PhoenixSss",
+        help="Project owner (default: PhoenixSss)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        set_project_status(
+            args.task,
+            project_number=args.project_number,
+            owner=args.owner,
+            field=args.field,
+            value=args.value,
+        )
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    print(f"Task #{args.task}: {args.field} → {args.value}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/lck/github_prs.py
+++ b/tools/lck/github_prs.py
@@ -1,0 +1,530 @@
+#!/usr/bin/env python3
+"""Deterministic, fail-closed PR resolve-or-create helper.
+
+This is NOT a Runner. It is a shared library that provides a single,
+non-fallback PR resolve/create path for use by delivery Skills.
+
+It enforces in code the command discipline previously described only in
+Skill prose: no stderr suppression, no empty-stdout-to-JSON, no retry with
+modified --json fields, no implicit PR selection after creation.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, Final
+
+from .common import (
+    CommandRunner,
+    WorkflowToolError,
+    command_warning,
+    read_json_text,
+    safe_text,
+)
+
+_PR_URL_PATTERN: Final = re.compile(
+    r"https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/pull/\d+"
+)
+_PR_LIST_FIELDS: Final = (
+    "number,url,state,isDraft,baseRefName,baseRefOid,headRefName,headRefOid,"
+    "mergeCommit,mergedAt,mergeable,reviewDecision,headRepository,statusCheckRollup,"
+    "closingIssuesReferences"
+)
+_PR_VIEW_FIELDS: Final = (
+    "number,url,state,isDraft,baseRefName,baseRefOid,headRefName,headRefOid,"
+    "mergeCommit,mergedAt,mergeable,reviewDecision,headRepository,statusCheckRollup,"
+    "closingIssuesReferences"
+)
+_REQUIRED_PR_FIELDS: Final = (
+    "number",
+    "url",
+    "state",
+    "isDraft",
+    "baseRefName",
+    "baseRefOid",
+    "headRefName",
+    "headRefOid",
+)
+
+
+def _pr_fields(
+    *,
+    include_checks: bool,
+    include_mergeability: bool,
+    include_history_details: bool,
+) -> str:
+    fields = list(_REQUIRED_PR_FIELDS)
+    if include_history_details:
+        fields.extend(
+            (
+                "mergeCommit",
+                "mergedAt",
+                "reviewDecision",
+                "headRepository",
+                "closingIssuesReferences",
+            )
+        )
+    if include_checks:
+        fields.append("statusCheckRollup")
+    if include_mergeability:
+        fields.append("mergeable")
+    return ",".join(fields)
+
+
+class PrResolveError(WorkflowToolError):
+    """Expected fail-closed error from PR resolve/create operations."""
+
+
+def _validate_pr_identity(
+    pr: Mapping[str, Any],
+    *,
+    repository: str,
+    expected_branch: str,
+    expected_base: str,
+    expected_head_sha: str | None,
+    expected_base_sha: str | None,
+    require_non_draft: bool = True,
+) -> None:
+    """Verify a PR dict has all required identity fields and matches expectations."""
+    missing = [f for f in _REQUIRED_PR_FIELDS if f not in pr]
+    if missing:
+        raise PrResolveError(
+            f"PR identity missing required fields: {', '.join(missing)}"
+        )
+
+    number = pr["number"]
+    if not isinstance(number, int) or isinstance(number, bool) or number <= 0:
+        raise PrResolveError(f"PR number is invalid: {number!r}")
+
+    url = pr.get("url")
+    if not isinstance(url, str) or not url:
+        raise PrResolveError("PR URL is missing or invalid")
+    if repository not in str(url):
+        raise PrResolveError(
+            f"PR URL repository mismatch: expected {repository} in {url}"
+        )
+
+    state = str(pr.get("state", "")).upper()
+    if state != "OPEN":
+        raise PrResolveError(f"PR state is not OPEN: {state}")
+
+    is_draft = pr.get("isDraft")
+    if require_non_draft and is_draft is not False:
+        raise PrResolveError(f"PR is Draft or draft status unknown: {is_draft!r}")
+
+    head_branch = pr.get("headRefName")
+    if not isinstance(head_branch, str) or head_branch != expected_branch:
+        raise PrResolveError(
+            f"PR head branch mismatch: expected {expected_branch!r}, "
+            f"observed {head_branch!r}"
+        )
+
+    base_branch = pr.get("baseRefName")
+    if not isinstance(base_branch, str) or base_branch != expected_base:
+        raise PrResolveError(
+            f"PR base branch mismatch: expected {expected_base!r}, "
+            f"observed {base_branch!r}"
+        )
+
+    if expected_base_sha is not None:
+        base_sha = pr.get("baseRefOid")
+        if not isinstance(base_sha, str) or base_sha != expected_base_sha:
+            raise PrResolveError(
+                f"PR base SHA mismatch: expected {expected_base_sha}, "
+                f"observed {base_sha!r}"
+            )
+
+    if expected_head_sha is not None:
+        head_sha = pr.get("headRefOid")
+        if not isinstance(head_sha, str) or head_sha != expected_head_sha:
+            raise PrResolveError(
+                f"PR head SHA mismatch: expected {expected_head_sha}, "
+                f"observed {head_sha!r}"
+            )
+
+
+def list_matching_prs(
+    runner: CommandRunner,
+    repository: str,
+    current_branch: str,
+    base_branch: str,
+    warnings: list[dict[str, Any]],
+    *,
+    state: str = "all",
+    limit: int = 100,
+    include_checks: bool = True,
+    include_mergeability: bool = True,
+    include_history_details: bool,
+) -> list[dict[str, Any]]:
+    """Read matching PRs for live-state consumers without any side effect."""
+    if state not in {"open", "closed", "merged", "all"}:
+        raise PrResolveError(f"unsupported PR list state: {state!r}")
+    if limit < 1 or limit > 100:
+        raise PrResolveError(f"invalid PR list limit: {limit!r}")
+    result = runner.run(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--repo",
+            repository,
+            "--head",
+            current_branch,
+            "--base",
+            base_branch,
+            "--state",
+            state,
+            "--limit",
+            str(limit),
+            "--json",
+            (
+                _pr_fields(
+                    include_checks=include_checks,
+                    include_mergeability=include_mergeability,
+                    include_history_details=True,
+                )
+                if include_history_details
+                else ",".join(
+                    (
+                        "number",
+                        "state",
+                        *(("statusCheckRollup",) if include_checks else ()),
+                        *(("mergeable",) if include_mergeability else ()),
+                    )
+                )
+            ),
+        ],
+        command_id="gh-pr-list-live-state-history",
+    )
+    if result.returncode != 0:
+        warnings.append(command_warning(result))
+        raise PrResolveError(
+            f"gh pr list failed with exit code {result.returncode}: "
+            f"{result.stderr.strip() or result.stdout.strip()}"
+        )
+    if not result.stdout.strip():
+        raise PrResolveError("gh pr list returned empty stdout — cannot read PR state")
+    value = read_json_text(result.stdout, field="gh-pr-list-live-state-history")
+    if not isinstance(value, list):
+        raise PrResolveError("live PR history result is not a JSON array")
+    items: list[dict[str, Any]] = []
+    for item in value:
+        if not isinstance(item, Mapping):
+            raise PrResolveError("live PR history item is not a JSON object")
+        items.append(dict(item))
+    return items
+
+
+def resolve_open_pr(
+    runner: CommandRunner,
+    repository: str,
+    current_branch: str,
+    base_branch: str,
+    warnings: list[dict[str, Any]],
+    include_checks: bool = True,
+    include_mergeability: bool = True,
+    include_history_details: bool = True,
+) -> dict[str, Any] | None:
+    """Resolve the unique matching OPEN PR without creating or changing one.
+
+    This is the read-only counterpart used by live-state resolution.  It keeps
+    the PR query and identity checks in the shared resolver instead of creating
+    a second GitHub query stack in the Local Control Kernel.
+    """
+    list_result = runner.run(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--repo",
+            repository,
+            "--head",
+            current_branch,
+            "--base",
+            base_branch,
+            "--state",
+            "open",
+            "--limit",
+            "2",
+            "--json",
+            _pr_fields(
+                include_checks=include_checks,
+                include_mergeability=include_mergeability,
+                include_history_details=include_history_details,
+            ),
+        ],
+        command_id="gh-pr-list-live-state",
+    )
+    if list_result.returncode != 0:
+        warnings.append(command_warning(list_result))
+        raise PrResolveError(
+            f"gh pr list failed with exit code {list_result.returncode}: "
+            f"{list_result.stderr.strip() or list_result.stdout.strip()}"
+        )
+    if not list_result.stdout.strip():
+        raise PrResolveError(
+            "gh pr list returned empty stdout — cannot resolve live PR state"
+        )
+    value = read_json_text(list_result.stdout, field="gh-pr-list-live-state")
+    if not isinstance(value, list):
+        raise PrResolveError("live PR list result is not a JSON array")
+    if not value:
+        return None
+    if len(value) > 1:
+        numbers = [
+            item.get("number") if isinstance(item, Mapping) else None for item in value
+        ]
+        raise PrResolveError(
+            f"multiple OPEN PRs for head={current_branch!r} "
+            f"base={base_branch!r}: {numbers}"
+        )
+
+    listed = value[0]
+    if not isinstance(listed, Mapping):
+        raise PrResolveError("live PR list item is not a JSON object")
+    pr_url = listed.get("url")
+    if not isinstance(pr_url, str) or not pr_url:
+        raise PrResolveError("live PR is missing URL")
+    view_result = runner.run(
+        [
+            "gh",
+            "pr",
+            "view",
+            pr_url,
+            "--repo",
+            repository,
+            "--json",
+            _pr_fields(
+                include_checks=include_checks,
+                include_mergeability=include_mergeability,
+                include_history_details=include_history_details,
+            ),
+        ],
+        command_id="gh-pr-view-live-state",
+    )
+    if view_result.returncode != 0:
+        warnings.append(command_warning(view_result))
+        raise PrResolveError(
+            f"gh pr view identity verification failed with exit code "
+            f"{view_result.returncode}: "
+            f"{view_result.stderr.strip() or view_result.stdout.strip()}"
+        )
+    viewed = read_json_text(view_result.stdout, field="gh-pr-view-live-state")
+    if not isinstance(viewed, Mapping):
+        raise PrResolveError("live PR view result is not a JSON object")
+    _validate_pr_identity(
+        viewed,
+        repository=repository,
+        expected_branch=current_branch,
+        expected_base=base_branch,
+        expected_head_sha=None,
+        expected_base_sha=None,
+        require_non_draft=False,
+    )
+    return dict(viewed)
+
+
+def resolve_or_create_pr(
+    runner: CommandRunner,
+    repository: str,
+    current_branch: str,
+    base_branch: str,
+    pr_title: str,
+    pr_body_file: Path | None,
+    expected_head_sha: str | None,
+    expected_base_sha: str | None,
+    warnings: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Resolve an existing matching PR or create one — exactly one path, no fallbacks.
+
+    Returns a dict with keys: action, number, url, state, is_draft,
+    base_branch, base_sha, head_branch, head_sha.
+
+    Raises PrResolveError on any failure: multiple matching PRs, identity
+    mismatch, command failure, empty stdout, invalid JSON, or missing fields.
+    """
+    # Step 1: Query for existing matching PRs
+    list_result = runner.run(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--repo",
+            repository,
+            "--head",
+            current_branch,
+            "--base",
+            base_branch,
+            "--state",
+            "open",
+            "--limit",
+            "2",
+            "--json",
+            _PR_LIST_FIELDS,
+        ],
+        command_id="gh-pr-list-resolve",
+    )
+
+    if list_result.returncode != 0:
+        warnings.append(command_warning(list_result))
+        raise PrResolveError(
+            f"gh pr list failed with exit code {list_result.returncode}: "
+            f"{list_result.stderr.strip() or list_result.stdout.strip()}"
+        )
+
+    if not list_result.stdout.strip():
+        raise PrResolveError(
+            "gh pr list returned empty stdout — cannot determine PR state"
+        )
+
+    try:
+        pr_list = read_json_text(list_result.stdout, field="gh-pr-list-resolve")
+    except WorkflowToolError as exc:
+        raise PrResolveError(str(exc)) from exc
+    if not isinstance(pr_list, list):
+        raise PrResolveError("gh pr list result is not a JSON array")
+
+    pr_url: str
+    pr_number: int
+
+    if len(pr_list) == 0:
+        # Step 2a: No matching PR — create one
+        create_argv: list[str] = [
+            "gh",
+            "pr",
+            "create",
+            "--repo",
+            repository,
+            "--base",
+            base_branch,
+            "--head",
+            current_branch,
+            "--title",
+            pr_title,
+        ]
+        if pr_body_file is not None:
+            create_argv.extend(["--body-file", str(pr_body_file)])
+
+        create_result = runner.run(
+            create_argv,
+            command_id="gh-pr-create",
+        )
+
+        if create_result.returncode != 0:
+            warnings.append(command_warning(create_result))
+            raise PrResolveError(
+                f"gh pr create failed with exit code {create_result.returncode}: "
+                f"{create_result.stderr.strip() or create_result.stdout.strip()}"
+            )
+
+        stdout = create_result.stdout.strip()
+        if not stdout:
+            raise PrResolveError("gh pr create returned empty stdout — no PR URL")
+
+        match = _PR_URL_PATTERN.search(stdout)
+        if match is None:
+            raise PrResolveError(
+                f"gh pr create stdout does not contain a PR URL: {safe_text(stdout, limit=200)}"
+            )
+        pr_url = match.group(0)
+        # Extract number from URL: https://github.com/owner/repo/pull/N
+        url_number_match = re.search(r"/pull/(\d+)$", pr_url.rstrip("/"))
+        if url_number_match is None:
+            raise PrResolveError(f"Cannot extract PR number from URL: {pr_url}")
+        pr_number = int(url_number_match.group(1))
+        action = "created"
+
+    elif len(pr_list) == 1:
+        # Step 2b: One matching PR — resolve it
+        pr_item = pr_list[0]
+        if not isinstance(pr_item, dict):
+            raise PrResolveError("gh pr list item is not a JSON object")
+
+        raw_url = pr_item.get("url")
+        raw_number = pr_item.get("number")
+        if not isinstance(raw_url, str) or not raw_url:
+            raise PrResolveError("resolved PR is missing URL")
+        if (
+            not isinstance(raw_number, int)
+            or isinstance(raw_number, bool)
+            or raw_number <= 0
+        ):
+            raise PrResolveError(f"resolved PR number is invalid: {raw_number!r}")
+
+        pr_url = raw_url
+        pr_number = raw_number
+        action = "resolved"
+
+    else:
+        # Step 2c: Multiple matching PRs — fail-closed
+        numbers = [
+            item.get("number") if isinstance(item, dict) else None for item in pr_list
+        ]
+        raise PrResolveError(
+            f"multiple matching PRs for head={current_branch!r} "
+            f"base={base_branch!r}: {numbers}"
+        )
+
+    # Step 3: Identity verification — exactly one gh pr view call, no fallback
+    view_result = runner.run(
+        [
+            "gh",
+            "pr",
+            "view",
+            pr_url,
+            "--repo",
+            repository,
+            "--json",
+            _PR_VIEW_FIELDS,
+        ],
+        command_id="gh-pr-view-identity",
+    )
+
+    if view_result.returncode != 0:
+        warnings.append(command_warning(view_result))
+        raise PrResolveError(
+            f"gh pr view identity verification failed with exit code "
+            f"{view_result.returncode}: "
+            f"{view_result.stderr.strip() or view_result.stdout.strip()}"
+        )
+
+    if not view_result.stdout.strip():
+        raise PrResolveError("gh pr view identity verification returned empty stdout")
+
+    try:
+        pr_identity = read_json_text(view_result.stdout, field="gh-pr-view-identity")
+    except WorkflowToolError as exc:
+        raise PrResolveError(str(exc)) from exc
+    if not isinstance(pr_identity, dict):
+        raise PrResolveError("gh pr view identity result is not a JSON object")
+
+    # Verify the resolved/created number matches the identity response
+    identity_number = pr_identity.get("number")
+    if identity_number != pr_number:
+        raise PrResolveError(
+            f"PR number mismatch: resolved/created {pr_number}, "
+            f"identity returned {identity_number!r}"
+        )
+
+    _validate_pr_identity(
+        pr_identity,
+        repository=repository,
+        expected_branch=current_branch,
+        expected_base=base_branch,
+        expected_head_sha=expected_head_sha,
+        expected_base_sha=expected_base_sha,
+    )
+
+    return {
+        "action": action,
+        "number": pr_number,
+        "url": pr_url,
+        "state": str(pr_identity.get("state", "")).upper(),
+        "is_draft": pr_identity.get("isDraft"),
+        "base_branch": safe_text(pr_identity.get("baseRefName")),
+        "base_sha": pr_identity.get("baseRefOid"),
+        "head_branch": safe_text(pr_identity.get("headRefName")),
+        "head_sha": pr_identity.get("headRefOid"),
+    }

--- a/tools/lck/issue_forms.py
+++ b/tools/lck/issue_forms.py
@@ -1,0 +1,260 @@
+"""Generic parsing for repository-owned typed Issue Form contracts.
+
+This module owns the structural contract shared by typed Issue policies:
+required textarea definitions, field uniqueness, and rendered Markdown section
+shape.  It deliberately knows nothing about a concrete Issue profile or its
+domain-specific evidence rules.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Final
+
+import yaml
+
+from .markdown_sections import extract_markdown_sections
+
+
+class IssueFormTemplateError(ValueError):
+    """A repository-owned Issue Form cannot define a usable contract."""
+
+
+@dataclass(frozen=True)
+class IssueFormTemplateContract:
+    """Required textarea fields declared by an Issue Form."""
+
+    field_ids: tuple[str, ...]
+    section_labels: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class IssueFormContractParseResult:
+    """Structural result plus private section details for domain policies."""
+
+    status: str
+    required_sections: tuple[str, ...] = ()
+    missing_sections: tuple[str, ...] = ()
+    duplicate_sections: tuple[str, ...] = ()
+    empty_sections: tuple[str, ...] = ()
+    template_path: str = ""
+    detail: str = ""
+    template: IssueFormTemplateContract | None = None
+    sections: tuple[tuple[str, str], ...] = ()
+
+    @property
+    def structurally_valid(self) -> bool:
+        """Return whether the Issue Form and rendered sections are usable."""
+
+        return (
+            self.template is not None
+            and self.status == "pass"
+            and not self.missing_sections
+            and not self.duplicate_sections
+            and not self.empty_sections
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the bounded, profile-neutral structural snapshot."""
+
+        return {
+            "status": self.status,
+            "required_sections": list(self.required_sections),
+            "missing_sections": list(self.missing_sections),
+            "duplicate_sections": list(self.duplicate_sections),
+            "empty_sections": list(self.empty_sections),
+            "template_path": self.template_path,
+            **({"detail": self.detail} if self.detail else {}),
+        }
+
+
+_RECLASSIFICATION_REQUIRED: Final = "reclassification_required"
+_PASS: Final = "pass"
+
+
+def load_issue_form_template(
+    path: Path,
+    *,
+    form_name: str = "Issue",
+    template_display_path: str | None = None,
+    error_type: type[IssueFormTemplateError] = IssueFormTemplateError,
+) -> IssueFormTemplateContract:
+    """Load and validate required textarea fields from one Issue Form YAML."""
+
+    display_path = template_display_path or path.as_posix()
+    try:
+        parsed = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as exc:
+        raise error_type(f"cannot read {display_path}: {exc}") from exc
+    if not isinstance(parsed, Mapping) or not isinstance(parsed.get("body"), list):
+        raise error_type(f"{display_path} must define a body list")
+
+    field_ids: list[str] = []
+    section_labels: list[str] = []
+    normalized_ids: set[str] = set()
+    normalized_labels: set[str] = set()
+    for field in parsed["body"]:
+        if not isinstance(field, Mapping):
+            raise error_type(f"{form_name} form body item is invalid")
+        validations = field.get("validations")
+        if (
+            not isinstance(validations, Mapping)
+            or validations.get("required") is not True
+        ):
+            continue
+        if field.get("type") != "textarea":
+            raise error_type(f"required {form_name} fields must be textarea sections")
+        field_id = field.get("id")
+        attributes = field.get("attributes")
+        label = attributes.get("label") if isinstance(attributes, Mapping) else None
+        if (
+            not isinstance(field_id, str)
+            or not field_id.strip()
+            or not isinstance(label, str)
+            or not label.strip()
+        ):
+            raise error_type(f"required {form_name} textarea must have an id and label")
+
+        normalized_id = field_id.strip()
+        normalized_label = " ".join(label.split())
+        normalized_id_key = normalized_id.casefold()
+        normalized_label_key = normalized_label.casefold()
+        if (
+            normalized_id_key in normalized_ids
+            or normalized_label_key in normalized_labels
+        ):
+            raise error_type(
+                f"required {form_name} fields must have unique ids and labels"
+            )
+        normalized_ids.add(normalized_id_key)
+        normalized_labels.add(normalized_label_key)
+        field_ids.append(normalized_id)
+        section_labels.append(normalized_label)
+
+    if not section_labels:
+        raise error_type(f"{display_path} has no required sections")
+    return IssueFormTemplateContract(tuple(field_ids), tuple(section_labels))
+
+
+def parse_issue_form_contract(
+    body: str | None,
+    *,
+    template_path: Path,
+    form_name: str = "Issue",
+    template_display_path: str | None = None,
+    error_type: type[IssueFormTemplateError] = IssueFormTemplateError,
+    valid_status: str = _PASS,
+    invalid_status: str = _RECLASSIFICATION_REQUIRED,
+) -> IssueFormContractParseResult:
+    """Parse one Issue Form and its rendered Markdown structural contract.
+
+    The returned ``sections`` are available to a typed policy for additional
+    domain validation but are intentionally omitted from ``to_dict``.
+    """
+
+    display_path = template_display_path or template_path.as_posix()
+    try:
+        template = load_issue_form_template(
+            template_path,
+            form_name=form_name,
+            template_display_path=display_path,
+            error_type=error_type,
+        )
+    except IssueFormTemplateError as exc:
+        return IssueFormContractParseResult(
+            invalid_status,
+            template_path=display_path,
+            detail=f"{form_name} template contract unavailable: {exc}",
+        )
+
+    if not isinstance(body, str) or not body.strip():
+        return IssueFormContractParseResult(
+            invalid_status,
+            required_sections=template.section_labels,
+            template_path=display_path,
+            template=template,
+            detail=f"{form_name} body is unavailable",
+        )
+
+    sections = tuple(
+        (section.name, section.content)
+        for section in extract_markdown_sections(
+            body, canonical_names=template.section_labels
+        )
+    )
+    section_keys = tuple(section.casefold() for section, _content in sections)
+    required_keys = tuple(section.casefold() for section in template.section_labels)
+    missing = tuple(
+        required
+        for required, key in zip(template.section_labels, required_keys, strict=True)
+        if key not in section_keys
+    )
+    duplicates = tuple(
+        required
+        for required, key in zip(template.section_labels, required_keys, strict=True)
+        if section_keys.count(key) > 1
+    )
+    empty = tuple(
+        required
+        for required, key in zip(template.section_labels, required_keys, strict=True)
+        if any(
+            section.casefold() == key and not content for section, content in sections
+        )
+    )
+    if missing or duplicates or empty:
+        parts: list[str] = []
+        if missing:
+            parts.append("missing sections: " + ", ".join(missing))
+        if duplicates:
+            parts.append("duplicate sections: " + ", ".join(duplicates))
+        if empty:
+            parts.append("empty sections: " + ", ".join(empty))
+        return IssueFormContractParseResult(
+            invalid_status,
+            required_sections=template.section_labels,
+            missing_sections=missing,
+            duplicate_sections=duplicates,
+            empty_sections=empty,
+            template_path=display_path,
+            template=template,
+            sections=sections,
+            detail="; ".join(parts),
+        )
+    return IssueFormContractParseResult(
+        valid_status,
+        required_sections=template.section_labels,
+        template_path=display_path,
+        template=template,
+        sections=sections,
+    )
+
+
+def issue_form_contract_snapshot(
+    body: str | None,
+    *,
+    template_path: Path,
+    form_name: str = "Issue",
+    template_display_path: str | None = None,
+    error_type: type[IssueFormTemplateError] = IssueFormTemplateError,
+    valid_status: str = _PASS,
+    invalid_status: str = _RECLASSIFICATION_REQUIRED,
+) -> dict[str, Any]:
+    """Return only the bounded structural snapshot for one Issue Form."""
+
+    return parse_issue_form_contract(
+        body,
+        template_path=template_path,
+        form_name=form_name,
+        template_display_path=template_display_path,
+        error_type=error_type,
+        valid_status=valid_status,
+        invalid_status=invalid_status,
+    ).to_dict()
+
+
+# Readability aliases for callers that distinguish template loading from the
+# complete rendered contract parse.
+parse_issue_form_template = load_issue_form_template
+issue_form_template_contract = load_issue_form_template

--- a/tools/lck/issue_profiles.py
+++ b/tools/lck/issue_profiles.py
@@ -1,0 +1,319 @@
+"""Canonical leaf Issue workflow profiles and type-label resolution.
+
+Issue labels are the only authoritative carrier for a leaf Issue's workflow
+kind.  This module deliberately contains policy facts only; lifecycle state
+acquisition and effects remain owned by the existing LCK controllers.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any, Final
+
+
+class LeafIssueKind(StrEnum):
+    TASK = "task"
+    BUG = "bug"
+    DOCUMENTATION = "documentation"
+    RESEARCH = "research"
+
+
+class IssueProfileResolutionStatus(StrEnum):
+    RESOLVED = "resolved"
+    MISSING_TYPE = "missing_type"
+    MULTIPLE_TYPES = "multiple_types"
+    UNKNOWN_TYPE = "unknown_type"
+    NON_LEAF_TYPE = "non_leaf_type"
+
+
+@dataclass(frozen=True)
+class WorkflowPolicyEntrypoints:
+    """Named policy entrypoints reserved by one profile.
+
+    The values are stable identifiers rather than callables so selecting a
+    profile cannot create a second lifecycle engine or introduce import
+    coupling between policy and phase controllers.
+    """
+
+    eligibility: str
+    validation: str
+    completion: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "eligibility": self.eligibility,
+            "validation": self.validation,
+            "completion": self.completion,
+        }
+
+
+@dataclass(frozen=True)
+class LeafIssueWorkflowProfile:
+    """The complete type-specific contract shared by all LCK phases."""
+
+    profile_id: str
+    issue_kind: LeafIssueKind
+    canonical_type_label: str
+    requires_critical_outcome: bool
+    branch_namespace: str
+    lifecycle_enabled: bool
+    policy_entrypoints: WorkflowPolicyEntrypoints
+    candidate_capability: str
+    contract_policy: str | None = None
+    change_policy: str | None = None
+    artifact_policy: str | None = None
+    supports_research_outcome: bool = False
+    allow_legacy_branch_aliases: bool = False
+
+    @property
+    def eligibility_policy(self) -> str:
+        return self.policy_entrypoints.eligibility
+
+    @property
+    def validation_policy(self) -> str:
+        return self.policy_entrypoints.validation
+
+    @property
+    def completion_policy(self) -> str:
+        return self.policy_entrypoints.completion
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "profile_id": self.profile_id,
+            "issue_kind": self.issue_kind.value,
+            "canonical_type_label": self.canonical_type_label,
+            "requires_critical_outcome": self.requires_critical_outcome,
+            "branch_namespace": self.branch_namespace,
+            "lifecycle_enabled": self.lifecycle_enabled,
+            "policy_entrypoints": self.policy_entrypoints.to_dict(),
+            "candidate_capability": self.candidate_capability,
+            "contract_policy": self.contract_policy,
+            "change_policy": self.change_policy,
+            "artifact_policy": self.artifact_policy,
+            "supports_research_outcome": self.supports_research_outcome,
+            "allow_legacy_branch_aliases": self.allow_legacy_branch_aliases,
+        }
+
+
+def _profile(
+    kind: LeafIssueKind,
+    *,
+    requires_critical_outcome: bool,
+    lifecycle_enabled: bool,
+    branch_namespace: str,
+    candidate_capability: str,
+    contract_policy: str | None = None,
+    change_policy: str | None = None,
+    artifact_policy: str | None = None,
+    supports_research_outcome: bool = False,
+    allow_legacy_branch_aliases: bool = False,
+) -> LeafIssueWorkflowProfile:
+    return LeafIssueWorkflowProfile(
+        profile_id=kind.value,
+        issue_kind=kind,
+        canonical_type_label=f"type:{kind.value}",
+        requires_critical_outcome=requires_critical_outcome,
+        branch_namespace=branch_namespace,
+        lifecycle_enabled=lifecycle_enabled,
+        policy_entrypoints=WorkflowPolicyEntrypoints(
+            eligibility=kind.value,
+            validation=kind.value,
+            completion=kind.value,
+        ),
+        candidate_capability=candidate_capability,
+        contract_policy=contract_policy,
+        change_policy=change_policy,
+        artifact_policy=artifact_policy,
+        supports_research_outcome=supports_research_outcome,
+        allow_legacy_branch_aliases=allow_legacy_branch_aliases,
+    )
+
+
+TASK_PROFILE: Final = _profile(
+    LeafIssueKind.TASK,
+    requires_critical_outcome=True,
+    lifecycle_enabled=True,
+    branch_namespace="task/",
+    candidate_capability="verify_critical_outcome",
+    allow_legacy_branch_aliases=True,
+)
+BUG_PROFILE: Final = _profile(
+    LeafIssueKind.BUG,
+    requires_critical_outcome=False,
+    lifecycle_enabled=True,
+    branch_namespace="bug/",
+    candidate_capability="validate_bug_contract",
+    contract_policy="bug",
+)
+DOCUMENTATION_PROFILE: Final = _profile(
+    LeafIssueKind.DOCUMENTATION,
+    requires_critical_outcome=False,
+    lifecycle_enabled=True,
+    branch_namespace="documentation/",
+    candidate_capability="validate_documentation_candidate",
+    contract_policy="documentation",
+    change_policy="documentation",
+)
+RESEARCH_PROFILE: Final = _profile(
+    LeafIssueKind.RESEARCH,
+    requires_critical_outcome=False,
+    lifecycle_enabled=True,
+    branch_namespace="research/",
+    candidate_capability="validate_research_artifact",
+    contract_policy="research",
+    artifact_policy="research",
+    supports_research_outcome=True,
+)
+
+PROFILES_BY_TYPE_LABEL: Final = {
+    profile.canonical_type_label: profile
+    for profile in (
+        TASK_PROFILE,
+        BUG_PROFILE,
+        DOCUMENTATION_PROFILE,
+        RESEARCH_PROFILE,
+    )
+}
+_NON_LEAF_TYPE_LABELS: Final = frozenset({"type:feature", "type:epic"})
+
+
+def _label_names(issue: Mapping[str, Any] | None) -> tuple[str, ...]:
+    if not isinstance(issue, Mapping):
+        return ()
+    raw_labels: Any = issue.get("labels")
+    if isinstance(raw_labels, Mapping):
+        raw_labels = raw_labels.get("items")
+    if not isinstance(raw_labels, list):
+        return ()
+    labels: list[str] = []
+    for item in raw_labels:
+        if isinstance(item, str):
+            labels.append(item)
+        elif isinstance(item, Mapping) and isinstance(item.get("name"), str):
+            labels.append(item["name"])
+    return tuple(labels)
+
+
+@dataclass(frozen=True)
+class IssueProfileResolution:
+    status: IssueProfileResolutionStatus
+    profile: LeafIssueWorkflowProfile | None = None
+    type_labels: tuple[str, ...] = ()
+    detail: str = ""
+
+    @property
+    def resolved(self) -> bool:
+        return self.status is IssueProfileResolutionStatus.RESOLVED
+
+    @property
+    def terminal_status(self) -> str:
+        if self.resolved and self.profile is not None:
+            return (
+                "PROFILE_ENABLED"
+                if self.profile.lifecycle_enabled
+                else "PROFILE_NOT_ENABLED"
+            )
+        return self.status.value.upper()
+
+    @property
+    def error_message(self) -> str:
+        if self.resolved:
+            if self.profile is None:
+                return "PROFILE_RESOLUTION_FAILED: resolved profile is unavailable"
+            if not self.profile.lifecycle_enabled:
+                return (
+                    "PROFILE_NOT_ENABLED: workflow profile "
+                    f"{self.profile.canonical_type_label} is not enabled"
+                )
+            return ""
+        return f"{self.terminal_status}: {self.detail}"
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "status": self.status.value,
+            "terminal_status": self.terminal_status,
+            "type_labels": list(self.type_labels),
+        }
+        if self.detail:
+            result["detail"] = self.detail
+        if self.profile is not None:
+            result["profile"] = self.profile.to_dict()
+        return result
+
+
+def resolve_leaf_issue_profile(
+    issue: Mapping[str, Any] | None,
+) -> IssueProfileResolution:
+    """Resolve exactly one profile from canonical ``type:*`` labels.
+
+    Title, body, GitHub's Issue Type field, and all non-type labels are
+    intentionally ignored.  Duplicate labels are treated as ambiguous input
+    even though GitHub normally prevents duplicate labels on one Issue.
+    """
+
+    labels = _label_names(issue)
+    type_labels = tuple(label for label in labels if label.startswith("type:"))
+    if not type_labels:
+        return IssueProfileResolution(
+            status=IssueProfileResolutionStatus.MISSING_TYPE,
+            detail="exactly one canonical type:* label is required",
+        )
+    if len(type_labels) != 1:
+        return IssueProfileResolution(
+            status=IssueProfileResolutionStatus.MULTIPLE_TYPES,
+            type_labels=type_labels,
+            detail=(
+                "exactly one canonical type:* label is required; found "
+                + ", ".join(type_labels)
+            ),
+        )
+
+    type_label = type_labels[0]
+    if type_label in _NON_LEAF_TYPE_LABELS:
+        return IssueProfileResolution(
+            status=IssueProfileResolutionStatus.NON_LEAF_TYPE,
+            type_labels=type_labels,
+            detail=(
+                "target Issue is not a type:task; non-leaf type labels are not "
+                f"eligible: {type_label}"
+            ),
+        )
+    profile = PROFILES_BY_TYPE_LABEL.get(type_label)
+    if profile is None:
+        return IssueProfileResolution(
+            status=IssueProfileResolutionStatus.UNKNOWN_TYPE,
+            type_labels=type_labels,
+            detail=f"unsupported canonical type label: {type_label}",
+        )
+    return IssueProfileResolution(
+        status=IssueProfileResolutionStatus.RESOLVED,
+        profile=profile,
+        type_labels=type_labels,
+    )
+
+
+def resolve_issue_profile(
+    issue: Mapping[str, Any] | None,
+) -> IssueProfileResolution:
+    """Compatibility-oriented name for the canonical leaf resolver."""
+
+    return resolve_leaf_issue_profile(issue)
+
+
+def canonical_branch_for_profile(
+    profile: LeafIssueWorkflowProfile,
+    issue_number: int,
+    title: str,
+) -> str:
+    """Derive a profile-owned branch name without reading Issue semantics."""
+
+    title_without_prefix = re.sub(r"^\s*\[[^]]+\]\s*", "", title)
+    normalized = unicodedata.normalize("NFKD", title_without_prefix)
+    ascii_title = normalized.encode("ascii", "ignore").decode("ascii")
+    words = re.findall(r"[a-zA-Z0-9]+", ascii_title.casefold())
+    slug = "-".join(words[:12]).strip("-") or profile.issue_kind.value
+    return f"{profile.branch_namespace}{issue_number}-{slug}"

--- a/tools/lck/markdown_sections.py
+++ b/tools/lck/markdown_sections.py
@@ -1,0 +1,125 @@
+"""Shared Markdown section extraction for typed Issue contracts.
+
+Issue contract headings are semantic markers.  Their Markdown level is only
+presentation, while fenced code examples are content and must not become
+sections.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Collection
+from dataclasses import dataclass
+from typing import Final
+
+_ATX_HEADING: Final = re.compile(
+    r"^[ \t]{0,3}(?P<marks>#{1,6})(?:[ \t]+(?P<name>.+?)[ \t]*|[ \t]*)$"
+)
+_FENCE: Final = re.compile(r"^[ \t]{0,3}(?P<marker>`{3,}|~{3,})(?P<remainder>.*)$")
+
+
+@dataclass(frozen=True)
+class MarkdownSection:
+    """One ATX heading and the content before the next real heading."""
+
+    name: str
+    level: int
+    content: str
+
+
+def _fence_marker(line: str) -> str | None:
+    match = _FENCE.fullmatch(line)
+    if match is None:
+        return None
+    marker = match.group("marker")
+    remainder = match.group("remainder")
+    # Backtick fences cannot have backticks in their info string.  Tilde
+    # fences have no equivalent restriction.
+    if marker[0] == "`" and "`" in remainder:
+        return None
+    return marker
+
+
+def _is_fence_close(line: str, opening_marker: str) -> bool:
+    match = _FENCE.fullmatch(line)
+    if match is None or match.group("remainder").strip():
+        return False
+    marker = match.group("marker")
+    return marker[0] == opening_marker[0] and len(marker) >= len(opening_marker)
+
+
+def extract_markdown_sections(
+    body: str,
+    *,
+    canonical_names: Collection[str] | None = None,
+) -> tuple[MarkdownSection, ...]:
+    """Extract real H1-H6 sections while ignoring fenced code blocks.
+
+    Only ATX headings with one to six markers are recognized.  Plain text,
+    headings indented as code, and headings inside backtick/tilde fences are
+    deliberately excluded.  Contract callers may provide canonical section
+    names to select sections after boundaries have been computed.  Canonical
+    headings are peer section boundaries regardless of level; non-canonical
+    headings retain normal Markdown hierarchy boundaries.
+    """
+    lines = body.splitlines()
+    sections: list[tuple[int, str, int]] = []
+    opening_fence: str | None = None
+
+    for index, line in enumerate(lines):
+        if opening_fence is not None:
+            if _is_fence_close(line, opening_fence):
+                opening_fence = None
+            continue
+
+        fence = _fence_marker(line)
+        if fence is not None:
+            opening_fence = fence
+            continue
+
+        heading = _ATX_HEADING.fullmatch(line)
+        if heading is None or not heading.group("name"):
+            continue
+        sections.append(
+            (
+                index,
+                " ".join(heading.group("name").split()),
+                len(heading.group("marks")),
+            )
+        )
+
+    canonical_keys = (
+        {" ".join(name.split()).casefold() for name in canonical_names}
+        if canonical_names is not None
+        else None
+    )
+    extracted: list[MarkdownSection] = []
+    for position, (line_index, name, level) in enumerate(sections):
+        next_line_index = len(lines)
+        for next_position in range(position + 1, len(sections)):
+            candidate_line_index, candidate_name, candidate_level = sections[
+                next_position
+            ]
+            candidate_is_canonical = (
+                canonical_keys is not None
+                and candidate_name.casefold() in canonical_keys
+            )
+            if (
+                canonical_keys is None
+                or candidate_is_canonical
+                or candidate_level <= level
+            ):
+                next_line_index = candidate_line_index
+                break
+        extracted.append(
+            MarkdownSection(
+                name=name,
+                level=level,
+                content="\n".join(lines[line_index + 1 : next_line_index]).strip(),
+            )
+        )
+    if canonical_keys is None:
+        return tuple(extracted)
+    return tuple(
+        section for section in extracted if section.name.casefold() in canonical_keys
+    )

--- a/tools/lck/models.py
+++ b/tools/lck/models.py
@@ -1,0 +1,1021 @@
+from __future__ import annotations
+
+import inspect
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any, Final, cast
+
+from .common import WorkflowToolError, is_sha
+from .issue_profiles import (
+    TASK_PROFILE,
+    LeafIssueWorkflowProfile,
+    canonical_branch_for_profile,
+)
+
+BASE_BRANCH: Final = "main"
+REQUIRED_CHECKS_WORKFLOW: Final = ".github/workflows/ci.yml"
+LCK_SCHEMA_VERSION: Final = 1
+TASK_BRANCH_PATTERN: Final = re.compile(
+    r"^(?:task/(?P<slash>\d+)(?:-.+)?|task-(?P<dash>\d+)(?:-.+)?|(?P<legacy>\d+)-.+)$"
+)
+RECOVERY_PR_FIELDS: Final = (
+    "number,url,state,isDraft,baseRefName,baseRefOid,headRefName,headRefOid,"
+    "mergeCommit,mergedAt,mergeable,reviewDecision,headRepository,"
+    "closingIssuesReferences"
+)
+
+
+class Phase(StrEnum):
+    """LCK phase capabilities exposed by the v1 core."""
+
+    DELIVERY_PREPARE = "Delivery Prepare"
+    DELIVERY_COMPLETE = "Delivery Complete"
+    REVIEW_PREPARE = "Review Prepare"
+    REVIEW_COMPLETE = "Review Complete"
+    REMEDIATION_PREPARE = "Remediation Prepare"
+    REMEDIATION_NO_CHANGE = "Remediation No Change"
+    REMEDIATION_COMPLETE = "Remediation Complete"
+    CLOSEOUT = "Closeout"
+
+
+class ResolutionStatus(StrEnum):
+    RESOLVED = "resolved"
+    STOP = "stop"
+
+
+@dataclass(frozen=True)
+class FactProfile:
+    """Stable bounded acquisition contract for one lifecycle operation."""
+
+    name: str
+    include_comments: bool = False
+    include_issue_closure: bool = False
+    include_leaf_contract: bool = True
+    include_git: bool = True
+    include_workspace_inventory: bool = False
+    include_local_issue_branches: bool = True
+    include_remote_issue_branches: bool = True
+    include_open_pr: bool = True
+    include_pr_history: bool = False
+    include_pr_history_details: bool = False
+    include_checks: bool = False
+    include_mergeability: bool = False
+
+    # Stable compatibility spellings for persisted fact-profile consumers.
+    @property
+    def include_task_contract(self) -> bool:
+        return self.include_leaf_contract
+
+    @property
+    def include_local_task_branches(self) -> bool:
+        return self.include_local_issue_branches
+
+    @property
+    def include_remote_task_branches(self) -> bool:
+        return self.include_remote_issue_branches
+
+    def facts(self) -> tuple[str, ...]:
+        """Return the stable legacy fact names used by persisted snapshots."""
+        enabled = []
+        for name in (
+            "comments",
+            "issue_closure",
+            "task_contract",
+            "git",
+            "workspace_inventory",
+            "local_task_branches",
+            "remote_task_branches",
+            "open_pr",
+            "pr_history",
+            "checks",
+            "mergeability",
+        ):
+            if getattr(self, f"include_{name}"):
+                enabled.append(name)
+        return tuple(enabled)
+
+    def neutral_facts(self) -> tuple[str, ...]:
+        """Return the canonical neutral names for new in-memory consumers."""
+        enabled = []
+        for name in (
+            "comments",
+            "issue_closure",
+            "leaf_contract",
+            "git",
+            "workspace_inventory",
+            "local_issue_branches",
+            "remote_issue_branches",
+            "open_pr",
+            "pr_history",
+            "checks",
+            "mergeability",
+        ):
+            if getattr(self, f"include_{name}"):
+                enabled.append(name)
+        return tuple(enabled)
+
+
+_DIAGNOSTIC_FACT_PROFILE: Final = FactProfile(
+    name="diagnostic",
+    include_comments=True,
+    include_issue_closure=True,
+    include_leaf_contract=True,
+    include_git=True,
+    include_workspace_inventory=True,
+    include_local_issue_branches=True,
+    include_remote_issue_branches=True,
+    include_open_pr=True,
+    include_pr_history=True,
+    include_pr_history_details=True,
+    include_checks=True,
+    include_mergeability=True,
+)
+
+_OPERATION_FACT_PROFILES: Final = {
+    "delivery-prepare": FactProfile(
+        name="delivery-prepare",
+        include_pr_history=True,
+    ),
+    "delivery-complete": FactProfile(
+        name="delivery-complete",
+        include_pr_history=True,
+        include_checks=True,
+    ),
+    "review-prepare": FactProfile(
+        name="review-prepare",
+        include_git=False,
+        include_local_issue_branches=False,
+        include_checks=True,
+    ),
+    "review-complete": FactProfile(
+        name="review-complete",
+        include_git=False,
+        include_local_issue_branches=False,
+        include_checks=True,
+    ),
+    # All phases that run eligibility need the current Issue contract so
+    # Documentation remains valid through its terminal lifecycle paths.
+    "remediation-prepare": FactProfile(
+        name="remediation-prepare",
+        include_leaf_contract=True,
+    ),
+    "remediation-no-change": FactProfile(
+        name="remediation-no-change",
+        include_leaf_contract=True,
+    ),
+    "remediation-complete": FactProfile(
+        name="remediation-complete",
+        include_checks=True,
+    ),
+    "merge-preflight": FactProfile(
+        name="merge-preflight",
+        include_git=False,
+        include_local_issue_branches=False,
+        include_checks=True,
+        include_mergeability=True,
+    ),
+    "closeout": FactProfile(
+        name="closeout",
+        include_issue_closure=True,
+        include_leaf_contract=True,
+        include_pr_history=True,
+        include_pr_history_details=True,
+    ),
+}
+
+
+def _operation_key(operation: str) -> str:
+    return operation.strip().casefold().replace(" ", "-").replace("_", "-")
+
+
+def fact_profile_for_operation(operation: str) -> FactProfile:
+    key = _operation_key(operation)
+    try:
+        return _OPERATION_FACT_PROFILES[key]
+    except KeyError as exc:
+        raise LckStopError(
+            f"unsupported authoritative operation profile: {operation}"
+        ) from exc
+
+
+class LckStopError(WorkflowToolError):
+    """A deterministic LCK gate could not identify one safe action."""
+
+
+class ReviewStaleError(LckStopError):
+    """The reviewed target is no longer current at a later operation boundary."""
+
+    def __init__(self, code: str, detail: str) -> None:
+        self.code = code
+        super().__init__(f"{code}: {detail}")
+
+
+def canonical_task_branch(task_number: int, title: str) -> str:
+    """Derive the canonical Task branch from live Issue identity.
+
+    ASCII words in the title are retained after Unicode normalization.  This
+    keeps the branch stable for mixed-language titles without trusting a
+    branch name supplied by an Agent.
+    """
+    return canonical_branch_for_profile(TASK_PROFILE, task_number, title)
+
+
+def _jsonable(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(key): _jsonable(nested) for key, nested in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(item) for item in value]
+    if isinstance(value, StrEnum):
+        return value.value
+    return value
+
+
+def _items(value: Any) -> list[Any]:
+    if isinstance(value, Mapping) and isinstance(value.get("items"), list):
+        return list(value["items"])
+    return []
+
+
+def _pr_agent_view(value: Any) -> dict[str, Any] | None:
+    """Keep only the identity needed to reason about a current PR."""
+    if not isinstance(value, Mapping):
+        return None
+    result: dict[str, Any] = {}
+    for output, candidates in (
+        ("number", ("number",)),
+        ("url", ("url",)),
+        ("state", ("state",)),
+        ("is_draft", ("isDraft", "is_draft")),
+        ("base_branch", ("baseRefName", "base_branch")),
+        ("base_sha", ("baseRefOid", "base_sha")),
+        ("head_branch", ("headRefName", "head_branch")),
+        ("head_sha", ("headRefOid", "head_sha")),
+    ):
+        for candidate in candidates:
+            if candidate in value and value[candidate] is not None:
+                result[output] = value[candidate]
+                break
+    return result or None
+
+
+def _checks_agent_view(value: Any) -> dict[str, Any]:
+    """Summarize checks without copying observed runs or command diagnostics."""
+    if not isinstance(value, Mapping):
+        return {"status": "unknown"}
+    result: dict[str, Any] = {}
+    for key in ("status", "check_state", "configuration", "limitation"):
+        item = value.get(key)
+        if item is not None:
+            result[key] = item
+    pr = _pr_agent_view(value.get("pr"))
+    if pr is not None:
+        result["pr"] = pr
+    required = value.get("required")
+    if isinstance(required, list):
+        result["required_count"] = len(required)
+    observed = value.get("observed")
+    if isinstance(observed, Mapping):
+        result["observed_count"] = len(observed)
+    for key in ("failed", "pending", "success", "skipped_or_unknown", "all_success"):
+        item = value.get(key)
+        if item is not None:
+            result[key] = item
+    return result
+
+
+def _validation_agent_view(value: Any) -> dict[str, Any]:
+    """Summarize validation identity and outcome, leaving diagnostics in Receipt."""
+    if not isinstance(value, Mapping):
+        return {"status": "unknown"}
+    result: dict[str, Any] = {}
+    for key in (
+        "status",
+        "validated_base_sha",
+        "validated_head_sha",
+        "profile",
+        "profile_version",
+    ):
+        item = value.get(key)
+        if item is not None:
+            result[key] = item
+    commands = value.get("commands")
+    if isinstance(commands, list):
+        result["command_count"] = len(commands)
+        failed = next(
+            (
+                item
+                for item in commands
+                if isinstance(item, Mapping) and item.get("status") == "fail"
+            ),
+            None,
+        )
+        if isinstance(failed, Mapping):
+            result["failed_command"] = {
+                key: failed[key] for key in ("command_id", "exit_code") if key in failed
+            }
+    return result
+
+
+def _critical_outcome_agent_view(value: Any) -> dict[str, Any] | None:
+    """Summarize the formal Critical Outcome gate."""
+    if value is None:
+        return None
+    if not isinstance(value, Mapping):
+        return {"status": "unknown"}
+    result: dict[str, Any] = {}
+    for key in ("status", "verification_test", "exit_code"):
+        item = value.get(key)
+        if item is not None:
+            result[key] = item
+    contract = value.get("contract")
+    if isinstance(contract, Mapping):
+        verification_test = contract.get("verification_test")
+        if verification_test is not None:
+            result.setdefault("verification_test", verification_test)
+    return result
+
+
+def _issue_agent_view(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, Mapping):
+        return None
+    result: dict[str, Any] = {}
+    for key in (
+        "number",
+        "title",
+        "url",
+        "state",
+        "project_status",
+        "bug_contract",
+        "research_outcome",
+    ):
+        item = value.get(key)
+        if item is not None:
+            result[key] = item
+    return result or None
+
+
+def _branch_matches_task(branch: str, task_number: int) -> bool:
+    match = TASK_BRANCH_PATTERN.fullmatch(branch)
+    if match is None:
+        return False
+    number = next(
+        (value for value in match.groups() if value is not None),
+        None,
+    )
+    return number == str(task_number)
+
+
+def branch_matches_profile(
+    branch: str,
+    issue_number: int,
+    profile: LeafIssueWorkflowProfile,
+) -> bool:
+    """Return whether a branch belongs to the profile-owned Issue namespace.
+
+    Task keeps its historical aliases for compatibility.  Other enabled leaf
+    profiles use only their canonical namespace, so a Documentation branch can
+    never be mistaken for a Task branch (or vice versa).
+    """
+
+    if profile.allow_legacy_branch_aliases:
+        return _branch_matches_task(branch, issue_number)
+    prefix = f"{profile.branch_namespace}{issue_number}-"
+    return bool(re.fullmatch(re.escape(prefix) + r"[a-z0-9][a-z0-9-]*", branch))
+
+
+def _is_clean_current_main(git: Mapping[str, Any]) -> bool:
+    """Return whether a new Task branch can safely be based on current main."""
+    head_sha = git.get("head_sha")
+    local_main_sha = git.get("local_main_sha")
+    remote_main_sha = git.get("remote_main_sha")
+    return (
+        git.get("branch") == BASE_BRANCH
+        and git.get("clean") is True
+        and is_sha(head_sha)
+        and is_sha(local_main_sha)
+        and is_sha(remote_main_sha)
+        and head_sha == local_main_sha == remote_main_sha
+    )
+
+
+def _remote_main_sha(git: Mapping[str, Any]) -> str | None:
+    """Return the current remote-main identity, without legacy fallbacks."""
+    value = git.get("remote_main_sha")
+    return value if isinstance(value, str) else None
+
+
+def _remote_refs(stdout: str) -> dict[str, str]:
+    refs: dict[str, str] = {}
+    for line in stdout.splitlines():
+        oid, separator, ref = line.partition("\t")
+        if not separator or not is_sha(oid) or not ref.startswith("refs/heads/"):
+            continue
+        refs[ref.removeprefix("refs/heads/")] = oid
+    return refs
+
+
+def _merge_commit_sha(pr: Mapping[str, Any] | None) -> str | None:
+    """Return a normalized squash-merge commit identity from a PR fact."""
+    if not isinstance(pr, Mapping):
+        return None
+    value = pr.get("mergeCommit")
+    if isinstance(value, Mapping):
+        value = value.get("oid")
+    if not is_sha(value):
+        value = pr.get("merge_commit_sha")
+    return value if is_sha(value) else None
+
+
+def _pr_head_sha(pr: Mapping[str, Any] | None) -> str | None:
+    if not isinstance(pr, Mapping):
+        return None
+    value = pr.get("headRefOid", pr.get("head_sha"))
+    return value if is_sha(value) else None
+
+
+def _pr_base_sha(pr: Mapping[str, Any] | None) -> str | None:
+    if not isinstance(pr, Mapping):
+        return None
+    value = pr.get("baseRefOid", pr.get("base_sha"))
+    return value if is_sha(value) else None
+
+
+def _called_from_dataclasses_replace() -> bool:
+    """Recognize Python's reconstruction path for legacy alias updates."""
+    frame = inspect.currentframe()
+    try:
+        while frame is not None:
+            if (
+                frame.f_globals.get("__name__") == "dataclasses"
+                and frame.f_code.co_name == "_replace"
+            ):
+                return True
+            frame = frame.f_back
+    finally:
+        del frame
+    return False
+
+
+def _coalesce_compatibility_value(
+    canonical_name: str,
+    canonical: Any,
+    legacy_name: str,
+    legacy: Any,
+) -> Any:
+    """Normalize one canonical value and its optional legacy projection.
+
+    Legacy serialized contracts historically contained a bounded projection of
+    the full contract.  Mapping values therefore use an overlap comparison so
+    that a complete canonical value and an older bounded projection can be
+    read together without creating a second source of truth.
+    """
+    if canonical is None:
+        return legacy
+    if legacy is None:
+        return canonical
+    if isinstance(canonical, Mapping) and isinstance(legacy, Mapping):
+        conflicts = [
+            key
+            for key, value in legacy.items()
+            if key in canonical and canonical[key] != value
+        ]
+        if conflicts:
+            if _called_from_dataclasses_replace():
+                return legacy
+            raise ValueError(
+                f"conflicting {canonical_name}/{legacy_name} values: "
+                + ", ".join(sorted(str(key) for key in conflicts))
+            )
+        return canonical
+    if canonical != legacy:
+        # ``dataclasses.replace`` reconstructs an object by passing every
+        # stored field plus the requested change.  A legacy property is not a
+        # stored field, but callers may still use the historical alias in a
+        # replace call.  Let that explicit replacement win while keeping all
+        # ordinary constructors and deserializers fail-closed below.
+        if _called_from_dataclasses_replace():
+            return legacy
+        raise ValueError(f"conflicting {canonical_name}/{legacy_name} values")
+    return canonical
+
+
+def _legacy_contract_projection(
+    leaf_contract: Mapping[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Return the bounded pre-neutralization ``task_contract`` projection."""
+    if not isinstance(leaf_contract, Mapping):
+        return None
+    return {
+        key: leaf_contract.get(key)
+        for key in (
+            "number",
+            "title",
+            "url",
+            "body_sha256",
+            "critical_outcome",
+            "bug_contract",
+            "documentation_contract",
+            "research_contract",
+            "research_outcome",
+        )
+    }
+
+
+def _contract_agent_view(
+    leaf_contract: Mapping[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Return a bounded contract projection without exposing the Issue body."""
+    if not isinstance(leaf_contract, Mapping):
+        return None
+    return _legacy_contract_projection(leaf_contract)
+
+
+def _issue_number_from_state(value: Any) -> int | None:
+    """Read an Issue number from canonical state with a legacy adapter fallback."""
+    issue_number = getattr(value, "issue_number", None)
+    if isinstance(issue_number, int) and not isinstance(issue_number, bool):
+        return issue_number
+    task_number = getattr(value, "task_number", None)
+    return (
+        task_number
+        if isinstance(task_number, int) and not isinstance(task_number, bool)
+        else None
+    )
+
+
+@dataclass(frozen=True, init=False)
+class LiveState:
+    """Current mechanical facts acquired from Git and GitHub for one Issue.
+
+    The neutral fields are the only stored identity, branch, and contract
+    values.  ``task_*`` names remain constructor and property compatibility
+    projections for existing Task callers and persisted consumers.
+    """
+
+    issue_number: int
+    repository: str | None
+    issue: Mapping[str, Any] | None
+    relationships: Mapping[str, Any]
+    git: Mapping[str, Any]
+    target_branch: str
+    local_issue_branch: str | None
+    local_issue_head: str | None
+    remote_issue_branch: str | None
+    remote_issue_oid: str | None
+    open_pr: Mapping[str, Any] | None
+    merged_pr_numbers: tuple[int, ...]
+    merged: bool | None
+    checks: Mapping[str, Any]
+    cleanup: Mapping[str, Any]
+    status: ResolutionStatus = ResolutionStatus.RESOLVED
+    stop_reasons: tuple[str, ...] = ()
+    warnings: tuple[Mapping[str, Any], ...] = ()
+    merged_pr: Mapping[str, Any] | None = None
+    leaf_contract: Mapping[str, Any] | None = None
+    issue_profile: Mapping[str, Any] | None = None
+
+    def __init__(
+        self,
+        issue_number: int | None = None,
+        repository: str | None = None,
+        issue: Mapping[str, Any] | None = None,
+        relationships: Mapping[str, Any] | None = None,
+        git: Mapping[str, Any] | None = None,
+        target_branch: str = "",
+        local_issue_branch: str | None = None,
+        local_issue_head: str | None = None,
+        remote_issue_branch: str | None = None,
+        remote_issue_oid: str | None = None,
+        open_pr: Mapping[str, Any] | None = None,
+        merged_pr_numbers: tuple[int, ...] | list[int] = (),
+        merged: bool | None = None,
+        checks: Mapping[str, Any] | None = None,
+        cleanup: Mapping[str, Any] | None = None,
+        status: ResolutionStatus = ResolutionStatus.RESOLVED,
+        stop_reasons: tuple[str, ...] | list[str] = (),
+        warnings: tuple[Mapping[str, Any], ...] | list[Mapping[str, Any]] = (),
+        merged_pr: Mapping[str, Any] | None = None,
+        leaf_contract: Mapping[str, Any] | None = None,
+        issue_profile: Mapping[str, Any] | None = None,
+        *,
+        task_number: int | None = None,
+        local_task_branch: str | None = None,
+        local_task_head: str | None = None,
+        remote_task_branch: str | None = None,
+        remote_task_oid: str | None = None,
+        task_contract: Mapping[str, Any] | None = None,
+    ) -> None:
+        resolved_number = _coalesce_compatibility_value(
+            "issue_number", issue_number, "task_number", task_number
+        )
+        if not isinstance(resolved_number, int) or isinstance(resolved_number, bool):
+            raise TypeError("LiveState issue_number must be an integer")
+
+        values = (
+            (
+                "local_issue_branch",
+                local_issue_branch,
+                "local_task_branch",
+                local_task_branch,
+            ),
+            (
+                "local_issue_head",
+                local_issue_head,
+                "local_task_head",
+                local_task_head,
+            ),
+            (
+                "remote_issue_branch",
+                remote_issue_branch,
+                "remote_task_branch",
+                remote_task_branch,
+            ),
+            (
+                "remote_issue_oid",
+                remote_issue_oid,
+                "remote_task_oid",
+                remote_task_oid,
+            ),
+        )
+        resolved_values = {
+            name: _coalesce_compatibility_value(name, canonical, legacy_name, legacy)
+            for name, canonical, legacy_name, legacy in values
+        }
+        resolved_contract = _coalesce_compatibility_value(
+            "leaf_contract", leaf_contract, "task_contract", task_contract
+        )
+        if resolved_contract is not None and not isinstance(resolved_contract, Mapping):
+            raise TypeError("LiveState leaf_contract must be a mapping or None")
+
+        if isinstance(status, str):
+            status = ResolutionStatus(status)
+        if not isinstance(status, ResolutionStatus):
+            raise TypeError("LiveState status must be a ResolutionStatus")
+        object.__setattr__(self, "issue_number", resolved_number)
+        object.__setattr__(self, "repository", repository)
+        object.__setattr__(self, "issue", issue)
+        object.__setattr__(self, "relationships", relationships or {})
+        object.__setattr__(self, "git", git or {})
+        object.__setattr__(self, "target_branch", target_branch)
+        for name, value in resolved_values.items():
+            object.__setattr__(self, name, value)
+        object.__setattr__(self, "open_pr", open_pr)
+        object.__setattr__(self, "merged_pr_numbers", tuple(merged_pr_numbers))
+        object.__setattr__(self, "merged", merged)
+        object.__setattr__(self, "checks", checks or {})
+        object.__setattr__(self, "cleanup", cleanup or {})
+        object.__setattr__(self, "status", status)
+        object.__setattr__(self, "stop_reasons", tuple(stop_reasons))
+        object.__setattr__(self, "warnings", tuple(warnings))
+        object.__setattr__(self, "merged_pr", merged_pr)
+        object.__setattr__(self, "leaf_contract", resolved_contract)
+        object.__setattr__(self, "issue_profile", issue_profile)
+
+    # Read-only legacy projections.  They intentionally do not appear in the
+    # dataclass storage or in ``__dict__`` and can never diverge from neutral
+    # state.
+    @property
+    def task_number(self) -> int:
+        return self.issue_number
+
+    @property
+    def local_task_branch(self) -> str | None:
+        return self.local_issue_branch
+
+    @property
+    def local_task_head(self) -> str | None:
+        return self.local_issue_head
+
+    @property
+    def remote_task_branch(self) -> str | None:
+        return self.remote_issue_branch
+
+    @property
+    def remote_task_oid(self) -> str | None:
+        return self.remote_issue_oid
+
+    @property
+    def task_contract(self) -> Mapping[str, Any] | None:
+        return self.leaf_contract
+
+    @property
+    def project_status(self) -> str | None:
+        return (
+            self.issue.get("project_status")
+            if isinstance(self.issue, Mapping)
+            and isinstance(self.issue.get("project_status"), str)
+            else None
+        )
+
+    @property
+    def issue_state(self) -> str | None:
+        return (
+            self.issue.get("state")
+            if isinstance(self.issue, Mapping)
+            and isinstance(self.issue.get("state"), str)
+            else None
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return cast(
+            dict[str, Any],
+            _jsonable(
+                {
+                    "schema_version": LCK_SCHEMA_VERSION,
+                    # Neutral fields are canonical.  The task_* entries below
+                    # are retained as additive compatibility projections.
+                    "issue_number": self.issue_number,
+                    "local_issue_branch": self.local_issue_branch,
+                    "local_issue_head": self.local_issue_head,
+                    "remote_issue_branch": self.remote_issue_branch,
+                    "remote_issue_oid": self.remote_issue_oid,
+                    "leaf_contract": self.leaf_contract,
+                    "task_number": self.issue_number,
+                    "repository": self.repository,
+                    "issue": self.issue,
+                    "task_contract": _legacy_contract_projection(self.leaf_contract),
+                    "issue_profile": self.issue_profile,
+                    "relationships": self.relationships,
+                    "git": self.git,
+                    "target_branch": self.target_branch,
+                    "local_task_branch": self.local_issue_branch,
+                    "local_task_head": self.local_issue_head,
+                    "remote_task_branch": self.remote_issue_branch,
+                    "remote_task_oid": self.remote_issue_oid,
+                    "open_pr": self.open_pr,
+                    "merged_pr_numbers": self.merged_pr_numbers,
+                    "merged": self.merged,
+                    "checks": self.checks,
+                    "cleanup": self.cleanup,
+                    "status": self.status,
+                    "stop_reasons": self.stop_reasons,
+                    "warnings": self.warnings,
+                    "merged_pr": self.merged_pr,
+                }
+            ),
+        )
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> LiveState:
+        """Deserialize canonical or legacy state into one neutral model.
+
+        Both schemas may be present in an additive receipt.  The constructor
+        performs overlap conflict detection and stores only the neutral form.
+        """
+        if not isinstance(value, Mapping):
+            raise TypeError("LiveState payload must be a mapping")
+        merged_numbers = value.get("merged_pr_numbers", ())
+        if not isinstance(merged_numbers, (list, tuple)):
+            raise TypeError("LiveState merged_pr_numbers must be a sequence")
+        stop_reasons = value.get("stop_reasons", ())
+        if not isinstance(stop_reasons, (list, tuple)):
+            raise TypeError("LiveState stop_reasons must be a sequence")
+        warnings = value.get("warnings", ())
+        if not isinstance(warnings, (list, tuple)):
+            raise TypeError("LiveState warnings must be a sequence")
+        return cls(
+            issue_number=value.get("issue_number"),
+            task_number=value.get("task_number"),
+            repository=value.get("repository"),
+            issue=value.get("issue"),
+            relationships=value.get("relationships"),
+            git=value.get("git"),
+            target_branch=value.get("target_branch", ""),
+            local_issue_branch=value.get("local_issue_branch"),
+            local_task_branch=value.get("local_task_branch"),
+            local_issue_head=value.get("local_issue_head"),
+            local_task_head=value.get("local_task_head"),
+            remote_issue_branch=value.get("remote_issue_branch"),
+            remote_task_branch=value.get("remote_task_branch"),
+            remote_issue_oid=value.get("remote_issue_oid"),
+            remote_task_oid=value.get("remote_task_oid"),
+            open_pr=value.get("open_pr"),
+            merged_pr_numbers=merged_numbers,
+            merged=value.get("merged"),
+            checks=value.get("checks"),
+            cleanup=value.get("cleanup"),
+            status=value.get("status", ResolutionStatus.RESOLVED),
+            stop_reasons=stop_reasons,
+            warnings=warnings,
+            merged_pr=value.get("merged_pr"),
+            leaf_contract=value.get("leaf_contract"),
+            task_contract=value.get("task_contract"),
+            issue_profile=value.get("issue_profile"),
+        )
+
+    def agent_view(self) -> dict[str, Any]:
+        """Return the compact result intended for the invoking Agent."""
+        return {
+            "schema_version": LCK_SCHEMA_VERSION,
+            "kind": "lck-agent-view",
+            "operation": "status",
+            "issue_number": self.issue_number,
+            "task_number": self.issue_number,
+            "repository": self.repository,
+            "status": self.status,
+            "issue": _issue_agent_view(self.issue),
+            "issue_profile": self.issue_profile,
+            "target_branch": self.target_branch,
+            "local_issue_branch": self.local_issue_branch,
+            "local_issue_head": self.local_issue_head,
+            "remote_issue_branch": self.remote_issue_branch,
+            "remote_issue_oid": self.remote_issue_oid,
+            "leaf_contract": _contract_agent_view(self.leaf_contract),
+            "task_branch": {
+                "local": self.local_issue_branch,
+                "local_head_sha": self.local_issue_head,
+                "remote": self.remote_issue_branch,
+                "remote_head_sha": self.remote_issue_oid,
+            },
+            "pr": _pr_agent_view(self.open_pr or self.merged_pr),
+            "checks": _checks_agent_view(self.checks),
+            "cleanup": _jsonable(self.cleanup),
+            "stop_reasons": list(self.stop_reasons),
+            "next_action": (
+                "inspect receipt and resolve STOP reasons"
+                if self.status is ResolutionStatus.STOP
+                else "use the phase-specific LCK operation for the next lifecycle action"
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class OperationSnapshot:
+    """Immutable authoritative inputs for one LCK lifecycle operation.
+
+    ``state`` is acquired exactly once at the operation boundary. Optional
+    phase-specific deterministic facts (currently the exact-base required-check
+    contract) are bound in the same bounded start window, after immutable Git
+    objects are materialized when Review isolation requires it. Downstream
+    helpers consume this object; they do not refresh Git/GitHub authority.
+    """
+
+    operation: str
+    state: LiveState
+    required_checks: Mapping[str, Any] | None = None
+    acquisition_warnings: tuple[Mapping[str, Any], ...] = ()
+    fact_profile: str = "diagnostic"
+    acquired_facts: tuple[str, ...] = ()
+
+    # The snapshot owns one LiveState object; these accessors expose its
+    # canonical neutral model without copying identity/branch/contract data.
+    @property
+    def issue_number(self) -> int:
+        return self.state.issue_number
+
+    @property
+    def local_issue_branch(self) -> str | None:
+        return self.state.local_issue_branch
+
+    @property
+    def local_issue_head(self) -> str | None:
+        return self.state.local_issue_head
+
+    @property
+    def remote_issue_branch(self) -> str | None:
+        return self.state.remote_issue_branch
+
+    @property
+    def remote_issue_oid(self) -> str | None:
+        return self.state.remote_issue_oid
+
+    @property
+    def leaf_contract(self) -> Mapping[str, Any] | None:
+        return self.state.leaf_contract
+
+    # Legacy names are read-only projections of the same snapshot state.
+    @property
+    def task_number(self) -> int:
+        return self.issue_number
+
+    @property
+    def local_task_branch(self) -> str | None:
+        return self.local_issue_branch
+
+    @property
+    def local_task_head(self) -> str | None:
+        return self.local_issue_head
+
+    @property
+    def remote_task_branch(self) -> str | None:
+        return self.remote_issue_branch
+
+    @property
+    def remote_task_oid(self) -> str | None:
+        return self.remote_issue_oid
+
+    @property
+    def task_contract(self) -> Mapping[str, Any] | None:
+        return self.leaf_contract
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": LCK_SCHEMA_VERSION,
+            "operation": self.operation,
+            # These are projections of ``state`` for consumers that read the
+            # operation envelope without unpacking its nested LiveState.
+            "issue_number": self.issue_number,
+            "local_issue_branch": self.local_issue_branch,
+            "local_issue_head": self.local_issue_head,
+            "remote_issue_branch": self.remote_issue_branch,
+            "remote_issue_oid": self.remote_issue_oid,
+            "leaf_contract": _jsonable(self.leaf_contract),
+            "task_number": self.issue_number,
+            "local_task_branch": self.local_issue_branch,
+            "local_task_head": self.local_issue_head,
+            "remote_task_branch": self.remote_issue_branch,
+            "remote_task_oid": self.remote_issue_oid,
+            "task_contract": _jsonable(_legacy_contract_projection(self.leaf_contract)),
+            "state": self.state.to_dict(),
+            "required_checks": _jsonable(self.required_checks),
+            "acquisition_warnings": _jsonable(self.acquisition_warnings),
+            "fact_profile": self.fact_profile,
+            "acquired_facts": list(self.acquired_facts),
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> OperationSnapshot:
+        """Deserialize a snapshot through the canonical LiveState adapter."""
+        if not isinstance(value, Mapping):
+            raise TypeError("OperationSnapshot payload must be a mapping")
+        state = value.get("state")
+        if not isinstance(state, Mapping):
+            raise TypeError("OperationSnapshot state payload must be a mapping")
+        restored_state = LiveState.from_dict(state)
+        for canonical_name, legacy_name, expected in (
+            ("issue_number", "task_number", restored_state.issue_number),
+            (
+                "local_issue_branch",
+                "local_task_branch",
+                restored_state.local_issue_branch,
+            ),
+            (
+                "local_issue_head",
+                "local_task_head",
+                restored_state.local_issue_head,
+            ),
+            (
+                "remote_issue_branch",
+                "remote_task_branch",
+                restored_state.remote_issue_branch,
+            ),
+            ("remote_issue_oid", "remote_task_oid", restored_state.remote_issue_oid),
+            ("leaf_contract", "task_contract", restored_state.leaf_contract),
+        ):
+            if canonical_name not in value and legacy_name not in value:
+                continue
+            observed = _coalesce_compatibility_value(
+                canonical_name,
+                value.get(canonical_name),
+                legacy_name,
+                value.get(legacy_name),
+            )
+            _coalesce_compatibility_value(
+                canonical_name,
+                expected,
+                "serialized_" + canonical_name,
+                observed,
+            )
+        warnings = value.get("acquisition_warnings", ())
+        facts = value.get("acquired_facts", ())
+        if not isinstance(warnings, (list, tuple)):
+            raise TypeError("OperationSnapshot acquisition_warnings must be a sequence")
+        if not isinstance(facts, (list, tuple)):
+            raise TypeError("OperationSnapshot acquired_facts must be a sequence")
+        operation = value.get("operation")
+        if not isinstance(operation, str) or not operation:
+            raise TypeError("OperationSnapshot operation must be a non-empty string")
+        return cls(
+            operation=operation,
+            state=restored_state,
+            required_checks=value.get("required_checks"),
+            acquisition_warnings=tuple(warnings),
+            fact_profile=str(value.get("fact_profile", "diagnostic")),
+            acquired_facts=tuple(str(fact) for fact in facts),
+        )
+
+
+@dataclass(frozen=True)
+class EffectReceipt:
+    effect: str
+    action: str
+    details: Mapping[str, Any]
+
+    @property
+    def is_complete(self) -> bool:
+        """Whether the effect produced a proven completion receipt.
+
+        Effect actions are executor-specific.  The kernel reserves only
+        ``pending`` for an effect whose postcondition is not proven, so
+        completion controllers must not maintain an action-name allowlist.
+        """
+        return self.action != "pending"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "effect": self.effect,
+            "action": self.action,
+            "details": _jsonable(self.details),
+        }

--- a/tools/lck/profile_policies.py
+++ b/tools/lck/profile_policies.py
@@ -1,0 +1,2279 @@
+"""Typed leaf policy dispatch and profile-owned evidence contracts.
+
+The LCK kernel owns lifecycle mechanics. This module owns the small seam at
+which a resolved leaf profile becomes executable policy. The seam is explicit:
+production uses :data:`DEFAULT_PROFILE_POLICY_REGISTRY` and tests may construct
+an independent registry without mutating production state.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Final, Protocol, cast, runtime_checkable
+
+from .bug_policy import bug_contract_snapshot, is_valid_bug_contract
+from .common import sha256_json
+from .critical_outcome import (
+    CriticalOutcomeError,
+    contract_from_snapshot,
+    critical_outcome_snapshot,
+    verify_critical_outcome,
+)
+from .documentation_policy import (
+    DocumentationChangeResult,
+    documentation_contract_snapshot,
+    evaluate_documentation_changes,
+    is_valid_documentation_contract,
+)
+from .effective_diff import calculate_effective_diff
+from .issue_profiles import (
+    IssueProfileResolution,
+    LeafIssueWorkflowProfile,
+    resolve_leaf_issue_profile,
+)
+from .models import LckStopError
+from .research_policy import (
+    RESEARCH_OUTCOME_FIELD,
+    ResearchPolicyError,
+    architecture_decision_is_consistent,
+    bind_research_outcome,
+    decision_contract_snapshot,
+    evaluate_research_changes,
+    is_implementation_outcome,
+    is_valid_research_contract,
+    parse_research_outcome,
+    require_typed_research_outcome,
+    research_artifact_binding,
+    research_artifact_outcome,
+    research_contract_snapshot,
+)
+from .shared_facts import (
+    canonical_project_field,
+    query_project_single_select_field,
+    relationship_contract,
+)
+
+PROFILE_EVIDENCE_SCHEMA_VERSION: Final = 1
+PROFILE_EVIDENCE_STAGES: Final = ("contract", "candidate", "review", "completion")
+_KIND_PATTERN: Final = r"^[a-z][a-z0-9_.-]*$"
+_CODE_PATTERN: Final = r"^[A-Z][A-Z0-9_.-]*$"
+_TYPE_LABEL_PATTERN: Final = r"^type:[a-z][a-z0-9_.-]*$"
+_SHA256_PATTERN: Final = r"^[0-9a-f]{64}$"
+_EFFECT_KIND_PATTERN: Final = r"^[a-z][a-z0-9_.-]*$"
+
+
+class ProfilePolicyError(ValueError):
+    """A profile policy or its typed evidence cannot be accepted safely."""
+
+
+class ProfileCandidateRejected(ProfilePolicyError):
+    """A candidate failed with a structured, policy-owned result."""
+
+    def __init__(self, detail: str, result: Mapping[str, Any]) -> None:
+        super().__init__(detail)
+        self.result = dict(result)
+
+
+@dataclass(frozen=True)
+class ProfileEffectDescriptor:
+    """A constrained, data-only intent emitted by a profile policy.
+
+    A descriptor is deliberately not executable.  The LCK kernel validates its
+    shape and dispatches the allow-listed ``effect_kind`` through its own
+    executor registry.  Keeping parameters, postconditions, and receipt
+    metadata as JSON data also prevents a policy from smuggling a callable or
+    an unbounded GitHub operation through the profile boundary.
+    """
+
+    effect_kind: str
+    schema_version: int
+    parameters: Mapping[str, Any]
+    postcondition: Mapping[str, Any]
+    receipt: Mapping[str, Any]
+
+    def __post_init__(self) -> None:
+        if (
+            not isinstance(self.effect_kind, str)
+            or re.fullmatch(_EFFECT_KIND_PATTERN, self.effect_kind) is None
+        ):
+            raise ProfilePolicyError("effect descriptor kind is malformed")
+        if (
+            not isinstance(self.schema_version, int)
+            or isinstance(self.schema_version, bool)
+            or self.schema_version != 1
+        ):
+            raise ProfilePolicyError("unsupported effect descriptor schema version")
+        for name, value in (
+            ("parameters", self.parameters),
+            ("postcondition", self.postcondition),
+            ("receipt", self.receipt),
+        ):
+            if not isinstance(value, Mapping):
+                raise ProfilePolicyError(f"effect descriptor {name} must be a mapping")
+            if any(not isinstance(key, str) for key in value):
+                raise ProfilePolicyError(
+                    f"effect descriptor {name} keys must be strings"
+                )
+            try:
+                _validate_json_data(value)
+                _canonical_json(value)
+            except (TypeError, ValueError) as exc:
+                raise ProfilePolicyError(
+                    f"effect descriptor {name} must be JSON data"
+                ) from exc
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "effect_kind": self.effect_kind,
+            "schema_version": self.schema_version,
+            "parameters": _jsonable(self.parameters),
+            "postcondition": _jsonable(self.postcondition),
+            "receipt": _jsonable(self.receipt),
+        }
+
+    def serialize(self) -> str:
+        return _canonical_json(self.to_dict())
+
+
+# Short aliases make the generic contract convenient for policy adapters and
+# for external test-only policies without exposing a second schema.
+EffectDescriptor = ProfileEffectDescriptor
+
+
+class DocumentationReclassificationRequired(LckStopError):
+    """The Documentation policy rejected the candidate file scope."""
+
+    code = "DOCUMENTATION_RECLASSIFICATION_REQUIRED"
+
+    def __init__(
+        self, message: str, *, result: Mapping[str, Any] | None = None
+    ) -> None:
+        super().__init__(message)
+        self.result = dict(result) if isinstance(result, Mapping) else None
+
+
+class ResearchReclassificationRequired(LckStopError):
+    """The Research policy rejected the candidate artifact scope."""
+
+    code = "RESEARCH_RECLASSIFICATION_REQUIRED"
+
+    def __init__(
+        self, message: str, *, result: Mapping[str, Any] | None = None
+    ) -> None:
+        super().__init__(message)
+        self.result = dict(result) if isinstance(result, Mapping) else None
+
+
+class ResearchOutcomeRequired(LckStopError):
+    """A Research completion boundary has no typed outcome."""
+
+    code = "RESEARCH_OUTCOME_REQUIRED"
+
+
+ProfileResolver = Callable[[Mapping[str, Any] | None], IssueProfileResolution]
+
+
+def _jsonable(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(key): _jsonable(nested) for key, nested in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(item) for item in value]
+    return value
+
+
+def _validate_json_data(value: Any) -> None:
+    if value is None or isinstance(value, (str, bool, int)):
+        return
+    if isinstance(value, float):
+        if math.isfinite(value):
+            return
+        raise TypeError("non-finite numbers are not JSON data")
+    if isinstance(value, Mapping):
+        for key, nested in value.items():
+            if not isinstance(key, str):
+                raise TypeError("JSON object keys must be strings")
+            _validate_json_data(nested)
+        return
+    if isinstance(value, (list, tuple)):
+        for nested in value:
+            _validate_json_data(nested)
+        return
+    raise TypeError(f"unsupported JSON data type: {type(value).__name__}")
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(
+        _jsonable(value),
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+@dataclass(frozen=True)
+class ProfileEvidenceRecord:
+    """One policy-owned, strongly shaped stage-evidence record."""
+
+    kind: str
+    schema_version: int
+    payload: Mapping[str, Any]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.kind, str) or not self.kind:
+            raise ProfilePolicyError("evidence kind is required")
+        if not isinstance(self.schema_version, int) or isinstance(
+            self.schema_version, bool
+        ):
+            raise ProfilePolicyError("evidence schema_version must be an integer")
+        if not isinstance(self.payload, Mapping):
+            raise ProfilePolicyError("evidence payload must be a mapping")
+        if any(not isinstance(key, str) for key in self.payload):
+            raise ProfilePolicyError("evidence payload keys must be strings")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "schema_version": self.schema_version,
+            "payload": _jsonable(self.payload),
+        }
+
+    def serialize(self) -> str:
+        """Return deterministic JSON for this record."""
+        return _canonical_json(self.to_dict())
+
+
+EvidenceRecord = ProfileEvidenceRecord
+StageEvidence = ProfileEvidenceRecord
+
+
+@dataclass(frozen=True)
+class PolicyBlocker:
+    """A normalized blocker emitted by one profile policy."""
+
+    code: str
+    kind: str
+    detail: str
+    evidence_ref: str | Mapping[str, Any] | None = None
+
+    @property
+    def stable_code(self) -> str:
+        return self.code
+
+    @property
+    def evidence_reference(self) -> str | Mapping[str, Any] | None:
+        return self.evidence_ref
+
+    def __post_init__(self) -> None:
+        if re.fullmatch(_CODE_PATTERN, self.code or "") is None:
+            raise ProfilePolicyError("policy blocker code is malformed")
+        if re.fullmatch(_KIND_PATTERN, self.kind or "") is None:
+            raise ProfilePolicyError("policy blocker kind is malformed")
+        if not isinstance(self.detail, str) or not self.detail.strip():
+            raise ProfilePolicyError("policy blocker detail is required")
+        if self.evidence_ref is not None and not isinstance(
+            self.evidence_ref, (str, Mapping)
+        ):
+            raise ProfilePolicyError("policy blocker evidence reference is malformed")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "code": self.code,
+            "kind": self.kind,
+            "detail": self.detail,
+            "evidence_ref": _jsonable(self.evidence_ref),
+        }
+
+
+ProfileBlocker = PolicyBlocker
+
+
+@dataclass(frozen=True)
+class ProfileEvidenceEnvelope:
+    """Frozen four-stage envelope shared by every leaf profile.
+
+    ``leaf_contract`` never appears here. The contract stage contains
+    validation evidence and may contain a bounded identity/digest reference to
+    the canonical acquisition input.
+    """
+
+    profile_id: str
+    schema_version: int = PROFILE_EVIDENCE_SCHEMA_VERSION
+    contract: ProfileEvidenceRecord | None = None
+    candidate: ProfileEvidenceRecord | None = None
+    review: ProfileEvidenceRecord | None = None
+    completion: ProfileEvidenceRecord | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "profile_id": self.profile_id,
+            "schema_version": self.schema_version,
+            "contract": self.contract.to_dict() if self.contract else None,
+            "candidate": self.candidate.to_dict() if self.candidate else None,
+            "review": self.review.to_dict() if self.review else None,
+            "completion": self.completion.to_dict() if self.completion else None,
+        }
+
+    def serialize(self) -> str:
+        return _canonical_json(self.to_dict())
+
+    def validated(
+        self,
+        registry: ProfilePolicyRegistry | None = None,
+        *,
+        leaf_contract: Mapping[str, Any] | None = None,
+    ) -> ProfileEvidenceEnvelope:
+        selected = registry or DEFAULT_PROFILE_POLICY_REGISTRY
+        if not isinstance(self.profile_id, str) or not self.profile_id:
+            raise ProfilePolicyError("evidence envelope profile_id is required")
+        if self.schema_version != PROFILE_EVIDENCE_SCHEMA_VERSION:
+            raise ProfilePolicyError(
+                "unsupported ProfileEvidenceEnvelope schema version"
+            )
+        policy = selected.resolve_profile_id(self.profile_id)
+        records = (
+            ("contract", self.contract),
+            ("candidate", self.candidate),
+            ("review", self.review),
+            ("completion", self.completion),
+        )
+        if leaf_contract is None and any(record is not None for _, record in records):
+            raise ProfilePolicyError(
+                "canonical leaf contract is required to validate profile evidence"
+            )
+        for stage, record in records:
+            if record is not None:
+                _validate_policy_evidence(
+                    policy,
+                    record,
+                    stage=stage,
+                    leaf_contract=leaf_contract,
+                )
+        return self
+
+    def validate_evidence(
+        self,
+        registry: ProfilePolicyRegistry | None = None,
+        *,
+        leaf_contract: Mapping[str, Any] | None = None,
+    ) -> ProfileEvidenceEnvelope:
+        """Compatibility spelling for the lifecycle validation boundary."""
+        return self.validated(registry, leaf_contract=leaf_contract)
+
+
+def serialize_profile_evidence(
+    value: ProfileEvidenceEnvelope,
+    *,
+    registry: ProfilePolicyRegistry | None = None,
+    leaf_contract: Mapping[str, Any] | None = None,
+) -> str:
+    """Serialize a validated envelope deterministically."""
+    return value.validated(registry, leaf_contract=leaf_contract).serialize()
+
+
+def validate_profile_evidence(
+    value: ProfileEvidenceEnvelope,
+    *,
+    registry: ProfilePolicyRegistry | None = None,
+    leaf_contract: Mapping[str, Any] | None = None,
+) -> ProfileEvidenceEnvelope:
+    """Validate and return an envelope at a lifecycle boundary."""
+    return value.validated(registry, leaf_contract=leaf_contract)
+
+
+@dataclass(frozen=True)
+class PolicyContext:
+    """Bounded inputs and callbacks exposed to a leaf policy."""
+
+    profile: LeafIssueWorkflowProfile | None = None
+    profile_id: str | None = None
+    phase: str | None = None
+    issue: Mapping[str, Any] | None = None
+    relationships: Mapping[str, Any] | None = None
+    repository: str | None = None
+    downstream_contract: Mapping[str, Any] | None = None
+    downstream_profile: LeafIssueWorkflowProfile | None = None
+    blocker_subject: str | None = None
+    repo_root: Path | None = None
+    runner: Any = None
+    base_sha: str | None = None
+    head_sha: str | None = None
+    include_index: bool = False
+    changed_files: tuple[str, ...] = ()
+    progress: Any = None
+    # ``services`` is a compatibility seam for deterministic test doubles.
+    # Production policies use the bounded inputs above and do not receive
+    # controller-owned concrete validators.
+    services: tuple[Any, ...] = ()
+    review_identity: Mapping[str, Any] | None = None
+    review_record: Mapping[str, Any] | None = None
+    merged_pr: Mapping[str, Any] | None = None
+    review_verdict: str | None = None
+    research_outcome: str | None = None
+    critical_outcome: Callable[[], Mapping[str, Any]] | None = None
+    documentation_validation: Callable[[], Mapping[str, Any]] | None = None
+    research_validation: Callable[[], Mapping[str, Any]] | None = None
+
+    @property
+    def resolved_profile_id(self) -> str | None:
+        return self.profile.profile_id if self.profile is not None else self.profile_id
+
+
+@runtime_checkable
+class LeafIssuePolicy(Protocol):
+    """Minimal executable policy API for one canonical leaf profile."""
+
+    @property
+    def profile_id(self) -> str: ...
+
+    def validate_contract(
+        self, context: PolicyContext, leaf_contract: Mapping[str, Any]
+    ) -> ProfileEvidenceRecord: ...
+
+    def evaluate_blockers(
+        self,
+        context: PolicyContext,
+        leaf_contract: Mapping[str, Any],
+        contract_evidence: ProfileEvidenceRecord,
+    ) -> Iterable[PolicyBlocker]: ...
+
+    def validate_candidate(
+        self,
+        context: PolicyContext,
+        leaf_contract: Mapping[str, Any],
+        contract_evidence: ProfileEvidenceRecord,
+    ) -> ProfileEvidenceRecord: ...
+
+    def validate_evidence(self, record: ProfileEvidenceRecord) -> bool: ...
+
+
+class ProfileReviewPolicy(Protocol):
+    """Optional generic review-stage capability supplied by a leaf policy."""
+
+    def validate_review(
+        self,
+        context: PolicyContext,
+        leaf_contract: Mapping[str, Any],
+        review_input: Mapping[str, Any],
+    ) -> ProfileEvidenceRecord: ...
+
+
+class ProfileCompletionPolicy(Protocol):
+    """Optional generic completion-stage capability supplied by a leaf policy."""
+
+    def validate_completion(
+        self,
+        context: PolicyContext,
+        leaf_contract: Mapping[str, Any],
+        completion_input: Mapping[str, Any],
+    ) -> ProfileEvidenceRecord | None: ...
+
+
+class ProfilePolicyRegistry:
+    """Immutable explicit registry used to resolve executable policies."""
+
+    def __init__(
+        self,
+        policies: Mapping[str, LeafIssuePolicy] | Iterable[LeafIssuePolicy],
+    ) -> None:
+        values = (
+            tuple(policies.values())
+            if isinstance(policies, Mapping)
+            else tuple(policies)
+        )
+        selected: dict[str, LeafIssuePolicy] = {}
+        by_type_label: dict[str, LeafIssuePolicy] = {}
+        for policy in values:
+            profile_id = getattr(policy, "profile_id", None)
+            if not isinstance(profile_id, str) or not profile_id:
+                raise ProfilePolicyError("registered policy has no profile_id")
+            if profile_id in selected:
+                raise ProfilePolicyError(f"duplicate registered profile: {profile_id}")
+            if not isinstance(policy, LeafIssuePolicy):
+                raise ProfilePolicyError(
+                    f"registered policy {profile_id!r} does not implement LeafIssuePolicy"
+                )
+            type_label = getattr(policy, "canonical_type_label", None)
+            if (
+                not isinstance(type_label, str)
+                or re.fullmatch(_TYPE_LABEL_PATTERN, type_label) is None
+            ):
+                raise ProfilePolicyError(
+                    f"registered policy {profile_id!r} has a malformed canonical type label"
+                )
+            if type_label in by_type_label:
+                raise ProfilePolicyError(
+                    f"duplicate canonical type label: {type_label}"
+                )
+            selected[profile_id] = policy
+            by_type_label[type_label] = policy
+        self._policies = MappingProxyType(selected)
+        self._policies_by_type_label = MappingProxyType(by_type_label)
+
+    @classmethod
+    def from_policies(cls, *policies: LeafIssuePolicy) -> ProfilePolicyRegistry:
+        return cls(policies)
+
+    @property
+    def policies(self) -> Mapping[str, LeafIssuePolicy]:
+        return self._policies
+
+    @property
+    def policies_by_type_label(self) -> Mapping[str, LeafIssuePolicy]:
+        return self._policies_by_type_label
+
+    def resolve_profile_id(self, profile_id: str) -> LeafIssuePolicy:
+        if not isinstance(profile_id, str) or not profile_id:
+            raise ProfilePolicyError("profile policy identity is unavailable")
+        try:
+            return self._policies[profile_id]
+        except KeyError as exc:
+            raise ProfilePolicyError(
+                f"profile policy is not registered: {profile_id}"
+            ) from exc
+
+    def resolve(self, profile: LeafIssueWorkflowProfile | str) -> LeafIssuePolicy:
+        if isinstance(profile, str):
+            if profile.startswith("type:"):
+                try:
+                    return self._policies_by_type_label[profile]
+                except KeyError as exc:
+                    raise ProfilePolicyError(
+                        f"profile policy is not registered: {profile}"
+                    ) from exc
+            return self.resolve_profile_id(profile)
+        if not isinstance(profile, LeafIssueWorkflowProfile):
+            raise ProfilePolicyError("profile metadata is malformed")
+        policy = self.resolve_profile_id(profile.profile_id)
+        policy_label = getattr(policy, "canonical_type_label", None)
+        if policy_label is not None and policy_label != profile.canonical_type_label:
+            raise ProfilePolicyError(
+                f"profile/policy canonical type label mismatch: {profile.profile_id}"
+            )
+        return policy
+
+    def resolve_issue(
+        self,
+        issue: Mapping[str, Any],
+        *,
+        profile_resolver: ProfileResolver = resolve_leaf_issue_profile,
+    ) -> tuple[LeafIssueWorkflowProfile, LeafIssuePolicy]:
+        resolution = profile_resolver(issue)
+        if not resolution.resolved or resolution.profile is None:
+            raise ProfilePolicyError(
+                resolution.error_message or "profile resolution failed"
+            )
+        return resolution.profile, self.resolve(resolution.profile)
+
+
+LeafIssuePolicyRegistry = ProfilePolicyRegistry
+
+
+def _contract_reference(leaf_contract: Mapping[str, Any]) -> dict[str, Any]:
+    body_sha256 = leaf_contract.get("body_sha256")
+    if isinstance(body_sha256, str) and body_sha256:
+        return {
+            "number": leaf_contract.get("number"),
+            "body_sha256": body_sha256,
+        }
+    return {
+        "number": leaf_contract.get("number"),
+        "contract_sha256": sha256_json(
+            {
+                "number": leaf_contract.get("number"),
+                "title": leaf_contract.get("title"),
+                "url": leaf_contract.get("url"),
+            }
+        ),
+    }
+
+
+def _valid_contract_reference(value: Any) -> bool:
+    if not isinstance(value, Mapping):
+        return False
+    number = value.get("number")
+    if not isinstance(number, int) or isinstance(number, bool) or number <= 0:
+        return False
+    body_sha256 = value.get("body_sha256")
+    contract_sha256 = value.get("contract_sha256")
+    if body_sha256 is not None and (
+        not isinstance(body_sha256, str)
+        or re.fullmatch(_SHA256_PATTERN, body_sha256) is None
+    ):
+        return False
+    if contract_sha256 is not None and (
+        not isinstance(contract_sha256, str)
+        or re.fullmatch(_SHA256_PATTERN, contract_sha256) is None
+    ):
+        return False
+    if body_sha256 is None and contract_sha256 is None:
+        return False
+    if body_sha256 is not None and contract_sha256 is not None:
+        return False
+    return set(value) == (
+        {"number", "body_sha256"}
+        if body_sha256 is not None
+        else {"number", "contract_sha256"}
+    )
+
+
+def _contract_reference_matches(
+    value: Any,
+    leaf_contract: Mapping[str, Any],
+) -> bool:
+    return _valid_contract_reference(value) and dict(value) == _contract_reference(
+        leaf_contract
+    )
+
+
+def _expected_evidence_kind(policy: LeafIssuePolicy, stage: str) -> str:
+    value = getattr(policy, f"{stage}_kind", None)
+    if value is None:
+        value = f"{policy.profile_id}.{stage}.v1"
+    if not isinstance(value, str) or re.fullmatch(_KIND_PATTERN, value) is None:
+        raise ProfilePolicyError(f"policy evidence kind for {stage} is malformed")
+    return value
+
+
+def _validate_policy_evidence(
+    policy: LeafIssuePolicy,
+    record: ProfileEvidenceRecord,
+    *,
+    stage: str | None = None,
+    leaf_contract: Mapping[str, Any] | None = None,
+) -> None:
+    if record.schema_version != PROFILE_EVIDENCE_SCHEMA_VERSION:
+        raise ProfilePolicyError(
+            f"unsupported evidence schema version for {record.kind}"
+        )
+    if stage is not None and record.kind != _expected_evidence_kind(policy, stage):
+        raise ProfilePolicyError(
+            f"policy evidence kind does not match {stage} stage: {record.kind}"
+        )
+    if leaf_contract is not None and not _contract_reference_matches(
+        record.payload.get("contract_ref"), leaf_contract
+    ):
+        raise ProfilePolicyError(
+            "profile evidence contract reference does not match the canonical leaf contract"
+        )
+    try:
+        valid = policy.validate_evidence(record)
+    except (ProfilePolicyError, ValueError) as exc:
+        raise ProfilePolicyError(str(exc)) from exc
+    if valid is not True:
+        raise ProfilePolicyError(f"policy rejected evidence kind: {record.kind}")
+
+
+def _coerce_evidence(value: Any) -> ProfileEvidenceRecord:
+    if isinstance(value, ProfileEvidenceRecord):
+        return value
+    if isinstance(value, Mapping):
+        kind = value.get("kind")
+        schema_version = value.get("schema_version")
+        payload = value.get("payload")
+        if (
+            not isinstance(kind, str)
+            or not isinstance(schema_version, int)
+            or isinstance(schema_version, bool)
+            or not isinstance(payload, Mapping)
+        ):
+            raise ProfilePolicyError("policy returned malformed evidence")
+        return ProfileEvidenceRecord(
+            kind=kind,
+            schema_version=schema_version,
+            payload=payload,
+        )
+    raise ProfilePolicyError("policy returned malformed evidence")
+
+
+class _BuiltinPolicy:
+    """Small common codec used only by repository-owned policies."""
+
+    profile_id: str
+    canonical_type_label: str
+    contract_kind: str
+    candidate_kind: str
+    policy_label: str
+    review_kind: str | None = None
+    completion_kind: str | None = None
+    legacy_result_field: str | None = None
+    candidate_requires_result: bool = False
+
+    def _kind(self, stage: str) -> str:
+        value = getattr(self, f"{stage}_kind", None)
+        return value if isinstance(value, str) else f"{self.profile_id}.{stage}.v1"
+
+    def _validate_contract_payload(self, value: object) -> bool:
+        del value
+        return False
+
+    def _record(
+        self,
+        kind: str,
+        context: PolicyContext,
+        leaf_contract: Mapping[str, Any],
+        **payload: Any,
+    ) -> ProfileEvidenceRecord:
+        del context
+        return ProfileEvidenceRecord(
+            kind,
+            PROFILE_EVIDENCE_SCHEMA_VERSION,
+            {
+                "policy_id": self.profile_id,
+                "contract_ref": _contract_reference(leaf_contract),
+                **payload,
+            },
+        )
+
+    def _contract_snapshot(
+        self,
+        leaf_contract: Mapping[str, Any],
+        field_name: str,
+        snapshot: Callable[[str | None], Mapping[str, Any]],
+    ) -> Mapping[str, Any]:
+        # Relationship metadata may expose a bounded legacy body. Typed
+        # policy parsers must use the separately verified complete contract.
+        if "contract" in leaf_contract:
+            return snapshot(_contract_body(leaf_contract))
+        value = leaf_contract.get(field_name)
+        if isinstance(value, Mapping):
+            return value
+        return snapshot(_contract_body(leaf_contract))
+
+    def validate_evidence(self, record: ProfileEvidenceRecord) -> bool:
+        if record.schema_version != PROFILE_EVIDENCE_SCHEMA_VERSION:
+            return False
+        if record.kind not in {
+            self.contract_kind,
+            self.candidate_kind,
+            self._kind("review"),
+            self._kind("completion"),
+        }:
+            return False
+        payload = record.payload
+        if payload.get("policy_id") != self.profile_id or not isinstance(
+            payload.get("contract_ref"), Mapping
+        ):
+            return False
+        if record.kind == self.contract_kind:
+            return self._validate_contract_payload(payload.get("contract"))
+        status = payload.get("status")
+        if status not in {"pass", "fail"}:
+            return False
+        result = payload.get("result")
+        if result is not None and not isinstance(result, Mapping):
+            return False
+        if status == "fail":
+            error = payload.get("error")
+            return isinstance(error, str) and bool(error.strip())
+        if record.kind == self.candidate_kind and self.candidate_requires_result:
+            return isinstance(result, Mapping) and result.get("status") == "pass"
+        return True
+
+    def validate_review(
+        self,
+        context: PolicyContext,
+        leaf_contract: Mapping[str, Any],
+        review_input: Mapping[str, Any],
+    ) -> ProfileEvidenceRecord:
+        return self._record(
+            self._kind("review"),
+            context,
+            leaf_contract,
+            result={"status": "pass"},
+            status="pass",
+            review=review_input,
+        )
+
+    def review_artifact(
+        self,
+        context: PolicyContext,
+        review_input: Mapping[str, Any],
+    ) -> Mapping[str, Any] | None:
+        del context, review_input
+        return None
+
+    def validate_completion(
+        self,
+        context: PolicyContext,
+        leaf_contract: Mapping[str, Any],
+        completion_input: Mapping[str, Any],
+    ) -> ProfileEvidenceRecord | None:
+        del context, leaf_contract, completion_input
+        return None
+
+    def evaluate_blockers(
+        self,
+        context: PolicyContext,
+        leaf_contract: Mapping[str, Any],
+        contract_evidence: ProfileEvidenceRecord,
+    ) -> Iterable[PolicyBlocker]:
+        del context
+        _validate_policy_evidence(
+            cast(LeafIssuePolicy, self),
+            contract_evidence,
+            stage="contract",
+            leaf_contract=leaf_contract,
+        )
+        return ()
+
+    def candidate_failure(
+        self,
+        context: PolicyContext,
+        leaf_contract: Mapping[str, Any],
+        contract_evidence: ProfileEvidenceRecord,
+        result: Mapping[str, Any] | None,
+        error: str,
+    ) -> ProfileEvidenceRecord:
+        return self._record(
+            self.candidate_kind,
+            context,
+            leaf_contract,
+            result=_jsonable(result) if result is not None else None,
+            status="fail",
+            error=error,
+        )
+
+    def legacy_result(self, result: Mapping[str, Any] | None) -> dict[str, Any]:
+        if self.legacy_result_field is None or result is None:
+            return {}
+        return {self.legacy_result_field: dict(result)}
+
+    def _service_result(self, context: PolicyContext) -> Mapping[str, Any] | None:
+        """Use an injected test service without making it a controller contract."""
+        if not context.services:
+            return None
+        service = context.services[0]
+        run = getattr(service, "run", None)
+        if not callable(run):
+            raise ProfilePolicyError("injected profile service is not executable")
+        try:
+            result = run(
+                context.base_sha,
+                head_sha=context.head_sha,
+                include_index=context.include_index,
+            )
+        except TypeError:
+            # Keep old test doubles that only accept a positional base SHA.
+            result = run(context.base_sha)
+        if not isinstance(result, Mapping):
+            raise ProfilePolicyError("profile candidate result is malformed")
+        return result
+
+
+def _candidate_effective_diff(context: PolicyContext, *, command_prefix: str) -> Any:
+    if context.runner is None or context.repo_root is None:
+        raise ProfilePolicyError("profile candidate diff context is unavailable")
+    if not isinstance(context.base_sha, str) or not context.base_sha:
+        raise ProfilePolicyError("profile candidate base identity is unavailable")
+    head_ref = "HEAD" if context.include_index else (context.head_sha or "HEAD")
+    return calculate_effective_diff(
+        context.runner,
+        base_sha=context.base_sha,
+        head_ref=head_ref,
+        command_id_prefix=command_prefix,
+        cwd=context.repo_root,
+        include_index=context.include_index,
+    )
+
+
+def _documentation_candidate_result(context: PolicyContext) -> dict[str, Any]:
+    effective_diff = _candidate_effective_diff(
+        context, command_prefix="lck-documentation"
+    )
+    policy = evaluate_documentation_changes(effective_diff.changed_files)
+    payload = policy.to_dict()
+    payload["effective_diff"] = {
+        "merge_base_sha": effective_diff.merge_base_sha,
+        "effective_diff_sha256": effective_diff.effective_diff_sha256,
+        "source": "index" if context.include_index else "head",
+    }
+    return payload
+
+
+def _research_candidate_result(context: PolicyContext) -> dict[str, Any]:
+    effective_diff = _candidate_effective_diff(context, command_prefix="lck-research")
+    policy = evaluate_research_changes(
+        effective_diff.changed_files, repo_root=context.repo_root
+    )
+    payload = policy.to_dict()
+    payload["effective_diff"] = {
+        "merge_base_sha": effective_diff.merge_base_sha,
+        "effective_diff_sha256": effective_diff.effective_diff_sha256,
+        "source": "index" if context.include_index else "head",
+    }
+    if context.repo_root is None:
+        raise ResearchReclassificationRequired("Research workspace is unavailable")
+    try:
+        artifact_outcome = research_artifact_outcome(
+            context.repo_root, policy.artifact_files
+        )
+    except ResearchPolicyError as exc:
+        raise ResearchReclassificationRequired(str(exc)) from exc
+    payload["artifact_outcome"] = (
+        artifact_outcome.value if artifact_outcome is not None else None
+    )
+    return payload
+
+
+class DocumentationValidationGate:
+    """Compatibility adapter; production Delivery uses policy dispatch."""
+
+    def __init__(self, resolver: Any) -> None:
+        self.resolver = resolver
+        self.last_result: dict[str, Any] | None = None
+
+    def run(self, base_sha: str) -> dict[str, Any]:
+        context = PolicyContext(
+            base_sha=base_sha,
+            repo_root=self.resolver.repo_root,
+            runner=self.resolver.runner,
+            include_index=True,
+        )
+        result = _documentation_candidate_result(context)
+        self.last_result = result
+        if result.get("status") != "pass":
+            raise DocumentationReclassificationRequired(
+                "DOCUMENTATION_RECLASSIFICATION_REQUIRED: "
+                + str(
+                    result.get("detail")
+                    or "Documentation policy rejected the candidate"
+                ),
+                result=result,
+            )
+        return result
+
+
+class ResearchValidationGate:
+    """Compatibility adapter; production Delivery uses policy dispatch."""
+
+    def __init__(self, resolver: Any) -> None:
+        self.resolver = resolver
+        self.last_result: dict[str, Any] | None = None
+
+    def run(
+        self,
+        base_sha: str,
+        *,
+        head_sha: str | None = None,
+        include_index: bool = False,
+    ) -> dict[str, Any]:
+        context = PolicyContext(
+            base_sha=base_sha,
+            head_sha=head_sha,
+            repo_root=self.resolver.repo_root,
+            runner=self.resolver.runner,
+            include_index=include_index,
+        )
+        result = _research_candidate_result(context)
+        self.last_result = result
+        if result.get("status") != "pass":
+            raise ResearchReclassificationRequired(
+                "RESEARCH_RECLASSIFICATION_REQUIRED: "
+                + str(result.get("detail") or "Research policy rejected the candidate"),
+                result=result,
+            )
+        return result
+
+
+class ResearchOutcomeEffect:
+    """Legacy read-only adapter retained for callers of the old helper.
+
+    Closeout no longer owns this profile-specific implementation; the generic
+    effect executor in ``effects.py`` owns completion side effects.
+    """
+
+    def __init__(self, resolver: Any) -> None:
+        self.resolver = resolver
+
+    def _query_outcome(self, repository: str, task_number: int) -> str | None:
+        return query_project_single_select_field(
+            self.resolver.runner,
+            repository=repository,
+            issue_number=task_number,
+            project_number=1,
+            field_name=RESEARCH_OUTCOME_FIELD,
+            command_id="lck-research-outcome-postcondition",
+        )
+
+
+class _TaskPolicy(_BuiltinPolicy):
+    profile_id = "task"
+    canonical_type_label = "type:task"
+    contract_kind = "task.contract.v1"
+    candidate_kind = "task.candidate.v1"
+    policy_label = "Critical Outcome"
+    legacy_result_field = "critical_outcome"
+    candidate_requires_result = True
+
+    def _validate_contract_payload(self, value: object) -> bool:
+        try:
+            contract_from_snapshot(value)
+        except (CriticalOutcomeError, ValueError):
+            return False
+        return True
+
+    def validate_contract(
+        self, context: PolicyContext, leaf_contract: Mapping[str, Any]
+    ) -> ProfileEvidenceRecord:
+        snapshot = self._contract_snapshot(
+            leaf_contract, "critical_outcome", critical_outcome_snapshot
+        )
+        try:
+            contract = contract_from_snapshot(snapshot)
+        except ValueError as exc:
+            raise ProfilePolicyError(str(exc)) from exc
+        return self._record(
+            self.contract_kind,
+            context,
+            leaf_contract,
+            contract=snapshot,
+            verification_test=contract.verification_test,
+        )
+
+    def validate_candidate(
+        self,
+        context: PolicyContext,
+        leaf_contract: Mapping[str, Any],
+        contract_evidence: ProfileEvidenceRecord,
+    ) -> ProfileEvidenceRecord:
+        _validate_policy_evidence(
+            self,
+            contract_evidence,
+            stage="contract",
+            leaf_contract=leaf_contract,
+        )
+        if context.critical_outcome is not None:
+            # Compatibility for callers that inject a deterministic candidate
+            # callback.  Production Delivery leaves this unset and uses the
+            # policy-owned verifier below.
+            result = context.critical_outcome()
+        else:
+            if context.repo_root is None or context.runner is None:
+                raise ProfilePolicyError(
+                    "Task Critical Outcome verifier is unavailable"
+                )
+            try:
+                contract = contract_from_snapshot(
+                    contract_evidence.payload.get("contract")
+                )
+                verified = verify_critical_outcome(
+                    context.repo_root,
+                    context.runner,
+                    contract,
+                    progress=context.progress,
+                )
+            except (CriticalOutcomeError, ValueError) as exc:
+                raise ProfilePolicyError(str(exc)) from exc
+            result = verified.to_dict()
+        if not isinstance(result, Mapping):
+            raise ProfilePolicyError("Task Critical Outcome result is malformed")
+        if result.get("status") != "pass":
+            detail = "Critical Outcome FAIL"
+            verification_test = contract_evidence.payload.get("verification_test")
+            exit_code = result.get("exit_code")
+            if isinstance(verification_test, str) and verification_test:
+                detail += f": {verification_test}"
+            if isinstance(exit_code, int) and not isinstance(exit_code, bool):
+                detail += f" exited {exit_code}"
+            raise ProfileCandidateRejected(detail, result)
+        return self._record(
+            self.candidate_kind,
+            context,
+            leaf_contract,
+            result=dict(result),
+            status=result.get("status"),
+        )
+
+
+class _BugPolicy(_BuiltinPolicy):
+    profile_id = "bug"
+    canonical_type_label = "type:bug"
+    contract_kind = "bug.contract.v1"
+    candidate_kind = "bug.candidate.v1"
+    policy_label = "Bug defect"
+
+    def _validate_contract_payload(self, value: object) -> bool:
+        return is_valid_bug_contract(value)
+
+    def validate_contract(
+        self, context: PolicyContext, leaf_contract: Mapping[str, Any]
+    ) -> ProfileEvidenceRecord:
+        snapshot = self._contract_snapshot(
+            leaf_contract, "bug_contract", bug_contract_snapshot
+        )
+        if not is_valid_bug_contract(snapshot):
+            raise ProfilePolicyError(
+                str(snapshot.get("detail") or "Bug defect contract is invalid")
+            )
+        return self._record(
+            self.contract_kind, context, leaf_contract, contract=snapshot
+        )
+
+    def validate_candidate(
+        self,
+        context: PolicyContext,
+        leaf_contract: Mapping[str, Any],
+        contract_evidence: ProfileEvidenceRecord,
+    ) -> ProfileEvidenceRecord:
+        _validate_policy_evidence(
+            self,
+            contract_evidence,
+            stage="contract",
+            leaf_contract=leaf_contract,
+        )
+        return self._record(self.candidate_kind, context, leaf_contract, status="pass")
+
+
+class _DocumentationPolicy(_BuiltinPolicy):
+    profile_id = "documentation"
+    canonical_type_label = "type:documentation"
+    contract_kind = "documentation.contract.v1"
+    candidate_kind = "documentation.candidate.v1"
+    policy_label = "Documentation"
+    legacy_result_field = "documentation_validation"
+    candidate_requires_result = True
+
+    def _validate_contract_payload(self, value: object) -> bool:
+        return is_valid_documentation_contract(value)
+
+    def validate_contract(
+        self, context: PolicyContext, leaf_contract: Mapping[str, Any]
+    ) -> ProfileEvidenceRecord:
+        snapshot = self._contract_snapshot(
+            leaf_contract, "documentation_contract", documentation_contract_snapshot
+        )
+        if not is_valid_documentation_contract(snapshot):
+            raise ProfilePolicyError(
+                str(snapshot.get("detail") or "Documentation contract is invalid")
+            )
+        return self._record(
+            self.contract_kind, context, leaf_contract, contract=snapshot
+        )
+
+    def validate_candidate(
+        self,
+        context: PolicyContext,
+        leaf_contract: Mapping[str, Any],
+        contract_evidence: ProfileEvidenceRecord,
+    ) -> ProfileEvidenceRecord:
+        _validate_policy_evidence(
+            self,
+            contract_evidence,
+            stage="contract",
+            leaf_contract=leaf_contract,
+        )
+        result = self._service_result(context)
+        if result is None:
+            if context.runner is None or context.repo_root is None:
+                result = evaluate_documentation_changes(context.changed_files).to_dict()
+            else:
+                result = _documentation_candidate_result(context)
+        if not isinstance(result, Mapping):
+            raise ProfilePolicyError("Documentation candidate result is malformed")
+        if result.get("status") != "pass":
+            raise DocumentationReclassificationRequired(
+                "DOCUMENTATION_RECLASSIFICATION_REQUIRED: "
+                + str(
+                    result.get("detail")
+                    or "Documentation policy rejected the candidate"
+                ),
+                result=result,
+            )
+        return self._record(
+            self.candidate_kind,
+            context,
+            leaf_contract,
+            result=dict(result),
+            status=result.get("status"),
+        )
+
+    def validate_review(
+        self,
+        context: PolicyContext,
+        leaf_contract: Mapping[str, Any],
+        review_input: Mapping[str, Any],
+    ) -> ProfileEvidenceRecord:
+        identity = review_input.get("identity", review_input)
+        changed_files = (
+            identity.get("changed_files") if isinstance(identity, Mapping) else None
+        )
+        if not isinstance(changed_files, (list, tuple)):
+            raise DocumentationReclassificationRequired(
+                "DOCUMENTATION_RECLASSIFICATION_REQUIRED: "
+                "Review changed-file inventory is unavailable"
+            )
+        result = evaluate_documentation_changes(changed_files).to_dict()
+        if result.get("status") != "pass":
+            raise DocumentationReclassificationRequired(
+                "DOCUMENTATION_RECLASSIFICATION_REQUIRED: "
+                + str(
+                    result.get("detail")
+                    or "Documentation policy rejected the Review target"
+                )
+            )
+        return self._record(
+            self._kind("review"),
+            context,
+            leaf_contract,
+            result=result,
+            status="pass",
+        )
+
+
+class _ResearchPolicy(_BuiltinPolicy):
+    profile_id = "research"
+    canonical_type_label = "type:research"
+    contract_kind = "research.contract.v1"
+    candidate_kind = "research.candidate.v1"
+    policy_label = "Research"
+    legacy_result_field = "research_validation"
+    candidate_requires_result = True
+
+    def _validate_contract_payload(self, value: object) -> bool:
+        return is_valid_research_contract(value)
+
+    def validate_contract(
+        self, context: PolicyContext, leaf_contract: Mapping[str, Any]
+    ) -> ProfileEvidenceRecord:
+        snapshot = self._contract_snapshot(
+            leaf_contract, "research_contract", research_contract_snapshot
+        )
+        if not is_valid_research_contract(snapshot):
+            raise ProfilePolicyError(
+                str(snapshot.get("detail") or "Research contract is invalid")
+            )
+        return self._record(
+            self.contract_kind, context, leaf_contract, contract=snapshot
+        )
+
+    def evaluate_blockers(
+        self,
+        context: PolicyContext,
+        leaf_contract: Mapping[str, Any],
+        contract_evidence: ProfileEvidenceRecord,
+    ) -> Iterable[PolicyBlocker]:
+        """Evaluate Research dependency semantics through the policy seam."""
+        _validate_policy_evidence(
+            self,
+            contract_evidence,
+            stage="contract",
+            leaf_contract=leaf_contract,
+        )
+        if str(leaf_contract.get("state", "")).upper() != "CLOSED":
+            return ()
+        if context.phase == "Closeout" and context.blocker_subject == "target":
+            # The target's completion postcondition is produced only after
+            # the exact reviewed artifact has been validated. It is not a
+            # prerequisite for entering that same completion path.
+            return ()
+
+        outcome = leaf_contract.get("research_outcome")
+        if outcome is None:
+            outcome = canonical_project_field(
+                leaf_contract.get("project_items"),
+                repository=context.repository,
+                issue_number=leaf_contract.get("number"),
+                field_name=RESEARCH_OUTCOME_FIELD,
+            )
+        try:
+            parsed = parse_research_outcome(outcome)
+        except ResearchPolicyError as exc:
+            return (
+                PolicyBlocker(
+                    code="RESEARCH_OUTCOME_UNKNOWN",
+                    kind="research-outcome",
+                    detail=str(exc),
+                ),
+            )
+
+        downstream_profile = context.downstream_profile
+        if downstream_profile is None:
+            return (
+                PolicyBlocker(
+                    code="DOWNSTREAM_PROFILE_UNKNOWN",
+                    kind="downstream-profile",
+                    detail="The downstream Issue profile is unavailable",
+                ),
+            )
+        if downstream_profile.profile_id in {"research", "documentation"}:
+            return ()
+        if downstream_profile.profile_id not in {"task", "bug"}:
+            return (
+                PolicyBlocker(
+                    code="DOWNSTREAM_PROFILE_UNKNOWN",
+                    kind="downstream-profile",
+                    detail=(
+                        "The downstream Issue profile does not have defined "
+                        "Research dependency semantics"
+                    ),
+                ),
+            )
+
+        if parsed.value == "ARCHITECTURE DECISION":
+            decision_contract = leaf_contract.get("decision_contract")
+            if not isinstance(decision_contract, Mapping):
+                decision_contract = decision_contract_snapshot(
+                    _contract_body(leaf_contract), research=True
+                )
+            if not architecture_decision_is_consistent(
+                decision_contract,
+                context.downstream_contract,
+            ):
+                return (
+                    PolicyBlocker(
+                        code="ARCHITECTURE_DECISION_UNMATCHED",
+                        kind="research-outcome",
+                        detail="Architecture Decision does not match the downstream contract",
+                    ),
+                )
+            return ()
+
+        if is_implementation_outcome(parsed):
+            return ()
+        return (
+            PolicyBlocker(
+                code="RESEARCH_OUTCOME_NOT_IMPLEMENTATION",
+                kind="research-outcome",
+                detail=f"Research Outcome {parsed.value!r} does not authorize implementation",
+            ),
+        )
+
+    def validate_candidate(
+        self,
+        context: PolicyContext,
+        leaf_contract: Mapping[str, Any],
+        contract_evidence: ProfileEvidenceRecord,
+    ) -> ProfileEvidenceRecord:
+        _validate_policy_evidence(
+            self,
+            contract_evidence,
+            stage="contract",
+            leaf_contract=leaf_contract,
+        )
+        result = self._service_result(context)
+        if result is None:
+            if context.runner is None or context.repo_root is None:
+                raise ProfilePolicyError("Research candidate validator is unavailable")
+            result = _research_candidate_result(context)
+        if not isinstance(result, Mapping):
+            raise ProfilePolicyError("Research candidate result is malformed")
+        if result.get("status") != "pass":
+            raise ResearchReclassificationRequired(
+                "RESEARCH_RECLASSIFICATION_REQUIRED: "
+                + str(result.get("detail") or "Research policy rejected the candidate"),
+                result=result,
+            )
+        return self._record(
+            self.candidate_kind,
+            context,
+            leaf_contract,
+            result=dict(result),
+            status=result.get("status"),
+        )
+
+    def review_artifact(
+        self,
+        context: PolicyContext,
+        review_input: Mapping[str, Any],
+    ) -> Mapping[str, Any] | None:
+        if context.repo_root is None:
+            raise ResearchPolicyError("Research Review workspace is unavailable")
+        identity = review_input.get("identity", review_input)
+        if not isinstance(identity, Mapping):
+            raise ResearchPolicyError("Research Review identity is unavailable")
+        required = {
+            key: identity.get(key)
+            for key in (
+                "task_number",
+                "pr_number",
+                "base_sha",
+                "head_sha",
+                "task_body_sha256",
+                "merge_base_sha",
+                "effective_diff_sha256",
+                "changed_files",
+            )
+        }
+        if not isinstance(required["changed_files"], (list, tuple)):
+            raise ResearchPolicyError(
+                "Research Review changed-file inventory is unavailable"
+            )
+        if not isinstance(required["task_number"], int) or not isinstance(
+            required["pr_number"], int
+        ):
+            raise ResearchPolicyError("Research Review Issue identity is unavailable")
+        for key in (
+            "base_sha",
+            "head_sha",
+            "task_body_sha256",
+            "merge_base_sha",
+            "effective_diff_sha256",
+        ):
+            if not isinstance(required[key], str):
+                raise ResearchPolicyError(
+                    f"Research Review {key} identity is unavailable"
+                )
+        try:
+            return research_artifact_binding(
+                context.repo_root,
+                task_number=required["task_number"],
+                pr_number=required["pr_number"],
+                base_sha=cast(str, required["base_sha"]),
+                head_sha=cast(str, required["head_sha"]),
+                task_body_sha256=cast(str, required["task_body_sha256"]),
+                merge_base_sha=cast(str, required["merge_base_sha"]),
+                effective_diff_sha256=cast(str, required["effective_diff_sha256"]),
+                changed_files=required["changed_files"],
+            )
+        except (ResearchPolicyError, TypeError, ValueError) as exc:
+            raise ResearchPolicyError(str(exc)) from exc
+
+    def validate_review(
+        self,
+        context: PolicyContext,
+        leaf_contract: Mapping[str, Any],
+        review_input: Mapping[str, Any],
+    ) -> ProfileEvidenceRecord:
+        artifact = review_input.get("artifact")
+        if not isinstance(artifact, Mapping):
+            artifact = self.review_artifact(context, review_input)
+        verdict = str(review_input.get("verdict") or "PASS").upper()
+        outcome = review_input.get("research_outcome")
+        if outcome is not None:
+            if not isinstance(artifact, Mapping):
+                raise ResearchOutcomeRequired(
+                    "Research Review Complete requires a reviewed artifact binding"
+                )
+            try:
+                artifact = bind_research_outcome(artifact, outcome)
+            except ResearchPolicyError as exc:
+                raise ResearchOutcomeRequired(str(exc)) from exc
+        if verdict == "PASS":
+            if not isinstance(artifact, Mapping):
+                raise ResearchOutcomeRequired(
+                    "Research Review Complete requires a reviewed artifact binding"
+                )
+            try:
+                require_typed_research_outcome(artifact)
+            except ResearchPolicyError as exc:
+                raise ResearchOutcomeRequired(
+                    f"Research Review Complete requires a typed outcome: {exc}"
+                ) from exc
+        payload: dict[str, Any] = {
+            "result": {"status": "pass"},
+            "status": "pass",
+            "verdict": verdict,
+        }
+        if isinstance(artifact, Mapping):
+            payload["artifact"] = dict(artifact)
+        return self._record(self._kind("review"), context, leaf_contract, **payload)
+
+    def validate_completion(
+        self,
+        context: PolicyContext,
+        leaf_contract: Mapping[str, Any],
+        completion_input: Mapping[str, Any],
+    ) -> ProfileEvidenceRecord:
+        review_record = completion_input.get("review_record")
+        artifact: Mapping[str, Any] | None = None
+        if isinstance(review_record, Mapping):
+            raw_artifact = review_record.get("research_artifact")
+            if not isinstance(raw_artifact, Mapping):
+                raw_identity = review_record.get("identity")
+                if isinstance(raw_identity, Mapping):
+                    raw_artifact = raw_identity.get("research_artifact")
+            if isinstance(raw_artifact, Mapping):
+                artifact = raw_artifact
+        if artifact is None:
+            raw_artifact = completion_input.get("artifact")
+            if isinstance(raw_artifact, Mapping):
+                artifact = raw_artifact
+        if artifact is None:
+            raise ResearchOutcomeRequired(
+                "Research completion requires a reviewed artifact binding"
+            )
+        self._validate_completion_artifact_binding(
+            artifact,
+            context=context,
+            leaf_contract=leaf_contract,
+            completion_input=completion_input,
+        )
+        try:
+            outcome = require_typed_research_outcome(artifact)
+        except ResearchPolicyError as exc:
+            raise ResearchOutcomeRequired(
+                f"Research completion requires a typed outcome: {exc}"
+            ) from exc
+        repository = completion_input.get("repository") or (
+            context.issue.get("repository")
+            if isinstance(context.issue, Mapping)
+            else None
+        )
+        task_number = completion_input.get("task_number")
+        if not isinstance(repository, str) or not repository:
+            raise ProfilePolicyError("Research completion repository is unavailable")
+        if (
+            not isinstance(task_number, int)
+            or isinstance(task_number, bool)
+            or task_number <= 0
+        ):
+            raise ProfilePolicyError("Research completion Task number is unavailable")
+        descriptor = ProfileEffectDescriptor(
+            effect_kind="project.single_select.set.v1",
+            schema_version=1,
+            parameters={
+                "repository": repository,
+                "task_number": task_number,
+                "project_number": 1,
+                "field": RESEARCH_OUTCOME_FIELD,
+                "value": outcome.value,
+            },
+            postcondition={
+                "kind": "project.single_select.equals",
+                "repository": repository,
+                "task_number": task_number,
+                "project_number": 1,
+                "field": RESEARCH_OUTCOME_FIELD,
+                "value": outcome.value,
+            },
+            receipt={"outcome": outcome.value},
+        )
+        return self._record(
+            self._kind("completion"),
+            context,
+            leaf_contract,
+            result={"status": "pass", "outcome": outcome.value},
+            status="pass",
+            effect=descriptor.to_dict(),
+        )
+
+    @staticmethod
+    def _validate_completion_artifact_binding(
+        artifact: Mapping[str, Any],
+        *,
+        context: PolicyContext,
+        leaf_contract: Mapping[str, Any],
+        completion_input: Mapping[str, Any],
+    ) -> None:
+        """Keep a Research completion effect bound to the accepted Review.
+
+        Closeout has already validated the outer Review identity against the
+        merged PR.  The Research policy owns the separate artifact binding and
+        therefore verifies that the artifact selected for the effect matches
+        both that identity and the current merged PR before producing intent.
+        """
+        review_record = completion_input.get("review_record")
+        if not isinstance(review_record, Mapping):
+            raise ResearchOutcomeRequired(
+                "Research completion requires a reviewed identity"
+            )
+        reviewed_identity = review_record.get("identity")
+        if not isinstance(reviewed_identity, Mapping):
+            raise ResearchOutcomeRequired(
+                "Research completion requires a reviewed identity"
+            )
+        identity_artifact = reviewed_identity.get("research_artifact")
+        if not isinstance(identity_artifact, Mapping):
+            raise ResearchOutcomeRequired(
+                "Research completion requires an identity-bound artifact"
+            )
+
+        merged_pr = completion_input.get("merged_pr")
+        if not isinstance(merged_pr, Mapping):
+            merged_pr = context.merged_pr
+        if not isinstance(merged_pr, Mapping):
+            raise ResearchOutcomeRequired(
+                "Research completion requires the current merged PR identity"
+            )
+
+        def first_value(source: Mapping[str, Any], *names: str) -> Any:
+            for name in names:
+                value = source.get(name)
+                if value is not None:
+                    return value
+            return None
+
+        current_identity = {
+            "task_number": completion_input.get("task_number"),
+            "pr_number": merged_pr.get("number"),
+            "base_sha": first_value(merged_pr, "baseRefOid", "base_sha"),
+            "head_sha": first_value(merged_pr, "headRefOid", "head_sha"),
+            "task_body_sha256": leaf_contract.get("body_sha256"),
+        }
+        for field, current_value in current_identity.items():
+            reviewed_value = reviewed_identity.get(field)
+            artifact_value = artifact.get(field)
+            if (
+                current_value is None
+                or reviewed_value != current_value
+                or artifact_value != current_value
+            ):
+                raise ResearchOutcomeRequired(
+                    f"Research completion artifact is not bound to the current {field}"
+                )
+
+        for field in ("merge_base_sha", "effective_diff_sha256"):
+            reviewed_value = reviewed_identity.get(field)
+            if reviewed_value is None or artifact.get(field) != reviewed_value:
+                raise ResearchOutcomeRequired(
+                    f"Research completion artifact is not bound to the reviewed {field}"
+                )
+
+        if dict(identity_artifact) != dict(artifact):
+            raise ResearchOutcomeRequired(
+                "Research completion artifact diverges from the reviewed identity"
+            )
+
+    def validate_evidence(self, record: ProfileEvidenceRecord) -> bool:
+        if not super().validate_evidence(record):
+            return False
+        if record.kind == self._kind("review"):
+            artifact = record.payload.get("artifact")
+            if artifact is not None and not isinstance(artifact, Mapping):
+                return False
+        if record.kind == self._kind("completion"):
+            effect = record.payload.get("effect")
+            if not isinstance(effect, Mapping):
+                return False
+            try:
+                ProfileEffectDescriptor(
+                    effect_kind=cast(str, effect.get("effect_kind")),
+                    schema_version=cast(int, effect.get("schema_version")),
+                    parameters=cast(Mapping[str, Any], effect.get("parameters")),
+                    postcondition=cast(Mapping[str, Any], effect.get("postcondition")),
+                    receipt=cast(Mapping[str, Any], effect.get("receipt")),
+                )
+            except (ProfilePolicyError, TypeError, ValueError):
+                return False
+        return True
+
+
+DEFAULT_PROFILE_POLICY_REGISTRY: Final = ProfilePolicyRegistry(
+    (_TaskPolicy(), _BugPolicy(), _DocumentationPolicy(), _ResearchPolicy())
+)
+PRODUCTION_PROFILE_POLICY_REGISTRY: Final = DEFAULT_PROFILE_POLICY_REGISTRY
+PROFILE_POLICY_REGISTRY: Final = DEFAULT_PROFILE_POLICY_REGISTRY
+POLICIES_BY_PROFILE_ID: Final = DEFAULT_PROFILE_POLICY_REGISTRY.policies
+
+
+@dataclass(frozen=True)
+class ProfileContractCheck:
+    """Bounded result for one profile's Issue contract."""
+
+    policy: str
+    label: str
+    valid: bool
+    contract: Mapping[str, Any] | None
+    detail: str = ""
+    evidence: ProfileEvidenceRecord | None = None
+
+    @property
+    def failure_reason(self) -> str:
+        return f"{self.label} contract invalid: {self.detail or 'contract is invalid'}"
+
+
+@dataclass(frozen=True)
+class ProfileGateResults:
+    """Results of generic profile candidate dispatch."""
+
+    critical_outcome: dict[str, Any] | None = None
+    documentation_validation: dict[str, Any] | None = None
+    research_validation: dict[str, Any] | None = None
+    profile_evidence: ProfileEvidenceEnvelope | None = None
+
+
+@dataclass(frozen=True)
+class ProfileGateFailure(LckStopError):
+    """Candidate policy failure carrying evidence produced before failure."""
+
+    detail: str
+    profile_evidence: ProfileEvidenceEnvelope | None = None
+    legacy_results: Mapping[str, Any] = MappingProxyType({})
+
+    def __str__(self) -> str:
+        return self.detail
+
+
+@dataclass(frozen=True)
+class _ContractPolicy:
+    label: str
+    snapshot: Callable[[str | None], Mapping[str, Any]]
+    is_valid: Callable[[object], bool]
+
+
+# Compatibility/readability map for typed Issue contract snapshots. Executable
+# behavior is owned by the registry above.
+_CONTRACT_POLICIES: Final = {
+    "bug": _ContractPolicy("Bug defect", bug_contract_snapshot, is_valid_bug_contract),
+    "documentation": _ContractPolicy(
+        "Documentation",
+        documentation_contract_snapshot,
+        is_valid_documentation_contract,
+    ),
+    "research": _ContractPolicy(
+        "Research", research_contract_snapshot, is_valid_research_contract
+    ),
+}
+
+
+def resolve_profile_policy(
+    profile: LeafIssueWorkflowProfile,
+    *,
+    registry: ProfilePolicyRegistry = DEFAULT_PROFILE_POLICY_REGISTRY,
+) -> LeafIssuePolicy:
+    """Resolve profile metadata to one executable policy through the registry."""
+    return registry.resolve(profile)
+
+
+def resolve_issue_policy(
+    issue: Mapping[str, Any],
+    *,
+    registry: ProfilePolicyRegistry = DEFAULT_PROFILE_POLICY_REGISTRY,
+    profile_resolver: ProfileResolver = resolve_leaf_issue_profile,
+) -> tuple[LeafIssueWorkflowProfile, LeafIssuePolicy]:
+    return registry.resolve_issue(issue, profile_resolver=profile_resolver)
+
+
+def _context_for(
+    profile: LeafIssueWorkflowProfile,
+    *,
+    issue: Mapping[str, Any] | None = None,
+    context: PolicyContext | None = None,
+    **updates: Any,
+) -> PolicyContext:
+    if context is not None:
+        return context
+    return PolicyContext(profile=profile, issue=issue, **updates)
+
+
+def _contract_body(leaf_contract: Mapping[str, Any]) -> str | None:
+    """Select only an identity-verified complete body for policy parsing."""
+
+    if "contract" in leaf_contract:
+        complete = relationship_contract(leaf_contract)
+        body = complete.get("body") if isinstance(complete, Mapping) else None
+        return body if isinstance(body, str) else None
+    body = leaf_contract.get("body")
+    return body if isinstance(body, str) else None
+
+
+def _raw_contract_snapshot(
+    profile: LeafIssueWorkflowProfile,
+    issue: Mapping[str, Any],
+) -> Mapping[str, Any] | None:
+    if profile.profile_id == "task":
+        field_name = "critical_outcome"
+    elif profile.contract_policy is not None:
+        field_name = f"{profile.contract_policy}_contract"
+    else:
+        return None
+    value = issue.get(field_name)
+    return value if isinstance(value, Mapping) else None
+
+
+def validate_profile_contract(
+    profile: LeafIssueWorkflowProfile,
+    issue: Mapping[str, Any],
+    *,
+    registry: ProfilePolicyRegistry = DEFAULT_PROFILE_POLICY_REGISTRY,
+    context: PolicyContext | None = None,
+) -> ProfileContractCheck:
+    """Validate one canonical contract through its executable policy."""
+    policy: LeafIssuePolicy | None = None
+    try:
+        policy = resolve_profile_policy(profile, registry=registry)
+        execution_context = _context_for(profile, issue=issue, context=context)
+        evidence = _coerce_evidence(policy.validate_contract(execution_context, issue))
+        _validate_policy_evidence(policy, evidence, leaf_contract=issue)
+    except (ProfilePolicyError, ValueError) as exc:
+        label = getattr(policy, "policy_label", profile.profile_id.title())
+        return ProfileContractCheck(
+            policy=profile.profile_id,
+            label=label,
+            valid=False,
+            contract=_raw_contract_snapshot(profile, issue),
+            detail=str(exc),
+        )
+    return ProfileContractCheck(
+        policy=profile.profile_id,
+        label=getattr(policy, "policy_label", profile.profile_id.title()),
+        valid=True,
+        contract=_raw_contract_snapshot(profile, issue),
+        evidence=evidence,
+    )
+
+
+def evaluate_profile_blockers(
+    profile: LeafIssueWorkflowProfile,
+    issue: Mapping[str, Any],
+    *,
+    contract_evidence: ProfileEvidenceRecord | None = None,
+    registry: ProfilePolicyRegistry = DEFAULT_PROFILE_POLICY_REGISTRY,
+    context: PolicyContext | None = None,
+) -> tuple[PolicyBlocker, ...]:
+    """Dispatch and validate generic profile blockers deterministically."""
+    policy = resolve_profile_policy(profile, registry=registry)
+    execution_context = _context_for(profile, issue=issue, context=context)
+    check = validate_profile_contract(
+        profile,
+        issue,
+        registry=registry,
+        context=execution_context,
+    )
+    if not check.valid or check.evidence is None:
+        return (
+            PolicyBlocker(
+                code="CONTRACT_INVALID",
+                kind="contract",
+                detail=check.failure_reason,
+                evidence_ref={"profile_id": profile.profile_id},
+            ),
+        )
+    evidence = contract_evidence if contract_evidence is not None else check.evidence
+    _validate_policy_evidence(policy, evidence, leaf_contract=issue)
+    raw = policy.evaluate_blockers(execution_context, issue, evidence)
+    if raw is None:
+        raise ProfilePolicyError("policy returned no blocker collection")
+    blockers = tuple(raw)
+    if any(not isinstance(blocker, PolicyBlocker) for blocker in blockers):
+        raise ProfilePolicyError("policy returned malformed blocker")
+    return tuple(sorted(blockers, key=lambda item: (item.code, item.kind, item.detail)))
+
+
+def validate_profile_candidate(
+    profile: LeafIssueWorkflowProfile,
+    issue: Mapping[str, Any],
+    *,
+    contract_evidence: ProfileEvidenceRecord | None = None,
+    registry: ProfilePolicyRegistry = DEFAULT_PROFILE_POLICY_REGISTRY,
+    context: PolicyContext | None = None,
+) -> ProfileEvidenceRecord:
+    """Dispatch one candidate validator without profile branching in callers."""
+    policy = resolve_profile_policy(profile, registry=registry)
+    execution_context = _context_for(profile, issue=issue, context=context)
+    check = validate_profile_contract(
+        profile,
+        issue,
+        registry=registry,
+        context=execution_context,
+    )
+    if not check.valid or check.evidence is None:
+        raise ProfilePolicyError(check.failure_reason)
+    evidence = contract_evidence if contract_evidence is not None else check.evidence
+    _validate_policy_evidence(policy, evidence, leaf_contract=issue)
+    candidate = _coerce_evidence(
+        policy.validate_candidate(execution_context, issue, evidence)
+    )
+    _validate_policy_evidence(
+        policy,
+        candidate,
+        stage="candidate",
+        leaf_contract=issue,
+    )
+    expected_kind = getattr(policy, "candidate_kind", candidate.kind)
+    if candidate.kind != expected_kind:
+        raise ProfilePolicyError("policy returned evidence for the wrong stage")
+    return candidate
+
+
+@dataclass(frozen=True)
+class ProfileReviewResult:
+    """Generic Review-stage output, including the optional workspace artifact."""
+
+    evidence: ProfileEvidenceRecord | None
+    artifact: Mapping[str, Any] | None = None
+    profile_evidence: ProfileEvidenceEnvelope | None = None
+
+
+@dataclass(frozen=True)
+class ProfileCompletionResult:
+    """Generic completion-stage output and its data-only effect intent."""
+
+    evidence: ProfileEvidenceRecord | None
+    effect: ProfileEffectDescriptor | None = None
+    profile_evidence: ProfileEvidenceEnvelope | None = None
+
+
+def _policy_context(
+    profile: LeafIssueWorkflowProfile,
+    issue: Mapping[str, Any],
+    *,
+    context: PolicyContext | None = None,
+    **updates: Any,
+) -> PolicyContext:
+    if context is not None:
+        values = {**context.__dict__, **updates}
+        return PolicyContext(**values)
+    return PolicyContext(profile=profile, issue=issue, **updates)
+
+
+def build_profile_review_artifact(
+    profile: LeafIssueWorkflowProfile,
+    issue: Mapping[str, Any],
+    review_input: Mapping[str, Any],
+    *,
+    repo_root: Path | None,
+    registry: ProfilePolicyRegistry = DEFAULT_PROFILE_POLICY_REGISTRY,
+) -> Mapping[str, Any] | None:
+    """Ask the selected policy for artifact semantics inside a review clone."""
+    policy = resolve_profile_policy(profile, registry=registry)
+    method = getattr(policy, "review_artifact", None)
+    if not callable(method):
+        return None
+    context = PolicyContext(
+        profile=profile,
+        phase="review",
+        issue=issue,
+        repo_root=repo_root,
+        review_identity=(
+            review_input.get("identity")
+            if isinstance(review_input.get("identity"), Mapping)
+            else review_input
+        ),
+    )
+    value = method(context, review_input)
+    if value is None:
+        return None
+    if not isinstance(value, Mapping):
+        raise ProfilePolicyError("policy returned malformed Review artifact")
+    return dict(value)
+
+
+def validate_profile_review(
+    profile: LeafIssueWorkflowProfile,
+    issue: Mapping[str, Any],
+    review_input: Mapping[str, Any],
+    *,
+    registry: ProfilePolicyRegistry = DEFAULT_PROFILE_POLICY_REGISTRY,
+    context: PolicyContext | None = None,
+) -> ProfileReviewResult:
+    """Dispatch the generic Review capability without profile switches."""
+    if review_input.get(
+        "research_outcome"
+    ) is not None and not profile_research_outcome_supported(profile):
+        raise ProfilePolicyError(
+            "--research-outcome is supported only for Research Issues"
+        )
+    policy = resolve_profile_policy(profile, registry=registry)
+    execution_context = _policy_context(
+        profile,
+        issue,
+        context=context,
+        phase="review",
+        review_identity=(
+            review_input.get("identity")
+            if isinstance(review_input.get("identity"), Mapping)
+            else review_input
+        ),
+        review_verdict=review_input.get("verdict"),
+        research_outcome=review_input.get("research_outcome"),
+    )
+    normalized_input = dict(review_input)
+    artifact = normalized_input.get("artifact")
+    identity = normalized_input.get("identity")
+    if not isinstance(artifact, Mapping) and isinstance(identity, Mapping):
+        identity_artifact = identity.get("research_artifact")
+        if isinstance(identity_artifact, Mapping):
+            artifact = identity_artifact
+            normalized_input["artifact"] = dict(identity_artifact)
+    if not isinstance(artifact, Mapping):
+        artifact = build_profile_review_artifact(
+            profile,
+            issue,
+            normalized_input,
+            repo_root=execution_context.repo_root,
+            registry=registry,
+        )
+        if artifact is not None:
+            normalized_input["artifact"] = dict(artifact)
+    method = getattr(policy, "validate_review", None)
+    evidence: ProfileEvidenceRecord | None = None
+    if callable(method):
+        evidence = _coerce_evidence(method(execution_context, issue, normalized_input))
+        _validate_policy_evidence(policy, evidence, stage="review", leaf_contract=issue)
+    artifact = normalized_input.get("artifact")
+    check = validate_profile_contract(
+        profile, issue, registry=registry, context=execution_context
+    )
+    if not check.valid or check.evidence is None:
+        raise ProfilePolicyError(check.failure_reason)
+    envelope = ProfileEvidenceEnvelope(
+        profile_id=profile.profile_id,
+        contract=check.evidence,
+        review=evidence,
+    ).validated(registry, leaf_contract=issue)
+    return ProfileReviewResult(
+        evidence=evidence,
+        artifact=dict(artifact) if isinstance(artifact, Mapping) else None,
+        profile_evidence=envelope,
+    )
+
+
+def validate_profile_completion(
+    profile: LeafIssueWorkflowProfile,
+    issue: Mapping[str, Any],
+    completion_input: Mapping[str, Any],
+    *,
+    registry: ProfilePolicyRegistry = DEFAULT_PROFILE_POLICY_REGISTRY,
+    context: PolicyContext | None = None,
+) -> ProfileCompletionResult:
+    """Dispatch and validate one profile's generic completion capability."""
+    policy = resolve_profile_policy(profile, registry=registry)
+    execution_context = _policy_context(
+        profile,
+        issue,
+        context=context,
+        phase="completion",
+        # Completion policies may declare effect intent only.  Do not allow a
+        # caller-provided command runner to cross the Kernel effect boundary.
+        runner=None,
+        review_record=completion_input.get("review_record")
+        if isinstance(completion_input.get("review_record"), Mapping)
+        else None,
+        merged_pr=completion_input.get("merged_pr")
+        if isinstance(completion_input.get("merged_pr"), Mapping)
+        else None,
+    )
+    method = getattr(policy, "validate_completion", None)
+    evidence: ProfileEvidenceRecord | None = None
+    if callable(method):
+        result = method(execution_context, issue, completion_input)
+        if result is not None:
+            evidence = _coerce_evidence(result)
+            _validate_policy_evidence(
+                policy, evidence, stage="completion", leaf_contract=issue
+            )
+    effect: ProfileEffectDescriptor | None = None
+    if evidence is not None:
+        raw_effect = evidence.payload.get("effect")
+        if raw_effect is not None:
+            if not isinstance(raw_effect, Mapping):
+                raise ProfilePolicyError("completion effect descriptor is malformed")
+            try:
+                effect = ProfileEffectDescriptor(
+                    effect_kind=cast(str, raw_effect.get("effect_kind")),
+                    schema_version=cast(int, raw_effect.get("schema_version")),
+                    parameters=cast(Mapping[str, Any], raw_effect.get("parameters")),
+                    postcondition=cast(
+                        Mapping[str, Any], raw_effect.get("postcondition")
+                    ),
+                    receipt=cast(Mapping[str, Any], raw_effect.get("receipt")),
+                )
+            except (ProfilePolicyError, TypeError, ValueError) as exc:
+                raise ProfilePolicyError(str(exc)) from exc
+    if evidence is None:
+        # Completion is an optional capability.  Profiles without a completion
+        # policy must not acquire or re-validate a profile-specific contract at
+        # this generic lifecycle boundary.
+        return ProfileCompletionResult(
+            evidence=None, effect=None, profile_evidence=None
+        )
+    check = validate_profile_contract(
+        profile, issue, registry=registry, context=execution_context
+    )
+    if not check.valid or check.evidence is None:
+        raise ProfilePolicyError(check.failure_reason)
+    review_record = completion_input.get("review_evidence")
+    review_evidence = (
+        _coerce_evidence(review_record) if review_record is not None else None
+    )
+    if review_evidence is not None:
+        _validate_policy_evidence(
+            policy, review_evidence, stage="review", leaf_contract=issue
+        )
+    envelope = ProfileEvidenceEnvelope(
+        profile_id=profile.profile_id,
+        contract=check.evidence,
+        review=review_evidence,
+        completion=evidence,
+    ).validated(registry, leaf_contract=issue)
+    return ProfileCompletionResult(
+        evidence=evidence, effect=effect, profile_evidence=envelope
+    )
+
+
+def _result_from_candidate(
+    record: ProfileEvidenceRecord | None,
+) -> dict[str, Any] | None:
+    if record is None:
+        return None
+    result = record.payload.get("result")
+    return dict(result) if isinstance(result, Mapping) else None
+
+
+def run_profile_delivery_gates(
+    profile: LeafIssueWorkflowProfile,
+    *,
+    base_sha: str,
+    head_sha: str | None,
+    include_index: bool,
+    progress: Any,
+    documentation_validation: Any = None,
+    research_validation: Any = None,
+    critical_outcome: Callable[[], dict[str, Any]] | None = None,
+    issue: Mapping[str, Any] | None = None,
+    registry: ProfilePolicyRegistry = DEFAULT_PROFILE_POLICY_REGISTRY,
+    repo_root: Path | None = None,
+    runner: Any = None,
+    services: Sequence[Any] = (),
+) -> ProfileGateResults:
+    """Run contract and candidate stages through the selected policy."""
+    policy = resolve_profile_policy(profile, registry=registry)
+    observed_result: dict[str, Any] | None = None
+
+    def run_documentation() -> Mapping[str, Any]:
+        nonlocal observed_result
+        try:
+            result = documentation_validation.run(base_sha)
+        except BaseException:
+            result = getattr(documentation_validation, "last_result", None)
+            if isinstance(result, Mapping):
+                observed_result = dict(result)
+            raise
+        if not isinstance(result, Mapping):
+            raise ProfilePolicyError("Documentation candidate result is malformed")
+        observed_result = dict(result)
+        return result
+
+    def run_research() -> Mapping[str, Any]:
+        nonlocal observed_result
+        try:
+            result = research_validation.run(
+                base_sha,
+                head_sha=head_sha,
+                include_index=include_index,
+            )
+        except BaseException:
+            result = getattr(research_validation, "last_result", None)
+            if isinstance(result, Mapping):
+                observed_result = dict(result)
+            raise
+        if not isinstance(result, Mapping):
+            raise ProfilePolicyError("Research candidate result is malformed")
+        observed_result = dict(result)
+        return result
+
+    def run_critical() -> Mapping[str, Any]:
+        nonlocal observed_result
+        if critical_outcome is None:
+            raise ProfilePolicyError("Critical Outcome validator is unavailable")
+        result = critical_outcome()
+        if not isinstance(result, Mapping):
+            raise ProfilePolicyError("Critical Outcome result is malformed")
+        observed_result = dict(result)
+        return result
+
+    context = PolicyContext(
+        profile=profile,
+        phase="delivery",
+        issue=issue,
+        repo_root=repo_root,
+        runner=runner,
+        base_sha=base_sha,
+        head_sha=head_sha,
+        include_index=include_index,
+        progress=progress,
+        critical_outcome=run_critical if critical_outcome is not None else None,
+        documentation_validation=(
+            run_documentation if documentation_validation is not None else None
+        ),
+        research_validation=run_research if research_validation is not None else None,
+        services=tuple(
+            item
+            for item in (*services, documentation_validation, research_validation)
+            if item is not None
+        ),
+    )
+    if not isinstance(issue, Mapping):
+        raise LckStopError("current leaf Issue contract is unavailable")
+    check = validate_profile_contract(
+        profile, issue, registry=registry, context=context
+    )
+    if not check.valid or check.evidence is None:
+        raise LckStopError(check.failure_reason)
+
+    try:
+        candidate = validate_profile_candidate(
+            profile,
+            issue,
+            contract_evidence=check.evidence,
+            registry=registry,
+            context=context,
+        )
+    except BaseException as exc:
+        failure_builder = getattr(policy, "candidate_failure", None)
+        failure = (
+            failure_builder(
+                context,
+                issue,
+                check.evidence,
+                observed_result,
+                str(exc),
+            )
+            if callable(failure_builder)
+            else None
+        )
+        structured_result = getattr(exc, "result", None)
+        if isinstance(structured_result, Mapping):
+            observed_result = dict(structured_result)
+            if callable(failure_builder):
+                failure = failure_builder(
+                    context,
+                    issue,
+                    check.evidence,
+                    observed_result,
+                    str(exc),
+                )
+        envelope = ProfileEvidenceEnvelope(
+            profile_id=profile.profile_id,
+            contract=check.evidence,
+            candidate=failure,
+        ).validated(registry, leaf_contract=issue)
+        legacy_failure: dict[str, Any] = getattr(
+            policy, "legacy_result", lambda _result: {}
+        )(observed_result)
+        raise ProfileGateFailure(
+            str(exc), envelope, legacy_results=legacy_failure
+        ) from exc
+
+    envelope = ProfileEvidenceEnvelope(
+        profile_id=profile.profile_id,
+        contract=check.evidence,
+        candidate=candidate,
+    ).validated(registry, leaf_contract=issue)
+    result = _result_from_candidate(candidate)
+    legacy: dict[str, Any] = getattr(policy, "legacy_result", lambda _result: {})(
+        result
+    )
+    return ProfileGateResults(
+        **legacy,
+        profile_evidence=envelope,
+    )
+
+
+def evaluate_profile_changes(
+    profile: LeafIssueWorkflowProfile,
+    changed_files: Sequence[str],
+) -> DocumentationChangeResult | None:
+    """Evaluate a profile's legacy Review change-policy projection."""
+    if profile.change_policy == "documentation":
+        return evaluate_documentation_changes(changed_files)
+    return None
+
+
+def profile_cleanup_label(profile: LeafIssueWorkflowProfile) -> str:
+    return profile.issue_kind.value.title()
+
+
+def profile_has_research_artifacts(profile: LeafIssueWorkflowProfile) -> bool:
+    return profile.artifact_policy == "research"
+
+
+def profile_research_outcome_supported(profile: LeafIssueWorkflowProfile) -> bool:
+    return profile.supports_research_outcome

--- a/tools/lck/receipts.py
+++ b/tools/lck/receipts.py
@@ -1,0 +1,642 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+
+from .closeout import CloseoutResult
+from .common import (
+    WorkflowToolError,
+    atomic_write_json,
+    read_json_file,
+    safe_text,
+    sha256_json,
+)
+from .delivery import DeliveryCompletionResult, DeliveryContext
+from .models import (
+    LCK_SCHEMA_VERSION,
+    EffectReceipt,
+    LckStopError,
+    LiveState,
+    OperationSnapshot,
+    _checks_agent_view,
+    _critical_outcome_agent_view,
+    _jsonable,
+    _pr_agent_view,
+    _pr_base_sha,
+    _pr_head_sha,
+    _remote_main_sha,
+    _validation_agent_view,
+)
+from .profile_policies import ProfileEvidenceEnvelope
+from .remediation import (
+    RemediationCompletionResult,
+    RemediationContext,
+    RemediationNoChangeResult,
+)
+from .review import MergePreflightResult, ReviewCompletionResult, ReviewContext
+from .review_workspace import ReviewInvocationStore
+from .state import _leaf_contract_from_state
+
+
+@dataclass(frozen=True)
+class AuditReceiptReference:
+    """Stable, bounded locator for one operation-owned audit receipt."""
+
+    operation_id: str
+    path: str
+    sha256: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "operation_id": self.operation_id,
+            "path": self.path,
+            "sha256": self.sha256,
+        }
+
+
+class AuditReceiptStore:
+    """Persist complete operation evidence below the ignored LCK runtime root.
+
+    Agent-facing results contain only a compact view and this reference.  The
+    receipt is deliberately content-addressed in its reference and refuses to
+    silently overwrite an existing operation with a different payload.
+    """
+
+    _OPERATION = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+    _ID = re.compile(r"^[0-9a-f]{32}$")
+
+    def __init__(self, repo_root: Path) -> None:
+        self.repo_root = repo_root.resolve()
+        self.root = self.repo_root / ".workflow.local" / "lck" / "audit-receipts"
+
+    def receipt_path(self, task_number: int, operation: str, operation_id: str) -> Path:
+        operation = operation.strip().casefold()
+        if self._OPERATION.fullmatch(operation) is None:
+            raise LckStopError("invalid LCK audit receipt operation")
+        if self._ID.fullmatch(operation_id) is None:
+            raise LckStopError("invalid LCK audit receipt operation id")
+        if not isinstance(task_number, int) or isinstance(task_number, bool):
+            raise LckStopError("invalid LCK audit receipt Task number")
+        return self.root / operation / f"task-{task_number}-{operation_id}.json"
+
+    def reference_for(
+        self, task_number: int, operation: str, operation_id: str, sha256: str
+    ) -> AuditReceiptReference:
+        path = self.receipt_path(task_number, operation, operation_id)
+        return AuditReceiptReference(
+            operation_id=operation_id,
+            path=path.relative_to(self.repo_root).as_posix(),
+            sha256=sha256,
+        )
+
+    def write(
+        self,
+        task_number: int,
+        operation: str,
+        operation_id: str,
+        payload: Mapping[str, Any],
+    ) -> AuditReceiptReference:
+        path = self.receipt_path(task_number, operation, operation_id)
+        normalized = cast(dict[str, Any], _jsonable(payload))
+        digest = sha256_json(normalized)
+        if path.exists():
+            existing = read_json_file(path)
+            if existing != normalized:
+                raise LckStopError(
+                    "existing LCK audit receipt does not match this operation"
+                )
+        else:
+            atomic_write_json(path, normalized)
+        return self.reference_for(task_number, operation, operation_id, digest)
+
+    def existing_reference(
+        self, task_number: int, operation: str, operation_id: str
+    ) -> AuditReceiptReference | None:
+        """Return the reference for an existing, identity-matching receipt."""
+        path = self.receipt_path(task_number, operation, operation_id)
+        if not path.exists():
+            return None
+        existing = read_json_file(path)
+        if (
+            not isinstance(existing, dict)
+            or existing.get("kind") != "lck-audit-receipt"
+            or existing.get("operation") != operation
+            or existing.get("operation_id") != operation_id
+            or existing.get("task_number") != task_number
+        ):
+            raise LckStopError("existing LCK audit receipt identity is invalid")
+        return self.reference_for(
+            task_number,
+            operation,
+            operation_id,
+            sha256_json(existing),
+        )
+
+    def read(self, reference: Mapping[str, Any]) -> dict[str, Any]:
+        path_value = reference.get("path")
+        expected_digest = reference.get("sha256")
+        operation_id = reference.get("operation_id")
+        if (
+            not isinstance(path_value, str)
+            or not isinstance(expected_digest, str)
+            or not isinstance(operation_id, str)
+            or self._ID.fullmatch(operation_id) is None
+        ):
+            raise LckStopError("LCK audit receipt reference is malformed")
+        path = (self.repo_root / path_value).resolve()
+        try:
+            path.relative_to(self.root)
+        except ValueError as exc:
+            raise LckStopError(
+                "LCK audit receipt reference escapes its owned root"
+            ) from exc
+        if not path.name.endswith(f"-{operation_id}.json"):
+            raise LckStopError(
+                "LCK audit receipt reference identity does not match its path"
+            )
+        value = read_json_file(path)
+        if (
+            not isinstance(value, dict)
+            or value.get("operation_id") != operation_id
+            or sha256_json(value) != expected_digest
+        ):
+            raise LckStopError("LCK audit receipt digest does not match its reference")
+        return value
+
+
+def _effect_agent_view(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, (list, tuple)):
+        return []
+    result: list[dict[str, Any]] = []
+    for item in value:
+        if isinstance(item, EffectReceipt):
+            result.append({"effect": item.effect, "action": item.action})
+        elif isinstance(item, Mapping):
+            compact = {key: item[key] for key in ("effect", "action") if key in item}
+            if compact:
+                result.append(compact)
+    return result
+
+
+def _delivery_prepare_effect_agent_view(value: Any) -> list[dict[str, Any]]:
+    result = _effect_agent_view(value)
+    if not isinstance(value, (list, tuple)):
+        return result
+    for compact, item in zip(result, value, strict=False):
+        details = (
+            item.details
+            if isinstance(item, EffectReceipt)
+            else item.get("details")
+            if isinstance(item, Mapping)
+            else None
+        )
+        if compact.get("effect") == "set_in_progress_status" and isinstance(
+            details, Mapping
+        ):
+            compact["postcondition"] = {
+                "status": details.get("postcondition"),
+                "project_status": details.get("status"),
+            }
+    return result
+
+
+def _delivery_pr_agent_view(effects: Any) -> dict[str, Any] | None:
+    if not isinstance(effects, (list, tuple)):
+        return None
+    for item in reversed(effects):
+        details: Mapping[str, Any] | None = None
+        if isinstance(item, EffectReceipt):
+            details = item.details
+        elif isinstance(item, Mapping) and isinstance(item.get("details"), Mapping):
+            details = cast(Mapping[str, Any], item["details"])
+        if details is not None and "number" in details:
+            return {
+                key: details[key]
+                for key in ("number", "url", "base_sha", "head_sha")
+                if key in details
+            }
+    return None
+
+
+def _issue_profile_agent_view(value: Any) -> Any:
+    """Return the bounded profile selected by the operation's live snapshot."""
+    if isinstance(value, ReviewContext):
+        return _jsonable(value.issue_profile)
+    if isinstance(value, ReviewCompletionResult):
+        return _jsonable(value.issue_profile)
+    snapshot = getattr(value, "operation_snapshot", None)
+    if isinstance(snapshot, OperationSnapshot):
+        return _jsonable(snapshot.state.issue_profile)
+    return None
+
+
+def _profile_evidence(value: Any) -> Any:
+    """Serialize the generic profile envelope without profile-specific fields."""
+    if isinstance(value, ProfileEvidenceEnvelope):
+        return value.to_dict()
+    if isinstance(value, Mapping):
+        return _jsonable(value)
+    return None
+
+
+def _agent_view_for_result(value: Any) -> dict[str, Any]:
+    """Convert one internal LCK result into the bounded Agent-facing view."""
+    if isinstance(value, LiveState):
+        return value.agent_view()
+    if isinstance(value, DeliveryContext):
+        return {
+            "schema_version": LCK_SCHEMA_VERSION,
+            "kind": "lck-agent-view",
+            "operation": "delivery-prepare",
+            "task_number": value.task_number,
+            "repository": value.repository,
+            "issue_profile": _issue_profile_agent_view(value),
+            "status": "READY_FOR_DELIVERY",
+            "branch": value.branch,
+            "base_sha": value.base_sha,
+            "action": value.action,
+            "task_contract": _jsonable(_leaf_contract_from_state(value.state)),
+            "eligibility": {
+                "eligible": value.eligibility.eligible,
+                "reasons": list(value.eligibility.reasons),
+            },
+            "effects": _delivery_prepare_effect_agent_view(value.effects),
+            "human_boundary": "implement the Task before LCK Delivery Complete",
+            "next_action": "implement the Task and run LCK Delivery Complete",
+        }
+    if isinstance(value, ReviewContext):
+        return {
+            "schema_version": LCK_SCHEMA_VERSION,
+            "kind": "lck-agent-view",
+            "operation": "review-prepare",
+            "status": "READY_FOR_SEMANTIC_REVIEW",
+            "task_number": value.identity.task_number,
+            "review_id": value.review_id,
+            "issue_profile": _issue_profile_agent_view(value),
+            "task_contract": _jsonable(value.task_contract),
+            "review_target": value.identity.to_dict(),
+            "profile_evidence": _profile_evidence(value.profile_evidence),
+            "structured_review_instructions": _jsonable(
+                value.structured_review_instructions
+            ),
+            "checks": _checks_agent_view(value.checks),
+            "validation": _validation_agent_view(value.validation),
+            "review_root": str(value.review_root),
+            "workspace_mode": "implementation-read-only",
+            "agent_role": ["Inspect", "Reason", "Judge", "Report"],
+            "mechanical_authority": "live Git/GitHub state resolved by LCK",
+            "human_boundary": "semantic Review must be completed before Review Complete",
+            "next_action": "perform an independent semantic Review, then run Review Complete",
+        }
+    if isinstance(value, ReviewCompletionResult):
+        return {
+            "schema_version": LCK_SCHEMA_VERSION,
+            "kind": "lck-agent-view",
+            "operation": "review-complete",
+            "task_number": value.task_number,
+            "review_id": value.review_id,
+            "verdict": value.verdict,
+            "status": value.status,
+            "issue_profile": _issue_profile_agent_view(value),
+            "review_target": value.identity.to_dict(),
+            "profile_evidence": _profile_evidence(value.profile_evidence),
+            "human_boundary": (
+                "STOP; run deterministic Merge Preflight before any manual merge"
+                if value.verdict == "PASS"
+                else "STOP; Human must explicitly choose remediation, redesign, or abandon"
+            ),
+            "next_action": (
+                "run LCK Merge Preflight"
+                if value.verdict == "PASS"
+                else "stop; Human must explicitly choose remediation, redesign, or abandon"
+            ),
+        }
+    if isinstance(value, DeliveryCompletionResult):
+        base_sha = _remote_main_sha(value.operation_snapshot.state.git)
+        return {
+            "schema_version": LCK_SCHEMA_VERSION,
+            "kind": "lck-agent-view",
+            "operation": "delivery-complete",
+            "task_number": value.task_number,
+            "issue_profile": _issue_profile_agent_view(value),
+            "status": value.status,
+            "branch": value.branch,
+            "base_sha": base_sha,
+            "head_sha": value.head_sha,
+            "pr": _delivery_pr_agent_view(value.effects),
+            "critical_outcome": _critical_outcome_agent_view(value.critical_outcome),
+            "research_artifact": _jsonable(value.research_artifact),
+            "profile_evidence": _profile_evidence(value.profile_evidence),
+            "validation": _validation_agent_view(value.validation),
+            "checks": _checks_agent_view(value.checks),
+            "effects": _effect_agent_view(value.effects),
+            "human_boundary": "Independent Review must be started separately",
+            "next_action": "start an independent Review in a fresh invocation",
+        }
+    if isinstance(value, MergePreflightResult):
+        return {
+            "schema_version": LCK_SCHEMA_VERSION,
+            "kind": "lck-agent-view",
+            "operation": "merge-preflight",
+            "task_number": value.task_number,
+            "issue_profile": _issue_profile_agent_view(value),
+            "status": value.status,
+            "pr": _pr_agent_view(value.pr),
+            "review": {
+                key: value.review[key]
+                for key in ("status", "review_id", "identity")
+                if key in value.review
+            },
+            "checks": _checks_agent_view(value.checks),
+            "blockers": {
+                key: value.blockers[key]
+                for key in ("status", "detail", "count")
+                if key in value.blockers
+            },
+            "mergeability": value.mergeability,
+            "human_boundary": "STOP — maintainer must perform the manual Squash Merge; LCK has no auto-merge path",
+            "next_action": "maintainer must perform the manual Squash Merge",
+        }
+    if isinstance(value, CloseoutResult):
+        return {
+            "schema_version": LCK_SCHEMA_VERSION,
+            "kind": "lck-agent-view",
+            "operation": "closeout",
+            "task_number": value.task_number,
+            "issue_profile": _issue_profile_agent_view(value),
+            "status": value.status,
+            "business_delivery": value.business_delivery,
+            "cleanup": value.cleanup,
+            "research_outcome": value.research_outcome,
+            "profile_evidence": _profile_evidence(value.profile_evidence),
+            "effects": _effect_agent_view(value.effects),
+            "automatic_merge": False,
+            "manual_issue_close": False,
+            "next_action": (
+                "stop; closeout is complete"
+                if value.business_delivery == "COMPLETE" and value.cleanup == "COMPLETE"
+                else "resolve pending Research Outcome and closeout effects"
+                if value.business_delivery != "COMPLETE"
+                else "resolve pending closeout cleanup"
+            ),
+        }
+    if isinstance(value, RemediationContext):
+        return {
+            "schema_version": LCK_SCHEMA_VERSION,
+            "kind": "lck-agent-view",
+            "operation": "remediation-prepare",
+            "task_number": value.task_number,
+            "review_id": value.review_id,
+            "issue_profile": _issue_profile_agent_view(value),
+            "status": "READY_FOR_REMEDIATION",
+            "action": value.action,
+            "findings": value.findings,
+            "findings_source": value.findings_source,
+            "task_contract": _jsonable(value.task_contract),
+            "live_target": {
+                "pr_number": (value.state.open_pr or {}).get("number"),
+                "base_sha": _pr_base_sha(value.state.open_pr),
+                "head_sha": _pr_head_sha(value.state.open_pr),
+                "branch": value.state.target_branch,
+            },
+            "next_action": "repair the implementation and run Remediation Complete",
+        }
+    if isinstance(value, RemediationNoChangeResult):
+        return {
+            "schema_version": LCK_SCHEMA_VERSION,
+            "kind": "lck-agent-view",
+            "operation": "remediation-no-change",
+            "task_number": value.task_number,
+            "review_id": value.review_id,
+            "issue_profile": _issue_profile_agent_view(value),
+            "status": "NO_IMPLEMENTATION_CHANGE",
+            "head_sha": value.head_sha,
+            "pr_number": value.pr_number,
+            "base_sha": value.base_sha,
+            "summary": value.summary,
+            "candidate_changed": False,
+            "fresh_review_required": False,
+            "session_released": True,
+            "replayed": value.replayed,
+            "human_boundary": "STOP — continue external acceptance work on the unchanged head",
+            "next_action": "continue external acceptance work on the unchanged head",
+        }
+    if isinstance(value, RemediationCompletionResult):
+        delivery = value.delivery
+        return {
+            "schema_version": LCK_SCHEMA_VERSION,
+            "kind": "lck-agent-view",
+            "operation": "remediation-complete",
+            "task_number": value.task_number,
+            "review_id": value.review_id,
+            "issue_profile": _issue_profile_agent_view(delivery),
+            "status": "READY_FOR_NEW_REVIEW",
+            "head_sha": delivery.head_sha,
+            "critical_outcome": _critical_outcome_agent_view(delivery.critical_outcome),
+            "profile_evidence": _profile_evidence(delivery.profile_evidence),
+            "validation": _validation_agent_view(delivery.validation),
+            "checks": _checks_agent_view(delivery.checks),
+            "effects": _effect_agent_view(delivery.effects),
+            "human_boundary": "STOP — a new Independent Review must be started explicitly in a fresh invocation",
+            "next_action": "start a new independent Review in a fresh invocation",
+        }
+    raise LckStopError(f"unsupported LCK result type: {type(value).__name__}")
+
+
+def _audit_payload_for_result(
+    value: Any,
+    *,
+    store: AuditReceiptStore,
+) -> dict[str, Any]:
+    """Build the complete receipt payload without using it as Agent output."""
+    payload = value.to_dict()
+    if isinstance(value, LiveState):
+        state_payload = dict(payload)
+        payload["operation_snapshot"] = {
+            "schema_version": LCK_SCHEMA_VERSION,
+            "operation": "status",
+            "state": state_payload,
+        }
+    elif isinstance(value, ReviewContext):
+        guard = ReviewInvocationStore(store.repo_root).read_guard(value.review_id)
+        payload["review_guard"] = guard
+        payload["operation_snapshot"] = guard.get("snapshot")
+    elif isinstance(value, ReviewCompletionResult):
+        if value.record_path.exists():
+            record = read_json_file(value.record_path)
+            payload["review_record"] = record
+            if isinstance(record, Mapping):
+                payload["operation_snapshot"] = record.get("completion_snapshot")
+    elif isinstance(value, MergePreflightResult):
+        if value.operation_snapshot is not None:
+            payload["operation_snapshot"] = value.operation_snapshot.to_dict()
+    return cast(dict[str, Any], _jsonable(payload))
+
+
+def _result_operation_id(value: Any, fallback: str) -> str:
+    for attribute in ("review_id",):
+        candidate = getattr(value, attribute, None)
+        if isinstance(candidate, str) and AuditReceiptStore._ID.fullmatch(candidate):
+            return candidate
+    return fallback
+
+
+def _write_success_receipt(
+    value: Any,
+    *,
+    operation: str,
+    task_number: int,
+    operation_id: str,
+    store: AuditReceiptStore,
+) -> dict[str, Any]:
+    agent_view = cast(dict[str, Any], _jsonable(_agent_view_for_result(value)))
+    if isinstance(value, RemediationNoChangeResult) and value.replayed:
+        existing = store.existing_reference(task_number, operation, operation_id)
+        if existing is not None:
+            agent_view["receipt_reference"] = existing.to_dict()
+            return agent_view
+    audit_payload = _audit_payload_for_result(value, store=store)
+    receipt_agent_view = dict(agent_view)
+    if isinstance(value, RemediationNoChangeResult):
+        # ``replayed`` describes this CLI invocation, not the durable operation.
+        # Keep the original operation receipt immutable across valid replays.
+        receipt_agent_view["replayed"] = False
+        audit_payload = dict(audit_payload)
+        audit_payload["replayed"] = False
+    receipt_payload = {
+        "schema_version": LCK_SCHEMA_VERSION,
+        "kind": "lck-audit-receipt",
+        "operation": operation,
+        "operation_id": operation_id,
+        "task_number": task_number,
+        "outcome": {"status": agent_view.get("status")},
+        "agent_view": receipt_agent_view,
+        "operation_snapshot": audit_payload.get("operation_snapshot"),
+        "audit": audit_payload,
+    }
+    reference = store.write(
+        task_number,
+        operation,
+        operation_id,
+        receipt_payload,
+    )
+    agent_view["receipt_reference"] = reference.to_dict()
+    return agent_view
+
+
+def _write_failure_receipt(
+    *,
+    operation: str,
+    task_number: int,
+    operation_id: str,
+    status: str,
+    code: str | None,
+    error: str,
+    handler: Any,
+    store: AuditReceiptStore,
+) -> dict[str, Any]:
+    snapshot = getattr(handler, "last_snapshot", None)
+    snapshot_payload = (
+        snapshot.to_dict() if isinstance(snapshot, OperationSnapshot) else None
+    )
+    detail = {
+        "status": status,
+        "code": code,
+        "error": safe_text(error, limit=2000),
+    }
+    next_action = _failure_next_action(status)
+    agent_view = {
+        "schema_version": LCK_SCHEMA_VERSION,
+        "kind": "lck-agent-view",
+        "operation": operation,
+        "task_number": task_number,
+        "issue_profile": _jsonable(
+            snapshot.state.issue_profile
+            if isinstance(snapshot, OperationSnapshot)
+            else None
+        ),
+        **detail,
+        "next_action": next_action,
+    }
+    receipt_payload = {
+        "schema_version": LCK_SCHEMA_VERSION,
+        "kind": "lck-audit-receipt",
+        "operation": operation,
+        "operation_id": operation_id,
+        "task_number": task_number,
+        "outcome": detail,
+        "agent_view": agent_view,
+        "operation_snapshot": snapshot_payload,
+        "audit": {
+            "outcome": detail,
+            "operation_snapshot": snapshot_payload,
+            "critical_outcome": _jsonable(
+                getattr(handler, "last_critical_outcome", None)
+            ),
+            "documentation_policy": _jsonable(
+                getattr(handler, "last_documentation_validation", None)
+            ),
+            "profile_evidence": _profile_evidence(
+                getattr(handler, "last_profile_evidence", None)
+            ),
+            "validation": _jsonable(getattr(handler, "last_validation", None)),
+            "checks": _jsonable(getattr(handler, "last_checks", None)),
+            "effects": _jsonable(
+                [
+                    item.to_dict() if isinstance(item, EffectReceipt) else item
+                    for item in getattr(handler, "last_effects", [])
+                ]
+            ),
+        },
+    }
+    reference = store.write(
+        task_number,
+        operation,
+        operation_id,
+        receipt_payload,
+    )
+    view = cast(dict[str, Any], dict(agent_view))
+    view["receipt_reference"] = reference.to_dict()
+    return cast(dict[str, Any], _jsonable(view))
+
+
+def _failure_next_action(status: str) -> str:
+    return (
+        "start a fresh Review Prepare for the current target"
+        if status == "stale"
+        else "inspect the receipt and resolve the STOP condition"
+    )
+
+
+def _failure_fallback(
+    *,
+    operation: str,
+    task_number: int,
+    operation_id: str,
+    status: str,
+    code: str | None,
+    error: str,
+    receipt_error: WorkflowToolError,
+    store: AuditReceiptStore,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "schema_version": LCK_SCHEMA_VERSION,
+        "kind": "lck-agent-view",
+        "operation": operation,
+        "task_number": task_number,
+        "status": status,
+        "code": code,
+        "error": safe_text(error, limit=2000),
+        "receipt_error": safe_text(str(receipt_error), limit=1000),
+        "next_action": _failure_next_action(status),
+    }
+    try:
+        reference = store.existing_reference(task_number, operation, operation_id)
+    except WorkflowToolError:
+        reference = None
+    if reference is not None:
+        payload["receipt_reference"] = reference.to_dict()
+    return payload

--- a/tools/lck/remediation.py
+++ b/tools/lck/remediation.py
@@ -1,0 +1,781 @@
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+
+from .common import is_sha
+from .delivery import DeliveryCompleter, DeliveryCompletionResult
+from .effects import ReuseExistingOpenPrEffect
+from .eligibility import PhaseEligibilityResolver
+from .models import (
+    LCK_SCHEMA_VERSION,
+    EffectReceipt,
+    LckStopError,
+    LiveState,
+    OperationSnapshot,
+    Phase,
+    _jsonable,
+)
+from .profile_policies import (
+    DEFAULT_PROFILE_POLICY_REGISTRY,
+    ProfileEvidenceEnvelope,
+    ProfilePolicyRegistry,
+    ProfileResolver,
+)
+from .review_workspace import ReviewInvocationStore, _identity_from_mapping
+from .state import (
+    LiveStateResolver,
+    OperationSnapshotBuilder,
+    _leaf_contract_from_state,
+)
+from .validation_gates import DeliveryChecksGate
+
+
+@dataclass(frozen=True)
+class RemediationContext:
+    task_number: int
+    review_id: str
+    findings: str
+    findings_source: str
+    operation_snapshot: OperationSnapshot
+    action: str
+
+    @property
+    def state(self) -> LiveState:
+        return self.operation_snapshot.state
+
+    @property
+    def task_contract(self) -> dict[str, Any]:
+        """Return the contract bound to this Remediation Prepare snapshot."""
+        return _leaf_contract_from_state(self.state)
+
+    def to_dict(self) -> dict[str, Any]:
+        pr = self.state.open_pr or {}
+        return {
+            "schema_version": LCK_SCHEMA_VERSION,
+            "operation": "remediation-prepare",
+            "status": "READY_FOR_REMEDIATION",
+            "task_number": self.task_number,
+            "review_id": self.review_id,
+            "action": self.action,
+            "issue_profile": _jsonable(self.state.issue_profile),
+            "findings": self.findings,
+            "findings_source": self.findings_source,
+            "task_contract": _jsonable(self.task_contract),
+            "operation_snapshot": self.operation_snapshot.to_dict(),
+            "live_target": {
+                "pr_number": pr.get("number"),
+                "base_sha": pr.get("baseRefOid"),
+                "head_sha": pr.get("headRefOid"),
+                "branch": self.state.target_branch,
+                "task_body_sha256": (
+                    self.state.issue.get("body_sha256")
+                    if isinstance(self.state.issue, Mapping)
+                    else None
+                ),
+            },
+            "mechanical_authority": (
+                "operation snapshot acquired at Remediation entry; Review findings are semantic "
+                "input only, whether loaded from the local audit record or an explicitly supplied "
+                "portable findings file"
+            ),
+            "acceptance_boundary": (
+                "Requirements whose evidence can only be truthfully produced after the repaired "
+                "candidate head exists, or by a separate provider/fresh Review invocation, do not "
+                "block Remediation Complete. They remain unsatisfied Review-acceptance requirements "
+                "and must not be fabricated or treated as satisfied by remediation."
+            ),
+        }
+
+
+def _failed_review_record(
+    store: ReviewInvocationStore, task_number: int, review_id: str
+) -> dict[str, Any]:
+    record = store.read_record(task_number, review_id)
+    if record.get("task_number") != task_number or record.get("verdict") != "FAIL":
+        raise LckStopError("Remediation requires a failed Independent Review record")
+    latest = store.read_latest_review(task_number)
+    if (
+        not isinstance(latest, Mapping)
+        or latest.get("review_id") != review_id
+        or latest.get("verdict") != "FAIL"
+    ):
+        raise LckStopError(
+            "Remediation requires the latest completed Independent Review to be this FAIL"
+        )
+    findings = record.get("findings")
+    if not isinstance(findings, str) or not findings.strip():
+        raise LckStopError(
+            "failed Independent Review record has no remediation findings"
+        )
+    identity = record.get("identity")
+    if not isinstance(identity, Mapping):
+        raise LckStopError("failed Independent Review record has no reviewed identity")
+    _identity_from_mapping(identity)
+    return record
+
+
+def _read_portable_review_findings(path: Path) -> str:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise LckStopError(f"cannot read portable Review findings file: {exc}") from exc
+    if not text.strip():
+        raise LckStopError("portable Review findings file is empty")
+    return text
+
+
+def _remediation_findings(
+    store: ReviewInvocationStore,
+    task_number: int,
+    review_id: str,
+    *,
+    findings_file: Path | None = None,
+) -> tuple[str, str]:
+    # Constructing the path validates the caller-provided review id even when the
+    # originating workspace-local audit record is unavailable.
+    record_path = store.record_path(task_number, review_id)
+    if record_path.exists():
+        record = _failed_review_record(store, task_number, review_id)
+        return cast(str, record["findings"]), "local-review-record"
+    if findings_file is None:
+        raise LckStopError(
+            "failed Review audit record is unavailable in this workspace; "
+            "for an explicit cross-workspace/provider Remediation handoff, provide "
+            "--findings-file with the completed Review findings. The file is semantic "
+            "input only; LCK still reacquires all mechanical authority from live state."
+        )
+    return _read_portable_review_findings(findings_file), "portable-findings-file"
+
+
+class RemediationPreparer:
+    """Explicitly enter repair using live mechanics plus semantic Review findings."""
+
+    def __init__(
+        self,
+        resolver: LiveStateResolver,
+        *,
+        eligibility: PhaseEligibilityResolver | None = None,
+        store: ReviewInvocationStore | None = None,
+        profile_resolver: ProfileResolver | None = None,
+    ) -> None:
+        self.resolver = resolver
+        self.snapshots = OperationSnapshotBuilder(resolver)
+        selected_profile_resolver = profile_resolver or getattr(
+            eligibility, "profile_resolver", None
+        )
+        self.eligibility = eligibility or PhaseEligibilityResolver(
+            profile_resolver=selected_profile_resolver
+        )
+        self.store = store or ReviewInvocationStore(resolver.repo_root)
+        self.last_snapshot: OperationSnapshot | None = None
+
+    def _run_git(self, args: Sequence[str], command_id: str) -> None:
+        result = self.resolver.runner.run(["git", *args], command_id=command_id)
+        if result.returncode != 0:
+            raise LckStopError(
+                f"{command_id} failed with exit code {result.returncode}: "
+                f"{result.stderr.strip() or result.stdout.strip()}"
+            )
+
+    def _verify_local_review_head(self, branch: str, expected_head: str) -> None:
+        current = self.resolver.runner.run(
+            ["git", "branch", "--show-current"],
+            command_id="lck-remediation-post-branch",
+        )
+        head = self.resolver.runner.run(
+            ["git", "rev-parse", "HEAD"],
+            command_id="lck-remediation-post-head",
+        )
+        if (
+            current.returncode != 0
+            or current.stdout.strip() != branch
+            or head.returncode != 0
+            or head.stdout.strip() != expected_head
+        ):
+            raise LckStopError(
+                "Remediation Prepare postcondition failed: workspace is not on "
+                "the operation snapshot PR head"
+            )
+
+    def prepare(
+        self,
+        task_number: int,
+        review_id: str,
+        *,
+        findings_file: Path | None = None,
+    ) -> RemediationContext:
+        required = self.store.read_review_required(task_number)
+        if required is not None:
+            raise LckStopError(
+                "Remediation STOP: a fresh Independent Review is required after the previous remediation"
+            )
+        findings, findings_source = _remediation_findings(
+            self.store,
+            task_number,
+            review_id,
+            findings_file=findings_file,
+        )
+        snapshot = self.snapshots.acquire(
+            task_number,
+            operation=Phase.REMEDIATION_PREPARE.value,
+        )
+        self.last_snapshot = snapshot
+        state = snapshot.state
+        decision = self.eligibility.resolve(state, Phase.REMEDIATION_PREPARE)
+        if not decision.eligible:
+            raise LckStopError(
+                f"Remediation Prepare STOP for Task #{task_number}: "
+                + "; ".join(decision.reasons)
+            )
+
+        branch = state.target_branch
+        current = state.git.get("branch")
+        clean = state.git.get("clean") is True
+        action = "already-prepared"
+        if state.local_issue_branch is None:
+            if not clean:
+                raise LckStopError(
+                    "restoring Remediation workspace requires a clean current worktree"
+                )
+            if state.remote_issue_branch != branch:
+                raise LckStopError(
+                    "current OPEN PR has no restorable remote Task branch"
+                )
+            self._run_git(
+                ["switch", "-c", branch, "--track", f"origin/{branch}"],
+                "lck-remediation-restore-branch",
+            )
+            action = "restored-remote-branch"
+        elif current != branch:
+            if not clean:
+                raise LckStopError(
+                    "cannot switch to Remediation branch with a dirty unrelated worktree"
+                )
+            self._run_git(["switch", branch], "lck-remediation-switch-branch")
+            action = "selected-existing-branch"
+        elif not clean:
+            action = "resumed-dirty-remediation"
+
+        pr_head = state.open_pr.get("headRefOid") if state.open_pr else None
+        if not is_sha(pr_head):
+            raise LckStopError("Remediation Prepare PR head is unavailable")
+        self._verify_local_review_head(branch, pr_head)
+        pr_number = state.open_pr.get("number") if state.open_pr else None
+        pr_base = state.open_pr.get("baseRefOid") if state.open_pr else None
+        if not isinstance(pr_number, int) or not is_sha(pr_base):
+            raise LckStopError("Remediation Prepare PR identity is unavailable")
+        self.store.write_remediation_session(
+            task_number,
+            {
+                "schema_version": LCK_SCHEMA_VERSION,
+                "kind": "remediation-session",
+                "task_number": task_number,
+                "review_id": review_id,
+                "operation_id": self.store.new_id(),
+                "start_head_sha": pr_head,
+                "pr_number": pr_number,
+                "base_sha": pr_base,
+                "findings_sha256": hashlib.sha256(findings.encode("utf-8")).hexdigest(),
+                "findings_source": findings_source,
+                "authority": (
+                    "operation-local continuity only; current mechanical target must be "
+                    "reacquired by the Remediation terminal operation"
+                ),
+            },
+        )
+        return RemediationContext(
+            task_number=task_number,
+            review_id=review_id,
+            findings=findings,
+            findings_source=findings_source,
+            operation_snapshot=snapshot,
+            action=action,
+        )
+
+
+@dataclass(frozen=True)
+class RemediationNoChangeResult:
+    task_number: int
+    review_id: str
+    head_sha: str
+    pr_number: int
+    base_sha: str
+    summary: str
+    operation_snapshot: OperationSnapshot
+    receipt_path: Path
+    replayed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": LCK_SCHEMA_VERSION,
+            "operation": "remediation-no-change",
+            "task_number": self.task_number,
+            "review_id": self.review_id,
+            "status": "NO_IMPLEMENTATION_CHANGE",
+            "issue_profile": _jsonable(self.operation_snapshot.state.issue_profile),
+            "head_sha": self.head_sha,
+            "pr_number": self.pr_number,
+            "base_sha": self.base_sha,
+            "summary": self.summary,
+            "candidate_changed": False,
+            "fresh_review_required": False,
+            "session_released": True,
+            "replayed": self.replayed,
+            "receipt_path": str(self.receipt_path),
+            "operation_snapshot": self.operation_snapshot.to_dict(),
+            "acceptance_boundary": (
+                "This receipt closes one prepared Remediation session without changing the "
+                "candidate. It records a real no-change implementation-path terminal state, "
+                "but it does not satisfy deferred provider/cross-runtime Review acceptance by itself."
+            ),
+            "human_boundary": (
+                "STOP — continue external acceptance work on the unchanged head; no fresh Review "
+                "is required solely because this no-change session was closed"
+            ),
+        }
+
+
+class RemediationNoChangeCompleter:
+    """Close one prepared Remediation session when semantic repair needs no tree change."""
+
+    def __init__(
+        self,
+        resolver: LiveStateResolver,
+        *,
+        eligibility: PhaseEligibilityResolver | None = None,
+        store: ReviewInvocationStore | None = None,
+        profile_resolver: ProfileResolver | None = None,
+    ) -> None:
+        self.resolver = resolver
+        self.snapshots = OperationSnapshotBuilder(resolver)
+        selected_profile_resolver = profile_resolver or getattr(
+            eligibility, "profile_resolver", None
+        )
+        self.eligibility = eligibility or PhaseEligibilityResolver(
+            profile_resolver=selected_profile_resolver
+        )
+        self.store = store or ReviewInvocationStore(resolver.repo_root)
+        self.last_snapshot: OperationSnapshot | None = None
+
+    @staticmethod
+    def _session_identity(
+        session: Mapping[str, Any],
+    ) -> tuple[str, int, str]:
+        head_sha = session.get("start_head_sha")
+        pr_number = session.get("pr_number")
+        base_sha = session.get("base_sha")
+        if (
+            not is_sha(head_sha)
+            or not isinstance(pr_number, int)
+            or isinstance(pr_number, bool)
+            or not is_sha(base_sha)
+        ):
+            raise LckStopError("Remediation session identity is incomplete")
+        return head_sha, pr_number, base_sha
+
+    @staticmethod
+    def _verify_current_target(
+        snapshot: OperationSnapshot,
+        *,
+        head_sha: str,
+        pr_number: int,
+        base_sha: str,
+    ) -> None:
+        state = snapshot.state
+        pr = state.open_pr or {}
+        if (
+            pr.get("number") != pr_number
+            or pr.get("headRefOid") != head_sha
+            or pr.get("baseRefOid") != base_sha
+            or state.local_issue_head != head_sha
+            or state.remote_issue_oid != head_sha
+        ):
+            raise LckStopError(
+                "Remediation No Change target no longer matches the prepared session"
+            )
+        if state.git.get("clean") is not True:
+            raise LckStopError(
+                "Remediation No Change requires a clean tracked and staged worktree"
+            )
+
+    def complete(
+        self,
+        task_number: int,
+        review_id: str,
+        *,
+        summary: str,
+    ) -> RemediationNoChangeResult:
+        if self.store.read_review_required(task_number) is not None:
+            raise LckStopError(
+                "Remediation STOP: a fresh Independent Review is required after the previous remediation"
+            )
+
+        session = self.store.read_remediation_session(task_number)
+        if session is None:
+            prior = self.store.read_remediation_no_change_receipt(
+                task_number, review_id
+            )
+            if prior is None:
+                raise LckStopError(
+                    "Remediation No Change requires a prepared Remediation session"
+                )
+            head_sha, pr_number, base_sha = self._session_identity(prior)
+            snapshot = self.snapshots.acquire(
+                task_number, operation=Phase.REMEDIATION_NO_CHANGE.value
+            )
+            self.last_snapshot = snapshot
+            decision = self.eligibility.resolve(
+                snapshot.state, Phase.REMEDIATION_NO_CHANGE
+            )
+            if not decision.eligible:
+                raise LckStopError(
+                    f"Remediation No Change STOP for Task #{task_number}: "
+                    + "; ".join(decision.reasons)
+                )
+            self._verify_current_target(
+                snapshot,
+                head_sha=head_sha,
+                pr_number=pr_number,
+                base_sha=base_sha,
+            )
+            return RemediationNoChangeResult(
+                task_number=task_number,
+                review_id=review_id,
+                head_sha=head_sha,
+                pr_number=pr_number,
+                base_sha=base_sha,
+                summary=str(prior.get("summary") or ""),
+                operation_snapshot=snapshot,
+                receipt_path=self.store.remediation_no_change_receipt_path(
+                    task_number, review_id
+                ),
+                replayed=True,
+            )
+
+        if session.get("review_id") != review_id:
+            raise LckStopError(
+                "Remediation No Change review id does not match the prepared Remediation session"
+            )
+        head_sha, pr_number, base_sha = self._session_identity(session)
+        snapshot = self.snapshots.acquire(
+            task_number, operation=Phase.REMEDIATION_NO_CHANGE.value
+        )
+        self.last_snapshot = snapshot
+        decision = self.eligibility.resolve(snapshot.state, Phase.REMEDIATION_NO_CHANGE)
+        if not decision.eligible:
+            raise LckStopError(
+                f"Remediation No Change STOP for Task #{task_number}: "
+                + "; ".join(decision.reasons)
+            )
+        self._verify_current_target(
+            snapshot,
+            head_sha=head_sha,
+            pr_number=pr_number,
+            base_sha=base_sha,
+        )
+
+        receipt = {
+            "schema_version": LCK_SCHEMA_VERSION,
+            "kind": "remediation-no-change-receipt",
+            "task_number": task_number,
+            "review_id": review_id,
+            "start_head_sha": head_sha,
+            "pr_number": pr_number,
+            "base_sha": base_sha,
+            "findings_sha256": session.get("findings_sha256"),
+            "findings_source": session.get("findings_source"),
+            "summary": summary,
+            "candidate_changed": False,
+            "fresh_review_required": False,
+            "authority": (
+                "formal no-change Remediation terminal receipt only; current mechanical "
+                "target was reacquired at completion"
+            ),
+        }
+        receipt_path = self.store.write_remediation_no_change_receipt(
+            task_number, review_id, receipt
+        )
+        self.store.clear_remediation_session(task_number)
+        return RemediationNoChangeResult(
+            task_number=task_number,
+            review_id=review_id,
+            head_sha=head_sha,
+            pr_number=pr_number,
+            base_sha=base_sha,
+            summary=summary,
+            operation_snapshot=snapshot,
+            receipt_path=receipt_path,
+        )
+
+
+@dataclass(frozen=True)
+class RemediationCompletionResult:
+    task_number: int
+    review_id: str
+    delivery: DeliveryCompletionResult
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = self.delivery.to_dict()
+        return {
+            "schema_version": LCK_SCHEMA_VERSION,
+            "operation": "remediation-complete",
+            "task_number": self.task_number,
+            "review_id": self.review_id,
+            "status": "READY_FOR_NEW_REVIEW",
+            "head_sha": self.delivery.head_sha,
+            "issue_profile": _jsonable(
+                self.delivery.operation_snapshot.state.issue_profile
+            ),
+            "critical_outcome": payload["critical_outcome"],
+            "profile_evidence": payload["profile_evidence"],
+            "validation": payload["validation"],
+            "checks": payload["checks"],
+            "effects": payload["effects"],
+            "operation_snapshot": payload["operation_snapshot"],
+            "human_boundary": (
+                "STOP — a new Independent Review must be started explicitly in a fresh invocation"
+            ),
+            "deferred_review_acceptance": (
+                "Any requirement whose evidence depends on this new head or on a separate provider/"
+                "fresh Review remains pending for the next Independent Review. READY_FOR_NEW_REVIEW "
+                "does not claim that such evidence is satisfied."
+            ),
+            "automatic_review": False,
+        }
+
+
+class RemediationCompleter:
+    """Reuse Task-2 Delivery effects for one explicitly started repair."""
+
+    def __init__(
+        self,
+        resolver: LiveStateResolver,
+        *,
+        eligibility: PhaseEligibilityResolver | None = None,
+        store: ReviewInvocationStore | None = None,
+        checks_gate: DeliveryChecksGate | None = None,
+        policy_registry: ProfilePolicyRegistry | None = None,
+        profile_resolver: ProfileResolver | None = None,
+    ) -> None:
+        self.resolver = resolver
+        self.snapshots = OperationSnapshotBuilder(resolver)
+        self.policy_registry = policy_registry or DEFAULT_PROFILE_POLICY_REGISTRY
+        self.profile_resolver = profile_resolver or getattr(
+            eligibility, "profile_resolver", None
+        )
+        self.eligibility = eligibility or PhaseEligibilityResolver(
+            registry=self.policy_registry,
+            profile_resolver=profile_resolver,
+        )
+        self.store = store or ReviewInvocationStore(resolver.repo_root)
+        self.checks_gate = checks_gate or DeliveryChecksGate(resolver)
+        self.last_snapshot: OperationSnapshot | None = None
+        self.last_critical_outcome: dict[str, Any] | None = None
+        self.last_profile_evidence: ProfileEvidenceEnvelope | None = None
+        self.last_validation: dict[str, Any] | None = None
+        self.last_checks: dict[str, Any] | None = None
+        self.last_effects: list[EffectReceipt] = []
+
+    def _capture_delivery_evidence(self, delivery: Any) -> None:
+        """Expose nested Delivery evidence to the outer failure receipt."""
+        snapshot = getattr(delivery, "last_snapshot", None)
+        if isinstance(snapshot, OperationSnapshot):
+            self.last_snapshot = snapshot
+        critical = getattr(delivery, "last_critical_outcome", None)
+        if isinstance(critical, dict):
+            self.last_critical_outcome = critical
+        profile_evidence = getattr(delivery, "last_profile_evidence", None)
+        if isinstance(profile_evidence, ProfileEvidenceEnvelope):
+            self.last_profile_evidence = profile_evidence
+        validation = getattr(delivery, "last_validation", None)
+        if isinstance(validation, dict):
+            self.last_validation = validation
+        checks = getattr(delivery, "last_checks", None)
+        if isinstance(checks, Mapping):
+            self.last_checks = dict(checks)
+        effects = getattr(delivery, "last_effects", None)
+        if isinstance(effects, list):
+            self.last_effects = effects
+
+    def _owned_candidate_recovery(
+        self,
+        session: Mapping[str, Any],
+        state: LiveState,
+        *,
+        task_number: int,
+        review_id: str,
+    ) -> bool:
+        candidate = session.get("candidate")
+        if not isinstance(candidate, Mapping):
+            return False
+        operation_id = session.get("operation_id")
+        start_head = session.get("start_head_sha")
+        candidate_head = candidate.get("head_sha")
+        candidate_tree = candidate.get("tree_oid")
+        pr = state.open_pr or {}
+        exact_identity = (
+            session.get("task_number") == task_number
+            and session.get("review_id") == review_id
+            and isinstance(operation_id, str)
+            and bool(operation_id)
+            and candidate.get("operation_id") == operation_id
+            and candidate.get("start_head_sha") == start_head
+            and is_sha(start_head)
+            and is_sha(candidate_head)
+            and is_sha(candidate_tree)
+            and pr.get("number") == session.get("pr_number")
+            and pr.get("baseRefOid") == session.get("base_sha")
+            and pr.get("headRefOid") == start_head
+            and state.remote_issue_oid == start_head
+            and state.local_issue_head == candidate_head
+            and state.git.get("branch") == state.target_branch
+            and state.git.get("clean") is True
+        )
+        if not exact_identity:
+            raise LckStopError(
+                "Remediation committed candidate does not exactly match its owned session target"
+            )
+        tree = self.resolver.runner.run(
+            ["git", "rev-parse", "HEAD^{tree}"],
+            command_id="lck-remediation-owned-candidate-tree",
+        )
+        if tree.returncode != 0 or tree.stdout.strip() != candidate_tree:
+            raise LckStopError(
+                "Remediation committed candidate tree does not match its owned session identity"
+            )
+        ancestor = self.resolver.runner.run(
+            [
+                "git",
+                "merge-base",
+                "--is-ancestor",
+                str(start_head),
+                str(candidate_head),
+            ],
+            command_id="lck-remediation-owned-candidate-ancestry",
+        )
+        if ancestor.returncode != 0:
+            raise LckStopError(
+                "Remediation committed candidate is not a descendant of its session start head"
+            )
+        return True
+
+    def complete(
+        self,
+        task_number: int,
+        review_id: str,
+        *,
+        commit_message: str,
+        summary: str,
+        risks: str = "",
+    ) -> RemediationCompletionResult:
+        self.last_checks = None
+        if self.store.read_review_required(task_number) is not None:
+            raise LckStopError(
+                "Remediation STOP: a fresh Independent Review is required after the previous remediation"
+            )
+        session = self.store.read_remediation_session(task_number)
+        start_head: str | None = None
+        if session is not None:
+            if session.get("review_id") != review_id:
+                raise LckStopError(
+                    "Remediation Complete review id does not match the prepared Remediation session"
+                )
+            candidate = session.get("start_head_sha")
+            if not is_sha(candidate):
+                raise LckStopError("Remediation session start head is unavailable")
+            start_head = candidate
+        else:
+            # Backward-compatible path for an already-prepared Codex workspace from
+            # before remediation sessions were introduced. Existing local Review
+            # records retain their previous behavior.
+            record = _failed_review_record(self.store, task_number, review_id)
+            reviewed_identity = _identity_from_mapping(
+                cast(Mapping[str, Any], record["identity"])
+            )
+            start_head = reviewed_identity.head_sha
+        snapshot = self.snapshots.acquire(
+            task_number,
+            operation=Phase.REMEDIATION_COMPLETE.value,
+        )
+        self.last_snapshot = snapshot
+        state = snapshot.state
+        owned_candidate = False
+        pr_head = state.open_pr.get("headRefOid") if state.open_pr else None
+        if (
+            session is not None
+            and session.get("candidate") is not None
+            and state.local_issue_head != pr_head
+        ):
+            owned_candidate = self._owned_candidate_recovery(
+                session,
+                state,
+                task_number=task_number,
+                review_id=review_id,
+            )
+        decision = self.eligibility.resolve(
+            state,
+            Phase.REMEDIATION_COMPLETE,
+            owned_remediation_candidate=owned_candidate,
+        )
+        if not decision.eligible:
+            raise LckStopError(
+                f"Remediation Complete STOP for Task #{task_number}: "
+                + "; ".join(decision.reasons)
+            )
+        if state.git.get("clean") is True and state.local_issue_head == start_head:
+            raise LckStopError(
+                "Remediation Complete requires a repaired head or uncommitted repair changes"
+            )
+
+        # Initial Delivery already owns the bounded validate/commit/push/check
+        # mechanics.  Remediation deliberately reuses those effects while
+        # replacing PR create/resolve with a strict existing-PR postcondition.
+        def record_candidate(head_sha: str, tree_oid: str) -> None:
+            if session is None or start_head is None:
+                return
+            self.store.record_remediation_candidate(
+                task_number,
+                review_id,
+                start_head_sha=start_head,
+                candidate_head_sha=head_sha,
+                candidate_tree_oid=tree_oid,
+            )
+
+        delivery_completer = DeliveryCompleter(
+            self.resolver,
+            pr_effect=cast(Any, ReuseExistingOpenPrEffect(self.resolver)),
+            checks_gate=self.checks_gate,
+            policy_registry=self.policy_registry,
+            profile_resolver=self.profile_resolver,
+            require_existing_open_pr=True,
+            candidate_recorder=record_candidate,
+        )
+        try:
+            delivery = delivery_completer.complete(
+                task_number,
+                commit_message=commit_message,
+                summary=summary,
+                risks=risks,
+                operation_snapshot=snapshot,
+                phase=Phase.REMEDIATION_COMPLETE,
+                owned_remediation_candidate=owned_candidate,
+            )
+        except BaseException:
+            self._capture_delivery_evidence(delivery_completer)
+            raise
+        self._capture_delivery_evidence(delivery_completer)
+        if delivery.head_sha == start_head:
+            raise LckStopError(
+                "Remediation Complete did not produce a new head; fresh Review boundary cannot advance"
+            )
+        self.store.write_review_required(task_number, review_id, delivery.head_sha)
+        self.store.clear_remediation_session(task_number)
+        return RemediationCompletionResult(
+            task_number=task_number,
+            review_id=review_id,
+            delivery=delivery,
+        )

--- a/tools/lck/research_policy.py
+++ b/tools/lck/research_policy.py
@@ -1,0 +1,569 @@
+"""Repository-backed Research artifact and decision policy.
+
+Research is deliberately a small, typed policy surface.  The lifecycle
+controllers remain shared with Task and Documentation; this module only
+answers the Research-specific questions: which files are artifacts, which
+decision values are accepted, and how an artifact is bound to a reviewed
+identity.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Any, Final
+
+from .common import sha256_json
+from .issue_forms import (
+    IssueFormTemplateContract,
+    IssueFormTemplateError,
+    load_issue_form_template,
+    parse_issue_form_contract,
+)
+from .markdown_sections import extract_markdown_sections
+
+RESEARCH_POLICY_ID: Final = "repository-research-artifact-v1"
+RESEARCH_ARTIFACT_PREFIX: Final = "docs/research/"
+RESEARCH_OUTCOME_FIELD: Final = "Research Outcome"
+RESEARCH_TEMPLATE_PATH: Final = Path(".github/ISSUE_TEMPLATE/research.yml")
+
+
+class ResearchOutcome(StrEnum):
+    """The only decisions that a Research workflow may persist."""
+
+    IMPLEMENT = "IMPLEMENT"
+    DO_NOT_IMPLEMENT = "DO NOT IMPLEMENT"
+    NEEDS_MORE_EVIDENCE = "NEEDS MORE EVIDENCE"
+    ARCHITECTURE_DECISION = "ARCHITECTURE DECISION"
+
+
+RESEARCH_OUTCOMES: Final = tuple(item.value for item in ResearchOutcome)
+_IMPLEMENTATION_OUTCOMES: Final = frozenset(
+    {ResearchOutcome.IMPLEMENT.value, ResearchOutcome.ARCHITECTURE_DECISION.value}
+)
+_OUTCOME_RE: Final = re.compile(
+    r"^\s*(?:research\s+outcome|outcome)\s*:\s*(.*?)\s*$",
+    re.IGNORECASE,
+)
+_OUTCOME_HEADING_RE: Final = re.compile(
+    r"^\s{0,3}#{1,6}\s+research\s+outcome\s*#*\s*$", re.IGNORECASE
+)
+_SAFE_ARTIFACT_SUFFIXES: Final = frozenset(
+    {".csv", ".json", ".md", ".txt", ".yaml", ".yml"}
+)
+
+
+class ResearchPolicyError(ValueError):
+    """A Research artifact or typed decision is not safe to accept."""
+
+
+class ResearchPolicyStatus(StrEnum):
+    PASS = "pass"
+    RECLASSIFICATION_REQUIRED = "reclassification_required"
+    OUTCOME_REQUIRED = "outcome_required"
+
+
+ResearchTemplateContract = IssueFormTemplateContract
+
+
+class ResearchTemplateError(IssueFormTemplateError):
+    """The repository-owned Research Issue form is not usable."""
+
+
+@dataclass(frozen=True)
+class ResearchContract:
+    status: ResearchPolicyStatus
+    required_sections: tuple[str, ...] = ()
+    missing_sections: tuple[str, ...] = ()
+    duplicate_sections: tuple[str, ...] = ()
+    empty_sections: tuple[str, ...] = ()
+    template_path: str = RESEARCH_TEMPLATE_PATH.as_posix()
+    detail: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status.value,
+            "required_sections": list(self.required_sections),
+            "missing_sections": list(self.missing_sections),
+            "duplicate_sections": list(self.duplicate_sections),
+            "empty_sections": list(self.empty_sections),
+            "template_path": self.template_path,
+            **({"detail": self.detail} if self.detail else {}),
+        }
+
+
+@dataclass(frozen=True)
+class ResearchChangeResult:
+    status: ResearchPolicyStatus
+    policy_id: str
+    changed_files: tuple[str, ...]
+    artifact_files: tuple[str, ...] = ()
+    disallowed_files: tuple[str, ...] = ()
+    detail: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "status": self.status.value,
+            "policy_id": self.policy_id,
+            "changed_files": list(self.changed_files),
+            "artifact_files": list(self.artifact_files),
+            "disallowed_files": list(self.disallowed_files),
+        }
+        if self.detail:
+            result["detail"] = self.detail
+        return result
+
+
+def _default_research_template_path() -> Path:
+    return Path(__file__).resolve().parents[2] / RESEARCH_TEMPLATE_PATH
+
+
+def research_template_contract(
+    template_path: Path | None = None,
+) -> ResearchTemplateContract:
+    """Load required Research fields from the formal Issue form."""
+
+    path = template_path or _default_research_template_path()
+    return load_issue_form_template(
+        path,
+        form_name="Research",
+        template_display_path=RESEARCH_TEMPLATE_PATH.as_posix(),
+        error_type=ResearchTemplateError,
+    )
+
+
+def research_contract_snapshot(
+    body: str | None,
+    *,
+    template_path: Path | None = None,
+) -> dict[str, Any]:
+    """Return a bounded typed snapshot of the Research Issue Form contract."""
+
+    parsed = parse_issue_form_contract(
+        body,
+        template_path=template_path or _default_research_template_path(),
+        form_name="Research",
+        template_display_path=RESEARCH_TEMPLATE_PATH.as_posix(),
+        error_type=ResearchTemplateError,
+        valid_status=ResearchPolicyStatus.PASS.value,
+        invalid_status=ResearchPolicyStatus.RECLASSIFICATION_REQUIRED.value,
+    )
+    return ResearchContract(
+        ResearchPolicyStatus(parsed.status),
+        required_sections=parsed.required_sections,
+        missing_sections=parsed.missing_sections,
+        duplicate_sections=parsed.duplicate_sections,
+        empty_sections=parsed.empty_sections,
+        template_path=parsed.template_path,
+        detail=parsed.detail,
+    ).to_dict()
+
+
+def is_valid_research_contract(value: object) -> bool:
+    """Validate the bounded Research contract consumed by LCK eligibility."""
+
+    if not isinstance(value, Mapping):
+        return False
+    try:
+        template = research_template_contract()
+    except ResearchTemplateError:
+        return False
+    return (
+        value.get("status") == ResearchPolicyStatus.PASS.value
+        and value.get("required_sections") == list(template.section_labels)
+        and value.get("missing_sections") == []
+        and value.get("duplicate_sections") == []
+        and value.get("empty_sections") == []
+        and value.get("template_path") == RESEARCH_TEMPLATE_PATH.as_posix()
+    )
+
+
+_DECISION_CONTRACT_HEADINGS: Final = frozenset(
+    {"decision contract", "architecture decision contract", "adr"}
+)
+
+
+def decision_contract_snapshot(
+    body: str | None,
+    *,
+    research: bool = False,
+) -> dict[str, Any]:
+    """Extract the explicit contract that an Architecture Decision authorizes.
+
+    Research uses its required Expected Outcome / Artifact section as the
+    fallback contract. Downstream implementation Issues must opt in with an
+    explicit Decision Contract (or ADR) section, so an empty or unrelated Task
+    body cannot satisfy an Architecture Decision dependency by accident.
+    """
+
+    if not isinstance(body, str) or not body.strip():
+        return {"status": "unknown", "detail": "decision contract body unavailable"}
+    sections = tuple(
+        (section.name, section.content)
+        for section in extract_markdown_sections(
+            body,
+            canonical_names=tuple(_DECISION_CONTRACT_HEADINGS)
+            + ("Expected Outcome / Artifact",),
+        )
+    )
+    selected: tuple[str, str] | None = None
+    for heading, content in sections:
+        if heading.casefold() in _DECISION_CONTRACT_HEADINGS:
+            if selected is not None:
+                return {
+                    "status": "unknown",
+                    "detail": "decision contract is duplicated",
+                }
+            selected = (heading, content)
+    if selected is None and research:
+        for heading, content in sections:
+            if heading.casefold() == "expected outcome / artifact":
+                selected = (heading, content)
+                break
+    if selected is None or not selected[1].strip():
+        return {
+            "status": "unknown",
+            "detail": "decision contract is missing or empty",
+        }
+    normalized = " ".join(selected[1].split())
+    return {
+        "status": "pass",
+        "heading": selected[0],
+        "contract_sha256": sha256_json({"contract": normalized}),
+    }
+
+
+def architecture_decision_is_consistent(
+    research_decision: object,
+    downstream_contract: object,
+) -> bool:
+    """Return whether a downstream Issue explicitly matches the decision."""
+
+    if not isinstance(research_decision, Mapping) or not isinstance(
+        downstream_contract, Mapping
+    ):
+        return False
+    if research_decision.get("status") != "pass":
+        return False
+    downstream_decision = downstream_contract.get("decision_contract")
+    if not isinstance(downstream_decision, Mapping):
+        body = downstream_contract.get("body")
+        downstream_decision = decision_contract_snapshot(
+            body if isinstance(body, str) else None
+        )
+    return downstream_decision.get("status") == "pass" and downstream_decision.get(
+        "contract_sha256"
+    ) == research_decision.get("contract_sha256")
+
+
+def parse_research_outcome(value: object) -> ResearchOutcome:
+    """Parse one exact typed outcome and reject unknown values."""
+
+    if not isinstance(value, str):
+        raise ResearchPolicyError("Research Outcome must be one of the typed values")
+    normalized = " ".join(value.split()).upper()
+    try:
+        return ResearchOutcome(normalized)
+    except ValueError as exc:
+        allowed = ", ".join(RESEARCH_OUTCOMES)
+        raise ResearchPolicyError(
+            f"unknown Research Outcome {value!r}; allowed values: {allowed}"
+        ) from exc
+
+
+def is_implementation_outcome(value: object) -> bool:
+    """Return whether a typed Research decision may satisfy implementation entry."""
+
+    try:
+        outcome = parse_research_outcome(value)
+    except ResearchPolicyError:
+        return False
+    return outcome.value in _IMPLEMENTATION_OUTCOMES
+
+
+def _safe_path(path: str) -> bool:
+    return bool(
+        path
+        and not path.startswith("/")
+        and "\\" not in path
+        and all(part not in {"", ".", ".."} for part in path.split("/"))
+    )
+
+
+def _is_allowed_artifact(path: str) -> bool:
+    return (
+        _safe_path(path)
+        and path.startswith(RESEARCH_ARTIFACT_PREFIX)
+        and path != RESEARCH_ARTIFACT_PREFIX
+        and Path(path).suffix.casefold() in _SAFE_ARTIFACT_SUFFIXES
+    )
+
+
+def _resolve_research_artifact_path(repo_root: Path, relative: str) -> Path:
+    """Resolve an artifact only when its complete path stays in the namespace."""
+
+    root = repo_root.resolve()
+    candidate = root / relative
+    current = root
+    try:
+        for part in Path(relative).parts:
+            current /= part
+            if current.is_symlink():
+                raise ResearchPolicyError(
+                    f"Research artifacts must not use symlinks: {relative}"
+                )
+        resolved = candidate.resolve()
+        artifact_root = (root / RESEARCH_ARTIFACT_PREFIX.rstrip("/")).resolve()
+        resolved.relative_to(artifact_root)
+    except ResearchPolicyError:
+        raise
+    except (OSError, RuntimeError) as exc:
+        raise ResearchPolicyError(
+            f"Research artifact path cannot be inspected: {relative}"
+        ) from exc
+    except ValueError as exc:
+        raise ResearchPolicyError(
+            f"Research artifact path resolves outside docs/research/: {relative}"
+        ) from exc
+    return resolved
+
+
+def _artifact_path_policy_error(repo_root: Path, relative: str) -> str | None:
+    try:
+        _resolve_research_artifact_path(repo_root, relative)
+    except ResearchPolicyError as exc:
+        return str(exc)
+    return None
+
+
+def evaluate_research_changes(
+    changed_files: Iterable[str],
+    *,
+    repo_root: Path | None = None,
+) -> ResearchChangeResult:
+    """Allow only versioned, non-executable Research artifacts.
+
+    ``repo_root`` is required for callers that will read the artifacts.  When
+    provided, the complete path is checked without following symlinks and its
+    resolved target must remain under ``docs/research/``.
+    """
+
+    normalized = tuple(sorted({path.strip() for path in changed_files if path.strip()}))
+    path_errors = {
+        path: _artifact_path_policy_error(repo_root, path)
+        for path in normalized
+        if repo_root is not None and _is_allowed_artifact(path)
+    }
+    disallowed = tuple(
+        path
+        for path in normalized
+        if not _is_allowed_artifact(path) or path_errors.get(path) is not None
+    )
+    if disallowed:
+        detail = (
+            "Research candidate exceeds the repository-owned artifact policy; "
+            "reclassification or split required for: " + ", ".join(disallowed)
+        )
+        reasons = tuple(
+            reason
+            for path in disallowed
+            if (reason := path_errors.get(path)) is not None
+        )
+        if reasons:
+            detail += "; " + "; ".join(reasons)
+        return ResearchChangeResult(
+            ResearchPolicyStatus.RECLASSIFICATION_REQUIRED,
+            RESEARCH_POLICY_ID,
+            normalized,
+            artifact_files=tuple(path for path in normalized if path not in disallowed),
+            disallowed_files=disallowed,
+            detail=detail,
+        )
+    if not normalized:
+        return ResearchChangeResult(
+            ResearchPolicyStatus.RECLASSIFICATION_REQUIRED,
+            RESEARCH_POLICY_ID,
+            normalized,
+            detail="Research candidate contains no versioned artifact files",
+        )
+    return ResearchChangeResult(
+        ResearchPolicyStatus.PASS,
+        RESEARCH_POLICY_ID,
+        normalized,
+        artifact_files=normalized,
+    )
+
+
+def _declared_outcomes(text: str, *, path: str) -> list[ResearchOutcome]:
+    values: list[ResearchOutcome] = []
+    lines = text.splitlines()
+    for index, line in enumerate(lines):
+        match = _OUTCOME_RE.match(line)
+        if match:
+            try:
+                values.append(parse_research_outcome(match.group(1)))
+            except ResearchPolicyError as exc:
+                raise ResearchPolicyError(f"{path}: {exc}") from exc
+            continue
+        if _OUTCOME_HEADING_RE.match(line):
+            following = next(
+                (
+                    candidate.strip()
+                    for candidate in lines[index + 1 :]
+                    if candidate.strip()
+                ),
+                "",
+            )
+            following = following.strip("`*_ ")
+            try:
+                values.append(parse_research_outcome(following))
+            except ResearchPolicyError as exc:
+                raise ResearchPolicyError(
+                    f"{path}: Research Outcome heading must be followed by a typed value"
+                ) from exc
+    return values
+
+
+def _artifact_digests(
+    repo_root: Path, artifact_files: tuple[str, ...]
+) -> list[dict[str, str]]:
+    digests: list[dict[str, str]] = []
+    for relative in artifact_files:
+        path = _resolve_research_artifact_path(repo_root, relative)
+        if not path.is_file():
+            raise ResearchPolicyError(f"Research artifact is unavailable: {relative}")
+        try:
+            content = path.read_bytes()
+        except OSError as exc:
+            raise ResearchPolicyError(
+                f"Research artifact cannot be read: {relative}"
+            ) from exc
+        digests.append(
+            {"path": relative, "sha256": hashlib.sha256(content).hexdigest()}
+        )
+    return digests
+
+
+def research_artifact_outcome(
+    repo_root: Path, artifact_files: Iterable[str]
+) -> ResearchOutcome | None:
+    """Read an optional typed outcome declaration from the artifact set."""
+
+    policy = evaluate_research_changes(artifact_files, repo_root=repo_root)
+    if policy.status is not ResearchPolicyStatus.PASS:
+        raise ResearchPolicyError(
+            policy.detail or "Research artifact policy rejected the candidate"
+        )
+    declared: list[ResearchOutcome] = []
+    for relative in policy.artifact_files:
+        path = _resolve_research_artifact_path(repo_root, relative)
+        if not path.is_file():
+            raise ResearchPolicyError(f"Research artifact is unavailable: {relative}")
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            raise ResearchPolicyError(
+                f"Research artifact cannot be read: {relative}"
+            ) from exc
+        declared.extend(_declared_outcomes(text, path=relative))
+    distinct = {item.value for item in declared}
+    if len(distinct) > 1:
+        raise ResearchPolicyError(
+            "Research artifacts declare conflicting outcomes: "
+            + ", ".join(sorted(distinct))
+        )
+    return next(iter(declared), None)
+
+
+def research_artifact_binding(
+    repo_root: Path,
+    *,
+    task_number: int,
+    pr_number: int | None,
+    base_sha: str,
+    head_sha: str,
+    task_body_sha256: str,
+    merge_base_sha: str,
+    effective_diff_sha256: str,
+    changed_files: Iterable[str],
+    outcome: object | None = None,
+) -> dict[str, Any]:
+    """Bind a Research decision candidate to exact artifact and diff identity."""
+
+    policy = evaluate_research_changes(changed_files, repo_root=repo_root)
+    if policy.status is not ResearchPolicyStatus.PASS:
+        raise ResearchPolicyError(
+            policy.detail or "Research artifact policy rejected the candidate"
+        )
+
+    artifact_digests = _artifact_digests(repo_root, policy.artifact_files)
+    declared: list[ResearchOutcome] = []
+    for item in artifact_digests:
+        try:
+            text = _resolve_research_artifact_path(repo_root, item["path"]).read_text(
+                encoding="utf-8"
+            )
+        except (OSError, UnicodeDecodeError) as exc:
+            raise ResearchPolicyError(
+                f"Research artifact cannot be read: {item['path']}"
+            ) from exc
+        declared.extend(_declared_outcomes(text, path=item["path"]))
+    distinct = {item.value for item in declared}
+    if len(distinct) > 1:
+        raise ResearchPolicyError(
+            "Research artifacts declare conflicting outcomes: "
+            + ", ".join(sorted(distinct))
+        )
+    declared_outcome = next(iter(declared), None)
+    explicit_outcome = parse_research_outcome(outcome) if outcome is not None else None
+    if (
+        explicit_outcome is not None
+        and declared_outcome is not None
+        and explicit_outcome is not declared_outcome
+    ):
+        raise ResearchPolicyError(
+            "Research Outcome does not match the reviewed artifact declaration"
+        )
+    selected = explicit_outcome or declared_outcome
+    return {
+        "policy_id": RESEARCH_POLICY_ID,
+        "outcome": selected.value if selected is not None else None,
+        "outcome_status": "typed" if selected is not None else "pending",
+        "task_number": task_number,
+        "pr_number": pr_number,
+        "base_sha": base_sha,
+        "head_sha": head_sha,
+        "task_body_sha256": task_body_sha256,
+        "merge_base_sha": merge_base_sha,
+        "effective_diff_sha256": effective_diff_sha256,
+        "artifact_files": list(policy.artifact_files),
+        "artifact_digests": artifact_digests,
+        "artifact_sha256": sha256_json(artifact_digests),
+    }
+
+
+def bind_research_outcome(
+    binding: Mapping[str, Any], outcome: object
+) -> dict[str, Any]:
+    """Return an existing artifact binding with one validated typed outcome."""
+
+    selected = parse_research_outcome(outcome)
+    current = binding.get("outcome")
+    if current is not None and parse_research_outcome(current) is not selected:
+        raise ResearchPolicyError(
+            "Research Outcome does not match the existing artifact binding"
+        )
+    result = dict(binding)
+    result["outcome"] = selected.value
+    result["outcome_status"] = "typed"
+    return result
+
+
+def require_typed_research_outcome(binding: Mapping[str, Any]) -> ResearchOutcome:
+    """Fail closed at the decision boundary when no typed outcome is bound."""
+
+    return parse_research_outcome(binding.get("outcome"))

--- a/tools/lck/review.py
+++ b/tools/lck/review.py
@@ -1,0 +1,919 @@
+from __future__ import annotations
+
+import hashlib
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any, cast
+
+from . import structured_review_instructions as structured_review_instruction_owner
+from .common import ProgressReporter, is_sha, safe_text
+from .eligibility import PhaseEligibilityResolver
+from .issue_profiles import resolve_leaf_issue_profile
+from .models import (
+    BASE_BRANCH,
+    LCK_SCHEMA_VERSION,
+    LckStopError,
+    LiveState,
+    OperationSnapshot,
+    Phase,
+    ResolutionStatus,
+    ReviewStaleError,
+    _jsonable,
+    _pr_base_sha,
+    _pr_head_sha,
+)
+from .profile_policies import (
+    DEFAULT_PROFILE_POLICY_REGISTRY,
+    PolicyContext,
+    ProfileEvidenceEnvelope,
+    ProfilePolicyError,
+    ProfilePolicyRegistry,
+    ProfileResolver,
+    resolve_issue_policy,
+    validate_profile_review,
+)
+from .review_workspace import (
+    ReviewIdentity,
+    ReviewInvocationStore,
+    ReviewWorkspaceManager,
+    _assert_review_applicable,
+    _assert_review_target_facts_applicable,
+    _identity_from_mapping,
+    _review_identity,
+    _review_target_refs,
+)
+from .state import (
+    LiveStateResolver,
+    OperationSnapshotBuilder,
+    _leaf_contract_from_state,
+    _policy_issue_from_state,
+)
+from .validation_gates import (
+    DeliveryChecksGate,
+    ReviewValidationGate,
+)
+
+
+@dataclass(frozen=True)
+class ReviewContext:
+    review_id: str
+    task_contract: Mapping[str, Any]
+    identity: ReviewIdentity
+    checks: Mapping[str, Any]
+    validation: Mapping[str, Any]
+    review_root: Path
+    issue_profile: Mapping[str, Any] | None = None
+    profile_evidence: ProfileEvidenceEnvelope | None = None
+    structured_review_instructions: Mapping[str, Any] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": LCK_SCHEMA_VERSION,
+            "operation": "review-prepare",
+            "status": "READY_FOR_SEMANTIC_REVIEW",
+            "review_id": self.review_id,
+            "issue_profile": _jsonable(self.issue_profile),
+            "task_contract": _jsonable(self.task_contract),
+            "review_target": self.identity.to_dict(),
+            "checks": _jsonable(self.checks),
+            "validation": _jsonable(self.validation),
+            "profile_evidence": (
+                self.profile_evidence.to_dict() if self.profile_evidence else None
+            ),
+            "structured_review_instructions": (
+                _jsonable(self.structured_review_instructions)
+                if self.structured_review_instructions is not None
+                else _jsonable(
+                    structured_review_instruction_owner.canonical_structured_review_instructions()
+                )
+            ),
+            "review_root": str(self.review_root),
+            "workspace_mode": "implementation-read-only",
+            "agent_role": ["Inspect", "Reason", "Judge", "Report"],
+            "mechanical_authority": "live Git/GitHub state resolved by LCK",
+            "forbidden_handoff_authority": [
+                "Delivery SHA",
+                "Delivery base SHA",
+                "Delivery PR identity",
+                "Delivery checks snapshot",
+                "Delivery validation snapshot",
+            ],
+        }
+
+
+def _review_validation_failure(payload: Mapping[str, Any]) -> str:
+    failed_command: Mapping[str, Any] | None = None
+    commands = payload.get("commands")
+    if isinstance(commands, list):
+        failed_command = next(
+            (
+                item
+                for item in commands
+                if isinstance(item, Mapping) and item.get("status") == "fail"
+            ),
+            None,
+        )
+    evidence = payload.get("evidence_path") or payload.get("output_dir")
+    detail = [f"formal Review validation failed: {payload.get('status', 'fail')}"]
+    if failed_command is not None:
+        command_id = failed_command.get("command_id", "unknown")
+        exit_code = failed_command.get("exit_code", "unknown")
+        diagnostic = safe_text(failed_command.get("diagnostic"), limit=1200)
+        detail.append(f"failed command {command_id} (exit {exit_code})")
+        if diagnostic:
+            detail.append(f"diagnostic: {diagnostic}")
+    base_sha = payload.get("validated_base_sha")
+    head_sha = payload.get("validated_head_sha")
+    if is_sha(base_sha) and is_sha(head_sha):
+        detail.append(f"validated base {base_sha}, head {head_sha}")
+    if isinstance(evidence, str) and evidence:
+        detail.append(f"evidence: {evidence}")
+    return "; ".join(detail)
+
+
+class ReviewPreparer:
+    """Resolve a fresh review target and construct one bounded read-only context."""
+
+    def __init__(
+        self,
+        resolver: LiveStateResolver,
+        *,
+        eligibility: PhaseEligibilityResolver | None = None,
+        validation: ReviewValidationGate | None = None,
+        checks_gate: DeliveryChecksGate | None = None,
+        workspace: ReviewWorkspaceManager | None = None,
+        store: ReviewInvocationStore | None = None,
+        policy_registry: ProfilePolicyRegistry | None = None,
+        profile_resolver: ProfileResolver | None = None,
+    ) -> None:
+        self.resolver = resolver
+        self.snapshots = OperationSnapshotBuilder(resolver)
+        self.policy_registry = policy_registry or DEFAULT_PROFILE_POLICY_REGISTRY
+        self.profile_resolver = (
+            profile_resolver
+            or getattr(eligibility, "profile_resolver", None)
+            or resolve_leaf_issue_profile
+        )
+        self.eligibility = eligibility or PhaseEligibilityResolver(
+            registry=self.policy_registry,
+            profile_resolver=self.profile_resolver,
+        )
+        self.validation = validation or ReviewValidationGate(resolver)
+        self.checks_gate = checks_gate or DeliveryChecksGate(resolver)
+        self.workspace = workspace or ReviewWorkspaceManager(resolver)
+        self.store = store or ReviewInvocationStore(resolver.repo_root)
+        self.last_snapshot: OperationSnapshot | None = None
+        self.last_validation: dict[str, Any] | None = None
+        self.last_documentation_validation: dict[str, Any] | None = None
+        self.last_profile_evidence: ProfileEvidenceEnvelope | None = None
+
+    def prepare(self, task_number: int) -> ReviewContext:
+        self.last_validation = None
+        if self.store.read_remediation_session(task_number) is not None:
+            raise LckStopError(
+                "Review Prepare STOP: a prepared Remediation session must be completed "
+                "or closed with remediation no-change first"
+            )
+        invocation = self.store.begin_review_prepare(task_number)
+        review_root: Path | None = None
+        progress = ProgressReporter("review-prepare")
+        last_stage = "initializing"
+
+        def mark(state: str, **fields: Any) -> None:
+            nonlocal last_stage
+            payload: dict[str, Any] = {
+                "schema_version": LCK_SCHEMA_VERSION,
+                "kind": "review-prepare-in-flight",
+                "operation_id": invocation.operation_id,
+                "task_number": task_number,
+                "pid": os.getpid(),
+                "state": state,
+                "review_root": str(review_root) if review_root else None,
+                "authority": "operation-local in-flight protection only",
+            }
+            payload.update(fields)
+            invocation.update(payload)
+            if state == "failed":
+                progress.failed(last_stage)
+            elif state == "handed-off":
+                progress.completed("handoff")
+            elif state == "started":
+                progress.started("initializing")
+            else:
+                progress.running(state)
+            last_stage = state
+
+        try:
+            mark("started")
+            recovered = invocation.recovered
+            if recovered is not None:
+                previous_root = recovered.get("review_root")
+                if previous_root is not None:
+                    if not isinstance(previous_root, str) or not previous_root:
+                        raise LckStopError(
+                            "stale Review Prepare has an invalid isolated clone path"
+                        )
+                    previous_path = Path(previous_root)
+                    if previous_path.exists():
+                        self.workspace.remove_recovered(previous_path)
+                previous_review_id = recovered.get("review_id")
+                if isinstance(previous_review_id, str):
+                    self.store.delete_guard(previous_review_id)
+            mark("resolving-live-state")
+            snapshot = self.snapshots.acquire(
+                task_number,
+                operation="review-prepare",
+            )
+            self.last_snapshot = snapshot
+            self.last_documentation_validation = None
+            state = snapshot.state
+            decision = self.eligibility.resolve(state, Phase.REVIEW_PREPARE)
+            if not decision.eligible:
+                raise LckStopError(
+                    f"Review Prepare STOP for Task #{task_number}: "
+                    + "; ".join(decision.reasons)
+                )
+            task_contract = _leaf_contract_from_state(state)
+            target = _review_target_refs(state, task_contract)
+            review_root = self.workspace.path_for(task_number, invocation.operation_id)
+            mark(
+                "clone-reserved",
+                target=target.to_dict(),
+                review_root=str(review_root),
+            )
+            self.workspace.create(
+                task_number, target.base_sha, target.head_sha, review_root
+            )
+            mark(
+                "clone-created",
+                target=target.to_dict(),
+                review_root=str(review_root),
+            )
+            mark(
+                "checking-current-pr",
+                target=target.to_dict(),
+            )
+            checks = self.checks_gate.observe(snapshot)
+            identity = _review_identity(
+                self.resolver,
+                state,
+                task_contract,
+                repo_root=review_root,
+                policy_registry=self.policy_registry,
+                profile_resolver=self.profile_resolver,
+            )
+            structured_instructions = structured_review_instruction_owner.canonical_structured_review_instructions()
+            profile, _policy = resolve_issue_policy(
+                _policy_issue_from_state(state),
+                registry=self.policy_registry,
+                profile_resolver=self.profile_resolver or resolve_leaf_issue_profile,
+            )
+            review_stage = validate_profile_review(
+                profile,
+                _policy_issue_from_state(state),
+                {"identity": identity.to_dict(), "verdict": "PREPARE"},
+                registry=self.policy_registry,
+                context=PolicyContext(
+                    profile=profile,
+                    phase="review",
+                    issue=_policy_issue_from_state(state),
+                    repo_root=review_root,
+                    runner=self.resolver.runner,
+                    review_identity=identity.to_dict(),
+                ),
+            )
+            self.last_profile_evidence = review_stage.profile_evidence
+            mark(
+                "review-target-derived",
+                identity=identity.to_dict(),
+                review_root=str(review_root),
+            )
+            mark("formal-validation", identity=identity.to_dict())
+            validation = self.validation.run(
+                review_root, identity.base_sha, identity.head_sha
+            )
+            # Preserve the structured validation result before applying the
+            # pass gate so a rejected Review Prepare has complete evidence.
+            self.last_validation = validation
+            mark(
+                "validation-persisted",
+                identity=identity.to_dict(),
+                validation=validation,
+            )
+            if validation.get("status") != "pass":
+                raise LckStopError(_review_validation_failure(validation))
+            mark(
+                "sealing-review-context",
+                identity=identity.to_dict(),
+                validation=validation,
+                checks=checks,
+            )
+            self.workspace.seal_for_review(review_root, identity.head_sha)
+            review_id = self.store.new_id()
+            guard = {
+                "schema_version": LCK_SCHEMA_VERSION,
+                "kind": "review-invocation-guard",
+                "review_id": review_id,
+                "task_number": task_number,
+                "identity": identity.to_dict(),
+                "review_root": str(review_root),
+                "validation": validation,
+                "checks": checks,
+                "profile_evidence": (
+                    review_stage.profile_evidence.to_dict()
+                    if review_stage.profile_evidence
+                    else None
+                ),
+                "structured_review_instructions": structured_instructions,
+                "snapshot": snapshot.to_dict(),
+                "authority": (
+                    "sealed Review Prepare target; historical identity for Review Complete "
+                    "applicability comparison, never current authority"
+                ),
+            }
+            self.store.write_guard(review_id, guard)
+            mark(
+                "handed-off",
+                identity=identity.to_dict(),
+                validation=validation,
+                checks=checks,
+                review_id=review_id,
+            )
+            context = ReviewContext(
+                review_id=review_id,
+                task_contract=task_contract,
+                identity=identity,
+                checks=checks,
+                validation=validation,
+                review_root=review_root,
+                issue_profile=state.issue_profile,
+                profile_evidence=review_stage.profile_evidence,
+                structured_review_instructions=structured_instructions,
+            )
+            invocation.release_lock()
+        except BaseException as exc:
+            cleanup_error: BaseException | None = None
+            try:
+                mark("failed", error=safe_text(str(exc), limit=1200))
+            except BaseException:
+                pass
+            if review_root is not None and review_root.exists():
+                try:
+                    self.workspace.remove(review_root)
+                except BaseException as remove_exc:
+                    cleanup_error = remove_exc
+            if cleanup_error is not None:
+                raise cleanup_error from exc
+            invocation.finish()
+            raise
+        return context
+
+
+@dataclass(frozen=True)
+class ReviewCompletionResult:
+    review_id: str
+    task_number: int
+    verdict: str
+    status: str
+    identity: ReviewIdentity
+    record_path: Path
+    issue_profile: Mapping[str, Any] | None = None
+    profile_evidence: ProfileEvidenceEnvelope | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        human_boundary = (
+            "STOP; run deterministic Merge Preflight before any manual merge"
+            if self.verdict == "PASS"
+            else "STOP; Human must explicitly choose remediation, redesign, or abandon"
+        )
+        return {
+            "schema_version": LCK_SCHEMA_VERSION,
+            "operation": "review-complete",
+            "review_id": self.review_id,
+            "task_number": self.task_number,
+            "verdict": self.verdict,
+            "status": self.status,
+            "issue_profile": _jsonable(self.issue_profile),
+            "review_target": self.identity.to_dict(),
+            "research_artifact": _jsonable(self.identity.research_artifact),
+            "record_path": str(self.record_path),
+            "profile_evidence": (
+                self.profile_evidence.to_dict() if self.profile_evidence else None
+            ),
+            "human_boundary": human_boundary,
+            "automatic_remediation": False,
+        }
+
+
+class ReviewCompleter:
+    """Accept a semantic verdict only if a fresh completion snapshot still applies.
+
+    ``review prepare`` and ``review complete`` are separate LCK operations.
+    Prepare seals the exact target that the semantic reviewer inspected. Complete
+    acquires one fresh, phase-specific authoritative snapshot, compares it with
+    that sealed target, and accepts the verdict only when the PR, base, head,
+    Task Contract, and effective diff are still identical. Downstream helpers do
+    not reacquire authority inside the Review Complete operation.
+    """
+
+    def __init__(
+        self,
+        resolver: LiveStateResolver,
+        *,
+        eligibility: PhaseEligibilityResolver | None = None,
+        checks_gate: DeliveryChecksGate | None = None,
+        store: ReviewInvocationStore | None = None,
+        workspace: ReviewWorkspaceManager | None = None,
+        policy_registry: ProfilePolicyRegistry | None = None,
+        profile_resolver: ProfileResolver | None = None,
+    ) -> None:
+        self.resolver = resolver
+        self.snapshots = OperationSnapshotBuilder(resolver)
+        self.policy_registry = policy_registry or DEFAULT_PROFILE_POLICY_REGISTRY
+        self.profile_resolver = (
+            profile_resolver
+            or getattr(eligibility, "profile_resolver", None)
+            or resolve_leaf_issue_profile
+        )
+        self.eligibility = eligibility or PhaseEligibilityResolver(
+            registry=self.policy_registry,
+            profile_resolver=self.profile_resolver,
+        )
+        self.checks_gate = checks_gate or DeliveryChecksGate(resolver)
+        self.store = store or ReviewInvocationStore(resolver.repo_root)
+        self.workspace = workspace or ReviewWorkspaceManager(resolver)
+        self.last_snapshot: OperationSnapshot | None = None
+        self.last_checks: dict[str, Any] | None = None
+        self.last_documentation_validation: dict[str, Any] | None = None
+        self.last_profile_evidence: ProfileEvidenceEnvelope | None = None
+
+    def _capture_checks_from_gate(self) -> None:
+        """Retain a check gate's result when strict evaluation raises."""
+        for attribute in ("last_result", "last_checks"):
+            value = getattr(self.checks_gate, attribute, None)
+            if isinstance(value, Mapping):
+                self.last_checks = dict(value)
+                return
+
+    @staticmethod
+    def _read_findings(path: Path | None, verdict: str) -> str:
+        if path is None:
+            if verdict == "FAIL":
+                raise LckStopError("FAIL verdict requires --findings-file")
+            return ""
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise LckStopError(f"cannot read findings file: {exc}") from exc
+        if verdict == "FAIL" and not text.strip():
+            raise LckStopError("FAIL verdict requires non-empty findings")
+        return text
+
+    def complete(
+        self,
+        task_number: int,
+        review_id: str,
+        *,
+        verdict: str,
+        findings_file: Path | None = None,
+        research_outcome: str | None = None,
+    ) -> ReviewCompletionResult:
+        self.last_checks = None
+        self.last_documentation_validation = None
+        verdict = verdict.upper()
+        if verdict not in {"PASS", "FAIL"}:
+            raise LckStopError("Review verdict must be PASS or FAIL")
+        findings = self._read_findings(findings_file, verdict)
+        guard = self.store.read_guard(review_id)
+        if guard.get("task_number") != task_number:
+            raise LckStopError("Review invocation does not belong to this Task")
+        raw_identity = guard.get("identity")
+        if not isinstance(raw_identity, Mapping):
+            raise LckStopError("Review invocation guard has no identity")
+        reviewed_identity = _identity_from_mapping(raw_identity)
+        review_root_value = guard.get("review_root")
+        if not isinstance(review_root_value, str) or not review_root_value:
+            raise LckStopError("Review invocation guard has no review root")
+        review_root = Path(review_root_value)
+
+        completion_terminal = False
+        try:
+            validation = guard.get("validation")
+            if (
+                not isinstance(validation, Mapping)
+                or validation.get("status") != "pass"
+            ):
+                raise LckStopError(
+                    "Review invocation has no successful formal validation"
+                )
+            if reviewed_identity.task_number != task_number:
+                raise LckStopError(
+                    "Review invocation identity does not belong to this Task"
+                )
+            prepared_checks = guard.get("checks")
+            if not isinstance(prepared_checks, Mapping):
+                raise LckStopError("Review invocation has no PR check observation")
+            self.last_checks = dict(prepared_checks)
+            prepared_snapshot = guard.get("snapshot")
+            if not isinstance(prepared_snapshot, Mapping):
+                raise LckStopError("Review invocation has no sealed operation snapshot")
+            if prepared_snapshot.get("operation") != "review-prepare":
+                raise LckStopError("Review invocation snapshot has the wrong operation")
+
+            completion_snapshot = self.snapshots.acquire(
+                task_number,
+                operation="review-complete",
+            )
+            self.last_snapshot = completion_snapshot
+            state = completion_snapshot.state
+            decision = self.eligibility.resolve(state, Phase.REVIEW_COMPLETE)
+            if not decision.eligible:
+                raise LckStopError(
+                    f"Review Complete STOP for Task #{task_number}: "
+                    + "; ".join(decision.reasons)
+                )
+            current_contract = _leaf_contract_from_state(state)
+            _assert_review_target_facts_applicable(
+                reviewed_identity,
+                state,
+                current_contract,
+            )
+            self.workspace.assert_ready_for_completion(
+                review_root, reviewed_identity.head_sha
+            )
+            current_identity = _review_identity(
+                self.resolver,
+                state,
+                current_contract,
+                repo_root=review_root,
+                policy_registry=self.policy_registry,
+                profile_resolver=self.profile_resolver,
+            )
+            _assert_review_applicable(reviewed_identity, current_identity)
+            try:
+                profile, _policy = resolve_issue_policy(
+                    _policy_issue_from_state(state),
+                    registry=self.policy_registry,
+                    profile_resolver=self.profile_resolver
+                    or resolve_leaf_issue_profile,
+                )
+                review_input: dict[str, Any] = {
+                    "identity": current_identity.to_dict(),
+                    "verdict": verdict,
+                }
+                if research_outcome is not None:
+                    review_input["research_outcome"] = research_outcome
+                review_stage = validate_profile_review(
+                    profile,
+                    _policy_issue_from_state(state),
+                    review_input,
+                    registry=self.policy_registry,
+                    context=PolicyContext(
+                        profile=profile,
+                        phase="review",
+                        issue=_policy_issue_from_state(state),
+                        repo_root=review_root,
+                        runner=self.resolver.runner,
+                        review_identity=current_identity.to_dict(),
+                        review_verdict=verdict,
+                        research_outcome=research_outcome,
+                    ),
+                )
+            except (ProfilePolicyError, TypeError, ValueError) as exc:
+                raise LckStopError(
+                    f"profile Review capability rejected the verdict: {exc}"
+                ) from exc
+            if review_stage.artifact is not None:
+                current_identity = replace(
+                    current_identity, research_artifact=review_stage.artifact
+                )
+            self.last_profile_evidence = review_stage.profile_evidence
+            if verdict == "PASS":
+                completion_snapshot = self.snapshots.bind_required_checks(
+                    completion_snapshot, repo_root=review_root
+                )
+                # Binding may return a new immutable snapshot. Publish it
+                # before the strict gate so a later failure receipt contains
+                # the policy bound to this Review Complete operation.
+                self.last_snapshot = completion_snapshot
+                try:
+                    completion_checks = self.checks_gate.evaluate(completion_snapshot)
+                except BaseException:
+                    self._capture_checks_from_gate()
+                    raise
+            else:
+                try:
+                    completion_checks = self.checks_gate.observe(completion_snapshot)
+                except BaseException:
+                    self._capture_checks_from_gate()
+                    raise
+            self.last_checks = dict(completion_checks)
+            record = {
+                "schema_version": LCK_SCHEMA_VERSION,
+                "kind": "independent-review-record",
+                "review_id": review_id,
+                "task_number": task_number,
+                "verdict": verdict,
+                "status": (
+                    "READY_FOR_MERGE_PREFLIGHT"
+                    if verdict == "PASS"
+                    else "STOP_REQUIRED"
+                ),
+                "identity": current_identity.to_dict(),
+                "research_artifact": _jsonable(current_identity.research_artifact),
+                "research_outcome": (
+                    current_identity.research_artifact.get("outcome")
+                    if isinstance(current_identity.research_artifact, Mapping)
+                    else None
+                ),
+                "findings": findings,
+                "findings_sha256": hashlib.sha256(findings.encode("utf-8")).hexdigest(),
+                "validation": validation,
+                "checks": dict(prepared_checks),
+                "completion_checks": completion_checks,
+                "profile_evidence": (
+                    review_stage.profile_evidence.to_dict()
+                    if review_stage.profile_evidence
+                    else None
+                ),
+                "review_snapshot": dict(prepared_snapshot),
+                "completion_snapshot": completion_snapshot.to_dict(),
+                "authority_note": (
+                    "Review Prepare target and fresh Review Complete snapshot matched; "
+                    "this record is audit evidence, while Merge Preflight must reacquire "
+                    "current Git/GitHub authority before human merge"
+                ),
+            }
+            record_path = self.store.write_record(task_number, review_id, record)
+            self.store.write_latest_review(task_number, review_id, verdict)
+            self.store.clear_review_required(task_number)
+            completion_terminal = True
+            return ReviewCompletionResult(
+                review_id=review_id,
+                task_number=task_number,
+                verdict=verdict,
+                status=cast(str, record["status"]),
+                identity=current_identity,
+                record_path=record_path,
+                issue_profile=completion_snapshot.state.issue_profile,
+                profile_evidence=review_stage.profile_evidence,
+            )
+        except ReviewStaleError:
+            # Stale is a formal terminal outcome for this prepared target.  It
+            # cannot be retried safely with the old target, so a fresh Prepare
+            # must reclaim this operation-owned state.
+            completion_terminal = True
+            raise
+        finally:
+            if completion_terminal:
+                cleanup_error: BaseException | None = None
+                try:
+                    self.workspace.remove(review_root)
+                except BaseException as exc:
+                    cleanup_error = exc
+                if cleanup_error is None:
+                    self.store.delete_guard(review_id)
+                    self.store.release_review_prepare(task_number, review_id)
+                else:
+                    raise cleanup_error
+
+
+class ReviewPassGate:
+    """Prove that the latest accepted Review PASS still matches live facts."""
+
+    def __init__(
+        self,
+        resolver: LiveStateResolver,
+        *,
+        store: ReviewInvocationStore | None = None,
+        policy_registry: ProfilePolicyRegistry | None = None,
+        profile_resolver: ProfileResolver | None = None,
+    ) -> None:
+        self.resolver = resolver
+        self.store = store or ReviewInvocationStore(resolver.repo_root)
+        self.policy_registry = policy_registry or DEFAULT_PROFILE_POLICY_REGISTRY
+        self.profile_resolver = profile_resolver
+
+    def run(self, task_number: int, state: LiveState) -> dict[str, Any]:
+        latest = self.store.read_latest_review(task_number)
+        if not isinstance(latest, Mapping) or latest.get("verdict") != "PASS":
+            raise LckStopError(
+                "Merge Preflight requires the latest Independent Review PASS"
+            )
+        review_id = latest.get("review_id")
+        if not isinstance(review_id, str):
+            raise LckStopError("latest Independent Review PASS has no review id")
+        record = self.store.read_record(task_number, review_id)
+        if (
+            record.get("task_number") != task_number
+            or record.get("review_id") != review_id
+            or record.get("verdict") != "PASS"
+            or record.get("status") != "READY_FOR_MERGE_PREFLIGHT"
+        ):
+            raise LckStopError("latest Independent Review PASS record is invalid")
+        raw_identity = record.get("identity")
+        if not isinstance(raw_identity, Mapping):
+            raise LckStopError("Independent Review PASS has no identity")
+        recorded = _identity_from_mapping(raw_identity)
+        current_contract = _leaf_contract_from_state(state)
+        try:
+            _assert_review_target_facts_applicable(
+                recorded,
+                state,
+                current_contract,
+            )
+        except ReviewStaleError as exc:
+            raise LckStopError(f"Review PASS is stale: {exc}") from exc
+        try:
+            profile, _policy = resolve_issue_policy(
+                _policy_issue_from_state(state),
+                registry=self.policy_registry,
+                profile_resolver=self.profile_resolver or resolve_leaf_issue_profile,
+            )
+            validate_profile_review(
+                profile,
+                _policy_issue_from_state(state),
+                {"identity": recorded.to_dict(), "verdict": "PASS"},
+                registry=self.policy_registry,
+                context=PolicyContext(
+                    profile=profile,
+                    phase="review",
+                    issue=_policy_issue_from_state(state),
+                    review_identity=recorded.to_dict(),
+                    review_verdict="PASS",
+                ),
+            )
+        except (ProfilePolicyError, TypeError, ValueError) as exc:
+            raise LckStopError(
+                f"Review PASS profile evidence is invalid: {exc}"
+            ) from exc
+        # Git commit objects are content-addressed. Once current PR/base/head and
+        # Task Contract identity still match the accepted Review receipt, the
+        # recorded merge-base/effective-diff identity remains mechanically bound
+        # to those same commits. Merge Preflight therefore needs no source-repo
+        # object materialization or duplicate local diff probe.
+        return {
+            "status": "pass",
+            "review_id": review_id,
+            "identity": recorded.to_dict(),
+            "recorded_identity": recorded.to_dict(),
+        }
+
+
+@dataclass(frozen=True)
+class MergePreflightResult:
+    task_number: int
+    status: str
+    pr: Mapping[str, Any]
+    review: Mapping[str, Any]
+    checks: Mapping[str, Any]
+    blockers: Mapping[str, Any]
+    mergeability: str
+    operation_snapshot: OperationSnapshot | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": LCK_SCHEMA_VERSION,
+            "operation": "merge-preflight",
+            "task_number": self.task_number,
+            "status": self.status,
+            "issue_profile": _jsonable(
+                self.operation_snapshot.state.issue_profile
+                if self.operation_snapshot is not None
+                else None
+            ),
+            "pr": _jsonable(self.pr),
+            "review": _jsonable(self.review),
+            "checks": _jsonable(self.checks),
+            "blockers": _jsonable(self.blockers),
+            "mergeability": self.mergeability,
+            "human_boundary": (
+                "STOP — maintainer must perform the manual Squash Merge; "
+                "LCK has no auto-merge path"
+            ),
+            "automatic_merge": False,
+        }
+
+
+class MergePreflight:
+    """Run deterministic merge gates without mutating GitHub."""
+
+    def __init__(
+        self,
+        resolver: LiveStateResolver,
+        *,
+        review_gate: ReviewPassGate | None = None,
+        checks_gate: DeliveryChecksGate | None = None,
+        policy_registry: ProfilePolicyRegistry | None = None,
+        profile_resolver: ProfileResolver | None = None,
+    ) -> None:
+        self.resolver = resolver
+        self.snapshots = OperationSnapshotBuilder(resolver)
+        self.policy_registry = policy_registry or DEFAULT_PROFILE_POLICY_REGISTRY
+        self.profile_resolver = profile_resolver
+        self.eligibility = PhaseEligibilityResolver(
+            registry=self.policy_registry,
+            profile_resolver=self.profile_resolver,
+        )
+        self.review_gate = review_gate or ReviewPassGate(
+            resolver,
+            policy_registry=self.policy_registry,
+            profile_resolver=self.profile_resolver,
+        )
+        self.checks_gate = checks_gate or DeliveryChecksGate(resolver)
+        self.last_snapshot: OperationSnapshot | None = None
+        self.last_checks: dict[str, Any] | None = None
+
+    def _capture_checks_from_gate(self) -> None:
+        """Retain a check gate's result when strict evaluation raises."""
+        for attribute in ("last_result", "last_checks"):
+            value = getattr(self.checks_gate, attribute, None)
+            if isinstance(value, Mapping):
+                self.last_checks = dict(value)
+                return
+
+    def run(self, task_number: int) -> MergePreflightResult:
+        self.last_checks = None
+        snapshot = self.snapshots.acquire(
+            task_number,
+            operation="merge-preflight",
+            include_required_checks=True,
+        )
+        self.last_snapshot = snapshot
+        state = snapshot.state
+        if state.status is not ResolutionStatus.RESOLVED:
+            raise LckStopError("Merge Preflight STOP: " + "; ".join(state.stop_reasons))
+        pr = state.open_pr
+        if not isinstance(pr, Mapping):
+            raise LckStopError("Merge Preflight requires one current OPEN PR")
+        if pr.get("isDraft") is not False:
+            raise LckStopError("Merge Preflight requires a non-Draft OPEN PR")
+        if str(pr.get("state", "")).upper() != "OPEN":
+            raise LckStopError("Merge Preflight requires an OPEN PR")
+        if pr.get("baseRefName") != BASE_BRANCH:
+            raise LckStopError("Merge Preflight PR base branch is not main")
+        if pr.get("headRefName") != state.target_branch:
+            raise LckStopError(
+                "Merge Preflight PR head branch is not the resolved Task branch"
+            )
+        head_sha = _pr_head_sha(pr)
+        base_sha = _pr_base_sha(pr)
+        if head_sha is None or base_sha is None:
+            raise LckStopError("Merge Preflight PR head/base identity is unavailable")
+        if state.remote_issue_oid != head_sha:
+            raise LckStopError(
+                "Merge Preflight remote Task branch diverges from PR head"
+            )
+        if state.local_issue_head is not None and state.local_issue_head != head_sha:
+            raise LckStopError(
+                "Merge Preflight local Task branch diverges from PR head"
+            )
+        if state.project_status != "Review":
+            raise LckStopError("Merge Preflight requires Project Status Review")
+
+        blocker_reasons = self.eligibility.blocker_reasons(
+            state,
+            phase=Phase.REVIEW_COMPLETE,
+        )
+        blockers = {
+            "status": "pass" if not blocker_reasons else "fail",
+            "detail": "; ".join(blocker_reasons),
+        }
+        if blocker_reasons:
+            raise LckStopError(
+                "Merge Preflight unresolved blockers: " + "; ".join(blocker_reasons)
+            )
+        review = self.review_gate.run(task_number, state)
+        try:
+            checks = self.checks_gate.evaluate(snapshot)
+        except BaseException:
+            self._capture_checks_from_gate()
+            raise
+        self.last_checks = dict(checks)
+        if checks.get("limitation"):
+            raise LckStopError(
+                "Merge Preflight cannot prove required checks: "
+                + str(checks["limitation"])
+            )
+        mergeability_value = pr.get("mergeable")
+        mergeability = str(mergeability_value or "").upper()
+        if mergeability not in {"MERGEABLE", "TRUE"}:
+            raise LckStopError(
+                "Merge Preflight mergeability is not proven: "
+                + (mergeability or "UNKNOWN")
+            )
+        return MergePreflightResult(
+            task_number=task_number,
+            status="READY_FOR_HUMAN_MERGE",
+            pr=pr,
+            review=review,
+            checks=checks,
+            blockers=blockers,
+            mergeability=mergeability,
+            operation_snapshot=snapshot,
+        )
+
+
+MergePreflightRunner = MergePreflight

--- a/tools/lck/review_authority.py
+++ b/tools/lck/review_authority.py
@@ -1,0 +1,115 @@
+"""Nominal authority contract for the production Review path."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from .common import is_sha
+from .models import LckStopError, LiveState
+
+
+def _required_sha(value: Any, *, field: str) -> str:
+    if not is_sha(value):
+        raise LckStopError(f"Review authority {field} is unavailable")
+    return str(value)
+
+
+@dataclass(frozen=True, slots=True)
+class LiveReviewAuthority:
+    """The production Review authority derived from one current OPEN PR."""
+
+    repository: str
+    task_number: int
+    pr_number: int
+    base_sha: str
+    head_sha: str
+    task_body_sha256: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.repository, str) or not self.repository.strip():
+            raise ValueError("live Review authority requires repository")
+        if (
+            not isinstance(self.task_number, int)
+            or isinstance(self.task_number, bool)
+            or self.task_number <= 0
+        ):
+            raise ValueError("live Review authority requires a positive Task number")
+        if (
+            not isinstance(self.pr_number, int)
+            or isinstance(self.pr_number, bool)
+            or self.pr_number <= 0
+        ):
+            raise ValueError("live Review authority requires a positive PR number")
+        object.__setattr__(
+            self,
+            "base_sha",
+            _required_sha(self.base_sha, field="base SHA"),
+        )
+        object.__setattr__(
+            self,
+            "head_sha",
+            _required_sha(self.head_sha, field="head SHA"),
+        )
+        if not isinstance(self.task_body_sha256, str) or not self.task_body_sha256:
+            raise ValueError("live Review authority requires Task Contract identity")
+
+    @classmethod
+    def from_state(
+        cls,
+        state: LiveState,
+        task_contract: Mapping[str, Any],
+    ) -> LiveReviewAuthority:
+        """Derive production authority from live-resolved state only."""
+        if not isinstance(state, LiveState):
+            raise TypeError("production Review authority requires LiveState")
+        pr = state.open_pr
+        if not isinstance(pr, Mapping):
+            raise LckStopError("Review target has no current OPEN PR")
+        pr_number = pr.get("number")
+        if (
+            not isinstance(pr_number, int)
+            or isinstance(pr_number, bool)
+            or pr_number <= 0
+        ):
+            raise LckStopError("Review target PR number is unavailable")
+        base_sha = _required_sha(pr.get("baseRefOid"), field="base SHA")
+        head_sha = _required_sha(pr.get("headRefOid"), field="head SHA")
+        task_body_sha256 = task_contract.get("body_sha256")
+        if not isinstance(task_body_sha256, str) or not task_body_sha256:
+            raise LckStopError("Review target Task Contract identity is unavailable")
+        if not isinstance(state.repository, str) or not state.repository:
+            raise LckStopError("Review target repository identity is unavailable")
+        return cls(
+            repository=state.repository,
+            task_number=state.issue_number,
+            pr_number=pr_number,
+            base_sha=base_sha,
+            head_sha=head_sha,
+            task_body_sha256=task_body_sha256,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "authority_kind": "live-pr",
+            "repository": self.repository,
+            "task_number": self.task_number,
+            "pr_number": self.pr_number,
+            "base_sha": self.base_sha,
+            "head_sha": self.head_sha,
+            "task_body_sha256": self.task_body_sha256,
+        }
+
+
+def require_live_review_authority(value: Any) -> LiveReviewAuthority:
+    """Enforce the production Review authority boundary."""
+    if type(value) is not LiveReviewAuthority:
+        raise TypeError("production Review requires LiveReviewAuthority")
+    return value
+
+
+__all__ = [
+    "LiveReviewAuthority",
+    "require_live_review_authority",
+]

--- a/tools/lck/review_models.py
+++ b/tools/lck/review_models.py
@@ -1,0 +1,1795 @@
+"""Canonical, provider-neutral Review vNext value contracts.
+
+The contracts carry compact facts and references.  They deliberately do not
+embed repository trees, complete command logs, reviewer prose, or provider
+specific fields.  Callers can retrieve referenced evidence on demand.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from enum import StrEnum
+from math import isfinite
+from types import MappingProxyType
+from typing import ClassVar, Final, Self, cast
+
+__all__ = [
+    "ALWAYS_ON_SURFACES",
+    "RISK_TRIGGERED_SURFACES",
+    "AssuranceObligation",
+    "AssuranceResult",
+    "AssuranceStatus",
+    "CandidateFinding",
+    "ChangeMapEntry",
+    "EvidenceReference",
+    "FindingBlockingStatus",
+    "FindingSeverity",
+    "FindingVerificationStatus",
+    "ReviewAuthorityIdentity",
+    "ReviewAuthorityKind",
+    "ReviewContractError",
+    "ReviewEvidencePackage",
+    "ReviewRiskProfile",
+    "ReviewRunReceipt",
+    "ReviewSurface",
+    "ReviewSurfacePlan",
+    "RunProvenance",
+    "SkippedSurface",
+    "TokenUsage",
+    "VerifiedFinding",
+]
+
+
+type JsonValue = (
+    None | bool | int | float | str | tuple[JsonValue, ...] | Mapping[str, JsonValue]
+)
+
+_SHA1_RE: Final[re.Pattern[str]] = re.compile(r"^[0-9a-f]{40}$")
+_SHA256_RE: Final[re.Pattern[str]] = re.compile(r"^[0-9a-f]{64}$")
+
+
+class ReviewContractError(ValueError):
+    """Raised when a Review contract violates its canonical invariants."""
+
+
+def _require_exact_fields(
+    value: object, *, expected: frozenset[str], model: str
+) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise TypeError(f"{model} serialized value must be a JSON object")
+    if any(not isinstance(key, str) for key in value):
+        raise TypeError(f"{model} serialized field names must be strings")
+    actual = set(value)
+    missing = expected - actual
+    extra = actual - expected
+    if missing or extra:
+        details: list[str] = []
+        if missing:
+            details.append(f"missing fields: {', '.join(sorted(missing))}")
+        if extra:
+            details.append(f"extra fields: {', '.join(sorted(extra))}")
+        raise ReviewContractError(f"invalid {model} fields ({'; '.join(details)})")
+    return cast(Mapping[str, object], value)
+
+
+def _require_text(value: object, *, field: str) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{field} must be a string")
+    if not value.strip():
+        raise ReviewContractError(f"{field} must not be empty")
+    return value
+
+
+def _require_nonnegative_int(value: object, *, field: str) -> int:
+    if type(value) is not int:
+        raise TypeError(f"{field} must be an integer")
+    if value < 0:
+        raise ReviewContractError(f"{field} must be non-negative")
+    return value
+
+
+def _require_positive_int(value: object, *, field: str) -> int:
+    number = _require_nonnegative_int(value, field=field)
+    if number == 0:
+        raise ReviewContractError(f"{field} must be positive")
+    return number
+
+
+def _require_sha(value: object, *, field: str, length: int) -> str:
+    text = _require_text(value, field=field)
+    pattern = _SHA1_RE if length == 40 else _SHA256_RE
+    if pattern.fullmatch(text) is None:
+        raise ReviewContractError(f"{field} must be a lowercase {length}-character SHA")
+    return text
+
+
+def _coerce_enum[EnumT: StrEnum](
+    value: object, enum_type: type[EnumT], *, field: str
+) -> EnumT:
+    if isinstance(value, enum_type):
+        return value
+    if not isinstance(value, str):
+        raise TypeError(f"{field} must be a supported string value")
+    try:
+        return enum_type(value)
+    except ValueError as error:
+        raise ReviewContractError(f"{field} has unsupported value {value!r}") from error
+
+
+def _deduplicate[T](values: Sequence[T], *, field: str) -> tuple[T, ...]:
+    result: list[T] = []
+    for value in values:
+        if value in result:
+            raise ReviewContractError(f"{field} must not contain duplicates")
+        result.append(value)
+    return tuple(result)
+
+
+def _normalize_text_tuple(
+    value: object, *, field: str, allow_empty: bool = False
+) -> tuple[str, ...]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        raise TypeError(f"{field} must be a sequence of strings")
+    values = tuple(_require_text(item, field=field) for item in value)
+    if not allow_empty and not values:
+        raise ReviewContractError(f"{field} must not be empty")
+    return _deduplicate(values, field=field)
+
+
+def _normalize_enum_tuple[EnumT: StrEnum](
+    value: object, enum_type: type[EnumT], *, field: str
+) -> tuple[EnumT, ...]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        raise TypeError(f"{field} must be a sequence")
+    return _deduplicate(
+        tuple(_coerce_enum(item, enum_type, field=field) for item in value),
+        field=field,
+    )
+
+
+def _freeze_json(value: object, *, field: str = "value") -> JsonValue:
+    if value is None or type(value) in (bool, int, str):
+        return cast(JsonValue, value)
+    if type(value) is float:
+        if not isfinite(value):
+            raise ReviewContractError(f"{field} must contain finite numbers")
+        return value
+    if isinstance(value, Mapping):
+        frozen: dict[str, JsonValue] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError(f"{field} object keys must be strings")
+            frozen[key] = _freeze_json(item, field=f"{field}.{key}")
+        return cast(JsonValue, MappingProxyType(frozen))
+    if isinstance(value, (list, tuple)):
+        return tuple(
+            _freeze_json(item, field=f"{field}[{index}]")
+            for index, item in enumerate(value)
+        )
+    raise TypeError(f"{field} must contain only JSON-compatible values")
+
+
+def _freeze_object(value: object, *, field: str) -> Mapping[str, JsonValue]:
+    if not isinstance(value, Mapping):
+        raise TypeError(f"{field} must be a JSON object")
+    frozen = _freeze_json(value, field=field)
+    if not isinstance(frozen, Mapping):
+        raise TypeError(f"{field} must be a JSON object")
+    return frozen
+
+
+def _thaw_json(value: JsonValue) -> object:
+    if isinstance(value, Mapping):
+        return {key: _thaw_json(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_thaw_json(item) for item in value]
+    return value
+
+
+def _json_dict(value: Mapping[str, JsonValue]) -> dict[str, object]:
+    thawed = _thaw_json(value)
+    if not isinstance(thawed, dict):
+        raise TypeError("expected a JSON object")
+    return thawed
+
+
+def _model_json(payload: Mapping[str, object]) -> str:
+    return json.dumps(
+        payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    )
+
+
+class ReviewSurface(StrEnum):
+    """Canonical assurance surfaces shared by all Review profiles."""
+
+    CONTRACT_CONFORMANCE = "contract_conformance"
+    FUNCTIONAL_CORRECTNESS = "functional_correctness"
+    STATE_TRANSITIONS = "state_transitions"
+    ERROR_FAILURE_PATHS = "error_failure_paths"
+    TESTS_VS_CLAIMS = "tests_vs_claims"
+    ARCHITECTURE = "architecture"
+    PERSISTENCE_ATOMICITY = "persistence_atomicity"
+    COMPATIBILITY_MIGRATION = "compatibility_migration"
+    CONCURRENCY = "concurrency"
+    SECURITY = "security"
+    RECOVERY_IDEMPOTENCY = "recovery_idempotency"
+    ACCOUNTING_DOMAIN_INVARIANTS = "accounting_domain_invariants"
+
+
+ALWAYS_ON_SURFACES: Final[tuple[ReviewSurface, ...]] = (
+    ReviewSurface.CONTRACT_CONFORMANCE,
+    ReviewSurface.FUNCTIONAL_CORRECTNESS,
+    ReviewSurface.STATE_TRANSITIONS,
+    ReviewSurface.ERROR_FAILURE_PATHS,
+    ReviewSurface.TESTS_VS_CLAIMS,
+)
+
+RISK_TRIGGERED_SURFACES: Final[tuple[ReviewSurface, ...]] = (
+    ReviewSurface.ARCHITECTURE,
+    ReviewSurface.PERSISTENCE_ATOMICITY,
+    ReviewSurface.COMPATIBILITY_MIGRATION,
+    ReviewSurface.CONCURRENCY,
+    ReviewSurface.SECURITY,
+    ReviewSurface.RECOVERY_IDEMPOTENCY,
+    ReviewSurface.ACCOUNTING_DOMAIN_INVARIANTS,
+)
+
+
+class ReviewAuthorityKind(StrEnum):
+    """Whether a Review run is tied to an explicit fixture or live repository state."""
+
+    FIXTURE = "fixture"
+    LIVE = "live"
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewAuthorityIdentity:
+    """Immutable identity of the exact Review subject and its authority."""
+
+    authority_kind: ReviewAuthorityKind
+    repository: str
+    task_number: int
+    pull_request_number: int | None
+    base_sha: str
+    head_sha: str
+    diff_sha256: str
+
+    KIND: ClassVar[str] = "review-authority-identity"
+    SCHEMA_VERSION: ClassVar[str] = "review-authority-identity.v1"
+    VERSION: ClassVar[str] = SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "authority_kind",
+            _coerce_enum(
+                self.authority_kind, ReviewAuthorityKind, field="authority_kind"
+            ),
+        )
+        object.__setattr__(
+            self, "repository", _require_text(self.repository, field="repository")
+        )
+        object.__setattr__(
+            self,
+            "task_number",
+            _require_positive_int(self.task_number, field="task_number"),
+        )
+        if self.pull_request_number is not None:
+            object.__setattr__(
+                self,
+                "pull_request_number",
+                _require_positive_int(
+                    self.pull_request_number, field="pull_request_number"
+                ),
+            )
+        object.__setattr__(
+            self, "base_sha", _require_sha(self.base_sha, field="base_sha", length=40)
+        )
+        object.__setattr__(
+            self, "head_sha", _require_sha(self.head_sha, field="head_sha", length=40)
+        )
+        object.__setattr__(
+            self,
+            "diff_sha256",
+            _require_sha(self.diff_sha256, field="diff_sha256", length=64),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "kind": self.KIND,
+            "schema_version": self.SCHEMA_VERSION,
+            "authority_kind": self.authority_kind.value,
+            "repository": self.repository,
+            "task_number": self.task_number,
+            "pull_request_number": self.pull_request_number,
+            "base_sha": self.base_sha,
+            "head_sha": self.head_sha,
+            "diff_sha256": self.diff_sha256,
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> Self:
+        fields = _require_exact_fields(
+            value,
+            expected=frozenset(
+                {
+                    "kind",
+                    "schema_version",
+                    "authority_kind",
+                    "repository",
+                    "task_number",
+                    "pull_request_number",
+                    "base_sha",
+                    "head_sha",
+                    "diff_sha256",
+                }
+            ),
+            model=cls.KIND,
+        )
+        if fields["kind"] != cls.KIND or fields["schema_version"] != cls.SCHEMA_VERSION:
+            raise ReviewContractError(
+                "ReviewAuthorityIdentity kind or schema_version is invalid"
+            )
+        pull_request_number = fields["pull_request_number"]
+        if pull_request_number is not None and type(pull_request_number) is not int:
+            raise TypeError("pull_request_number must be an integer or null")
+        return cls(
+            authority_kind=_coerce_enum(
+                fields["authority_kind"], ReviewAuthorityKind, field="authority_kind"
+            ),
+            repository=_require_text(fields["repository"], field="repository"),
+            task_number=_require_positive_int(
+                fields["task_number"], field="task_number"
+            ),
+            pull_request_number=pull_request_number,
+            base_sha=_require_sha(fields["base_sha"], field="base_sha", length=40),
+            head_sha=_require_sha(fields["head_sha"], field="head_sha", length=40),
+            diff_sha256=_require_sha(
+                fields["diff_sha256"], field="diff_sha256", length=64
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceReference:
+    """Compact pointer to retrievable evidence, never the evidence payload."""
+
+    reference_id: str
+    kind: str
+    locator: str
+    summary: str
+    digest_sha256: str | None = None
+
+    KIND: ClassVar[str] = "evidence-reference"
+    SCHEMA_VERSION: ClassVar[str] = "evidence-reference.v1"
+    VERSION: ClassVar[str] = SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        for field_name in ("reference_id", "kind", "locator", "summary"):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_text(getattr(self, field_name), field=field_name),
+            )
+        if self.digest_sha256 is not None:
+            object.__setattr__(
+                self,
+                "digest_sha256",
+                _require_sha(self.digest_sha256, field="digest_sha256", length=64),
+            )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "kind": self.KIND,
+            "schema_version": self.SCHEMA_VERSION,
+            "reference_id": self.reference_id,
+            "evidence_kind": self.kind,
+            "locator": self.locator,
+            "summary": self.summary,
+            "digest_sha256": self.digest_sha256,
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> Self:
+        fields = _require_exact_fields(
+            value,
+            expected=frozenset(
+                {
+                    "kind",
+                    "schema_version",
+                    "reference_id",
+                    "evidence_kind",
+                    "locator",
+                    "summary",
+                    "digest_sha256",
+                }
+            ),
+            model=cls.KIND,
+        )
+        if fields["kind"] != cls.KIND or fields["schema_version"] != cls.SCHEMA_VERSION:
+            raise ReviewContractError(
+                "EvidenceReference kind or schema_version is invalid"
+            )
+        digest = fields["digest_sha256"]
+        if digest is not None and not isinstance(digest, str):
+            raise TypeError("digest_sha256 must be a string or null")
+        return cls(
+            reference_id=_require_text(fields["reference_id"], field="reference_id"),
+            kind=_require_text(fields["evidence_kind"], field="kind"),
+            locator=_require_text(fields["locator"], field="locator"),
+            summary=_require_text(fields["summary"], field="summary"),
+            digest_sha256=digest,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ChangeMapEntry:
+    """One high-signal changed-location summary."""
+
+    path: str
+    change_kind: str
+    locations: tuple[str, ...]
+    summary: str
+
+    KIND: ClassVar[str] = "change-map-entry"
+    SCHEMA_VERSION: ClassVar[str] = "change-map-entry.v1"
+    VERSION: ClassVar[str] = SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "path", _require_text(self.path, field="path"))
+        object.__setattr__(
+            self, "change_kind", _require_text(self.change_kind, field="change_kind")
+        )
+        object.__setattr__(
+            self,
+            "locations",
+            _normalize_text_tuple(self.locations, field="locations", allow_empty=True),
+        )
+        object.__setattr__(
+            self, "summary", _require_text(self.summary, field="summary")
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "kind": self.KIND,
+            "schema_version": self.SCHEMA_VERSION,
+            "path": self.path,
+            "change_kind": self.change_kind,
+            "locations": list(self.locations),
+            "summary": self.summary,
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> Self:
+        fields = _require_exact_fields(
+            value,
+            expected=frozenset(
+                {
+                    "kind",
+                    "schema_version",
+                    "path",
+                    "change_kind",
+                    "locations",
+                    "summary",
+                }
+            ),
+            model=cls.KIND,
+        )
+        if fields["kind"] != cls.KIND or fields["schema_version"] != cls.SCHEMA_VERSION:
+            raise ReviewContractError(
+                "ChangeMapEntry kind or schema_version is invalid"
+            )
+        return cls(
+            path=_require_text(fields["path"], field="path"),
+            change_kind=_require_text(fields["change_kind"], field="change_kind"),
+            locations=_normalize_text_tuple(
+                fields["locations"], field="locations", allow_empty=True
+            ),
+            summary=_require_text(fields["summary"], field="summary"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewRiskProfile:
+    """Deterministic risk facts and conservative surface escalation."""
+
+    deterministic_facts: Mapping[str, JsonValue]
+    triggered_surfaces: tuple[ReviewSurface, ...]
+    semantic_escalation_requests: tuple[ReviewSurface, ...] = ()
+
+    KIND: ClassVar[str] = "review-risk-profile"
+    SCHEMA_VERSION: ClassVar[str] = "review-risk-profile.v1"
+    VERSION: ClassVar[str] = SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "deterministic_facts",
+            _freeze_object(self.deterministic_facts, field="deterministic_facts"),
+        )
+        object.__setattr__(
+            self,
+            "triggered_surfaces",
+            _normalize_enum_tuple(
+                self.triggered_surfaces, ReviewSurface, field="triggered_surfaces"
+            ),
+        )
+        object.__setattr__(
+            self,
+            "semantic_escalation_requests",
+            _normalize_enum_tuple(
+                self.semantic_escalation_requests,
+                ReviewSurface,
+                field="semantic_escalation_requests",
+            ),
+        )
+
+    @property
+    def deterministic_required_surfaces(self) -> tuple[ReviewSurface, ...]:
+        """Alias emphasizing that triggered surfaces cannot be removed by a Reviewer."""
+        return self.triggered_surfaces
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "kind": self.KIND,
+            "schema_version": self.SCHEMA_VERSION,
+            "deterministic_facts": _json_dict(self.deterministic_facts),
+            "triggered_surfaces": [
+                surface.value for surface in self.triggered_surfaces
+            ],
+            "semantic_escalation_requests": [
+                surface.value for surface in self.semantic_escalation_requests
+            ],
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> Self:
+        fields = _require_exact_fields(
+            value,
+            expected=frozenset(
+                {
+                    "kind",
+                    "schema_version",
+                    "deterministic_facts",
+                    "triggered_surfaces",
+                    "semantic_escalation_requests",
+                }
+            ),
+            model=cls.KIND,
+        )
+        if fields["kind"] != cls.KIND or fields["schema_version"] != cls.SCHEMA_VERSION:
+            raise ReviewContractError(
+                "ReviewRiskProfile kind or schema_version is invalid"
+            )
+        return cls(
+            deterministic_facts=_freeze_object(
+                fields["deterministic_facts"], field="deterministic_facts"
+            ),
+            triggered_surfaces=_normalize_enum_tuple(
+                fields["triggered_surfaces"], ReviewSurface, field="triggered_surfaces"
+            ),
+            semantic_escalation_requests=_normalize_enum_tuple(
+                fields["semantic_escalation_requests"],
+                ReviewSurface,
+                field="semantic_escalation_requests",
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SkippedSurface:
+    """A surface explicitly skipped with an auditable reason."""
+
+    surface: ReviewSurface
+    reason: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "surface", _coerce_enum(self.surface, ReviewSurface, field="surface")
+        )
+        object.__setattr__(self, "reason", _require_text(self.reason, field="reason"))
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewSurfacePlan:
+    """Mechanical required/covered/skipped surface accounting."""
+
+    required: tuple[ReviewSurface, ...] = ALWAYS_ON_SURFACES
+    covered: tuple[ReviewSurface, ...] = ()
+    skipped_with_reason: Mapping[str, str] | Sequence[SkippedSurface] = ()
+    risk_triggered: tuple[ReviewSurface, ...] = ()
+    semantic_escalation_requests: tuple[ReviewSurface, ...] = ()
+
+    KIND: ClassVar[str] = "review-surface-plan"
+    SCHEMA_VERSION: ClassVar[str] = "review-surface-plan.v1"
+    VERSION: ClassVar[str] = SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        required = _normalize_enum_tuple(self.required, ReviewSurface, field="required")
+        covered = _normalize_enum_tuple(self.covered, ReviewSurface, field="covered")
+        risk_triggered = _normalize_enum_tuple(
+            self.risk_triggered, ReviewSurface, field="risk_triggered"
+        )
+        semantic_escalations = _normalize_enum_tuple(
+            self.semantic_escalation_requests,
+            ReviewSurface,
+            field="semantic_escalation_requests",
+        )
+        missing_always_on = [
+            surface.value for surface in ALWAYS_ON_SURFACES if surface not in required
+        ]
+        if missing_always_on:
+            raise ReviewContractError(
+                "required surfaces must include always-on surfaces: "
+                + ", ".join(missing_always_on)
+            )
+        if any(surface not in required for surface in risk_triggered):
+            raise ReviewContractError("every risk-triggered surface must be required")
+        skipped = self._normalize_skipped(self.skipped_with_reason)
+        if set(covered) & set(skipped):
+            raise ReviewContractError("a surface cannot be both covered and skipped")
+        object.__setattr__(self, "required", required)
+        object.__setattr__(self, "covered", covered)
+        object.__setattr__(self, "risk_triggered", risk_triggered)
+        object.__setattr__(self, "semantic_escalation_requests", semantic_escalations)
+        object.__setattr__(self, "skipped_with_reason", MappingProxyType(skipped))
+
+    @staticmethod
+    def _normalize_skipped(
+        value: Mapping[str, str] | Sequence[SkippedSurface],
+    ) -> dict[str, str]:
+        if isinstance(value, Mapping):
+            result: dict[str, str] = {}
+            for surface, reason in value.items():
+                normalized_surface = _coerce_enum(
+                    surface, ReviewSurface, field="skipped surface"
+                )
+                if normalized_surface.value in result:
+                    raise ReviewContractError(
+                        "skipped surfaces must not contain duplicates"
+                    )
+                result[normalized_surface.value] = _require_text(
+                    reason, field="skip reason"
+                )
+            return result
+        if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+            raise TypeError("skipped_with_reason must be a mapping or sequence")
+        result = {}
+        for item in value:
+            if not isinstance(item, SkippedSurface):
+                raise TypeError(
+                    "skipped_with_reason sequence must contain SkippedSurface values"
+                )
+            if item.surface.value in result:
+                raise ReviewContractError(
+                    "skipped surfaces must not contain duplicates"
+                )
+            result[item.surface.value] = item.reason
+        return result
+
+    @property
+    def missing_required(self) -> tuple[ReviewSurface, ...]:
+        return tuple(
+            surface for surface in self.required if surface not in self.covered
+        )
+
+    @property
+    def is_complete(self) -> bool:
+        return not self.missing_required
+
+    @property
+    def coverage_status(self) -> str:
+        return "complete" if self.is_complete else "incomplete"
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "kind": self.KIND,
+            "schema_version": self.SCHEMA_VERSION,
+            "required": [surface.value for surface in self.required],
+            "covered": [surface.value for surface in self.covered],
+            "skipped_with_reason": dict(
+                cast(Mapping[str, str], self.skipped_with_reason)
+            ),
+            "risk_triggered": [surface.value for surface in self.risk_triggered],
+            "semantic_escalation_requests": [
+                surface.value for surface in self.semantic_escalation_requests
+            ],
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> Self:
+        fields = _require_exact_fields(
+            value,
+            expected=frozenset(
+                {
+                    "kind",
+                    "schema_version",
+                    "required",
+                    "covered",
+                    "skipped_with_reason",
+                    "risk_triggered",
+                    "semantic_escalation_requests",
+                }
+            ),
+            model=cls.KIND,
+        )
+        if fields["kind"] != cls.KIND or fields["schema_version"] != cls.SCHEMA_VERSION:
+            raise ReviewContractError(
+                "ReviewSurfacePlan kind or schema_version is invalid"
+            )
+        skipped = fields["skipped_with_reason"]
+        if not isinstance(skipped, Mapping):
+            raise TypeError("skipped_with_reason must be a JSON object")
+        return cls(
+            required=_normalize_enum_tuple(
+                fields["required"], ReviewSurface, field="required"
+            ),
+            covered=_normalize_enum_tuple(
+                fields["covered"], ReviewSurface, field="covered"
+            ),
+            skipped_with_reason=cast(Mapping[str, str], skipped),
+            risk_triggered=_normalize_enum_tuple(
+                fields["risk_triggered"], ReviewSurface, field="risk_triggered"
+            ),
+            semantic_escalation_requests=_normalize_enum_tuple(
+                fields["semantic_escalation_requests"],
+                ReviewSurface,
+                field="semantic_escalation_requests",
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class RunProvenance:
+    """Origin identity retained on every candidate finding."""
+
+    run_id: str
+    authority: ReviewAuthorityIdentity
+    harness_id: str
+    protocol_id: str
+
+    KIND: ClassVar[str] = "review-run-provenance"
+    SCHEMA_VERSION: ClassVar[str] = "review-run-provenance.v1"
+    VERSION: ClassVar[str] = SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "run_id", _require_text(self.run_id, field="run_id"))
+        if not isinstance(self.authority, ReviewAuthorityIdentity):
+            raise TypeError("authority must be a ReviewAuthorityIdentity")
+        object.__setattr__(
+            self, "harness_id", _require_text(self.harness_id, field="harness_id")
+        )
+        object.__setattr__(
+            self, "protocol_id", _require_text(self.protocol_id, field="protocol_id")
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "kind": self.KIND,
+            "schema_version": self.SCHEMA_VERSION,
+            "run_id": self.run_id,
+            "authority": self.authority.to_dict(),
+            "harness_id": self.harness_id,
+            "protocol_id": self.protocol_id,
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> Self:
+        fields = _require_exact_fields(
+            value,
+            expected=frozenset(
+                {
+                    "kind",
+                    "schema_version",
+                    "run_id",
+                    "authority",
+                    "harness_id",
+                    "protocol_id",
+                }
+            ),
+            model=cls.KIND,
+        )
+        if fields["kind"] != cls.KIND or fields["schema_version"] != cls.SCHEMA_VERSION:
+            raise ReviewContractError("RunProvenance kind or schema_version is invalid")
+        return cls(
+            run_id=_require_text(fields["run_id"], field="run_id"),
+            authority=ReviewAuthorityIdentity.from_dict(fields["authority"]),
+            harness_id=_require_text(fields["harness_id"], field="harness_id"),
+            protocol_id=_require_text(fields["protocol_id"], field="protocol_id"),
+        )
+
+
+def _normalize_provenance(value: object, *, field: str) -> tuple[RunProvenance, ...]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        raise TypeError(f"{field} must be a sequence of RunProvenance values")
+    result = tuple(
+        item if isinstance(item, RunProvenance) else RunProvenance.from_dict(item)
+        for item in value
+    )
+    if not result:
+        raise ReviewContractError(f"{field} must not be empty")
+    _deduplicate(tuple(item.run_id for item in result), field=field)
+    return result
+
+
+def _normalize_references(
+    value: object, *, field: str
+) -> tuple[EvidenceReference, ...]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        raise TypeError(f"{field} must be a sequence of EvidenceReference values")
+    result = tuple(
+        item
+        if isinstance(item, EvidenceReference)
+        else EvidenceReference.from_dict(item)
+        for item in value
+    )
+    if not result:
+        raise ReviewContractError(f"{field} must not be empty")
+    _deduplicate(tuple(item.reference_id for item in result), field=field)
+    return result
+
+
+def _normalize_finding_refs(
+    value: object, *, field: str, allow_empty: bool = False
+) -> tuple[str, ...]:
+    refs = _normalize_text_tuple(value, field=field, allow_empty=allow_empty)
+    return refs
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateFinding:
+    """A reported claim awaiting independent verification and classification."""
+
+    finding_id: str
+    surface: ReviewSurface
+    claim: str
+    affected_locations: tuple[str, ...]
+    contract_invariant: str
+    failure_scenario: str
+    evidence_refs: tuple[str, ...]
+    originating_runs: tuple[RunProvenance, ...]
+
+    KIND: ClassVar[str] = "candidate-finding"
+    SCHEMA_VERSION: ClassVar[str] = "candidate-finding.v1"
+    VERSION: ClassVar[str] = SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "finding_id", _require_text(self.finding_id, field="finding_id")
+        )
+        object.__setattr__(
+            self, "surface", _coerce_enum(self.surface, ReviewSurface, field="surface")
+        )
+        object.__setattr__(self, "claim", _require_text(self.claim, field="claim"))
+        object.__setattr__(
+            self,
+            "affected_locations",
+            _normalize_text_tuple(self.affected_locations, field="affected_locations"),
+        )
+        object.__setattr__(
+            self,
+            "contract_invariant",
+            _require_text(self.contract_invariant, field="contract_invariant"),
+        )
+        object.__setattr__(
+            self,
+            "failure_scenario",
+            _require_text(self.failure_scenario, field="failure_scenario"),
+        )
+        object.__setattr__(
+            self,
+            "evidence_refs",
+            _normalize_finding_refs(self.evidence_refs, field="evidence_refs"),
+        )
+        object.__setattr__(
+            self,
+            "originating_runs",
+            _normalize_provenance(self.originating_runs, field="originating_runs"),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "kind": self.KIND,
+            "schema_version": self.SCHEMA_VERSION,
+            "finding_id": self.finding_id,
+            "surface": self.surface.value,
+            "claim": self.claim,
+            "affected_locations": list(self.affected_locations),
+            "contract_invariant": self.contract_invariant,
+            "failure_scenario": self.failure_scenario,
+            "evidence_refs": list(self.evidence_refs),
+            "originating_runs": [run.to_dict() for run in self.originating_runs],
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> Self:
+        fields = _require_exact_fields(
+            value,
+            expected=frozenset(
+                {
+                    "kind",
+                    "schema_version",
+                    "finding_id",
+                    "surface",
+                    "claim",
+                    "affected_locations",
+                    "contract_invariant",
+                    "failure_scenario",
+                    "evidence_refs",
+                    "originating_runs",
+                }
+            ),
+            model=cls.KIND,
+        )
+        if fields["kind"] != cls.KIND or fields["schema_version"] != cls.SCHEMA_VERSION:
+            raise ReviewContractError(
+                "CandidateFinding kind or schema_version is invalid"
+            )
+        return cls(
+            finding_id=_require_text(fields["finding_id"], field="finding_id"),
+            surface=_coerce_enum(fields["surface"], ReviewSurface, field="surface"),
+            claim=_require_text(fields["claim"], field="claim"),
+            affected_locations=_normalize_text_tuple(
+                fields["affected_locations"], field="affected_locations"
+            ),
+            contract_invariant=_require_text(
+                fields["contract_invariant"], field="contract_invariant"
+            ),
+            failure_scenario=_require_text(
+                fields["failure_scenario"], field="failure_scenario"
+            ),
+            evidence_refs=_normalize_finding_refs(
+                fields["evidence_refs"], field="evidence_refs"
+            ),
+            originating_runs=_normalize_provenance(
+                fields["originating_runs"], field="originating_runs"
+            ),
+        )
+
+
+class FindingVerificationStatus(StrEnum):
+    """Independent disposition of a candidate finding."""
+
+    CONFIRMED = "confirmed"
+    REJECTED = "rejected"
+    NEEDS_MORE_EVIDENCE = "needs_more_evidence"
+    INCONCLUSIVE = "inconclusive"
+
+
+class FindingSeverity(StrEnum):
+    """Severity assigned only after verification."""
+
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+
+class FindingBlockingStatus(StrEnum):
+    """Explicit blocker classification, separate from candidate status."""
+
+    BLOCKING = "blocking"
+    NON_BLOCKING = "non_blocking"
+    NOT_ASSESSED = "not_assessed"
+
+
+@dataclass(frozen=True, slots=True)
+class VerifiedFinding:
+    """A candidate finding plus explicit independent verification facts."""
+
+    finding_id: str
+    surface: ReviewSurface
+    claim: str
+    affected_locations: tuple[str, ...]
+    contract_invariant: str
+    failure_scenario: str
+    evidence_refs: tuple[str, ...]
+    originating_runs: tuple[RunProvenance, ...]
+    verification_status: FindingVerificationStatus
+    verification_evidence_refs: tuple[str, ...]
+    severity: FindingSeverity
+    blocking_status: FindingBlockingStatus
+
+    KIND: ClassVar[str] = "verified-finding"
+    SCHEMA_VERSION: ClassVar[str] = "verified-finding.v1"
+    VERSION: ClassVar[str] = SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        candidate = CandidateFinding(
+            finding_id=self.finding_id,
+            surface=self.surface,
+            claim=self.claim,
+            affected_locations=self.affected_locations,
+            contract_invariant=self.contract_invariant,
+            failure_scenario=self.failure_scenario,
+            evidence_refs=self.evidence_refs,
+            originating_runs=self.originating_runs,
+        )
+        for field_name in (
+            "finding_id",
+            "surface",
+            "claim",
+            "affected_locations",
+            "contract_invariant",
+            "failure_scenario",
+            "evidence_refs",
+            "originating_runs",
+        ):
+            object.__setattr__(self, field_name, getattr(candidate, field_name))
+        object.__setattr__(
+            self,
+            "verification_status",
+            _coerce_enum(
+                self.verification_status,
+                FindingVerificationStatus,
+                field="verification_status",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "verification_evidence_refs",
+            _normalize_finding_refs(
+                self.verification_evidence_refs,
+                field="verification_evidence_refs",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "severity",
+            _coerce_enum(self.severity, FindingSeverity, field="severity"),
+        )
+        object.__setattr__(
+            self,
+            "blocking_status",
+            _coerce_enum(
+                self.blocking_status,
+                FindingBlockingStatus,
+                field="blocking_status",
+            ),
+        )
+        if self.verification_status is FindingVerificationStatus.CONFIRMED:
+            if self.blocking_status is FindingBlockingStatus.NOT_ASSESSED:
+                raise ReviewContractError(
+                    "confirmed finding requires an explicit blocking status"
+                )
+        elif self.blocking_status is not FindingBlockingStatus.NOT_ASSESSED:
+            raise ReviewContractError(
+                "only a confirmed finding may have a blocking or non-blocking status"
+            )
+
+    @classmethod
+    def from_candidate(
+        cls,
+        candidate: CandidateFinding,
+        *,
+        verification_status: FindingVerificationStatus,
+        verification_evidence_refs: tuple[str, ...],
+        severity: FindingSeverity,
+        blocking_status: FindingBlockingStatus,
+    ) -> Self:
+        if not isinstance(candidate, CandidateFinding):
+            raise TypeError("candidate must be a CandidateFinding")
+        return cls(
+            finding_id=candidate.finding_id,
+            surface=candidate.surface,
+            claim=candidate.claim,
+            affected_locations=candidate.affected_locations,
+            contract_invariant=candidate.contract_invariant,
+            failure_scenario=candidate.failure_scenario,
+            evidence_refs=candidate.evidence_refs,
+            originating_runs=candidate.originating_runs,
+            verification_status=verification_status,
+            verification_evidence_refs=verification_evidence_refs,
+            severity=severity,
+            blocking_status=blocking_status,
+        )
+
+    @property
+    def candidate(self) -> CandidateFinding:
+        return CandidateFinding(
+            finding_id=self.finding_id,
+            surface=self.surface,
+            claim=self.claim,
+            affected_locations=self.affected_locations,
+            contract_invariant=self.contract_invariant,
+            failure_scenario=self.failure_scenario,
+            evidence_refs=self.evidence_refs,
+            originating_runs=self.originating_runs,
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "kind": self.KIND,
+            "schema_version": self.SCHEMA_VERSION,
+            "finding_id": self.finding_id,
+            "surface": self.surface.value,
+            "claim": self.claim,
+            "affected_locations": list(self.affected_locations),
+            "contract_invariant": self.contract_invariant,
+            "failure_scenario": self.failure_scenario,
+            "evidence_refs": list(self.evidence_refs),
+            "originating_runs": [run.to_dict() for run in self.originating_runs],
+            "verification_status": self.verification_status.value,
+            "verification_evidence_refs": list(self.verification_evidence_refs),
+            "severity": self.severity.value,
+            "blocking_status": self.blocking_status.value,
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> Self:
+        fields = _require_exact_fields(
+            value,
+            expected=frozenset(
+                {
+                    "kind",
+                    "schema_version",
+                    "finding_id",
+                    "surface",
+                    "claim",
+                    "affected_locations",
+                    "contract_invariant",
+                    "failure_scenario",
+                    "evidence_refs",
+                    "originating_runs",
+                    "verification_status",
+                    "verification_evidence_refs",
+                    "severity",
+                    "blocking_status",
+                }
+            ),
+            model=cls.KIND,
+        )
+        if fields["kind"] != cls.KIND or fields["schema_version"] != cls.SCHEMA_VERSION:
+            raise ReviewContractError(
+                "VerifiedFinding kind or schema_version is invalid"
+            )
+        return cls(
+            finding_id=_require_text(fields["finding_id"], field="finding_id"),
+            surface=_coerce_enum(fields["surface"], ReviewSurface, field="surface"),
+            claim=_require_text(fields["claim"], field="claim"),
+            affected_locations=_normalize_text_tuple(
+                fields["affected_locations"], field="affected_locations"
+            ),
+            contract_invariant=_require_text(
+                fields["contract_invariant"], field="contract_invariant"
+            ),
+            failure_scenario=_require_text(
+                fields["failure_scenario"], field="failure_scenario"
+            ),
+            evidence_refs=_normalize_finding_refs(
+                fields["evidence_refs"], field="evidence_refs"
+            ),
+            originating_runs=_normalize_provenance(
+                fields["originating_runs"], field="originating_runs"
+            ),
+            verification_status=_coerce_enum(
+                fields["verification_status"],
+                FindingVerificationStatus,
+                field="verification_status",
+            ),
+            verification_evidence_refs=_normalize_finding_refs(
+                fields["verification_evidence_refs"],
+                field="verification_evidence_refs",
+            ),
+            severity=_coerce_enum(
+                fields["severity"], FindingSeverity, field="severity"
+            ),
+            blocking_status=_coerce_enum(
+                fields["blocking_status"],
+                FindingBlockingStatus,
+                field="blocking_status",
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class TokenUsage:
+    """Bounded token accounting attached to a Review run."""
+
+    input_tokens: int
+    output_tokens: int
+    total_tokens: int
+
+    KIND: ClassVar[str] = "review-token-usage"
+    SCHEMA_VERSION: ClassVar[str] = "review-token-usage.v1"
+    VERSION: ClassVar[str] = SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        for field_name in ("input_tokens", "output_tokens", "total_tokens"):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_nonnegative_int(getattr(self, field_name), field=field_name),
+            )
+        if self.total_tokens != self.input_tokens + self.output_tokens:
+            raise ReviewContractError(
+                "total_tokens must equal input_tokens + output_tokens"
+            )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "kind": self.KIND,
+            "schema_version": self.SCHEMA_VERSION,
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+            "total_tokens": self.total_tokens,
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> Self:
+        fields = _require_exact_fields(
+            value,
+            expected=frozenset(
+                {
+                    "kind",
+                    "schema_version",
+                    "input_tokens",
+                    "output_tokens",
+                    "total_tokens",
+                }
+            ),
+            model=cls.KIND,
+        )
+        if fields["kind"] != cls.KIND or fields["schema_version"] != cls.SCHEMA_VERSION:
+            raise ReviewContractError("TokenUsage kind or schema_version is invalid")
+        return cls(
+            input_tokens=_require_nonnegative_int(
+                fields["input_tokens"], field="input_tokens"
+            ),
+            output_tokens=_require_nonnegative_int(
+                fields["output_tokens"], field="output_tokens"
+            ),
+            total_tokens=_require_nonnegative_int(
+                fields["total_tokens"], field="total_tokens"
+            ),
+        )
+
+
+class AssuranceStatus(StrEnum):
+    PASS = "pass"
+    FAIL = "fail"
+    PENDING = "pending"
+    NOT_APPLICABLE = "not_applicable"
+
+
+@dataclass(frozen=True, slots=True)
+class AssuranceObligation:
+    """A declared assurance obligation and its relevant required surfaces."""
+
+    obligation_id: str
+    description: str
+    required_surfaces: tuple[ReviewSurface, ...]
+
+    KIND: ClassVar[str] = "assurance-obligation"
+    SCHEMA_VERSION: ClassVar[str] = "assurance-obligation.v1"
+    VERSION: ClassVar[str] = SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "obligation_id",
+            _require_text(self.obligation_id, field="obligation_id"),
+        )
+        object.__setattr__(
+            self, "description", _require_text(self.description, field="description")
+        )
+        object.__setattr__(
+            self,
+            "required_surfaces",
+            _normalize_enum_tuple(
+                self.required_surfaces, ReviewSurface, field="required_surfaces"
+            ),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "kind": self.KIND,
+            "schema_version": self.SCHEMA_VERSION,
+            "obligation_id": self.obligation_id,
+            "description": self.description,
+            "required_surfaces": [surface.value for surface in self.required_surfaces],
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> Self:
+        fields = _require_exact_fields(
+            value,
+            expected=frozenset(
+                {
+                    "kind",
+                    "schema_version",
+                    "obligation_id",
+                    "description",
+                    "required_surfaces",
+                }
+            ),
+            model=cls.KIND,
+        )
+        if fields["kind"] != cls.KIND or fields["schema_version"] != cls.SCHEMA_VERSION:
+            raise ReviewContractError(
+                "AssuranceObligation kind or schema_version is invalid"
+            )
+        return cls(
+            obligation_id=_require_text(fields["obligation_id"], field="obligation_id"),
+            description=_require_text(fields["description"], field="description"),
+            required_surfaces=_normalize_enum_tuple(
+                fields["required_surfaces"], ReviewSurface, field="required_surfaces"
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class AssuranceResult:
+    """Result and retrievable evidence for one assurance obligation."""
+
+    obligation_id: str
+    status: AssuranceStatus
+    evidence_refs: tuple[str, ...]
+    summary: str
+
+    KIND: ClassVar[str] = "assurance-result"
+    SCHEMA_VERSION: ClassVar[str] = "assurance-result.v1"
+    VERSION: ClassVar[str] = SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "obligation_id",
+            _require_text(self.obligation_id, field="obligation_id"),
+        )
+        object.__setattr__(
+            self, "status", _coerce_enum(self.status, AssuranceStatus, field="status")
+        )
+        object.__setattr__(
+            self,
+            "evidence_refs",
+            _normalize_finding_refs(
+                self.evidence_refs, field="evidence_refs", allow_empty=True
+            ),
+        )
+        object.__setattr__(
+            self, "summary", _require_text(self.summary, field="summary")
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "kind": self.KIND,
+            "schema_version": self.SCHEMA_VERSION,
+            "obligation_id": self.obligation_id,
+            "status": self.status.value,
+            "evidence_refs": list(self.evidence_refs),
+            "summary": self.summary,
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> Self:
+        fields = _require_exact_fields(
+            value,
+            expected=frozenset(
+                {
+                    "kind",
+                    "schema_version",
+                    "obligation_id",
+                    "status",
+                    "evidence_refs",
+                    "summary",
+                }
+            ),
+            model=cls.KIND,
+        )
+        if fields["kind"] != cls.KIND or fields["schema_version"] != cls.SCHEMA_VERSION:
+            raise ReviewContractError(
+                "AssuranceResult kind or schema_version is invalid"
+            )
+        return cls(
+            obligation_id=_require_text(fields["obligation_id"], field="obligation_id"),
+            status=_coerce_enum(fields["status"], AssuranceStatus, field="status"),
+            evidence_refs=_normalize_finding_refs(
+                fields["evidence_refs"], field="evidence_refs", allow_empty=True
+            ),
+            summary=_require_text(fields["summary"], field="summary"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewEvidencePackage:
+    """Canonical high-signal package exchanged by Review vNext components."""
+
+    summary: str
+    authority: ReviewAuthorityIdentity
+    task_contract: Mapping[str, JsonValue]
+    change_map: tuple[ChangeMapEntry, ...]
+    deterministic_evidence: tuple[EvidenceReference, ...]
+    risk_profile: ReviewRiskProfile
+    surface_plan: ReviewSurfacePlan
+    targeted_retrieval_references: tuple[EvidenceReference, ...]
+
+    KIND: ClassVar[str] = "review-evidence-package"
+    SCHEMA_VERSION: ClassVar[str] = "review-evidence-package.v1"
+    VERSION: ClassVar[str] = SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "summary", _require_text(self.summary, field="summary")
+        )
+        if not isinstance(self.authority, ReviewAuthorityIdentity):
+            raise TypeError("authority must be a ReviewAuthorityIdentity")
+        object.__setattr__(
+            self,
+            "task_contract",
+            _freeze_object(self.task_contract, field="task_contract"),
+        )
+        change_map = tuple(
+            item if isinstance(item, ChangeMapEntry) else ChangeMapEntry.from_dict(item)
+            for item in self.change_map
+        )
+        if not change_map:
+            raise ReviewContractError("change_map must not be empty")
+        object.__setattr__(self, "change_map", change_map)
+        deterministic = _normalize_references(
+            self.deterministic_evidence, field="deterministic_evidence"
+        )
+        retrieval = _normalize_references(
+            self.targeted_retrieval_references,
+            field="targeted_retrieval_references",
+        )
+        all_reference_ids = tuple(
+            item.reference_id for item in (*deterministic, *retrieval)
+        )
+        _deduplicate(all_reference_ids, field="evidence reference IDs")
+        object.__setattr__(self, "deterministic_evidence", deterministic)
+        object.__setattr__(self, "targeted_retrieval_references", retrieval)
+        if not isinstance(self.risk_profile, ReviewRiskProfile):
+            raise TypeError("risk_profile must be a ReviewRiskProfile")
+        if not isinstance(self.surface_plan, ReviewSurfacePlan):
+            raise TypeError("surface_plan must be a ReviewSurfacePlan")
+        if set(self.risk_profile.triggered_surfaces) != set(
+            self.surface_plan.risk_triggered
+        ):
+            raise ReviewContractError(
+                "surface plan risk_triggered must equal risk profile deterministic triggers"
+            )
+        if set(self.risk_profile.semantic_escalation_requests) != set(
+            self.surface_plan.semantic_escalation_requests
+        ):
+            raise ReviewContractError(
+                "surface plan semantic escalation requests must match risk profile"
+            )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "kind": self.KIND,
+            "schema_version": self.SCHEMA_VERSION,
+            "summary": self.summary,
+            "authority": self.authority.to_dict(),
+            "task_contract": _json_dict(self.task_contract),
+            "change_map": [item.to_dict() for item in self.change_map],
+            "deterministic_evidence": [
+                item.to_dict() for item in self.deterministic_evidence
+            ],
+            "risk_profile": self.risk_profile.to_dict(),
+            "surface_plan": self.surface_plan.to_dict(),
+            "targeted_retrieval_references": [
+                item.to_dict() for item in self.targeted_retrieval_references
+            ],
+        }
+
+    def to_json(self) -> str:
+        return _model_json(self.to_dict())
+
+    @classmethod
+    def from_dict(cls, value: object) -> Self:
+        fields = _require_exact_fields(
+            value,
+            expected=frozenset(
+                {
+                    "kind",
+                    "schema_version",
+                    "summary",
+                    "authority",
+                    "task_contract",
+                    "change_map",
+                    "deterministic_evidence",
+                    "risk_profile",
+                    "surface_plan",
+                    "targeted_retrieval_references",
+                }
+            ),
+            model=cls.KIND,
+        )
+        if fields["kind"] != cls.KIND or fields["schema_version"] != cls.SCHEMA_VERSION:
+            raise ReviewContractError(
+                "ReviewEvidencePackage kind or schema_version is invalid"
+            )
+        return cls(
+            summary=_require_text(fields["summary"], field="summary"),
+            authority=ReviewAuthorityIdentity.from_dict(fields["authority"]),
+            task_contract=_freeze_object(
+                fields["task_contract"], field="task_contract"
+            ),
+            change_map=tuple(
+                ChangeMapEntry.from_dict(item)
+                for item in _require_sequence(fields["change_map"], field="change_map")
+            ),
+            deterministic_evidence=tuple(
+                EvidenceReference.from_dict(item)
+                for item in _require_sequence(
+                    fields["deterministic_evidence"], field="deterministic_evidence"
+                )
+            ),
+            risk_profile=ReviewRiskProfile.from_dict(fields["risk_profile"]),
+            surface_plan=ReviewSurfacePlan.from_dict(fields["surface_plan"]),
+            targeted_retrieval_references=tuple(
+                EvidenceReference.from_dict(item)
+                for item in _require_sequence(
+                    fields["targeted_retrieval_references"],
+                    field="targeted_retrieval_references",
+                )
+            ),
+        )
+
+    @classmethod
+    def from_json(cls, value: str) -> Self:
+        if not isinstance(value, str):
+            raise TypeError("ReviewEvidencePackage JSON value must be a string")
+        try:
+            payload = json.loads(value)
+        except json.JSONDecodeError as error:
+            raise ReviewContractError(
+                "ReviewEvidencePackage JSON is invalid"
+            ) from error
+        return cls.from_dict(payload)
+
+
+def _require_sequence(value: object, *, field: str) -> Sequence[object]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        raise TypeError(f"{field} must be a JSON array")
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewRunReceipt:
+    """Auditable receipt for one fixture or live Review run."""
+
+    run_id: str
+    authority: ReviewAuthorityIdentity
+    harness_config: Mapping[str, JsonValue]
+    protocol_config: Mapping[str, JsonValue]
+    model_config: Mapping[str, JsonValue]
+    coverage: ReviewSurfacePlan
+    candidate_findings: tuple[CandidateFinding, ...]
+    verified_findings: tuple[VerifiedFinding, ...]
+    token_usage: TokenUsage
+    wall_clock_ms: int
+    assurance_obligations: tuple[AssuranceObligation, ...]
+    assurance_results: tuple[AssuranceResult, ...]
+
+    KIND: ClassVar[str] = "review-run-receipt"
+    SCHEMA_VERSION: ClassVar[str] = "review-run-receipt.v1"
+    VERSION: ClassVar[str] = SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "run_id", _require_text(self.run_id, field="run_id"))
+        if not isinstance(self.authority, ReviewAuthorityIdentity):
+            raise TypeError("authority must be a ReviewAuthorityIdentity")
+        for field_name in ("harness_config", "protocol_config", "model_config"):
+            object.__setattr__(
+                self,
+                field_name,
+                _freeze_object(getattr(self, field_name), field=field_name),
+            )
+        if not isinstance(self.coverage, ReviewSurfacePlan):
+            raise TypeError("coverage must be a ReviewSurfacePlan")
+        object.__setattr__(
+            self,
+            "candidate_findings",
+            self._normalize_candidates(self.candidate_findings),
+        )
+        object.__setattr__(
+            self, "verified_findings", self._normalize_verified(self.verified_findings)
+        )
+        if not isinstance(self.token_usage, TokenUsage):
+            raise TypeError("token_usage must be a TokenUsage")
+        object.__setattr__(
+            self,
+            "wall_clock_ms",
+            _require_nonnegative_int(self.wall_clock_ms, field="wall_clock_ms"),
+        )
+        obligations = tuple(
+            item
+            if isinstance(item, AssuranceObligation)
+            else AssuranceObligation.from_dict(item)
+            for item in self.assurance_obligations
+        )
+        results = tuple(
+            item
+            if isinstance(item, AssuranceResult)
+            else AssuranceResult.from_dict(item)
+            for item in self.assurance_results
+        )
+        _deduplicate(
+            tuple(item.obligation_id for item in obligations),
+            field="assurance_obligations",
+        )
+        _deduplicate(
+            tuple(item.obligation_id for item in results), field="assurance_results"
+        )
+        if not set(item.obligation_id for item in results).issubset(
+            {item.obligation_id for item in obligations}
+        ):
+            raise ReviewContractError(
+                "assurance results must refer to declared obligations"
+            )
+        object.__setattr__(self, "assurance_obligations", obligations)
+        object.__setattr__(self, "assurance_results", results)
+
+    @staticmethod
+    def _normalize_candidates(value: object) -> tuple[CandidateFinding, ...]:
+        if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+            raise TypeError("candidate_findings must be a sequence")
+        result = tuple(
+            item
+            if isinstance(item, CandidateFinding)
+            else CandidateFinding.from_dict(item)
+            for item in value
+        )
+        _deduplicate(
+            tuple(item.finding_id for item in result), field="candidate_findings"
+        )
+        return result
+
+    @staticmethod
+    def _normalize_verified(value: object) -> tuple[VerifiedFinding, ...]:
+        if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+            raise TypeError("verified_findings must be a sequence")
+        result = tuple(
+            item
+            if isinstance(item, VerifiedFinding)
+            else VerifiedFinding.from_dict(item)
+            for item in value
+        )
+        _deduplicate(
+            tuple(item.finding_id for item in result), field="verified_findings"
+        )
+        return result
+
+    @property
+    def coverage_complete(self) -> bool:
+        return self.coverage.is_complete
+
+    @property
+    def review_complete(self) -> bool:
+        results_by_id = {item.obligation_id: item for item in self.assurance_results}
+        if not self.coverage_complete or len(results_by_id) != len(
+            self.assurance_obligations
+        ):
+            return False
+        coverage_required = set(self.coverage.required)
+        coverage_covered = set(self.coverage.covered)
+        if any(
+            not set(obligation.required_surfaces).issubset(coverage_required)
+            or not set(obligation.required_surfaces).issubset(coverage_covered)
+            for obligation in self.assurance_obligations
+        ):
+            return False
+        return all(
+            results_by_id[item.obligation_id].status
+            in (AssuranceStatus.PASS, AssuranceStatus.NOT_APPLICABLE)
+            for item in self.assurance_obligations
+        )
+
+    @property
+    def review_status(self) -> str:
+        return "complete" if self.review_complete else "incomplete"
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "kind": self.KIND,
+            "schema_version": self.SCHEMA_VERSION,
+            "run_id": self.run_id,
+            "authority": self.authority.to_dict(),
+            "harness_config": _json_dict(self.harness_config),
+            "protocol_config": _json_dict(self.protocol_config),
+            "model_config": _json_dict(self.model_config),
+            "coverage": self.coverage.to_dict(),
+            "candidate_findings": [item.to_dict() for item in self.candidate_findings],
+            "verified_findings": [item.to_dict() for item in self.verified_findings],
+            "token_usage": self.token_usage.to_dict(),
+            "wall_clock_ms": self.wall_clock_ms,
+            "assurance_obligations": [
+                item.to_dict() for item in self.assurance_obligations
+            ],
+            "assurance_results": [item.to_dict() for item in self.assurance_results],
+            "review_status": self.review_status,
+        }
+
+    def to_json(self) -> str:
+        return _model_json(self.to_dict())
+
+    @classmethod
+    def from_dict(cls, value: object) -> Self:
+        fields = _require_exact_fields(
+            value,
+            expected=frozenset(
+                {
+                    "kind",
+                    "schema_version",
+                    "run_id",
+                    "authority",
+                    "harness_config",
+                    "protocol_config",
+                    "model_config",
+                    "coverage",
+                    "candidate_findings",
+                    "verified_findings",
+                    "token_usage",
+                    "wall_clock_ms",
+                    "assurance_obligations",
+                    "assurance_results",
+                    "review_status",
+                }
+            ),
+            model=cls.KIND,
+        )
+        if fields["kind"] != cls.KIND or fields["schema_version"] != cls.SCHEMA_VERSION:
+            raise ReviewContractError(
+                "ReviewRunReceipt kind or schema_version is invalid"
+            )
+        receipt = cls(
+            run_id=_require_text(fields["run_id"], field="run_id"),
+            authority=ReviewAuthorityIdentity.from_dict(fields["authority"]),
+            harness_config=_freeze_object(
+                fields["harness_config"], field="harness_config"
+            ),
+            protocol_config=_freeze_object(
+                fields["protocol_config"], field="protocol_config"
+            ),
+            model_config=_freeze_object(fields["model_config"], field="model_config"),
+            coverage=ReviewSurfacePlan.from_dict(fields["coverage"]),
+            candidate_findings=tuple(
+                CandidateFinding.from_dict(item)
+                for item in _require_sequence(
+                    fields["candidate_findings"], field="candidate_findings"
+                )
+            ),
+            verified_findings=tuple(
+                VerifiedFinding.from_dict(item)
+                for item in _require_sequence(
+                    fields["verified_findings"], field="verified_findings"
+                )
+            ),
+            token_usage=TokenUsage.from_dict(fields["token_usage"]),
+            wall_clock_ms=_require_nonnegative_int(
+                fields["wall_clock_ms"], field="wall_clock_ms"
+            ),
+            assurance_obligations=tuple(
+                AssuranceObligation.from_dict(item)
+                for item in _require_sequence(
+                    fields["assurance_obligations"], field="assurance_obligations"
+                )
+            ),
+            assurance_results=tuple(
+                AssuranceResult.from_dict(item)
+                for item in _require_sequence(
+                    fields["assurance_results"], field="assurance_results"
+                )
+            ),
+        )
+        if fields["review_status"] != receipt.review_status:
+            raise ReviewContractError(
+                "review_status does not match coverage and assurance results"
+            )
+        return receipt
+
+    @classmethod
+    def from_json(cls, value: str) -> Self:
+        if not isinstance(value, str):
+            raise TypeError("ReviewRunReceipt JSON value must be a string")
+        try:
+            payload = json.loads(value)
+        except json.JSONDecodeError as error:
+            raise ReviewContractError("ReviewRunReceipt JSON is invalid") from error
+        return cls.from_dict(payload)

--- a/tools/lck/review_workspace.py
+++ b/tools/lck/review_workspace.py
@@ -1,0 +1,1004 @@
+from __future__ import annotations
+
+import fcntl
+import os
+import re
+import shutil
+import stat
+import tempfile
+import uuid
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Final, cast
+
+from .common import WorkflowToolError, atomic_write_json, is_sha, read_json_file
+from .effective_diff import calculate_effective_diff
+from .issue_profiles import resolve_leaf_issue_profile
+from .models import (
+    LCK_SCHEMA_VERSION,
+    LckStopError,
+    LiveState,
+    ReviewStaleError,
+    _pr_base_sha,
+    _pr_head_sha,
+)
+from .profile_policies import (
+    DEFAULT_PROFILE_POLICY_REGISTRY,
+    ProfilePolicyError,
+    ProfilePolicyRegistry,
+    ProfileResolver,
+    build_profile_review_artifact,
+    resolve_issue_policy,
+)
+from .review_authority import LiveReviewAuthority
+from .state import LiveStateResolver
+
+
+@dataclass(frozen=True)
+class ReviewTargetRefs:
+    """Authoritative Review target facts acquired before repository materialization."""
+
+    task_number: int
+    pr_number: int
+    base_sha: str
+    head_sha: str
+    task_body_sha256: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "task_number": self.task_number,
+            "pr_number": self.pr_number,
+            "base_sha": self.base_sha,
+            "head_sha": self.head_sha,
+            "task_body_sha256": self.task_body_sha256,
+        }
+
+
+@dataclass(frozen=True)
+class ReviewIdentity:
+    task_number: int
+    pr_number: int
+    base_sha: str
+    head_sha: str
+    task_body_sha256: str
+    merge_base_sha: str
+    effective_diff_sha256: str
+    changed_files: tuple[str, ...]
+    research_artifact: Mapping[str, Any] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "task_number": self.task_number,
+            "pr_number": self.pr_number,
+            "base_sha": self.base_sha,
+            "head_sha": self.head_sha,
+            "task_body_sha256": self.task_body_sha256,
+            "merge_base_sha": self.merge_base_sha,
+            "effective_diff_sha256": self.effective_diff_sha256,
+            "changed_files": list(self.changed_files),
+        }
+        if self.research_artifact is not None:
+            result["research_artifact"] = dict(self.research_artifact)
+        return result
+
+
+def _review_target_refs(
+    state: LiveState,
+    task_contract: Mapping[str, Any],
+) -> ReviewTargetRefs:
+    """Extract immutable Git/GitHub identities without requiring local Git objects."""
+    authority = LiveReviewAuthority.from_state(state, task_contract)
+    return ReviewTargetRefs(
+        task_number=authority.task_number,
+        pr_number=authority.pr_number,
+        base_sha=authority.base_sha,
+        head_sha=authority.head_sha,
+        task_body_sha256=authority.task_body_sha256,
+    )
+
+
+def _review_identity(
+    resolver: LiveStateResolver,
+    state: LiveState,
+    task_contract: Mapping[str, Any],
+    *,
+    repo_root: Path,
+    policy_registry: ProfilePolicyRegistry = DEFAULT_PROFILE_POLICY_REGISTRY,
+    profile_resolver: ProfileResolver | None = None,
+) -> ReviewIdentity:
+    """Derive the effective diff from frozen refs inside a materialized repository.
+
+    GitHub supplies the authoritative PR/base/head/Task identities.  Merge-base,
+    effective diff, and changed-file inventory are derived facts and therefore
+    must be computed only after those exact commits exist in the isolated Review
+    clone.  The source repository is not required to contain the current PR head.
+    """
+    target = _review_target_refs(state, task_contract)
+    effective_diff = calculate_effective_diff(
+        resolver.runner,
+        base_sha=target.base_sha,
+        head_ref=target.head_sha,
+        command_id_prefix="lck-review",
+        cwd=repo_root,
+    )
+    artifact_input = {
+        "task_number": target.task_number,
+        "pr_number": target.pr_number,
+        "base_sha": target.base_sha,
+        "head_sha": target.head_sha,
+        "task_body_sha256": target.task_body_sha256,
+        "merge_base_sha": effective_diff.merge_base_sha,
+        "effective_diff_sha256": effective_diff.effective_diff_sha256,
+        "changed_files": effective_diff.changed_files,
+    }
+    try:
+        profile, _policy = resolve_issue_policy(
+            state.issue or {},
+            registry=policy_registry,
+            profile_resolver=profile_resolver or resolve_leaf_issue_profile,
+        )
+        research_artifact = build_profile_review_artifact(
+            profile,
+            state.issue or {},
+            artifact_input,
+            repo_root=repo_root,
+            registry=policy_registry,
+        )
+    except (ProfilePolicyError, ValueError) as exc:
+        raise LckStopError(
+            f"Research artifact policy rejected the Review target: {exc}"
+        ) from exc
+    return ReviewIdentity(
+        task_number=target.task_number,
+        pr_number=target.pr_number,
+        base_sha=target.base_sha,
+        head_sha=target.head_sha,
+        task_body_sha256=target.task_body_sha256,
+        merge_base_sha=effective_diff.merge_base_sha,
+        effective_diff_sha256=effective_diff.effective_diff_sha256,
+        changed_files=effective_diff.changed_files,
+        research_artifact=research_artifact,
+    )
+
+
+class ReviewWorkspaceManager:
+    """Own one standalone temporary clone for an Independent Review session.
+
+    Review is read-only with respect to the source repository.  The reviewed
+    workspace is therefore a self-contained temporary clone rather than a Git
+    worktree registered in the source repository.  All Review Git metadata writes
+    stay inside the temporary clone; durable validation evidence is copied only
+    to the ignored LCK local evidence root before clone cleanup.
+    """
+
+    OWNER_FILE: Final = "lck-review-owner.json"
+
+    def __init__(self, resolver: LiveStateResolver) -> None:
+        self.resolver = resolver
+
+    @staticmethod
+    def _validated_workspace_path(path: Path) -> Path:
+        resolved = path.resolve(strict=False)
+        temp_root = Path(tempfile.gettempdir()).resolve()
+        try:
+            relative = resolved.relative_to(temp_root)
+        except ValueError as exc:
+            raise LckStopError(
+                "Review workspace cleanup path is outside the temporary root"
+            ) from exc
+        if len(relative.parts) != 1 or not resolved.name.startswith(
+            "tracequant-lck-review-"
+        ):
+            raise LckStopError("Review workspace cleanup path is not LCK-owned")
+        return resolved
+
+    def path_for(self, task_number: int, operation_id: str) -> Path:
+        """Return an uncreated, operation-owned temporary clone path."""
+        return self._validated_workspace_path(
+            Path(tempfile.gettempdir())
+            / f"tracequant-lck-review-{task_number}-{operation_id}"
+        )
+
+    def _source_remote_url(self) -> str:
+        result = self.resolver.runner.run(
+            ["git", "remote", "get-url", "origin"],
+            command_id="lck-review-source-origin",
+        )
+        remote_url = result.stdout.strip()
+        if result.returncode != 0 or not remote_url:
+            raise LckStopError(
+                "cannot resolve source repository origin for isolated Review clone: "
+                + (
+                    result.stderr.strip()
+                    or result.stdout.strip()
+                    or "origin unavailable"
+                )
+            )
+        return remote_url
+
+    @classmethod
+    def _owner_path(cls, path: Path) -> Path:
+        return path / ".git" / cls.OWNER_FILE
+
+    def _write_owner(
+        self,
+        path: Path,
+        *,
+        task_number: int,
+        base_sha: str,
+        head_sha: str,
+    ) -> None:
+        atomic_write_json(
+            self._owner_path(path),
+            {
+                "schema_version": LCK_SCHEMA_VERSION,
+                "kind": "lck-review-standalone-clone",
+                "task_number": task_number,
+                "review_root": str(path),
+                "source_repo": str(self.resolver.repo_root),
+                "expected_base_sha": base_sha,
+                "expected_head_sha": head_sha,
+                "authority": "operation-owned temporary Review workspace only",
+            },
+        )
+
+    def _assert_owned_clone(
+        self,
+        path: Path,
+        *,
+        expected_head_sha: str | None = None,
+    ) -> Mapping[str, Any]:
+        path = self._validated_workspace_path(path)
+        if not path.is_dir() or not (path / ".git").is_dir():
+            raise LckStopError("isolated Review clone is unavailable")
+        owner_path = self._owner_path(path)
+        try:
+            value = read_json_file(owner_path)
+        except WorkflowToolError as exc:
+            raise LckStopError(
+                "isolated Review clone ownership marker is unavailable"
+            ) from exc
+        if not isinstance(value, Mapping):
+            raise LckStopError("isolated Review clone ownership marker is invalid")
+        if value.get("kind") != "lck-review-standalone-clone":
+            raise LckStopError("isolated Review clone ownership marker is invalid")
+        if value.get("review_root") != str(path):
+            raise LckStopError("isolated Review clone ownership path does not match")
+        if value.get("source_repo") != str(self.resolver.repo_root):
+            raise LckStopError("isolated Review clone belongs to another repository")
+        if (
+            expected_head_sha is not None
+            and value.get("expected_head_sha") != expected_head_sha
+        ):
+            raise LckStopError("isolated Review clone expected HEAD does not match")
+        return value
+
+    def _ensure_commit(self, path: Path, sha: str, *, label: str) -> None:
+        available = self.resolver.runner.run(
+            ["git", "cat-file", "-e", f"{sha}^{{commit}}"],
+            command_id=f"lck-review-clone-{label}-available",
+            cwd=path,
+        )
+        if available.returncode == 0:
+            return
+        fetched = self.resolver.runner.run(
+            ["git", "fetch", "--no-tags", "origin", sha],
+            command_id=f"lck-review-clone-fetch-{label}",
+            cwd=path,
+            retries=1,
+        )
+        if fetched.returncode != 0:
+            raise LckStopError(
+                f"cannot materialize reviewed {label} commit in temporary clone: "
+                + (
+                    fetched.stderr.strip()
+                    or fetched.stdout.strip()
+                    or f"exit {fetched.returncode}"
+                )
+            )
+        verified = self.resolver.runner.run(
+            ["git", "cat-file", "-e", f"{sha}^{{commit}}"],
+            command_id=f"lck-review-clone-{label}-verified",
+            cwd=path,
+        )
+        if verified.returncode != 0:
+            raise LckStopError(
+                f"temporary Review clone does not contain expected {label} commit"
+            )
+
+    def create(
+        self,
+        task_number: int,
+        base_sha: str,
+        head_sha: str,
+        path: Path | None = None,
+    ) -> Path:
+        path = self.path_for(task_number, uuid.uuid4().hex) if path is None else path
+        path = self._validated_workspace_path(path)
+        if path.exists():
+            raise LckStopError("isolated Review clone path is already occupied")
+        remote_url = self._source_remote_url()
+        clone = self.resolver.runner.run(
+            [
+                "git",
+                "clone",
+                "--no-checkout",
+                "--no-hardlinks",
+                str(self.resolver.repo_root),
+                str(path),
+            ],
+            command_id="lck-review-clone-create",
+        )
+        if clone.returncode != 0:
+            shutil.rmtree(path, ignore_errors=True)
+            raise LckStopError(
+                "cannot create isolated Review clone: "
+                + (
+                    clone.stderr.strip()
+                    or clone.stdout.strip()
+                    or f"exit {clone.returncode}"
+                )
+            )
+        try:
+            self._write_owner(
+                path,
+                task_number=task_number,
+                base_sha=base_sha,
+                head_sha=head_sha,
+            )
+            set_origin = self.resolver.runner.run(
+                ["git", "remote", "set-url", "origin", remote_url],
+                command_id="lck-review-clone-set-origin",
+                cwd=path,
+            )
+            if set_origin.returncode != 0:
+                raise LckStopError(
+                    "cannot restore authoritative origin in isolated Review clone: "
+                    + (set_origin.stderr.strip() or set_origin.stdout.strip())
+                )
+            self._ensure_commit(path, base_sha, label="base")
+            self._ensure_commit(path, head_sha, label="head")
+            checkout = self.resolver.runner.run(
+                ["git", "checkout", "--detach", head_sha],
+                command_id="lck-review-clone-checkout",
+                cwd=path,
+            )
+            if checkout.returncode != 0:
+                raise LckStopError(
+                    "cannot checkout exact reviewed HEAD in isolated Review clone: "
+                    + (checkout.stderr.strip() or checkout.stdout.strip())
+                )
+            self._assert_clean_exact(path, head_sha)
+        except BaseException:
+            self._make_removable(path)
+            shutil.rmtree(path, ignore_errors=True)
+            raise
+        return path
+
+    def _assert_clean_exact(self, path: Path, expected_head_sha: str) -> None:
+        if not path.is_dir():
+            raise LckStopError("isolated Review clone is unavailable")
+        status = self.resolver.runner.run(
+            ["git", "status", "--porcelain=v1", "--untracked-files=all"],
+            command_id="lck-review-clone-clean",
+            cwd=path,
+            env={"GIT_OPTIONAL_LOCKS": "0"},
+        )
+        head = self.resolver.runner.run(
+            ["git", "rev-parse", "HEAD"],
+            command_id="lck-review-clone-head",
+            cwd=path,
+            env={"GIT_OPTIONAL_LOCKS": "0"},
+        )
+        if status.returncode != 0 or head.returncode != 0:
+            raise LckStopError("cannot verify isolated Review clone")
+        if status.stdout.strip():
+            raise LckStopError("formal Review validation changed the isolated clone")
+        if head.stdout.strip() != expected_head_sha:
+            raise LckStopError("isolated Review clone HEAD changed during validation")
+
+    @staticmethod
+    def _assert_read_only(path: Path) -> None:
+        for root, dirs, files in os.walk(path, topdown=True, followlinks=False):
+            root_path = Path(root)
+            if root_path.stat().st_mode & 0o222:
+                raise LckStopError("isolated Review clone is not read-only")
+            for name in (*dirs, *files):
+                target = root_path / name
+                if not target.is_symlink() and target.stat().st_mode & 0o222:
+                    raise LckStopError("isolated Review clone is not read-only")
+
+    def seal_for_review(self, path: Path, expected_head_sha: str) -> None:
+        """Verify exact contents, seal the independent clone, and keep it clean."""
+        path = self._validated_workspace_path(path)
+        self._assert_owned_clone(path, expected_head_sha=expected_head_sha)
+        self._assert_clean_exact(path, expected_head_sha)
+        self.seal_read_only(path)
+        self._assert_clean_exact(path, expected_head_sha)
+        self._assert_read_only(path)
+
+    def assert_ready_for_completion(self, path: Path, expected_head_sha: str) -> None:
+        """Fail closed unless the prepared standalone Review clone is intact."""
+        path = self._validated_workspace_path(path)
+        self._assert_owned_clone(path, expected_head_sha=expected_head_sha)
+        self._assert_clean_exact(path, expected_head_sha)
+        self._assert_read_only(path)
+
+    @staticmethod
+    def _remove_write_bits(path: Path) -> None:
+        mode = stat.S_IMODE(path.stat().st_mode)
+        os.chmod(path, mode & ~0o222)
+
+    @classmethod
+    def seal_read_only(cls, path: Path) -> None:
+        for root, dirs, files in os.walk(path, topdown=False, followlinks=False):
+            root_path = Path(root)
+            for name in files:
+                target = root_path / name
+                if not target.is_symlink():
+                    cls._remove_write_bits(target)
+            for name in dirs:
+                target = root_path / name
+                if not target.is_symlink():
+                    cls._remove_write_bits(target)
+        cls._remove_write_bits(path)
+
+    @staticmethod
+    def _make_removable(path: Path) -> None:
+        if not path.exists():
+            return
+        os.chmod(path, 0o755)
+        for root, dirs, files in os.walk(path, topdown=True, followlinks=False):
+            root_path = Path(root)
+            os.chmod(root_path, 0o755)
+            for name in dirs:
+                target = root_path / name
+                if not target.is_symlink():
+                    os.chmod(target, 0o755)
+            for name in files:
+                target = root_path / name
+                if not target.is_symlink():
+                    os.chmod(target, 0o644)
+
+    def remove(self, path: Path) -> None:
+        path = self._validated_workspace_path(path)
+        if not path.exists():
+            return
+        self._assert_owned_clone(path)
+        self._make_removable(path)
+        shutil.rmtree(path, ignore_errors=True)
+        if path.exists():
+            raise LckStopError("failed to remove isolated Review clone directory")
+
+    def remove_recovered(self, path: Path) -> None:
+        """Remove a marker-owned clone, including an interrupted partial clone."""
+        path = self._validated_workspace_path(path)
+        if not path.exists():
+            return
+        self._make_removable(path)
+        shutil.rmtree(path, ignore_errors=True)
+        if path.exists():
+            raise LckStopError("failed to remove recovered Review clone directory")
+
+
+@dataclass
+class ReviewPrepareInvocation:
+    """Own one operation-local Review Prepare marker until it finishes."""
+
+    path: Path
+    operation_id: str
+    _lock_fd: int
+    recovered: Mapping[str, Any] | None = None
+
+    def update(self, payload: Mapping[str, Any]) -> None:
+        atomic_write_json(self.path, payload)
+
+    def release_lock(self) -> None:
+        """Release the process lock while retaining durable handoff state."""
+        if self._lock_fd < 0:
+            return
+        fcntl.flock(self._lock_fd, fcntl.LOCK_UN)
+        os.close(self._lock_fd)
+        self._lock_fd = -1
+
+    def finish(self) -> None:
+        try:
+            self.path.unlink()
+        finally:
+            self.release_lock()
+
+
+class ReviewInvocationStore:
+    """Persist invocation-local guards and diagnostic review records only."""
+
+    _ID = re.compile(r"^[0-9a-f]{32}$")
+
+    def __init__(self, repo_root: Path) -> None:
+        self.root = repo_root / ".workflow.local" / "lck"
+
+    def new_id(self) -> str:
+        return uuid.uuid4().hex
+
+    def _validate_id(self, review_id: str) -> None:
+        if self._ID.fullmatch(review_id) is None:
+            raise LckStopError("invalid Review invocation id")
+
+    def guard_path(self, review_id: str) -> Path:
+        self._validate_id(review_id)
+        return self.root / "review-invocations" / f"{review_id}.json"
+
+    def record_path(self, task_number: int, review_id: str) -> Path:
+        self._validate_id(review_id)
+        return self.root / "reviews" / f"task-{task_number}" / f"{review_id}.json"
+
+    def latest_review_path(self, task_number: int) -> Path:
+        return self.root / "review-state" / f"task-{task_number}-latest.json"
+
+    def review_required_path(self, task_number: int) -> Path:
+        return self.root / "review-state" / f"task-{task_number}-required.json"
+
+    def remediation_session_path(self, task_number: int) -> Path:
+        return self.root / "remediation-sessions" / f"task-{task_number}.json"
+
+    def remediation_no_change_receipt_path(
+        self, task_number: int, review_id: str
+    ) -> Path:
+        self._validate_id(review_id)
+        return (
+            self.root
+            / "remediation-receipts"
+            / f"task-{task_number}"
+            / f"{review_id}-no-change.json"
+        )
+
+    def review_prepare_inflight_path(self, task_number: int) -> Path:
+        return self.root / "review-inflight" / f"task-{task_number}.json"
+
+    def review_prepare_lock_path(self, task_number: int) -> Path:
+        return self.root / "review-inflight" / f"task-{task_number}.lock"
+
+    @staticmethod
+    def _pid_is_alive(pid: int) -> bool:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            return True
+        return True
+
+    def begin_review_prepare(self, task_number: int) -> ReviewPrepareInvocation:
+        """Claim one Task-local Review Prepare operation before side effects."""
+        path = self.review_prepare_inflight_path(task_number)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path = self.review_prepare_lock_path(task_number)
+        lock_fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+        try:
+            try:
+                fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError as exc:
+                try:
+                    active = read_json_file(path)
+                except WorkflowToolError:
+                    active = {}
+                operation_id = (
+                    active.get("operation_id") if isinstance(active, Mapping) else None
+                )
+                state = active.get("state") if isinstance(active, Mapping) else None
+                raise LckStopError(
+                    f"Review Prepare already in flight for Task #{task_number}"
+                    + (
+                        f" (operation {operation_id}, state {state})"
+                        if operation_id
+                        else ""
+                    )
+                ) from exc
+
+            existing: Mapping[str, Any] | None = None
+            if path.exists():
+                parsed = read_json_file(path)
+                if not isinstance(parsed, Mapping):
+                    raise LckStopError("Review Prepare in-flight state is invalid")
+                if parsed.get("task_number") != task_number:
+                    raise LckStopError(
+                        "Review Prepare in-flight Task identity is invalid"
+                    )
+                owner_pid = parsed.get("pid")
+                if (
+                    not isinstance(owner_pid, int)
+                    or isinstance(owner_pid, bool)
+                    or owner_pid <= 0
+                ):
+                    raise LckStopError(
+                        "Review Prepare in-flight owner identity is invalid"
+                    )
+                if self._pid_is_alive(owner_pid):
+                    raise LckStopError(
+                        f"Review Prepare already in flight for Task #{task_number}"
+                    )
+                if parsed.get("state") == "handed-off":
+                    review_id = parsed.get("review_id")
+                    review_root = parsed.get("review_root")
+                    guard_exists = (
+                        isinstance(review_id, str)
+                        and self.guard_path(review_id).exists()
+                    )
+                    root_exists = (
+                        isinstance(review_root, str) and Path(review_root).exists()
+                    )
+                    if guard_exists and root_exists:
+                        raise LckStopError(
+                            "Review Prepare handoff is still owned by the prior "
+                            f"operation (review {review_id})"
+                        )
+                existing = dict(parsed)
+
+            operation_id = self.new_id()
+            payload: dict[str, Any] = {
+                "schema_version": LCK_SCHEMA_VERSION,
+                "kind": "review-prepare-in-flight",
+                "operation_id": operation_id,
+                "task_number": task_number,
+                "pid": os.getpid(),
+                "state": "starting",
+                "review_root": None,
+                "authority": "operation-local in-flight protection only",
+            }
+            if existing is not None:
+                payload["recovered_from"] = existing.get("operation_id")
+                payload["previous_review_root"] = existing.get("review_root")
+            invocation = ReviewPrepareInvocation(
+                path=path,
+                operation_id=operation_id,
+                _lock_fd=lock_fd,
+                recovered=existing,
+            )
+            invocation.update(payload)
+            return invocation
+        except BaseException:
+            os.close(lock_fd)
+            raise
+
+    def release_review_prepare(self, task_number: int, review_id: str) -> None:
+        """Release a successful Prepare handoff after Review cleanup."""
+        path = self.review_prepare_inflight_path(task_number)
+        if not path.exists():
+            return
+        lock_path = self.review_prepare_lock_path(task_number)
+        lock_fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+        try:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX)
+            if not path.exists():
+                return
+            value = read_json_file(path)
+            if not isinstance(value, Mapping):
+                raise LckStopError("Review Prepare in-flight state is invalid")
+            owner_review_id = value.get("review_id")
+            if owner_review_id != review_id:
+                raise LckStopError(
+                    "Review Prepare handoff belongs to a different Review invocation"
+                )
+            path.unlink()
+        finally:
+            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            os.close(lock_fd)
+
+    def write_guard(self, review_id: str, payload: Mapping[str, Any]) -> None:
+        atomic_write_json(self.guard_path(review_id), payload)
+
+    def read_guard(self, review_id: str) -> dict[str, Any]:
+        value = read_json_file(self.guard_path(review_id))
+        if not isinstance(value, dict):
+            raise LckStopError("Review invocation guard is not an object")
+        return value
+
+    def delete_guard(self, review_id: str) -> None:
+        try:
+            self.guard_path(review_id).unlink()
+        except FileNotFoundError:
+            pass
+
+    def write_record(
+        self, task_number: int, review_id: str, payload: Mapping[str, Any]
+    ) -> Path:
+        path = self.record_path(task_number, review_id)
+        atomic_write_json(path, payload)
+        return path
+
+    def read_record(self, task_number: int, review_id: str) -> dict[str, Any]:
+        value = read_json_file(self.record_path(task_number, review_id))
+        if not isinstance(value, dict):
+            raise LckStopError("Review record is not an object")
+        return value
+
+    def write_latest_review(
+        self, task_number: int, review_id: str, verdict: str
+    ) -> None:
+        self._validate_id(review_id)
+        atomic_write_json(
+            self.latest_review_path(task_number),
+            {
+                "schema_version": LCK_SCHEMA_VERSION,
+                "kind": "latest-independent-review",
+                "task_number": task_number,
+                "review_id": review_id,
+                "verdict": verdict,
+                "authority": "semantic predecessor only; never mechanical target authority",
+            },
+        )
+
+    def read_latest_review(self, task_number: int) -> dict[str, Any] | None:
+        path = self.latest_review_path(task_number)
+        if not path.exists():
+            return None
+        value = read_json_file(path)
+        if not isinstance(value, dict) or value.get("task_number") != task_number:
+            raise LckStopError("latest Review state is invalid")
+        return value
+
+    def write_review_required(
+        self, task_number: int, review_id: str, head_sha: str
+    ) -> None:
+        self._validate_id(review_id)
+        if not is_sha(head_sha):
+            raise LckStopError("review-required state needs a valid remediation head")
+        atomic_write_json(
+            self.review_required_path(task_number),
+            {
+                "schema_version": LCK_SCHEMA_VERSION,
+                "kind": "fresh-review-required",
+                "task_number": task_number,
+                "source_review_id": review_id,
+                "remediated_head": head_sha,
+                "authority": "negative lifecycle boundary only; current target remains live-resolved",
+            },
+        )
+
+    def read_review_required(self, task_number: int) -> dict[str, Any] | None:
+        path = self.review_required_path(task_number)
+        if not path.exists():
+            return None
+        value = read_json_file(path)
+        if not isinstance(value, dict) or value.get("task_number") != task_number:
+            raise LckStopError("review-required state is invalid")
+        return value
+
+    def clear_review_required(self, task_number: int) -> None:
+        try:
+            self.review_required_path(task_number).unlink()
+        except FileNotFoundError:
+            pass
+
+    def write_remediation_session(
+        self, task_number: int, payload: Mapping[str, Any]
+    ) -> Path:
+        path = self.remediation_session_path(task_number)
+        existing: Mapping[str, Any] | None = None
+        if path.exists():
+            value = read_json_file(path)
+            if not isinstance(value, Mapping):
+                raise LckStopError("Remediation session state is invalid")
+            existing = value
+        if existing is not None and (
+            existing.get("review_id") != payload.get("review_id")
+            or existing.get("start_head_sha") != payload.get("start_head_sha")
+        ):
+            raise LckStopError(
+                "another Remediation session is already prepared for this Task"
+            )
+        atomic_write_json(path, payload)
+        return path
+
+    def record_remediation_candidate(
+        self,
+        task_number: int,
+        review_id: str,
+        *,
+        start_head_sha: str,
+        candidate_head_sha: str,
+        candidate_tree_oid: str,
+    ) -> Path:
+        """Bind one exact committed candidate to its prepared Remediation session."""
+        session = self.read_remediation_session(task_number)
+        if session is None:
+            raise LckStopError(
+                "cannot record a Remediation candidate without a prepared session"
+            )
+        if (
+            session.get("review_id") != review_id
+            or session.get("start_head_sha") != start_head_sha
+        ):
+            raise LckStopError(
+                "Remediation candidate does not belong to the prepared session"
+            )
+        if not is_sha(candidate_head_sha) or not is_sha(candidate_tree_oid):
+            raise LckStopError("Remediation candidate identity is incomplete")
+        operation_id = session.get("operation_id")
+        if not isinstance(operation_id, str) or not operation_id:
+            operation_id = self.new_id()
+            session["operation_id"] = operation_id
+        candidate = {
+            "operation_id": operation_id,
+            "start_head_sha": start_head_sha,
+            "head_sha": candidate_head_sha,
+            "tree_oid": candidate_tree_oid,
+        }
+        existing = session.get("candidate")
+        if existing is not None and existing != candidate:
+            raise LckStopError(
+                "prepared Remediation session already owns a different candidate"
+            )
+        session["candidate"] = candidate
+        return self.write_remediation_session(task_number, session)
+
+    def read_remediation_session(self, task_number: int) -> dict[str, Any] | None:
+        path = self.remediation_session_path(task_number)
+        if not path.exists():
+            return None
+        value = read_json_file(path)
+        if not isinstance(value, dict) or value.get("task_number") != task_number:
+            raise LckStopError("Remediation session state is invalid")
+        return value
+
+    def clear_remediation_session(self, task_number: int) -> None:
+        try:
+            self.remediation_session_path(task_number).unlink()
+        except FileNotFoundError:
+            pass
+
+    def write_remediation_no_change_receipt(
+        self, task_number: int, review_id: str, payload: Mapping[str, Any]
+    ) -> Path:
+        path = self.remediation_no_change_receipt_path(task_number, review_id)
+        if path.exists():
+            existing = read_json_file(path)
+            if existing != dict(payload):
+                raise LckStopError(
+                    "existing Remediation no-change receipt does not match this completion"
+                )
+            return path
+        atomic_write_json(path, payload)
+        return path
+
+    def read_remediation_no_change_receipt(
+        self, task_number: int, review_id: str
+    ) -> dict[str, Any] | None:
+        path = self.remediation_no_change_receipt_path(task_number, review_id)
+        if not path.exists():
+            return None
+        value = read_json_file(path)
+        if (
+            not isinstance(value, dict)
+            or value.get("task_number") != task_number
+            or value.get("review_id") != review_id
+            or value.get("kind") != "remediation-no-change-receipt"
+        ):
+            raise LckStopError("Remediation no-change receipt is invalid")
+        return value
+
+
+def _identity_from_mapping(value: Mapping[str, Any]) -> ReviewIdentity:
+    changed = value.get("changed_files")
+    if not isinstance(changed, list) or not all(
+        isinstance(item, str) for item in changed
+    ):
+        raise LckStopError("Review invocation identity has invalid changed-files data")
+    fields = {
+        "task_number": value.get("task_number"),
+        "pr_number": value.get("pr_number"),
+        "base_sha": value.get("base_sha"),
+        "head_sha": value.get("head_sha"),
+        "task_body_sha256": value.get("task_body_sha256"),
+        "merge_base_sha": value.get("merge_base_sha"),
+        "effective_diff_sha256": value.get("effective_diff_sha256"),
+    }
+    if not isinstance(fields["task_number"], int) or not isinstance(
+        fields["pr_number"], int
+    ):
+        raise LckStopError("Review invocation identity is incomplete")
+    for name in ("base_sha", "head_sha", "merge_base_sha"):
+        if not is_sha(fields[name]):
+            raise LckStopError(f"Review invocation identity has invalid {name}")
+    for name in ("task_body_sha256", "effective_diff_sha256"):
+        item = fields[name]
+        if not isinstance(item, str) or re.fullmatch(r"[0-9a-f]{64}", item) is None:
+            raise LckStopError(f"Review invocation identity has invalid {name}")
+    raw_research_artifact = value.get("research_artifact")
+    if raw_research_artifact is not None and not isinstance(
+        raw_research_artifact, Mapping
+    ):
+        raise LckStopError("Review invocation identity has invalid Research artifact")
+    return ReviewIdentity(
+        task_number=fields["task_number"],
+        pr_number=fields["pr_number"],
+        base_sha=cast(str, fields["base_sha"]),
+        head_sha=cast(str, fields["head_sha"]),
+        task_body_sha256=cast(str, fields["task_body_sha256"]),
+        merge_base_sha=cast(str, fields["merge_base_sha"]),
+        effective_diff_sha256=cast(str, fields["effective_diff_sha256"]),
+        changed_files=tuple(changed),
+        research_artifact=(
+            dict(raw_research_artifact)
+            if isinstance(raw_research_artifact, Mapping)
+            else None
+        ),
+    )
+
+
+def _assert_review_target_facts_applicable(
+    reviewed: ReviewIdentity,
+    state: LiveState,
+    task_contract: Mapping[str, Any],
+) -> None:
+    """Reject obvious stale Review identity before computing the current diff.
+
+    This ordering matters when another actor pushed a new head that is visible on
+    GitHub but whose Git object is not materialized locally.  Head/base/Task
+    staleness must still produce the precise REVIEW_STALE_* result without a
+    fetch or a failed local diff probe.
+    """
+    pr = state.open_pr
+    if not isinstance(pr, Mapping):
+        raise ReviewStaleError(
+            "REVIEW_STALE_PR",
+            f"reviewed PR #{reviewed.pr_number} is no longer the unique current OPEN PR",
+        )
+    current_number = pr.get("number")
+    if current_number != reviewed.pr_number:
+        raise ReviewStaleError(
+            "REVIEW_STALE_PR",
+            f"OPEN PR changed from #{reviewed.pr_number} to #{current_number}",
+        )
+    current_head = _pr_head_sha(pr)
+    if current_head != reviewed.head_sha:
+        raise ReviewStaleError(
+            "REVIEW_STALE_HEAD",
+            f"PR head changed from {reviewed.head_sha} to {current_head or 'unavailable'}",
+        )
+    current_base = _pr_base_sha(pr)
+    if current_base != reviewed.base_sha:
+        raise ReviewStaleError(
+            "REVIEW_STALE_BASE",
+            f"PR base changed from {reviewed.base_sha} to {current_base or 'unavailable'}",
+        )
+    current_task = task_contract.get("body_sha256")
+    if current_task != reviewed.task_body_sha256:
+        raise ReviewStaleError(
+            "REVIEW_STALE_TASK",
+            "Task Contract changed since Review Prepare",
+        )
+
+
+def _assert_review_applicable(start: ReviewIdentity, current: ReviewIdentity) -> None:
+    """Compare exact reviewed/current identities after basic target facts match."""
+    if current.pr_number != start.pr_number:
+        raise ReviewStaleError(
+            "REVIEW_STALE_PR",
+            f"OPEN PR changed from #{start.pr_number} to #{current.pr_number}",
+        )
+    if current.head_sha != start.head_sha:
+        raise ReviewStaleError(
+            "REVIEW_STALE_HEAD",
+            f"PR head changed from {start.head_sha} to {current.head_sha}",
+        )
+    if current.base_sha != start.base_sha:
+        raise ReviewStaleError(
+            "REVIEW_STALE_BASE",
+            f"PR base changed from {start.base_sha} to {current.base_sha}",
+        )
+    if current.task_body_sha256 != start.task_body_sha256:
+        raise ReviewStaleError(
+            "REVIEW_STALE_TASK",
+            "Task Contract changed during this Review invocation",
+        )
+    if (
+        current.merge_base_sha != start.merge_base_sha
+        or current.effective_diff_sha256 != start.effective_diff_sha256
+        or current.changed_files != start.changed_files
+        or current.research_artifact != start.research_artifact
+    ):
+        raise ReviewStaleError(
+            "REVIEW_STALE_DIFF",
+            "effective diff or Research artifact changed during this Review invocation",
+        )

--- a/tools/lck/shared_facts.py
+++ b/tools/lck/shared_facts.py
@@ -1,0 +1,1388 @@
+"""Authoritative, profile-neutral Git and GitHub fact acquisition.
+
+This module owns the bounded queries and canonical normalization shared by LCK
+and Feature audit.  It deliberately does not resolve Issue profiles or parse
+profile contracts.  Profile-specific interpretation belongs to
+``profile_policies`` and the Feature-audit adapter in ``workflow_evidence``.
+"""
+
+from __future__ import annotations
+
+import unicodedata
+from collections.abc import Mapping, Sequence
+from typing import Any, Final
+
+from .common import (
+    CommandResult,
+    CommandRunner,
+    bounded_list,
+    command_warning,
+    is_sha,
+    parse_repository_slug,
+    read_json_text,
+    safe_text,
+    sha256_json,
+)
+
+SCHEMA_VERSION: Final = 1
+MAX_CHILDREN: Final = 50
+MAX_FILES: Final = 100
+CANONICAL_PROJECT_NUMBER: Final = 1
+CANONICAL_PROJECT_TITLE: Final = "Quant System Development"
+
+ISSUE_PROJECT_ITEMS_QUERY: Final = r"""
+query($owner:String!, $name:String!, $number:Int!) {
+  repository(owner:$owner, name:$name) {
+    issue(number:$number) {
+      number
+      projectItems(first:20) {
+        nodes {
+          project {
+            number
+            title
+            owner {
+              ... on User { login }
+              ... on Organization { login }
+            }
+          }
+          content {
+            ... on Issue { number repository { nameWithOwner } }
+          }
+          fieldValues(first:100) {
+            nodes {
+              __typename
+              ... on ProjectV2ItemFieldSingleSelectValue {
+                name
+                field { ... on ProjectV2SingleSelectField { name } }
+              }
+            }
+            pageInfo { hasNextPage }
+          }
+        }
+        pageInfo { hasNextPage }
+      }
+    }
+  }
+}
+"""
+
+RELATIONSHIPS_QUERY: Final = r"""
+query($owner:String!, $name:String!, $number:Int!) {
+  repository(owner:$owner, name:$name) {
+    issue(number:$number) {
+      number
+      title
+      state
+      body
+      labels(first:100) { nodes { name } pageInfo { hasNextPage } }
+      issueType { name }
+      parent { number title state }
+      subIssues(first:100) {
+        nodes {
+          number
+          title
+          state
+          body
+          labels(first:100) { nodes { name } pageInfo { hasNextPage } }
+        }
+        pageInfo { hasNextPage }
+      }
+      blockedBy(first:50) {
+        nodes {
+          number
+          title
+          state
+          body
+          labels(first:100) { nodes { name } pageInfo { hasNextPage } }
+          projectItems(first:20) {
+            nodes {
+              project {
+                number
+                title
+                owner {
+                  ... on User { login }
+                  ... on Organization { login }
+                }
+              }
+              content {
+                ... on Issue { number repository { nameWithOwner } }
+              }
+              fieldValues(first:100) {
+                nodes {
+                  __typename
+                  ... on ProjectV2ItemFieldSingleSelectValue {
+                    name
+                    field { ... on ProjectV2SingleSelectField { name } }
+                  }
+                }
+                pageInfo { hasNextPage }
+              }
+            }
+            pageInfo { hasNextPage }
+          }
+        }
+        pageInfo { hasNextPage }
+      }
+      blocking(first:50) {
+        nodes {
+          number
+          title
+          state
+          body
+          labels(first:100) { nodes { name } pageInfo { hasNextPage } }
+          projectItems(first:20) {
+            nodes {
+              project {
+                number
+                title
+                owner {
+                  ... on User { login }
+                  ... on Organization { login }
+                }
+              }
+              content {
+                ... on Issue { number repository { nameWithOwner } }
+              }
+              fieldValues(first:100) {
+                nodes {
+                  __typename
+                  ... on ProjectV2ItemFieldSingleSelectValue {
+                    name
+                    field { ... on ProjectV2SingleSelectField { name } }
+                  }
+                }
+                pageInfo { hasNextPage }
+              }
+            }
+            pageInfo { hasNextPage }
+          }
+        }
+        pageInfo { hasNextPage }
+      }
+    }
+  }
+}
+"""
+
+ISSUE_CLOSURE_QUERY: Final = r"""
+query($owner:String!, $name:String!, $number:Int!) {
+  repository(owner:$owner, name:$name) {
+    issue(number:$number) {
+      number
+      state
+      closedAt
+      closedByPullRequestsReferences(first:20, includeClosedPrs:true) {
+        nodes {
+          number
+          state
+          merged
+          mergedAt
+          url
+          repository { nameWithOwner }
+        }
+        pageInfo { hasNextPage }
+      }
+      timelineItems(last:50, itemTypes:[CLOSED_EVENT, REOPENED_EVENT]) {
+        nodes {
+          __typename
+          ... on ClosedEvent {
+            createdAt
+            closer {
+              __typename
+              ... on PullRequest {
+                number
+                state
+                merged
+                mergedAt
+                url
+                repository { nameWithOwner }
+              }
+            }
+          }
+          ... on ReopenedEvent { createdAt }
+        }
+        pageInfo { hasPreviousPage }
+      }
+    }
+  }
+}
+"""
+
+
+def normalize_title(value: str) -> str:
+    """Normalize titles for mechanical identity comparisons."""
+    normalized = unicodedata.normalize("NFKC", value)
+    return " ".join(normalized.split()).casefold()
+
+
+def gate(status: str, detail: str | None = None) -> dict[str, Any]:
+    result: dict[str, Any] = {"status": status}
+    if detail:
+        result["detail"] = safe_text(detail, limit=256)
+    return result
+
+
+def _git_value(
+    runner: CommandRunner,
+    args: Sequence[str],
+    *,
+    command_id: str,
+    warnings: list[dict[str, Any]],
+) -> str | None:
+    result = runner.run(["git", *args], command_id=command_id)
+    if result.returncode != 0:
+        warnings.append(command_warning(result))
+        return None
+    return result.stdout.strip() or None
+
+
+def _git_lines(
+    runner: CommandRunner,
+    args: Sequence[str],
+    *,
+    command_id: str,
+    warnings: list[dict[str, Any]],
+) -> list[str]:
+    value = _git_value(runner, args, command_id=command_id, warnings=warnings)
+    return [] if value is None else [line for line in value.splitlines() if line]
+
+
+def _remote_main_sha(
+    runner: CommandRunner, warnings: list[dict[str, Any]]
+) -> str | None:
+    """Read authoritative remote main without changing local refs."""
+    result = runner.run(
+        ["git", "ls-remote", "origin", "refs/heads/main"],
+        command_id="git-remote-main",
+        retries=1,
+    )
+    if result.returncode != 0:
+        warnings.append(command_warning(result))
+        return None
+    matches = [
+        line.split("\t", 1)[0]
+        for line in result.stdout.splitlines()
+        if "\t" in line and line.split("\t", 1)[1] == "refs/heads/main"
+    ]
+    if len(matches) != 1 or not is_sha(matches[0]):
+        warnings.append(
+            {
+                "command_id": result.command_id,
+                "exit_code": result.returncode,
+                "error": "authoritative refs/heads/main result is missing or malformed",
+            }
+        )
+        return None
+    return matches[0]
+
+
+def _repository_slug(
+    runner: CommandRunner,
+    explicit: str | None,
+    warnings: list[dict[str, Any]],
+) -> str | None:
+    if explicit:
+        return explicit
+    remote = _git_value(
+        runner,
+        ["remote", "get-url", "origin"],
+        command_id="git-origin-url",
+        warnings=warnings,
+    )
+    if remote:
+        slug = parse_repository_slug(remote)
+        if slug:
+            return slug
+    result = runner.run(
+        ["gh", "repo", "view", "--json", "nameWithOwner"],
+        command_id="gh-repo-view",
+        retries=1,
+    )
+    if result.returncode != 0:
+        warnings.append(command_warning(result))
+        return None
+    value = read_json_text(result.stdout, field="gh repo view")
+    if isinstance(value, Mapping) and isinstance(value.get("nameWithOwner"), str):
+        return str(value["nameWithOwner"])
+    return None
+
+
+def _git_snapshot(
+    runner: CommandRunner,
+    warnings: list[dict[str, Any]],
+    *,
+    read_only_local_refs: bool = False,
+    include_workspace_inventory: bool = True,
+) -> dict[str, Any]:
+    """Collect bounded, profile-neutral Git facts."""
+    fetch: CommandResult | None = None
+    if not read_only_local_refs:
+        fetch = runner.run(
+            ["git", "fetch", "--prune", "origin"],
+            command_id="git-fetch-origin",
+            retries=1,
+        )
+        if fetch.returncode != 0:
+            warnings.append(command_warning(fetch))
+    branch = _git_value(
+        runner,
+        ["branch", "--show-current"],
+        command_id="git-current-branch",
+        warnings=warnings,
+    )
+    head = _git_value(
+        runner, ["rev-parse", "HEAD"], command_id="git-head", warnings=warnings
+    )
+    local_main = _git_value(
+        runner,
+        ["rev-parse", "refs/heads/main"],
+        command_id="git-local-main",
+        warnings=warnings,
+    )
+    tracking_main = _git_value(
+        runner,
+        ["rev-parse", "refs/remotes/origin/main"],
+        command_id="git-tracking-main",
+        warnings=warnings,
+    )
+    remote_main = _remote_main_sha(runner, warnings)
+    status_result = runner.run(
+        ["git", "status", "--short", "--untracked-files=all"],
+        command_id="git-status",
+    )
+    if status_result.returncode != 0:
+        warnings.append(command_warning(status_result))
+        status_lines: list[str] | None = None
+    else:
+        status_lines = [line for line in status_result.stdout.splitlines() if line]
+    staged = (
+        _git_lines(
+            runner,
+            ["diff", "--cached", "--name-only"],
+            command_id="git-staged-files",
+            warnings=warnings,
+        )
+        if include_workspace_inventory
+        else []
+    )
+    changed = (
+        _git_lines(
+            runner,
+            ["diff", "--name-only"],
+            command_id="git-changed-files",
+            warnings=warnings,
+        )
+        if include_workspace_inventory
+        else []
+    )
+    worktrees = (
+        _git_lines(
+            runner,
+            ["worktree", "list", "--porcelain"],
+            command_id="git-worktrees",
+            warnings=warnings,
+        )
+        if include_workspace_inventory
+        else []
+    )
+    worktree_branches = sorted(
+        line.removeprefix("branch refs/heads/")
+        for line in worktrees
+        if line.startswith("branch refs/heads/")
+    )
+    return {
+        "origin_fetch": (
+            "pass"
+            if read_only_local_refs
+            else "pass"
+            if fetch is not None and fetch.returncode == 0
+            else "unknown"
+        ),
+        "origin_refresh": "skipped-read-only" if read_only_local_refs else "attempted",
+        "branch": safe_text(branch),
+        "head_sha": head if is_sha(head) else None,
+        "local_main_sha": local_main if is_sha(local_main) else None,
+        "tracking_main_sha": tracking_main if is_sha(tracking_main) else None,
+        "remote_main_sha": remote_main,
+        "tracking_main_stale": (
+            is_sha(tracking_main)
+            and is_sha(remote_main)
+            and tracking_main != remote_main
+        ),
+        "remote_main_query": "pass" if is_sha(remote_main) else "unknown",
+        "clean": None if status_lines is None else len(status_lines) == 0,
+        "status_entries": None if status_lines is None else len(status_lines),
+        "staged_files": bounded_list(staged, item_limit=MAX_FILES)
+        if include_workspace_inventory
+        else None,
+        "changed_files": bounded_list(changed, item_limit=MAX_FILES)
+        if include_workspace_inventory
+        else None,
+        "worktree_count": (
+            sum(1 for line in worktrees if line.startswith("worktree "))
+            if include_workspace_inventory
+            else None
+        ),
+        "worktree_branches": bounded_list(worktree_branches, item_limit=MAX_FILES)
+        if include_workspace_inventory
+        else None,
+    }
+
+
+def _repository_name(value: Mapping[str, Any]) -> str | None:
+    repository = value.get("repository")
+    return (
+        safe_text(repository.get("nameWithOwner"))
+        if isinstance(repository, Mapping)
+        else None
+    )
+
+
+def _normalize_closing_pr(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, Mapping):
+        return None
+    return {
+        "number": value.get("number"),
+        "state": safe_text(value.get("state")),
+        "merged": value.get("merged")
+        if isinstance(value.get("merged"), bool)
+        else None,
+        "merged_at": safe_text(value.get("mergedAt")),
+        "url": safe_text(value.get("url")),
+        "repository": _repository_name(value),
+    }
+
+
+def _graphql(
+    runner: CommandRunner,
+    repository: str,
+    number: int,
+    query: str,
+    *,
+    command_id: str,
+    warnings: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    owner, name = repository.split("/", 1)
+    result = runner.run(
+        [
+            "gh",
+            "api",
+            "graphql",
+            "-f",
+            f"query={' '.join(query.split())}",
+            "-F",
+            f"owner={owner}",
+            "-F",
+            f"name={name}",
+            "-F",
+            f"number={number}",
+        ],
+        command_id=command_id,
+        retries=1,
+    )
+    if result.returncode != 0:
+        warnings.append(command_warning(result))
+        return None
+    value = read_json_text(result.stdout, field=command_id)
+    if not isinstance(value, dict):
+        warnings.append(
+            {
+                "command_id": command_id,
+                "exit_code": 0,
+                "error": "GraphQL response is not an object",
+            }
+        )
+        return None
+    if value.get("errors"):
+        warnings.append(
+            {
+                "command_id": command_id,
+                "exit_code": 0,
+                "error": safe_text(value.get("errors"), limit=1000),
+            }
+        )
+        return None
+    return value
+
+
+def _normalize_project_items(value: Any) -> dict[str, Any]:
+    """Normalize complete ProjectV2 single-select facts without policy meaning."""
+    if isinstance(value, Mapping):
+        nodes = value.get("nodes")
+        page = value.get("pageInfo")
+    else:
+        return {"items": [], "count": 0, "truncated": True, "complete": False}
+    if not isinstance(nodes, list) or not isinstance(page, Mapping):
+        return {"items": [], "count": 0, "truncated": True, "complete": False}
+    page_complete = page.get("hasNextPage") is False
+    normalized: list[dict[str, Any]] = []
+    all_items_complete = True
+    for item in nodes:
+        if not isinstance(item, Mapping):
+            all_items_complete = False
+            continue
+        project = item.get("project")
+        if not isinstance(project, Mapping):
+            all_items_complete = False
+            continue
+        owner = project.get("owner")
+        owner_login = owner.get("login") if isinstance(owner, Mapping) else None
+        project_number = project.get("number")
+        project_title = project.get("title")
+        content = item.get("content")
+        content_number = content.get("number") if isinstance(content, Mapping) else None
+        content_repository = (
+            content.get("repository") if isinstance(content, Mapping) else None
+        )
+        content_repository_name = (
+            content_repository.get("nameWithOwner")
+            if isinstance(content_repository, Mapping)
+            else None
+        )
+        item_identity_complete = (
+            isinstance(project_number, int)
+            and not isinstance(project_number, bool)
+            and project_number > 0
+            and isinstance(project_title, str)
+            and bool(project_title.strip())
+            and isinstance(owner_login, str)
+            and bool(owner_login.strip())
+            and isinstance(content, Mapping)
+            and isinstance(content_number, int)
+            and not isinstance(content_number, bool)
+            and content_number > 0
+            and isinstance(content_repository_name, str)
+            and bool(content_repository_name.strip())
+        )
+        fields_value = item.get("fieldValues")
+        fields: dict[str, str] = {}
+        fields_complete = False
+        if isinstance(fields_value, Mapping):
+            raw_fields = fields_value.get("nodes")
+            field_page = fields_value.get("pageInfo")
+            if isinstance(raw_fields, list):
+                fields_complete = (
+                    isinstance(field_page, Mapping)
+                    and field_page.get("hasNextPage") is False
+                )
+                for field_value in raw_fields:
+                    if not isinstance(field_value, Mapping):
+                        fields_complete = False
+                        continue
+                    field_type = field_value.get("__typename")
+                    if field_type != "ProjectV2ItemFieldSingleSelectValue":
+                        if isinstance(field_type, str) and field_type:
+                            continue
+                        fields_complete = False
+                        continue
+                    field = field_value.get("field")
+                    field_name = (
+                        field.get("name") if isinstance(field, Mapping) else None
+                    )
+                    field_value_name = field_value.get("name")
+                    if (
+                        isinstance(field_name, str)
+                        and isinstance(field_value_name, str)
+                        and field_name.strip()
+                        and field_value_name.strip()
+                    ):
+                        normalized_name = safe_text(field_name)
+                        normalized_value = safe_text(field_value_name)
+                        if normalized_name is None or normalized_value is None:
+                            fields_complete = False
+                        elif normalized_name in fields:
+                            fields_complete = False
+                        else:
+                            fields[normalized_name] = normalized_value
+                    else:
+                        fields_complete = False
+        item_complete = item_identity_complete and fields_complete
+        all_items_complete = all_items_complete and item_complete
+        normalized.append(
+            {
+                "number": project_number,
+                "title": safe_text(project_title),
+                "owner": safe_text(owner_login),
+                "content_number": content_number,
+                "content_repository": safe_text(content_repository_name),
+                "fields": fields,
+                "fields_complete": fields_complete,
+                "identity_complete": item_identity_complete,
+            }
+        )
+    bounded = bounded_list(normalized)
+    bounded["truncated"] = bounded["truncated"] or not page_complete
+    bounded["complete"] = (
+        page_complete and not bounded["truncated"] and all_items_complete
+    )
+    return bounded
+
+
+def _issue_project_items_snapshot(
+    runner: CommandRunner,
+    repository: str,
+    number: int,
+    warnings: list[dict[str, Any]],
+    *,
+    command_id: str | None = None,
+) -> dict[str, Any]:
+    """Acquire one root Issue's canonical ProjectV2 facts."""
+    query_command_id = command_id or f"gh-issue-project-items-{number}"
+    value = _graphql(
+        runner,
+        repository,
+        number,
+        ISSUE_PROJECT_ITEMS_QUERY,
+        command_id=query_command_id,
+        warnings=warnings,
+    )
+    issue = None
+    if isinstance(value, Mapping):
+        data = value.get("data")
+        repo = data.get("repository") if isinstance(data, Mapping) else None
+        issue = repo.get("issue") if isinstance(repo, Mapping) else None
+    if not isinstance(issue, Mapping) or issue.get("number") != number:
+        warnings.append(
+            {
+                "command_id": query_command_id,
+                "exit_code": 0,
+                "error": "ProjectV2 Issue response is missing or has the wrong identity",
+            }
+        )
+        return {"items": [], "count": 0, "truncated": True, "complete": False}
+    project_items = _normalize_project_items(issue.get("projectItems"))
+    if project_items.get("complete") is not True:
+        warnings.append(
+            {
+                "command_id": query_command_id,
+                "exit_code": 0,
+                "error": "ProjectV2 item or single-select field facts are incomplete",
+            }
+        )
+    return project_items
+
+
+def _find_project_field(value: Any, field_name: str) -> str | None:
+    """Find a normalized or raw Project field value by its mechanical name."""
+    if isinstance(value, Mapping):
+        fields = value.get("fields")
+        if isinstance(fields, Mapping):
+            candidate = fields.get(field_name)
+            if isinstance(candidate, str) and candidate.strip():
+                return safe_text(candidate)
+        field = value.get("field")
+        if isinstance(field, Mapping) and field.get("name") == field_name:
+            for key in ("name", "value", "text"):
+                candidate = value.get(key)
+                if isinstance(candidate, str) and candidate.strip():
+                    return safe_text(candidate)
+        for key, nested in value.items():
+            if str(key).casefold() == field_name.casefold():
+                if isinstance(nested, str) and nested.strip():
+                    return safe_text(nested)
+                if isinstance(nested, Mapping):
+                    for candidate_key in ("name", "value", "text"):
+                        candidate = nested.get(candidate_key)
+                        if isinstance(candidate, str) and candidate.strip():
+                            return safe_text(candidate)
+            result = _find_project_field(nested, field_name)
+            if result is not None:
+                return result
+    elif isinstance(value, list):
+        for nested in value:
+            result = _find_project_field(nested, field_name)
+            if result is not None:
+                return result
+    return None
+
+
+def _find_project_status(value: Any) -> str | None:
+    return _find_project_field(value, "Status")
+
+
+def canonical_project_field(
+    value: Any,
+    *,
+    repository: str | None,
+    issue_number: int | None,
+    field_name: str,
+) -> str | None:
+    """Return a field from the repository owner's canonical Project item.
+
+    Project identity and field normalization are mechanical facts.  The caller
+    chooses which normalized field has business meaning.
+    """
+    if (
+        not isinstance(value, Mapping)
+        or repository is None
+        or value.get("complete") is not True
+    ):
+        return None
+    owner, separator, _name = repository.partition("/")
+    if not separator or not owner:
+        return None
+    items = value.get("items")
+    if not isinstance(items, list) or value.get("truncated") is True:
+        return None
+    canonical = [
+        item
+        for item in items
+        if isinstance(item, Mapping)
+        and item.get("number") == CANONICAL_PROJECT_NUMBER
+        and item.get("title") == CANONICAL_PROJECT_TITLE
+        and isinstance(item.get("owner"), str)
+        and item.get("owner", "").casefold() == owner.casefold()
+        and isinstance(item.get("content_repository"), str)
+        and item.get("content_repository", "").casefold() == repository.casefold()
+        and item.get("content_number") == issue_number
+        and item.get("identity_complete") is True
+        and item.get("fields_complete") is True
+    ]
+    if len(canonical) != 1:
+        return None
+    fields = canonical[0].get("fields")
+    if not isinstance(fields, Mapping):
+        return None
+    result = fields.get(field_name)
+    return safe_text(result) if isinstance(result, str) and result.strip() else None
+
+
+def project_single_select_field(
+    value: Any,
+    *,
+    repository: str,
+    issue_number: int,
+    project_number: int,
+    field_name: str,
+) -> str | None:
+    """Return one exact Project single-select field from complete Issue facts."""
+    if not isinstance(value, Mapping) or value.get("complete") is not True:
+        return None
+    owner, separator, name = repository.partition("/")
+    if (
+        not separator
+        or not owner
+        or not name
+        or not isinstance(issue_number, int)
+        or isinstance(issue_number, bool)
+        or issue_number <= 0
+        or not isinstance(project_number, int)
+        or isinstance(project_number, bool)
+        or project_number <= 0
+        or not field_name
+    ):
+        return None
+    items = value.get("items")
+    if not isinstance(items, list) or value.get("truncated") is True:
+        return None
+    matching = [
+        item
+        for item in items
+        if isinstance(item, Mapping)
+        and item.get("number") == project_number
+        and isinstance(item.get("owner"), str)
+        and item.get("owner", "").casefold() == owner.casefold()
+        and isinstance(item.get("content_repository"), str)
+        and item.get("content_repository", "").casefold() == repository.casefold()
+        and item.get("content_number") == issue_number
+        and item.get("identity_complete") is True
+        and item.get("fields_complete") is True
+    ]
+    if len(matching) != 1:
+        return None
+    fields = matching[0].get("fields")
+    if not isinstance(fields, Mapping):
+        return None
+    result = fields.get(field_name)
+    return safe_text(result) if isinstance(result, str) and result.strip() else None
+
+
+def query_project_single_select_field(
+    runner: CommandRunner,
+    *,
+    repository: str,
+    issue_number: int,
+    project_number: int,
+    field_name: str,
+    command_id: str,
+) -> str | None:
+    """Freshly read one exact field through the repository-owned Issue path."""
+    owner, separator, name = repository.partition("/")
+    if not separator or not owner or not name:
+        return None
+    warnings: list[dict[str, Any]] = []
+    project_items = _issue_project_items_snapshot(
+        runner,
+        repository,
+        issue_number,
+        warnings,
+        command_id=command_id,
+    )
+    if warnings:
+        return None
+    return project_single_select_field(
+        project_items,
+        repository=repository,
+        issue_number=issue_number,
+        project_number=project_number,
+        field_name=field_name,
+    )
+
+
+def _issue_closure_snapshot(
+    runner: CommandRunner,
+    repository: str,
+    number: int,
+    warnings: list[dict[str, Any]],
+) -> dict[str, Any]:
+    value = _graphql(
+        runner,
+        repository,
+        number,
+        ISSUE_CLOSURE_QUERY,
+        command_id=f"gh-issue-closure-{number}",
+        warnings=warnings,
+    )
+    if not isinstance(value, Mapping):
+        return {
+            "status": "unknown",
+            "reason": "issue-closure-query-unavailable",
+            "evidence_status": "partial",
+        }
+    data = value.get("data")
+    repo = data.get("repository") if isinstance(data, Mapping) else None
+    issue = repo.get("issue") if isinstance(repo, Mapping) else None
+    if not isinstance(issue, Mapping):
+        return {
+            "status": "unknown",
+            "reason": "issue-closure-metadata-unavailable",
+            "evidence_status": "partial",
+        }
+    refs = issue.get("closedByPullRequestsReferences")
+    ref_nodes = (
+        refs.get("nodes")
+        if isinstance(refs, Mapping)
+        else refs
+        if isinstance(refs, list)
+        else []
+    )
+    ref_items = (
+        [
+            normalized
+            for normalized in (_normalize_closing_pr(item) for item in ref_nodes)
+            if normalized is not None
+        ]
+        if isinstance(ref_nodes, list)
+        else []
+    )
+    ref_page = refs.get("pageInfo") if isinstance(refs, Mapping) else None
+    refs_truncated = (
+        isinstance(ref_page, Mapping) and ref_page.get("hasNextPage") is True
+    )
+    timeline = issue.get("timelineItems")
+    timeline_nodes = timeline.get("nodes") if isinstance(timeline, Mapping) else []
+    timeline_page = timeline.get("pageInfo") if isinstance(timeline, Mapping) else None
+    timeline_truncated = (
+        isinstance(timeline_page, Mapping)
+        and timeline_page.get("hasPreviousPage") is True
+    )
+    events: list[dict[str, Any]] = []
+    if isinstance(timeline_nodes, list):
+        for item in timeline_nodes:
+            if not isinstance(item, Mapping):
+                continue
+            typename = safe_text(item.get("__typename"))
+            created_at = safe_text(item.get("createdAt"))
+            if typename == "ClosedEvent":
+                closer = item.get("closer")
+                closer_type = (
+                    safe_text(closer.get("__typename"))
+                    if isinstance(closer, Mapping)
+                    else None
+                )
+                event: dict[str, Any] = {
+                    "type": "closed",
+                    "created_at": created_at,
+                    "closer_type": closer_type,
+                }
+                if closer_type == "PullRequest" and isinstance(closer, Mapping):
+                    event["closer"] = _normalize_closing_pr(closer)
+                events.append(event)
+            elif typename == "ReopenedEvent":
+                events.append({"type": "reopened", "created_at": created_at})
+    latest_closure: dict[str, Any] | None = None
+    for event in sorted(events, key=lambda item: str(item.get("created_at") or "")):
+        if event.get("type") == "closed":
+            latest_closure = event
+        elif event.get("type") == "reopened":
+            latest_closure = None
+    state = safe_text(issue.get("state"))
+    closed_at = safe_text(issue.get("closedAt"))
+    evidence_status = "complete"
+    reason = "closed-by-pr"
+    status = "closed-by-pr"
+    if refs_truncated:
+        evidence_status, reason, status = (
+            "partial",
+            "closing-pr-references-truncated",
+            "unknown",
+        )
+    elif timeline_truncated:
+        evidence_status, reason, status = "partial", "timeline-truncated", "unknown"
+    elif state != "CLOSED":
+        reason, status = "issue-not-closed", "not-closed"
+    elif latest_closure is None:
+        evidence_status, reason, status = (
+            "partial",
+            "latest-effective-close-event-unavailable",
+            "unknown",
+        )
+    elif latest_closure.get("closer_type") != "PullRequest":
+        reason, status = "latest-closer-is-not-pull-request", "not-pr-closer"
+    elif not isinstance(latest_closure.get("closer"), Mapping):
+        evidence_status, reason, status = (
+            "partial",
+            "latest-closer-pr-metadata-unavailable",
+            "unknown",
+        )
+    closer = (
+        latest_closure.get("closer") if isinstance(latest_closure, Mapping) else None
+    )
+    return {
+        "status": status,
+        "reason": reason,
+        "state": state,
+        "closed_at": closed_at,
+        "latest_effective_event": latest_closure,
+        "closer_type": latest_closure.get("closer_type")
+        if isinstance(latest_closure, Mapping)
+        else None,
+        "closer_repository": closer.get("repository")
+        if isinstance(closer, Mapping)
+        else None,
+        "closer_number": closer.get("number") if isinstance(closer, Mapping) else None,
+        "closed_by_pull_requests": bounded_list(ref_items),
+        "evidence_status": evidence_status,
+        "evidence_complete": evidence_status == "complete",
+        "conflict": False,
+    }
+
+
+def _issue_view_with_contract(
+    runner: CommandRunner,
+    repository: str,
+    number: int,
+    warnings: list[dict[str, Any]],
+    include_comments: bool = True,
+    include_closure: bool = True,
+    include_contract: bool = True,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    """Read and normalize one Issue without profile interpretation."""
+    fields = ["number", "title", "state", "labels", "url"]
+    if include_contract:
+        fields.append("body")
+    if include_comments:
+        fields.append("comments")
+    if include_closure:
+        fields.extend(("closedAt", "closedByPullRequestsReferences"))
+    result = runner.run(
+        [
+            "gh",
+            "issue",
+            "view",
+            str(number),
+            "--repo",
+            repository,
+            "--json",
+            ",".join(fields),
+        ],
+        command_id=f"gh-issue-view-{number}",
+        retries=1,
+    )
+    if result.returncode != 0:
+        fallback = runner.run(
+            [
+                "gh",
+                "issue",
+                "view",
+                str(number),
+                "--repo",
+                repository,
+                "--json",
+                ",".join(
+                    field
+                    for field in fields
+                    if field
+                    not in {
+                        "comments",
+                        "closedByPullRequestsReferences",
+                    }
+                ),
+            ],
+            command_id=f"gh-issue-view-fallback-{number}",
+        )
+        if fallback.returncode != 0:
+            warnings.extend((command_warning(result), command_warning(fallback)))
+            return None, None
+        result = fallback
+    value = read_json_text(result.stdout, field=f"Issue #{number}")
+    if not isinstance(value, Mapping):
+        warnings.append(
+            {
+                "command_id": result.command_id,
+                "exit_code": 0,
+                "error": "Issue response is not an object",
+            }
+        )
+        return None, None
+    labels = value.get("labels", [])
+    normalized_labels: list[str] = []
+    if isinstance(labels, list):
+        for item in labels:
+            if isinstance(item, Mapping) and isinstance(item.get("name"), str):
+                normalized_labels.append(item["name"])
+            elif isinstance(item, str):
+                normalized_labels.append(item)
+    raw_comments = value.get("comments", [])
+    comments: list[dict[str, Any]] = []
+    if isinstance(raw_comments, list):
+        for comment in raw_comments:
+            if not isinstance(comment, Mapping):
+                continue
+            author = comment.get("author")
+            comments.append(
+                {
+                    "author": author.get("login")
+                    if isinstance(author, Mapping)
+                    else None,
+                    "created_at": comment.get("createdAt"),
+                    "updated_at": comment.get("updatedAt"),
+                    "body": comment.get("body")
+                    if isinstance(comment.get("body"), str)
+                    else None,
+                }
+            )
+    body = value.get("body") if isinstance(value.get("body"), str) else None
+    project_items = _issue_project_items_snapshot(runner, repository, number, warnings)
+    pull_refs: list[dict[str, Any]] = []
+    raw_pull_refs = value.get("closedByPullRequestsReferences", [])
+    if isinstance(raw_pull_refs, list):
+        pull_refs = [
+            normalized
+            for normalized in (_normalize_closing_pr(item) for item in raw_pull_refs)
+            if normalized is not None
+        ]
+    issue: dict[str, Any] = {
+        "number": value.get("number"),
+        "title": safe_text(value.get("title")),
+        "content_sha256": sha256_json(
+            {"body": body, "comments": comments if include_comments else None}
+        ),
+        "body_sha256": sha256_json({"body": body}),
+        "body_characters": len(body) if body is not None else None,
+        "comment_count": len(comments) if include_comments else None,
+        "state": safe_text(value.get("state")),
+        "labels": bounded_list(sorted(normalized_labels)),
+        "project_items": project_items,
+        "project_status": canonical_project_field(
+            project_items,
+            repository=repository,
+            issue_number=number,
+            field_name="Status",
+        ),
+        "url": safe_text(value.get("url")),
+        "closed_at": safe_text(value.get("closedAt")),
+        "closing_pull_requests": bounded_list(pull_refs),
+    }
+    if include_closure:
+        issue["issue_closure"] = _issue_closure_snapshot(
+            runner, repository, number, warnings
+        )
+    contract = (
+        {
+            "number": value.get("number"),
+            "title": safe_text(value.get("title")),
+            "url": safe_text(value.get("url")),
+            "body": body,
+            "body_sha256": issue["body_sha256"],
+        }
+        if include_contract and body is not None
+        else None
+    )
+    return issue, contract
+
+
+def _issue_view(
+    runner: CommandRunner,
+    repository: str,
+    number: int,
+    warnings: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    issue, _contract = _issue_view_with_contract(runner, repository, number, warnings)
+    return issue
+
+
+def _normalize_relationship_item(item: Any) -> dict[str, Any] | None:
+    if not isinstance(item, Mapping):
+        return None
+    labels: list[str] = []
+    raw_labels = item.get("labels")
+    labels_complete = False
+    if isinstance(raw_labels, Mapping) and isinstance(raw_labels.get("nodes"), list):
+        labels = [
+            label["name"]
+            for label in raw_labels["nodes"]
+            if isinstance(label, Mapping) and isinstance(label.get("name"), str)
+        ]
+        page = raw_labels.get("pageInfo")
+        labels_complete = isinstance(page, Mapping) and page.get("hasNextPage") is False
+    number = item.get("number")
+    title = safe_text(item.get("title"))
+    state = safe_text(item.get("state"))
+    body = item.get("body") if isinstance(item.get("body"), str) else None
+    body_sha256 = sha256_json({"body": body}) if body is not None else None
+    # Relationship metadata is intentionally bounded below.  Keep the full
+    # canonical Issue contract in a separate, explicitly named value so the
+    # bounded display projection can never become semantic parser input.
+    contract = (
+        {
+            "number": number,
+            "title": title,
+            "state": state,
+            "body": body,
+            "body_sha256": body_sha256,
+            "body_characters": len(body),
+        }
+        if body is not None
+        else None
+    )
+    return {
+        "number": number,
+        "title": title,
+        "state": state,
+        "labels": sorted(labels),
+        "labels_complete": labels_complete,
+        "body": body,
+        "body_sha256": body_sha256,
+        "body_characters": len(body) if body is not None else None,
+        "contract": contract,
+        "project_items": _normalize_project_items(item.get("projectItems")),
+    }
+
+
+def relationship_contract(item: Mapping[str, Any]) -> Mapping[str, Any] | None:
+    """Return a verified complete raw contract from one relationship item.
+
+    Relationship items expose a bounded top-level metadata projection.  The
+    nested contract is the only value that may contain the complete Issue
+    body.  Verify both the relationship identity and body digest before any
+    profile policy is allowed to interpret it.
+    """
+
+    raw_contract = item.get("contract")
+    if not isinstance(raw_contract, Mapping):
+        return None
+    number = item.get("number")
+    contract_number = raw_contract.get("number")
+    if (
+        not isinstance(number, int)
+        or isinstance(number, bool)
+        or number <= 0
+        or contract_number != number
+    ):
+        return None
+    body = raw_contract.get("body")
+    body_sha256 = raw_contract.get("body_sha256")
+    if not isinstance(body, str) or not isinstance(body_sha256, str):
+        return None
+    if sha256_json({"body": body}) != body_sha256:
+        return None
+    item_sha256 = item.get("body_sha256")
+    if item_sha256 is not None and item_sha256 != body_sha256:
+        return None
+    body_characters = raw_contract.get("body_characters")
+    if (
+        not isinstance(body_characters, int)
+        or isinstance(body_characters, bool)
+        or body_characters != len(body)
+    ):
+        return None
+    item_characters = item.get("body_characters")
+    if item_characters is not None and item_characters != body_characters:
+        return None
+    return {
+        "number": number,
+        "title": raw_contract.get("title"),
+        "state": raw_contract.get("state"),
+        "body": body,
+        "body_sha256": body_sha256,
+        "body_characters": body_characters,
+    }
+
+
+def _relationship_snapshot(
+    runner: CommandRunner,
+    repository: str,
+    number: int,
+    warnings: list[dict[str, Any]],
+) -> dict[str, Any]:
+    value = _graphql(
+        runner,
+        repository,
+        number,
+        RELATIONSHIPS_QUERY,
+        command_id=f"gh-issue-relationships-{number}",
+        warnings=warnings,
+    )
+    issue = None
+    if isinstance(value, Mapping):
+        data = value.get("data")
+        repo = data.get("repository") if isinstance(data, Mapping) else None
+        issue = repo.get("issue") if isinstance(repo, Mapping) else None
+    if not isinstance(issue, Mapping):
+        return {
+            "available": False,
+            "repository": repository,
+            "issue_type": None,
+            "parent": None,
+            "sub_issues": bounded_list([]),
+            "sub_issue_set_digest": None,
+            "sub_issues_complete": False,
+            "blocked_by": bounded_list([]),
+            "blocking": bounded_list([]),
+        }
+
+    def nodes(field: str) -> list[dict[str, Any]]:
+        connection = issue.get(field)
+        raw_nodes = (
+            connection.get("nodes", []) if isinstance(connection, Mapping) else []
+        )
+        return (
+            [
+                normalized
+                for normalized in (
+                    _normalize_relationship_item(item) for item in raw_nodes
+                )
+                if normalized is not None
+            ]
+            if isinstance(raw_nodes, list)
+            else []
+        )
+
+    def bounded_connection(field: str) -> dict[str, Any]:
+        connection = issue.get(field)
+        normalized = bounded_list(nodes(field))
+        page = connection.get("pageInfo") if isinstance(connection, Mapping) else None
+        if isinstance(page, Mapping) and page.get("hasNextPage") is True:
+            normalized["truncated"] = True
+        return normalized
+
+    parent = issue.get("parent")
+    normalized_parent = (
+        {
+            "number": parent.get("number"),
+            "title": safe_text(parent.get("title")),
+            "state": safe_text(parent.get("state")),
+        }
+        if isinstance(parent, Mapping)
+        else None
+    )
+    issue_type = issue.get("issueType")
+    sub_issue_nodes = nodes("subIssues")
+    sub_connection = issue.get("subIssues")
+    sub_page = (
+        sub_connection.get("pageInfo") if isinstance(sub_connection, Mapping) else None
+    )
+    sub_has_next = isinstance(sub_page, Mapping) and sub_page.get("hasNextPage") is True
+    sub_bounded = bounded_list(sub_issue_nodes, item_limit=MAX_CHILDREN)
+    return {
+        "available": True,
+        "repository": repository,
+        "issue_type": safe_text(issue_type.get("name"))
+        if isinstance(issue_type, Mapping)
+        else None,
+        "parent": normalized_parent,
+        "sub_issues": sub_bounded,
+        "sub_issue_set_digest": sha256_json(
+            sorted(
+                item.get("number")
+                for item in sub_issue_nodes
+                if isinstance(item.get("number"), int)
+            )
+        ),
+        "sub_issues_complete": not sub_has_next and not sub_bounded["truncated"],
+        "blocked_by": bounded_connection("blockedBy"),
+        "blocking": bounded_connection("blocking"),
+    }
+
+
+def _normalize_checks(value: Any) -> dict[str, Any]:
+    if not isinstance(value, list):
+        return {
+            "count": 0,
+            "success": 0,
+            "pending": 0,
+            "failed": 0,
+            "skipped_or_unknown": 0,
+            "all_success": None,
+            "items": bounded_list([]),
+        }
+    items: list[dict[str, Any]] = []
+    success = pending = failed = skipped = 0
+    for item in value:
+        if not isinstance(item, Mapping):
+            continue
+        name = (
+            item.get("name")
+            or item.get("context")
+            or item.get("workflowName")
+            or "unnamed"
+        )
+        state = (
+            item.get("conclusion")
+            or item.get("state")
+            or item.get("status")
+            or "UNKNOWN"
+        )
+        normalized_state = str(state).upper()
+        if normalized_state in {"SUCCESS", "NEUTRAL"}:
+            success += 1
+            category = "success"
+        elif normalized_state in {
+            "PENDING",
+            "QUEUED",
+            "IN_PROGRESS",
+            "EXPECTED",
+            "WAITING",
+        }:
+            pending += 1
+            category = "pending"
+        elif normalized_state in {
+            "FAILURE",
+            "ERROR",
+            "CANCELLED",
+            "TIMED_OUT",
+            "ACTION_REQUIRED",
+        }:
+            failed += 1
+            category = "failed"
+        else:
+            skipped += 1
+            category = "skipped-or-unknown"
+        items.append(
+            {
+                "name": safe_text(name, limit=160),
+                "state": safe_text(normalized_state, limit=64),
+                "category": category,
+            }
+        )
+    count = len(items)
+    return {
+        "count": count,
+        "success": success,
+        "pending": pending,
+        "failed": failed,
+        "skipped_or_unknown": skipped,
+        "all_success": None if count == 0 else success == count,
+        "items": bounded_list(items),
+    }

--- a/tools/lck/skill_audit.py
+++ b/tools/lck/skill_audit.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Audit canonical LCK Skills and their thin agent-specific adapters."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Final
+
+SCHEMA_VERSION: Final = 7
+SKILLS: Final = (
+    "task-delivery-runner",
+    "task-pr-review-runner",
+    "task-closeout",
+    "feature-completion-audit",
+)
+REQUIRED: Final = {
+    "task-delivery-runner": ("delivery prepare", "delivery complete"),
+    "task-pr-review-runner": ("review prepare", "review complete"),
+    "task-closeout": ("merge preflight", "closeout"),
+    "feature-completion-audit": ("feature-audit-snapshot", "feature-audit-recheck"),
+}
+SHARED_DOCS: Final = (
+    Path("docs/workflows/lck/lifecycle.md"),
+    Path("docs/workflows/lck/review-and-remediation.md"),
+)
+FORBIDDEN: Final = (
+    "tools/agent_workflow",
+    "git commit",
+    "git push",
+    "gh pr create",
+    "gh pr merge",
+    "write_actions_allowed",
+    "snapshot_id",
+)
+
+
+def _sha256(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def audit(repo_root: Path) -> tuple[dict[str, object], int]:
+    canonical_results: dict[str, object] = {}
+    adapter_results: dict[str, object] = {}
+    violations: list[str] = []
+
+    for name in SKILLS:
+        canonical_relative = Path(".agents/skills") / name / "SKILL.md"
+        adapter_relative = Path(".claude/skills") / name / "SKILL.md"
+        canonical_path = repo_root / canonical_relative
+        adapter_path = repo_root / adapter_relative
+        if not canonical_path.is_file():
+            violations.append(f"missing canonical Skill {canonical_relative}")
+            continue
+        if not adapter_path.is_file():
+            violations.append(f"missing adapter Skill {adapter_relative}")
+            continue
+
+        canonical = canonical_path.read_text(encoding="utf-8")
+        adapter = adapter_path.read_text(encoding="utf-8")
+        missing = [token for token in REQUIRED[name] if token not in canonical]
+        forbidden = [token for token in FORBIDDEN if token in canonical]
+        if "python -m tools.lck" not in canonical:
+            missing.append("python -m tools.lck")
+        if missing:
+            violations.append(f"{canonical_relative}: missing {', '.join(missing)}")
+        if forbidden:
+            violations.append(f"{canonical_relative}: forbidden {', '.join(forbidden)}")
+
+        canonical_ref = canonical_relative.as_posix()
+        adapter_ok = canonical_ref in adapter and len(adapter.splitlines()) < 15
+        if not adapter_ok:
+            violations.append(f"{adapter_relative}: not a thin canonical adapter")
+
+        canonical_results[name] = {
+            "path": canonical_ref,
+            "sha256": _sha256(canonical),
+            "missing_contract_tokens": missing,
+            "forbidden_paths": forbidden,
+        }
+        adapter_results[name] = {
+            "path": adapter_relative.as_posix(),
+            "sha256": _sha256(adapter),
+            "canonical_reference": canonical_ref,
+            "thin": adapter_ok,
+        }
+
+    shared_docs = {
+        path.as_posix(): (repo_root / path).is_file() for path in SHARED_DOCS
+    }
+    for path, present in shared_docs.items():
+        if not present:
+            violations.append(f"missing shared doc {path}")
+
+    output: dict[str, object] = {
+        "schema_version": SCHEMA_VERSION,
+        "status": "pass" if not violations else "fail",
+        "canonical_skills": canonical_results,
+        "adapters": adapter_results,
+        "shared_docs": shared_docs,
+        "violations": violations,
+    }
+    return output, 0 if not violations else 1
+
+
+def main() -> int:
+    output, returncode = audit(Path.cwd().resolve())
+    print(json.dumps(output, ensure_ascii=False, sort_keys=True, separators=(",", ":")))
+    return returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lck/state.py
+++ b/tools/lck/state.py
@@ -1,0 +1,897 @@
+from __future__ import annotations
+
+import copy
+import re
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from typing import Any, cast
+
+import yaml
+
+from .common import (
+    CommandRunner,
+    WorkflowToolError,
+    command_warning,
+    is_sha,
+    read_json_text,
+    sha256_json,
+)
+from .github_prs import PrResolveError, list_matching_prs, resolve_open_pr
+from .issue_profiles import (
+    LeafIssueWorkflowProfile,
+    canonical_branch_for_profile,
+    resolve_issue_profile,
+)
+from .models import (
+    _DIAGNOSTIC_FACT_PROFILE,
+    BASE_BRANCH,
+    RECOVERY_PR_FIELDS,
+    REQUIRED_CHECKS_WORKFLOW,
+    FactProfile,
+    LckStopError,
+    LiveState,
+    OperationSnapshot,
+    Phase,
+    ResolutionStatus,
+    _branch_matches_task,
+    _pr_base_sha,
+    _remote_main_sha,
+    _remote_refs,
+    branch_matches_profile,
+    canonical_task_branch,
+    fact_profile_for_operation,
+)
+from .shared_facts import (
+    _git_snapshot,
+    _issue_view_with_contract,
+    _normalize_checks,
+    _relationship_snapshot,
+    _repository_slug,
+)
+
+
+class LiveStateResolver:
+    """Resolve one Task from current local and GitHub authority."""
+
+    def __init__(
+        self,
+        repo_root: Path,
+        *,
+        runner: CommandRunner | None = None,
+        repository: str | None = None,
+    ) -> None:
+        self.repo_root = repo_root.resolve()
+        self.runner = runner or CommandRunner(self.repo_root)
+        self.repository = repository
+
+    def _git_lines(
+        self,
+        args: Sequence[str],
+        *,
+        command_id: str,
+        warnings: list[dict[str, Any]],
+    ) -> list[str]:
+        result = self.runner.run(["git", *args], command_id=command_id)
+        if result.returncode != 0:
+            warnings.append(command_warning(result))
+            return []
+        return [line for line in result.stdout.splitlines() if line]
+
+    def _task_branches(
+        self,
+        task_number: int,
+        warnings: list[dict[str, Any]],
+        *,
+        include_local: bool = True,
+        include_remote: bool = True,
+        profile: LeafIssueWorkflowProfile | None = None,
+    ) -> tuple[set[str], dict[str, str], bool]:
+        matcher: Callable[[str], bool] = (
+            (lambda branch: branch_matches_profile(branch, task_number, profile))
+            if profile is not None
+            else (lambda branch: _branch_matches_task(branch, task_number))
+        )
+        local_lines = (
+            self._git_lines(
+                ["for-each-ref", "--format=%(refname:short)", "refs/heads"],
+                command_id="lck-local-task-branches",
+                warnings=warnings,
+            )
+            if include_local
+            else []
+        )
+        local = {branch for branch in local_lines if matcher(branch)}
+        if not include_remote:
+            return local, {}, True
+        remote_result = self.runner.run(
+            ["git", "ls-remote", "--heads", "origin"],
+            command_id="lck-remote-task-branches",
+            retries=1,
+        )
+        if remote_result.returncode != 0:
+            warnings.append(command_warning(remote_result))
+            return local, {}, False
+        remote_all = _remote_refs(remote_result.stdout)
+        remote = {branch: oid for branch, oid in remote_all.items() if matcher(branch)}
+        return local, remote, True
+
+    def _recover_merged_pr_branch(
+        self,
+        task_number: int,
+        repository: str,
+        issue: Mapping[str, Any] | None,
+        warnings: list[dict[str, Any]],
+        profile: LeafIssueWorkflowProfile | None = None,
+    ) -> tuple[str | None, Mapping[str, Any] | None, str | None]:
+        """Recover a deleted Task ref from authoritative closing-PR facts."""
+        if not isinstance(issue, Mapping):
+            return None, None, None
+        if str(issue.get("state", "")).upper() != "CLOSED":
+            return None, None, None
+
+        closure = issue.get("issue_closure")
+        if not isinstance(closure, Mapping):
+            return (
+                None,
+                None,
+                "Task branch identity unavailable after ref deletion: "
+                "Issue closure facts are unavailable",
+            )
+        if closure.get("evidence_status") != "complete":
+            return (
+                None,
+                None,
+                "Task branch identity unavailable after ref deletion: "
+                "Issue closure facts are incomplete",
+            )
+        refs = closure.get("closed_by_pull_requests")
+        if not isinstance(refs, Mapping) or refs.get("truncated") is True:
+            return (
+                None,
+                None,
+                "Task branch identity unavailable after ref deletion: "
+                "closing PR references are incomplete",
+            )
+        items = refs.get("items")
+        if not isinstance(items, list):
+            return (
+                None,
+                None,
+                "Task branch identity unavailable after ref deletion: "
+                "closing PR references are malformed",
+            )
+        merged_refs = [
+            item
+            for item in items
+            if isinstance(item, Mapping)
+            and item.get("repository") == repository
+            and item.get("merged") is True
+            and str(item.get("state", "")).upper() == "MERGED"
+            and isinstance(item.get("number"), int)
+            and not isinstance(item.get("number"), bool)
+        ]
+        if len(merged_refs) != 1:
+            return (
+                None,
+                None,
+                "Task branch identity unavailable after ref deletion: "
+                f"expected one merged closing PR, found {len(merged_refs)}",
+            )
+
+        pr_number = merged_refs[0]["number"]
+        result = self.runner.run(
+            [
+                "gh",
+                "pr",
+                "view",
+                str(pr_number),
+                "--repo",
+                repository,
+                "--json",
+                RECOVERY_PR_FIELDS,
+            ],
+            command_id="lck-recover-merged-pr",
+        )
+        if result.returncode != 0 or not result.stdout.strip():
+            warnings.append(command_warning(result))
+            return (
+                None,
+                None,
+                "Task branch identity unavailable after ref deletion: "
+                "merged PR identity cannot be read",
+            )
+        try:
+            value = read_json_text(result.stdout, field="lck-recover-merged-pr")
+        except WorkflowToolError as exc:
+            warnings.append(
+                {
+                    "command_id": result.command_id,
+                    "exit_code": result.returncode,
+                    "error": str(exc),
+                }
+            )
+            return (
+                None,
+                None,
+                "Task branch identity unavailable after ref deletion: "
+                "merged PR identity is malformed",
+            )
+        if not isinstance(value, Mapping):
+            return (
+                None,
+                None,
+                "Task branch identity unavailable after ref deletion: "
+                "merged PR identity is not an object",
+            )
+        if (
+            value.get("number") != pr_number
+            or str(value.get("state", "")).upper() != "MERGED"
+            or value.get("baseRefName") != BASE_BRANCH
+            or not (
+                branch_matches_profile(
+                    str(value.get("headRefName", "")),
+                    task_number,
+                    profile,
+                )
+                if profile is not None
+                else _branch_matches_task(
+                    str(value.get("headRefName", "")), task_number
+                )
+            )
+        ):
+            return (
+                None,
+                None,
+                "Task branch identity unavailable after ref deletion: "
+                "merged PR identity does not match this Task",
+            )
+        head_repository = value.get("headRepository")
+        if (
+            not isinstance(head_repository, Mapping)
+            or head_repository.get("nameWithOwner") != repository
+        ):
+            return (
+                None,
+                None,
+                "Task branch identity unavailable after ref deletion: "
+                "merged PR head repository is not this repository",
+            )
+        closing = value.get("closingIssuesReferences")
+        closing_numbers = (
+            [
+                item.get("number")
+                for item in closing
+                if isinstance(item, Mapping) and isinstance(item.get("number"), int)
+            ]
+            if isinstance(closing, list)
+            else []
+        )
+        if task_number not in closing_numbers:
+            return (
+                None,
+                None,
+                "Task branch identity unavailable after ref deletion: "
+                "merged PR does not close this Task",
+            )
+        head_branch = value.get("headRefName")
+        return str(head_branch), dict(value), None
+
+    def resolve(self, task_number: int) -> LiveState:
+        """Return the intentionally broad diagnostic status view."""
+        return self._resolve(task_number, _DIAGNOSTIC_FACT_PROFILE)
+
+    def resolve_for_operation(self, task_number: int, operation: str) -> LiveState:
+        """Acquire exactly one operation-bound current authority fact profile."""
+        return self._resolve(task_number, fact_profile_for_operation(operation))
+
+    def _resolve(self, task_number: int, profile: FactProfile) -> LiveState:
+        if task_number <= 0:
+            raise LckStopError(f"Task number must be positive: {task_number}")
+
+        warnings: list[dict[str, Any]] = []
+        reasons: list[str] = []
+        repository = _repository_slug(self.runner, self.repository, warnings)
+        issue: Mapping[str, Any] | None = None
+        leaf_contract: Mapping[str, Any] | None = None
+        relationships: Mapping[str, Any] = {"available": False}
+        if repository is not None:
+            issue, leaf_contract = _issue_view_with_contract(
+                self.runner,
+                repository,
+                task_number,
+                warnings,
+                profile.include_comments,
+                profile.include_issue_closure,
+                profile.include_leaf_contract,
+            )
+            relationships = _relationship_snapshot(
+                self.runner, repository, task_number, warnings
+            )
+        else:
+            reasons.append("repository identity unavailable")
+
+        profile_resolution = resolve_issue_profile(issue)
+        issue_profile = profile_resolution.to_dict()
+        if not profile_resolution.resolved:
+            reasons.append(profile_resolution.error_message)
+
+        git: Mapping[str, Any]
+        if profile.include_git:
+            if profile.include_workspace_inventory:
+                git = _git_snapshot(
+                    self.runner,
+                    warnings,
+                    read_only_local_refs=True,
+                )
+            else:
+                git = _git_snapshot(
+                    self.runner,
+                    warnings,
+                    read_only_local_refs=True,
+                    include_workspace_inventory=False,
+                )
+            if not isinstance(git.get("branch"), str) or not git.get("branch"):
+                reasons.append("current local branch is unavailable")
+            if not is_sha(git.get("head_sha")):
+                reasons.append("current local HEAD is unavailable")
+            if not is_sha(git.get("local_main_sha")):
+                reasons.append("local main ref unavailable")
+            if not is_sha(_remote_main_sha(git)):
+                reasons.append("remote main query failed")
+            if git.get("clean") not in {True, False}:
+                reasons.append("current worktree cleanliness is unavailable")
+        else:
+            git = {}
+        if issue is None:
+            reasons.append("Task metadata unavailable")
+        if relationships.get("available") is not True:
+            reasons.append("Task relationship facts unavailable")
+        branch_warning_count = len(warnings)
+        branch_profile = profile_resolution.profile
+        branch_match_profile = (
+            None
+            if branch_profile is None or branch_profile.allow_legacy_branch_aliases
+            else branch_profile
+        )
+        if branch_match_profile is None:
+            # Keep the legacy call shape for the canonical Task path.  Apart
+            # from preserving compatibility with resolver doubles, this makes
+            # the shared branch inventory helper's default behavior explicit.
+            if (
+                profile.include_local_issue_branches
+                and profile.include_remote_issue_branches
+            ):
+                local_branches, remote_branches, remote_available = self._task_branches(
+                    task_number, warnings
+                )
+            else:
+                local_branches, remote_branches, remote_available = self._task_branches(
+                    task_number,
+                    warnings,
+                    include_local=profile.include_local_issue_branches,
+                    include_remote=profile.include_remote_issue_branches,
+                )
+        else:
+            local_branches, remote_branches, remote_available = self._task_branches(
+                task_number,
+                warnings,
+                include_local=profile.include_local_issue_branches,
+                include_remote=profile.include_remote_issue_branches,
+                profile=branch_match_profile,
+            )
+        if len(warnings) > branch_warning_count:
+            reasons.append("Task branch inventory contains unavailable facts")
+        if not remote_available:
+            reasons.append("remote Task branch facts unavailable")
+        title = issue.get("title") if isinstance(issue, Mapping) else None
+        title_text = title if isinstance(title, str) else f"Task {task_number}"
+        canonical = (
+            canonical_branch_for_profile(
+                profile_resolution.profile,
+                task_number,
+                title_text,
+            )
+            if profile_resolution.profile is not None
+            else canonical_task_branch(task_number, title_text)
+        )
+        candidates = sorted(local_branches | set(remote_branches))
+        if len(candidates) > 1:
+            reasons.append(f"multiple Task branch candidates: {candidates}")
+        recovered_branch: str | None = None
+        recovered_pr: Mapping[str, Any] | None = None
+        if not candidates and repository is not None:
+            recovery_reason: str | None
+            recovered_branch, recovered_pr, recovery_reason = (
+                self._recover_merged_pr_branch(
+                    task_number,
+                    repository,
+                    issue,
+                    warnings,
+                    branch_profile,
+                )
+            )
+            if recovery_reason:
+                reasons.append(recovery_reason)
+        target_branch = (
+            candidates[0] if len(candidates) == 1 else recovered_branch or canonical
+        )
+        local_branch = target_branch if target_branch in local_branches else None
+        remote_branch = target_branch if target_branch in remote_branches else None
+
+        local_head: str | None = None
+        if local_branch is not None:
+            result = self.runner.run(
+                ["git", "rev-parse", f"refs/heads/{local_branch}"],
+                command_id="lck-local-task-head",
+            )
+            if result.returncode == 0 and is_sha(result.stdout.strip()):
+                local_head = result.stdout.strip()
+            else:
+                warnings.append(command_warning(result))
+                reasons.append("local Task branch tip unavailable")
+        remote_oid = remote_branches.get(target_branch)
+        # Tip differences are live facts, not global resolver ambiguity.
+        # Delivery Prepare rejects them; Delivery Complete may legitimately
+        # observe a local validated commit that is not pushed yet.
+
+        open_pr: Mapping[str, Any] | None = None
+        merged_pr: Mapping[str, Any] | None = None
+        merged_numbers: tuple[int, ...] = ()
+        if repository is not None and profile.include_open_pr:
+            try:
+                if profile is _DIAGNOSTIC_FACT_PROFILE:
+                    open_pr = resolve_open_pr(
+                        self.runner,
+                        repository,
+                        target_branch,
+                        BASE_BRANCH,
+                        warnings,
+                    )
+                else:
+                    open_pr = resolve_open_pr(
+                        self.runner,
+                        repository,
+                        target_branch,
+                        BASE_BRANCH,
+                        warnings,
+                        profile.include_checks,
+                        profile.include_mergeability,
+                        False,
+                    )
+            except PrResolveError as exc:
+                reasons.append(str(exc))
+        if repository is not None and profile.include_pr_history:
+            try:
+                if profile is _DIAGNOSTIC_FACT_PROFILE:
+                    history = list_matching_prs(
+                        self.runner,
+                        repository,
+                        target_branch,
+                        BASE_BRANCH,
+                        warnings,
+                        include_history_details=True,
+                    )
+                else:
+                    history = list_matching_prs(
+                        self.runner,
+                        repository,
+                        target_branch,
+                        BASE_BRANCH,
+                        warnings,
+                        include_checks=False,
+                        include_mergeability=False,
+                        include_history_details=profile.include_pr_history_details,
+                    )
+                if not history and recovered_pr is not None:
+                    history = [dict(recovered_pr)]
+                merged_items = [
+                    item
+                    for item in history
+                    if str(item.get("state", "")).upper() == "MERGED"
+                    and isinstance(item.get("number"), int)
+                ]
+                merged_numbers = tuple(
+                    sorted(int(item["number"]) for item in merged_items)
+                )
+                if len(merged_items) == 1:
+                    merged_pr = dict(merged_items[0])
+            except PrResolveError as exc:
+                reasons.append(str(exc))
+
+        if open_pr is not None and profile.include_checks:
+            checks = _normalize_checks(open_pr.get("statusCheckRollup"))
+        else:
+            checks = _normalize_checks([])
+        if len(merged_numbers) > 1:
+            reasons.append(
+                f"multiple merged PRs for the Task branch: {list(merged_numbers)}"
+            )
+        if open_pr is not None:
+            pr_head_oid = open_pr.get("headRefOid")
+            if not is_sha(pr_head_oid):
+                reasons.append("current OPEN PR head OID is unavailable")
+            elif local_branch is None and remote_branch is None:
+                reasons.append("current OPEN PR has no local or remote Task branch")
+            else:
+                if remote_oid is not None and remote_oid != pr_head_oid:
+                    reasons.append(
+                        "current OPEN PR head OID differs from remote Task branch tip"
+                    )
+        if open_pr is not None:
+            merged: bool | None = False
+        elif len(merged_numbers) == 1:
+            merged = True
+        elif len(merged_numbers) == 0:
+            merged = False
+        else:
+            merged = None
+
+        cleanup = {
+            "business_delivery": "complete" if merged is True else "pending",
+            "cleanup": "pending" if merged is True else "not-applicable",
+            "local_branch_present": local_branch is not None,
+            "remote_branch_present": remote_branch is not None,
+            "open_pr_number": (
+                open_pr.get("number") if isinstance(open_pr, Mapping) else None
+            ),
+            "merged_pr_numbers": merged_numbers,
+            "merged_pr_number": (
+                merged_pr.get("number") if isinstance(merged_pr, Mapping) else None
+            ),
+        }
+        status = ResolutionStatus.STOP if reasons else ResolutionStatus.RESOLVED
+        return LiveState(
+            issue_number=task_number,
+            repository=repository,
+            issue=issue,
+            leaf_contract=leaf_contract,
+            relationships=relationships,
+            git=git,
+            target_branch=target_branch,
+            local_issue_branch=local_branch,
+            local_issue_head=local_head,
+            remote_issue_branch=remote_branch,
+            remote_issue_oid=remote_oid,
+            open_pr=open_pr,
+            merged_pr_numbers=merged_numbers,
+            merged=merged,
+            checks=checks,
+            cleanup=cleanup,
+            status=status,
+            stop_reasons=tuple(reasons),
+            warnings=tuple(warnings),
+            merged_pr=merged_pr,
+            issue_profile=issue_profile,
+        )
+
+
+def _parse_required_checks_workflow(
+    text: str,
+    *,
+    source_sha: str,
+) -> dict[str, Any]:
+    """Derive required GitHub check contexts from canonical CI at one base commit.
+
+    Required-check policy is lifecycle control policy, so a candidate must not be
+    able to weaken the checks that authorize its own transition. LCK therefore
+    reads the canonical CI workflow from the immutable trusted base commit.
+    Only statically named, non-matrix jobs are supported in v1; anything dynamic
+    fails closed rather than guessing the check-run identity.
+    """
+
+    if not is_sha(source_sha):
+        raise LckStopError("required PR check policy source SHA is invalid")
+    try:
+        parsed = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise LckStopError(
+            "required PR check policy is malformed at trusted base "
+            f"{source_sha}: {REQUIRED_CHECKS_WORKFLOW}: {exc}"
+        ) from exc
+    if not isinstance(parsed, Mapping):
+        raise LckStopError(
+            "required PR check policy is unresolved at trusted base "
+            f"{source_sha}: {REQUIRED_CHECKS_WORKFLOW} must contain a mapping"
+        )
+    jobs = parsed.get("jobs")
+    if not isinstance(jobs, Mapping) or not jobs:
+        raise LckStopError(
+            "required PR check policy is unresolved at trusted base "
+            f"{source_sha}: {REQUIRED_CHECKS_WORKFLOW} must define static jobs"
+        )
+
+    names: list[str] = []
+    job_bindings: list[dict[str, str]] = []
+    for raw_job_id, raw_job in jobs.items():
+        if not isinstance(raw_job_id, str) or not raw_job_id.strip():
+            raise LckStopError(
+                "required PR check policy is invalid: CI job id must be a non-empty string"
+            )
+        job_id = raw_job_id.strip()
+        if not isinstance(raw_job, Mapping):
+            raise LckStopError(
+                f"required PR check policy is invalid: CI job {job_id!r} is malformed"
+            )
+        strategy = raw_job.get("strategy")
+        if isinstance(strategy, Mapping) and "matrix" in strategy:
+            raise LckStopError(
+                "required PR check policy is unresolved: matrix CI jobs are not "
+                f"supported by LCK v1 ({job_id!r})"
+            )
+        raw_name = raw_job.get("name")
+        if raw_name is None:
+            check_name = job_id
+        elif isinstance(raw_name, str) and raw_name.strip():
+            check_name = raw_name.strip()
+        else:
+            raise LckStopError(
+                f"required PR check policy is invalid: CI job {job_id!r} has an invalid name"
+            )
+        if "${{" in check_name:
+            raise LckStopError(
+                "required PR check policy is unresolved: dynamic CI job names are not "
+                f"supported by LCK v1 ({job_id!r})"
+            )
+        if check_name in names:
+            raise LckStopError(
+                f"required PR check policy is invalid: duplicate check {check_name!r}"
+            )
+        names.append(check_name)
+        job_bindings.append({"job_id": job_id, "check_name": check_name})
+
+    contract_payload = {
+        "workflow": REQUIRED_CHECKS_WORKFLOW,
+        "required-checks": names,
+    }
+    return {
+        "configuration": "repository-base-ci",
+        "source": f"git:{source_sha}:{REQUIRED_CHECKS_WORKFLOW}:jobs",
+        "source_sha": source_sha,
+        "workflow_path": REQUIRED_CHECKS_WORKFLOW,
+        "contract_sha256": sha256_json(contract_payload),
+        "jobs": job_bindings,
+        "contexts": {
+            "items": names,
+            "count": len(names),
+            "truncated": False,
+        },
+    }
+
+
+def _repository_required_checks_at_commit(
+    resolver: LiveStateResolver,
+    source_sha: str,
+    *,
+    repo_root: Path | None = None,
+) -> dict[str, Any]:
+    """Read required checks from canonical CI at an exact trusted-base commit.
+
+    ``repo_root`` may be the source repository or an isolated Review clone.
+    Working-tree files and candidate-head policy are deliberately ignored.
+    """
+
+    if not is_sha(source_sha):
+        raise LckStopError("required PR check policy trusted base is unavailable")
+    result = resolver.runner.run(
+        ["git", "show", f"{source_sha}:{REQUIRED_CHECKS_WORKFLOW}"],
+        command_id="lck-required-check-policy-from-base-ci",
+        cwd=repo_root or resolver.repo_root,
+        env={"GIT_OPTIONAL_LOCKS": "0"},
+    )
+    if result.returncode != 0:
+        detail = (
+            result.stderr.strip()
+            or result.stdout.strip()
+            or f"exit {result.returncode}"
+        )
+        raise LckStopError(
+            "required PR check policy is unavailable at trusted base "
+            f"{source_sha}: {REQUIRED_CHECKS_WORKFLOW}: {detail}"
+        )
+    return _parse_required_checks_workflow(result.stdout, source_sha=source_sha)
+
+
+def _required_checks_policy_source_sha(
+    state: LiveState,
+    operation: str,
+) -> str:
+    """Return the immutable base commit that governs required-check policy.
+
+    Candidate heads cannot authorize their own checks. Operations on an existing
+    PR are governed by the exact PR base commit; the legacy Delivery branch is
+    retained for callers that still request that policy source explicitly.
+    """
+
+    if operation == Phase.DELIVERY_COMPLETE.value:
+        source_sha = _remote_main_sha(state.git)
+    else:
+        pr = state.open_pr
+        source_sha = _pr_base_sha(pr) if isinstance(pr, Mapping) else None
+    if not is_sha(source_sha):
+        raise LckStopError(
+            f"required PR check policy trusted base is unavailable for {operation}"
+        )
+    return str(source_sha)
+
+
+def _required_check_contract(required: Mapping[str, Any] | None) -> tuple[str, ...]:
+    """Validate and return the exact-base-bound required-check set.
+
+    Legacy GitHub-discovery states and mutable working-tree configuration are
+    diagnostic inputs only and can never authorize an LCK lifecycle effect.
+    """
+
+    if not isinstance(required, Mapping):
+        raise LckStopError("required PR check policy was not acquired")
+    if required.get("configuration") != "repository-base-ci":
+        raise LckStopError(
+            "required PR check policy is unresolved; LCK requires the "
+            "exact trusted-base canonical-CI check contract before lifecycle effects"
+        )
+    source_sha = required.get("source_sha")
+    if not is_sha(source_sha):
+        raise LckStopError("required PR check policy source SHA is malformed")
+    contract_sha256 = required.get("contract_sha256")
+    if (
+        not isinstance(contract_sha256, str)
+        or re.fullmatch(r"[0-9a-f]{64}", contract_sha256) is None
+    ):
+        raise LckStopError("required PR check policy contract hash is malformed")
+    contexts = required.get("contexts")
+    if not isinstance(contexts, Mapping):
+        raise LckStopError("required PR check policy contexts are malformed")
+    items = contexts.get("items")
+    if not isinstance(items, list):
+        raise LckStopError("required PR check policy items are malformed")
+    names: list[str] = []
+    for item in items:
+        if not isinstance(item, str) or not item:
+            raise LckStopError(
+                "required PR check policy contains an invalid check name"
+            )
+        if item in names:
+            raise LckStopError(
+                f"required PR check policy contains duplicate check {item!r}"
+            )
+        names.append(item)
+    workflow_path = required.get("workflow_path")
+    if workflow_path != REQUIRED_CHECKS_WORKFLOW:
+        raise LckStopError("required PR check policy workflow path is malformed")
+    if (
+        sha256_json({"workflow": REQUIRED_CHECKS_WORKFLOW, "required-checks": names})
+        != contract_sha256
+    ):
+        raise LckStopError("required PR check policy contract hash does not match")
+    return tuple(names)
+
+
+def _required_check_contract_for_snapshot(
+    snapshot: OperationSnapshot,
+) -> tuple[str, ...]:
+    """Validate that required-check policy is bound to this snapshot's base."""
+
+    required = snapshot.required_checks
+    names = _required_check_contract(required)
+    required_mapping = cast(Mapping[str, Any], required)
+    expected_sha = _required_checks_policy_source_sha(
+        snapshot.state, snapshot.operation
+    )
+    if required_mapping.get("source_sha") != expected_sha:
+        raise LckStopError(
+            "required PR check policy is not bound to the operation trusted base: "
+            "expected "
+            f"{expected_sha}, got "
+            f"{required_mapping.get('source_sha') or 'unavailable'}"
+        )
+    return names
+
+
+class OperationSnapshotBuilder:
+    """Acquire one phase-specific authoritative snapshot at operation entry."""
+
+    def __init__(self, resolver: LiveStateResolver) -> None:
+        self.resolver = resolver
+
+    def acquire(
+        self,
+        task_number: int,
+        *,
+        operation: str,
+        include_required_checks: bool = False,
+    ) -> OperationSnapshot:
+        profile = fact_profile_for_operation(operation)
+        operation_resolver = getattr(self.resolver, "resolve_for_operation", None)
+        if callable(operation_resolver):
+            state = copy.deepcopy(operation_resolver(task_number, operation))
+        else:
+            # Test/dedicated resolvers may already provide a pre-bounded state.
+            state = copy.deepcopy(self.resolver.resolve(task_number))
+        snapshot = OperationSnapshot(
+            operation=operation,
+            state=state,
+            required_checks=None,
+            acquisition_warnings=(),
+            fact_profile=profile.name,
+            acquired_facts=profile.facts(),
+        )
+        if include_required_checks:
+            snapshot = self.bind_required_checks(snapshot)
+        return snapshot
+
+    def bind_required_checks(
+        self,
+        snapshot: OperationSnapshot,
+        *,
+        repo_root: Path | None = None,
+    ) -> OperationSnapshot:
+        """Bind one snapshot to the policy stored at its immutable trusted base.
+
+        This method never re-resolves Git/GitHub state.  ``repo_root`` is only a
+        repository object source; Review may pass its standalone clone after the
+        exact base/head objects have been materialized there.
+        """
+
+        if snapshot.required_checks is not None:
+            _required_check_contract(snapshot.required_checks)
+            return snapshot
+        source_sha = _required_checks_policy_source_sha(
+            snapshot.state, snapshot.operation
+        )
+        required = _repository_required_checks_at_commit(
+            self.resolver,
+            source_sha,
+            repo_root=repo_root,
+        )
+        _required_check_contract(required)
+        return OperationSnapshot(
+            operation=snapshot.operation,
+            state=snapshot.state,
+            required_checks=required,
+            acquisition_warnings=snapshot.acquisition_warnings,
+            fact_profile=snapshot.fact_profile,
+            acquired_facts=snapshot.acquired_facts,
+        )
+
+
+def _policy_issue_from_state(state: LiveState) -> dict[str, Any]:
+    """Combine mechanical Issue facts with the operation-bound contract.
+
+    Shared fact acquisition keeps the raw Issue view and semantic contract
+    separate.  Policy entrypoints receive this explicit, operation-scoped
+    adapter so they can validate the contract without making the state owner
+    interpret profile semantics.
+    """
+    result = dict(state.issue) if isinstance(state.issue, Mapping) else {}
+    if isinstance(state.leaf_contract, Mapping):
+        result.update(state.leaf_contract)
+    return result
+
+
+def _leaf_contract_from_state(state: LiveState) -> dict[str, Any]:
+    """Return the Issue contract captured by the operation-start snapshot."""
+    if state.status is not ResolutionStatus.RESOLVED:
+        raise LckStopError("cannot read Issue Contract from unresolved live state")
+    value = state.leaf_contract
+    if not isinstance(value, Mapping):
+        raise LckStopError(
+            "current Issue Contract is unavailable in operation snapshot"
+        )
+    body = value.get("body")
+    body_sha256 = value.get("body_sha256")
+    if not isinstance(body, str) or not isinstance(body_sha256, str):
+        raise LckStopError("current Issue Contract body is unavailable")
+    issue = state.issue
+    if (
+        not isinstance(issue, Mapping)
+        or issue.get("body_sha256") != body_sha256
+        or value.get("number") != state.issue_number
+        or value.get("title") != issue.get("title")
+        or str(issue.get("state", "")).upper() != "OPEN"
+    ):
+        raise LckStopError("Issue Contract is inconsistent inside operation snapshot")
+    return dict(value)
+
+
+def _task_contract_from_state(state: LiveState) -> dict[str, Any]:
+    """Compatibility adapter for callers that still use the Task spelling."""
+    return _leaf_contract_from_state(state)

--- a/tools/lck/structured_review_instructions.py
+++ b/tools/lck/structured_review_instructions.py
@@ -1,0 +1,111 @@
+"""Canonical semantic instructions for production Independent Review.
+
+This module owns the reviewer-facing Structured Review v2 guidance.  It is
+instruction data only: it does not create a completion gate, receipt protocol,
+new verdict, or lifecycle state.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final
+
+from .review_models import ReviewSurface
+
+STRUCTURED_REVIEW_INSTRUCTION_OWNER: Final[str] = (
+    "tools/lck/structured_review_instructions.py"
+)
+STRUCTURED_REVIEW_INSTRUCTION_VERSION: Final[str] = "v2"
+
+
+_OBLIGATIONS: Final[tuple[dict[str, Any], ...]] = (
+    {
+        "obligation_id": "contract-critical-outcome",
+        "instruction": (
+            "Map the Objective, Requirements, Acceptance Criteria, Critical "
+            "Outcome, constraints, and non-goals to the implementation and "
+            "available evidence."
+        ),
+        "review_surfaces": (ReviewSurface.CONTRACT_CONFORMANCE.value,),
+    },
+    {
+        "obligation_id": "functional-invariants",
+        "instruction": (
+            "Identify the relevant functional invariants and caller/callee "
+            "assumptions, then construct applicable counterexamples."
+        ),
+        "review_surfaces": (ReviewSurface.FUNCTIONAL_CORRECTNESS.value,),
+    },
+    {
+        "obligation_id": "boundary-conversion-error",
+        "instruction": (
+            "Enumerate applicable boundary, parsing, conversion, external-input, "
+            "transport, exception, timeout, retry, malformed, missing, partial, "
+            "and result-mapping outcomes."
+        ),
+        "review_surfaces": (ReviewSurface.ERROR_FAILURE_PATHS.value,),
+    },
+    {
+        "obligation_id": "state-persistence-compatibility",
+        "instruction": (
+            "When applicable, inspect state transitions, persistence behavior, "
+            "recovery and conflict paths, and Base-to-Head compatibility."
+        ),
+        "review_surfaces": (
+            ReviewSurface.STATE_TRANSITIONS.value,
+            ReviewSurface.PERSISTENCE_ATOMICITY.value,
+            ReviewSurface.COMPATIBILITY_MIGRATION.value,
+        ),
+    },
+    {
+        "obligation_id": "tests-vs-claims",
+        "instruction": (
+            "Distinguish what tests and deterministic evidence actually prove "
+            "from happy-path-only claims and remaining failure, boundary, state, "
+            "compatibility, and invariant gaps."
+        ),
+        "review_surfaces": (ReviewSurface.TESTS_VS_CLAIMS.value,),
+    },
+    {
+        "obligation_id": "adversarial-residual-sweep",
+        "instruction": (
+            "Before the final verdict, assume supported findings are fixed and "
+            "search for independent root causes and residual risks across the "
+            "applicable review surfaces."
+        ),
+        "review_surfaces": (ReviewSurface.FUNCTIONAL_CORRECTNESS.value,),
+    },
+)
+
+
+def canonical_structured_review_instructions() -> dict[str, Any]:
+    """Return the fresh reviewer handoff owned by this module."""
+    return {
+        "owner": STRUCTURED_REVIEW_INSTRUCTION_OWNER,
+        "version": STRUCTURED_REVIEW_INSTRUCTION_VERSION,
+        "obligations": [
+            {
+                **obligation,
+                "review_surfaces": list(obligation["review_surfaces"]),
+            }
+            for obligation in _OBLIGATIONS
+        ],
+        "review_sequence": [
+            "Complete every applicable obligation before the final verdict.",
+            "A High or Medium blocker does not end semantic review; continue all "
+            "remaining applicable surfaces.",
+            "Perform the adversarial residual sweep before the existing final verdict.",
+        ],
+        "finding_guidance": [
+            "Use the existing canonical finding/report semantics.",
+            "When applicable, include affected location, violated contract or "
+            "invariant, concrete failure scenario, supporting evidence, why "
+            "current tests/evidence do not exclude it, and falsification reasoning.",
+        ],
+    }
+
+
+__all__ = [
+    "STRUCTURED_REVIEW_INSTRUCTION_OWNER",
+    "STRUCTURED_REVIEW_INSTRUCTION_VERSION",
+    "canonical_structured_review_instructions",
+]

--- a/tools/lck/validation_gates.py
+++ b/tools/lck/validation_gates.py
@@ -1,0 +1,581 @@
+from __future__ import annotations
+
+import shutil
+import sys
+import uuid
+from collections.abc import Callable, Mapping
+from pathlib import Path
+from typing import Any, Final
+
+from .common import (
+    ProgressReporter,
+    WorkflowToolError,
+    atomic_write_json,
+    is_sha,
+    read_json_text,
+    stderr_tail,
+)
+from .models import (
+    LCK_SCHEMA_VERSION,
+    LckStopError,
+    LiveState,
+    OperationSnapshot,
+    ResolutionStatus,
+)
+from .shared_facts import _normalize_checks
+from .state import (
+    LiveStateResolver,
+    _required_check_contract,
+    _required_check_contract_for_snapshot,
+)
+
+
+class FormalValidationGate:
+    """Run the repository-owned deterministic Delivery validation plan."""
+
+    def __init__(self, resolver: LiveStateResolver) -> None:
+        self.resolver = resolver
+        self.last_payload: dict[str, Any] | None = None
+
+    def run(self, base_sha: str) -> dict[str, Any]:
+        self.last_payload = None
+        if not is_sha(base_sha):
+            raise LckStopError("formal validation base SHA is unavailable")
+        reporter = ProgressReporter("workflow-validation")
+        reporter.started("formal-validation")
+        try:
+            result = self.resolver.runner.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "tools.lck.validation_runner",
+                    "run",
+                    "--repo-root",
+                    str(self.resolver.repo_root),
+                    "--phase",
+                    "delivery",
+                    "--base-sha",
+                    base_sha,
+                    "--include-skill-validators",
+                    "--require-skill-validator",
+                ],
+                command_id="lck-formal-delivery-validation",
+                validation=True,
+                progress=lambda: reporter.heartbeat(
+                    "formal-validation",
+                    command_id="lck-formal-delivery-validation",
+                ),
+            )
+            if not result.stdout.strip():
+                raise LckStopError(
+                    "formal Delivery validation produced no structured result: "
+                    + (result.stderr.strip() or f"exit {result.returncode}")
+                )
+            try:
+                payload = read_json_text(
+                    result.stdout, field="lck-formal-delivery-validation"
+                )
+            except WorkflowToolError as exc:
+                raise LckStopError(str(exc)) from exc
+            if not isinstance(payload, dict):
+                raise LckStopError("formal Delivery validation result is not an object")
+            # Keep the structured result available to the owning phase before
+            # applying the gate.  A failed validation is still the evidence
+            # needed by the failure Receipt.
+            self.last_payload = payload
+            if result.returncode != 0 or payload.get("status") != "pass":
+                raise LckStopError(
+                    "formal Delivery validation failed: "
+                    + str(payload.get("status") or result.returncode)
+                )
+        except BaseException:
+            reporter.failed("formal-validation")
+            raise
+        reporter.completed("formal-validation")
+        return payload
+
+
+class ReviewValidationGate:
+    """Run current Review validation inside the isolated reviewed clone."""
+
+    def __init__(self, resolver: LiveStateResolver) -> None:
+        self.resolver = resolver
+
+    def _persist_validation_artifacts(
+        self,
+        review_root: Path,
+        payload: dict[str, Any],
+        *,
+        base_sha: str,
+        head_sha: str,
+    ) -> dict[str, Any]:
+        raw_output_dir = payload.get("output_dir")
+        if not isinstance(raw_output_dir, str) or not raw_output_dir:
+            raise LckStopError(
+                "formal Review validation did not provide an output directory"
+            )
+        output_dir = Path(raw_output_dir)
+        if output_dir.is_absolute():
+            raise LckStopError(
+                "formal Review validation output directory must be relative"
+            )
+        review_root = review_root.resolve()
+        source = (review_root / output_dir).resolve()
+        try:
+            source.relative_to(review_root)
+        except ValueError as exc:
+            raise LckStopError(
+                "formal Review validation output escaped the Review clone"
+            ) from exc
+        if not source.is_dir():
+            raise LckStopError(
+                "formal Review validation output directory is unavailable"
+            )
+
+        durable_root = (
+            self.resolver.repo_root / ".workflow.local" / "lck" / "review-validation"
+        ).resolve()
+        durable_root.mkdir(parents=True, exist_ok=True)
+        destination = durable_root / f"lck-review-{uuid.uuid4().hex}"
+        try:
+            shutil.copytree(source, destination)
+        except OSError as exc:
+            shutil.rmtree(destination, ignore_errors=True)
+            raise LckStopError(
+                f"cannot preserve formal Review validation artifacts: {exc}"
+            ) from exc
+
+        durable_relative = destination.relative_to(
+            self.resolver.repo_root.resolve()
+        ).as_posix()
+        preserved = dict(payload)
+        preserved["output_dir"] = durable_relative
+        preserved["evidence_path"] = durable_relative
+        preserved["validated_base_sha"] = base_sha
+        preserved["validated_head_sha"] = head_sha
+        commands = preserved.get("commands")
+        if isinstance(commands, list):
+            for command in commands:
+                if not isinstance(command, dict):
+                    continue
+                raw_log_path = command.get("log_path")
+                if not isinstance(raw_log_path, str) or not raw_log_path:
+                    continue
+                log_path = Path(raw_log_path)
+                try:
+                    log_relative = log_path.relative_to(output_dir)
+                except ValueError as exc:
+                    raise LckStopError(
+                        "formal Review validation log path escaped its output directory"
+                    ) from exc
+                command["log_path"] = (Path(durable_relative) / log_relative).as_posix()
+        evidence_file = (
+            Path(durable_relative) / "lck-review-validation-result.json"
+        ).as_posix()
+        preserved["evidence_file"] = evidence_file
+        atomic_write_json(destination / "lck-review-validation-result.json", preserved)
+        return preserved
+
+    def _persist_unstructured_failure(
+        self,
+        result: Any,
+        *,
+        base_sha: str,
+        head_sha: str,
+    ) -> dict[str, Any]:
+        durable_root = (
+            self.resolver.repo_root / ".workflow.local" / "lck" / "review-validation"
+        ).resolve()
+        durable_root.mkdir(parents=True, exist_ok=True)
+        destination = durable_root / f"lck-review-{uuid.uuid4().hex}"
+        destination.mkdir()
+        durable_relative = destination.relative_to(
+            self.resolver.repo_root.resolve()
+        ).as_posix()
+        diagnostic = stderr_tail(result.stderr or result.stdout, limit=2000)
+        payload: dict[str, Any] = {
+            "schema_version": LCK_SCHEMA_VERSION,
+            "operation": "workflow-validation",
+            "phase": "review",
+            "status": "fail",
+            "base_sha": base_sha,
+            "validated_base_sha": base_sha,
+            "validated_head_sha": head_sha,
+            "commands": [
+                {
+                    "command_id": result.command_id,
+                    "status": "fail",
+                    "exit_code": result.returncode,
+                    "diagnostic": diagnostic,
+                }
+            ],
+            "output_dir": durable_relative,
+            "evidence_path": durable_relative,
+        }
+        payload["evidence_file"] = (
+            Path(durable_relative) / "lck-review-validation-result.json"
+        ).as_posix()
+        atomic_write_json(destination / "lck-review-validation-result.json", payload)
+        return payload
+
+    def run(self, review_root: Path, base_sha: str, head_sha: str) -> dict[str, Any]:
+        if not is_sha(base_sha):
+            raise LckStopError("formal Review validation base SHA is unavailable")
+        if not is_sha(head_sha):
+            raise LckStopError("formal Review validation head SHA is unavailable")
+        tool = review_root / "tools" / "lck" / "validation_runner.py"
+        if not tool.is_file():
+            raise LckStopError(
+                "reviewed head does not contain the LCK validation runner"
+            )
+        reporter = ProgressReporter("review-prepare")
+        reporter.started("formal-validation")
+        try:
+            result = self.resolver.runner.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "tools.lck.validation_runner",
+                    "run",
+                    "--repo-root",
+                    str(review_root),
+                    "--phase",
+                    "review",
+                    "--base-sha",
+                    base_sha,
+                    "--include-skill-validators",
+                    "--require-skill-validator",
+                ],
+                command_id="lck-formal-review-validation",
+                cwd=review_root,
+                validation=True,
+                progress=lambda: reporter.heartbeat(
+                    "formal-validation",
+                    command_id="lck-formal-review-validation",
+                ),
+            )
+            if not result.stdout.strip():
+                payload = self._persist_unstructured_failure(
+                    result, base_sha=base_sha, head_sha=head_sha
+                )
+            else:
+                try:
+                    parsed = read_json_text(
+                        result.stdout, field="lck-formal-review-validation"
+                    )
+                except WorkflowToolError:
+                    parsed = None
+                if not isinstance(parsed, dict):
+                    payload = self._persist_unstructured_failure(
+                        result, base_sha=base_sha, head_sha=head_sha
+                    )
+                else:
+                    candidate = dict(parsed)
+                    if result.returncode != 0 and candidate.get("status") == "pass":
+                        candidate["status"] = "fail"
+                    try:
+                        payload = self._persist_validation_artifacts(
+                            review_root,
+                            candidate,
+                            base_sha=base_sha,
+                            head_sha=head_sha,
+                        )
+                    except LckStopError:
+                        if candidate.get("status") != "fail" and result.returncode == 0:
+                            raise
+                        payload = self._persist_unstructured_failure(
+                            result, base_sha=base_sha, head_sha=head_sha
+                        )
+        except BaseException:
+            reporter.failed()
+            raise
+        if payload.get("status") == "pass":
+            reporter.completed("formal-validation")
+        else:
+            reporter.failed("formal-validation")
+        return payload
+
+
+class DeliveryChecksGate:
+    """Observe or strictly evaluate PR checks from an operation snapshot/query.
+
+    This gate never resolves lifecycle state and never polls.  Delivery and
+    Review Prepare use the non-blocking observation path; Review Complete and
+    Merge Preflight use the strict evaluation path.
+    """
+
+    PR_FIELDS: Final = (
+        "number,state,isDraft,baseRefName,baseRefOid,headRefName,headRefOid,"
+        "statusCheckRollup,mergeable,url"
+    )
+
+    def __init__(self, resolver: LiveStateResolver) -> None:
+        self.runner = resolver.runner
+        self.last_result: dict[str, Any] | None = None
+
+    def _remember_result(self, result: dict[str, Any]) -> None:
+        self.last_result = dict(result)
+
+    @staticmethod
+    def _required_names(required: Mapping[str, Any]) -> set[str]:
+        return set(_required_check_contract(required))
+
+    @staticmethod
+    def _observed_categories(checks: Mapping[str, Any]) -> dict[str, str]:
+        bounded = checks.get("items")
+        if not isinstance(bounded, Mapping):
+            return {}
+        items = bounded.get("items")
+        if not isinstance(items, list):
+            return {}
+        values: dict[str, str] = {}
+        for item in items:
+            if not isinstance(item, Mapping):
+                continue
+            name = item.get("name")
+            category = item.get("category")
+            if isinstance(name, str) and isinstance(category, str):
+                values[name] = category
+        return values
+
+    @staticmethod
+    def _pr_identity_from_pr(pr: Mapping[str, Any]) -> dict[str, Any]:
+        return {
+            "number": pr.get("number"),
+            "head_sha": pr.get("headRefOid"),
+            "base_sha": pr.get("baseRefOid"),
+        }
+
+    @staticmethod
+    def _pr_identity(state: LiveState) -> dict[str, Any]:
+        pr = state.open_pr
+        if not isinstance(pr, Mapping):
+            return {}
+        return DeliveryChecksGate._pr_identity_from_pr(pr)
+
+    @classmethod
+    def _evaluate_pr_checks(
+        cls,
+        pr: Mapping[str, Any],
+        required: Mapping[str, Any] | None,
+        *,
+        require_success: bool = True,
+        capture: Callable[[dict[str, Any]], None] | None = None,
+    ) -> dict[str, Any]:
+        checks = _normalize_checks(pr.get("statusCheckRollup"))
+        required_names = (
+            cls._required_names(required) if required is not None else set()
+        )
+        config = required.get("configuration") if required is not None else None
+        observed = cls._observed_categories(checks)
+        try:
+            failed = int(checks.get("failed", 0) or 0)
+            unknown = int(checks.get("skipped_or_unknown", 0) or 0)
+            pending = int(checks.get("pending", 0) or 0)
+        except (TypeError, ValueError) as exc:
+            raise LckStopError("PR check summary is malformed") from exc
+
+        failed_required = {
+            name
+            for name in required_names
+            if observed.get(name) not in {None, "success"}
+        }
+        missing = required_names - set(observed)
+        if failed > 0 or failed_required:
+            check_state = "failed"
+        elif unknown > 0:
+            check_state = "unknown"
+        elif pending > 0:
+            check_state = "pending"
+        elif missing:
+            check_state = "missing"
+        else:
+            check_state = "pass"
+
+        result = {
+            "status": "pass" if require_success else "observed",
+            "configuration": config,
+            "required": sorted(required_names),
+            "pr": cls._pr_identity_from_pr(pr),
+            "checks": checks,
+        }
+        if not require_success:
+            result.update(
+                {
+                    "gate": "non-blocking",
+                    "check_state": check_state,
+                }
+            )
+        if capture is not None:
+            failed_result = dict(result)
+            if require_success:
+                failed_result["check_state"] = check_state
+                if check_state != "pass":
+                    failed_result["status"] = "fail"
+            capture(failed_result)
+        if require_success:
+            if failed > 0 or unknown > 0:
+                raise LckStopError("PR checks failed, cancelled, skipped, or unknown")
+            if pending > 0:
+                raise LckStopError(
+                    "PR checks are pending; strict check gate is not satisfied"
+                )
+            if failed_required:
+                raise LckStopError(
+                    "required PR checks are not successful: "
+                    + ", ".join(sorted(failed_required))
+                )
+            if missing:
+                raise LckStopError(
+                    "required PR checks are not present: " + ", ".join(sorted(missing))
+                )
+        return result
+
+    def evaluate(self, snapshot: OperationSnapshot) -> dict[str, Any]:
+        self.last_result = None
+        state = snapshot.state
+        if state.status is not ResolutionStatus.RESOLVED:
+            raise LckStopError(
+                "cannot evaluate checks from unresolved operation snapshot: "
+                + "; ".join(state.stop_reasons)
+            )
+        pr = state.open_pr
+        if not isinstance(pr, Mapping):
+            raise LckStopError("PR checks require one OPEN PR in operation snapshot")
+        required = snapshot.required_checks
+        if not isinstance(required, Mapping):
+            raise LckStopError("required PR check configuration was not acquired")
+        _required_check_contract_for_snapshot(snapshot)
+        return self._evaluate_pr_checks(
+            pr,
+            required,
+            require_success=True,
+            capture=self._remember_result,
+        )
+
+    def observe(self, snapshot: OperationSnapshot) -> dict[str, Any]:
+        """Return a bounded check observation without requiring CI success."""
+        self.last_result = None
+        state = snapshot.state
+        if state.status is not ResolutionStatus.RESOLVED:
+            raise LckStopError(
+                "cannot observe checks from unresolved operation snapshot: "
+                + "; ".join(state.stop_reasons)
+            )
+        pr = state.open_pr
+        if not isinstance(pr, Mapping):
+            raise LckStopError("PR checks require one OPEN PR in operation snapshot")
+        return self._evaluate_pr_checks(
+            pr,
+            None,
+            require_success=False,
+            capture=self._remember_result,
+        )
+
+    def query_exact_pr(
+        self,
+        repository: str,
+        pr_number: int,
+        *,
+        expected_head_sha: str,
+        expected_base_sha: str,
+        required_checks: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        """Targeted strict query for a PR created/updated by this operation."""
+        return self._query_exact_pr(
+            repository,
+            pr_number,
+            expected_head_sha=expected_head_sha,
+            expected_base_sha=expected_base_sha,
+            required_checks=required_checks,
+            require_success=True,
+        )
+
+    def _query_exact_pr(
+        self,
+        repository: str,
+        pr_number: int,
+        *,
+        expected_head_sha: str,
+        expected_base_sha: str,
+        required_checks: Mapping[str, Any] | None,
+        require_success: bool,
+    ) -> dict[str, Any]:
+        self.last_result = None
+        result = self.runner.run(
+            [
+                "gh",
+                "pr",
+                "view",
+                str(pr_number),
+                "--repo",
+                repository,
+                "--json",
+                self.PR_FIELDS,
+            ],
+            command_id="lck-checks-exact-pr",
+        )
+        if result.returncode != 0 or not result.stdout.strip():
+            raise LckStopError(
+                "cannot query the exact PR after the PR effect: "
+                + (result.stderr.strip() or f"exit {result.returncode}")
+            )
+        value = read_json_text(result.stdout, field="lck-checks-exact-pr")
+        if not isinstance(value, Mapping):
+            raise LckStopError("exact PR check query returned a non-object")
+        if (
+            value.get("number") != pr_number
+            or str(value.get("state", "")).upper() != "OPEN"
+            or value.get("isDraft") is not False
+            or value.get("headRefOid") != expected_head_sha
+            or value.get("baseRefOid") != expected_base_sha
+        ):
+            raise LckStopError("exact PR identity changed after the PR effect")
+        return self._evaluate_pr_checks(
+            value,
+            required_checks,
+            require_success=require_success,
+            capture=self._remember_result,
+        )
+
+    def observe_exact_pr(
+        self,
+        repository: str,
+        pr_number: int,
+        *,
+        expected_head_sha: str,
+        expected_base_sha: str,
+    ) -> dict[str, Any]:
+        """Observe a post-effect PR without making CI success a Delivery gate."""
+        return self._query_exact_pr(
+            repository,
+            pr_number,
+            expected_head_sha=expected_head_sha,
+            expected_base_sha=expected_base_sha,
+            required_checks=None,
+            require_success=False,
+        )
+
+    @staticmethod
+    def _checks_postcondition(
+        state: LiveState,
+        checks_result: Mapping[str, Any],
+    ) -> bool:
+        """Compare a snapshot PR/check fact to a previously completed check gate."""
+        if checks_result.get("status") != "pass":
+            return False
+        current_pr = state.open_pr
+        gated_pr = checks_result.get("pr")
+        if not isinstance(current_pr, Mapping) or not isinstance(gated_pr, Mapping):
+            return False
+        if DeliveryChecksGate._pr_identity_from_pr(current_pr) != {
+            "number": gated_pr.get("number"),
+            "head_sha": gated_pr.get("head_sha"),
+            "base_sha": gated_pr.get("base_sha"),
+        }:
+            return False
+        current_checks = _normalize_checks(current_pr.get("statusCheckRollup"))
+        expected_checks = checks_result.get("checks")
+        if not isinstance(expected_checks, Mapping):
+            return False
+        return current_checks == expected_checks

--- a/tools/lck/validation_runner.py
+++ b/tools/lck/validation_runner.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""Run current repository validation with compact, bounded JSON output."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import re
+import sys
+import time
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Final
+
+if __package__ in {None, ""}:  # Support the documented direct-file fallback.
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+    __package__ = "tools.lck"
+
+from .common import (
+    MAX_LOG_BYTES,
+    CommandRunner,
+    ProgressReporter,
+    WorkflowToolError,
+    is_sha,
+    print_json,
+    redact_machine_paths,
+    redact_sensitive,
+    require_exact_ignored_directory,
+    safe_text,
+    sha256_json,
+    stderr_tail,
+)
+
+SCHEMA_VERSION: Final = 1
+OUTPUT_DIR: Final = ".agents/validation.local"
+SKILLS: Final = (
+    "task-delivery-runner",
+    "task-pr-review-runner",
+    "task-closeout",
+    "feature-completion-audit",
+)
+
+
+@dataclass(frozen=True)
+class ValidationCommand:
+    command_id: str
+    argv: tuple[str, ...]
+    required: bool = True
+
+
+def _git_changed_files(runner: CommandRunner, base_sha: str | None) -> list[str]:
+    diff_target = f"{base_sha}...HEAD" if base_sha else "HEAD"
+    result = runner.run(
+        ["git", "diff", "--name-only", diff_target],
+        command_id="git-validation-changed-files",
+    )
+    if result.returncode != 0:
+        raise WorkflowToolError(
+            "cannot determine validation change scope: "
+            + stderr_tail(result.stderr or result.stdout, limit=500)
+        )
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def _discover_skill_validator(explicit: str | None) -> Path | None:
+    if explicit:
+        candidate = Path(explicit).expanduser()
+        return candidate.resolve() if candidate.is_file() else None
+    env_value = os.environ.get("CODEX_SKILL_VALIDATOR")
+    if env_value:
+        candidate = Path(env_value).expanduser()
+        return candidate.resolve() if candidate.is_file() else None
+    candidates: list[Path] = [
+        Path.home() / ".codex/skills/.system/skill-creator/scripts/quick_validate.py",
+        Path.home()
+        / ".codex"
+        / "skills"
+        / ".system"
+        / "skill-creator"
+        / "scripts"
+        / "quick_validate.py",
+    ]
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate.resolve()
+    return None
+
+
+def _build_plan(
+    repo_root: Path,
+    runner: CommandRunner,
+    *,
+    include_skill_validators: bool,
+    skill_validator: Path | None,
+    base_sha: str | None,
+) -> tuple[list[ValidationCommand], list[str]]:
+    commands: list[ValidationCommand] = []
+    limitations: list[str] = []
+    pyproject = repo_root / "pyproject.toml"
+    lock = repo_root / "uv.lock"
+    tests = repo_root / "tests"
+    if lock.exists():
+        commands.append(ValidationCommand("uv-lock-check", ("uv", "lock", "--check")))
+    if tests.exists():
+        commands.append(
+            ValidationCommand("pytest", ("uv", "run", "--frozen", "pytest"))
+        )
+    if pyproject.exists():
+        content = pyproject.read_text(encoding="utf-8")
+        if "[tool.ruff" in content:
+            commands.extend(
+                [
+                    ValidationCommand(
+                        "ruff-check", ("uv", "run", "--frozen", "ruff", "check", ".")
+                    ),
+                    ValidationCommand(
+                        "ruff-format-check",
+                        ("uv", "run", "--frozen", "ruff", "format", "--check", "."),
+                    ),
+                ]
+            )
+        if "[tool.mypy]" in content:
+            commands.append(
+                ValidationCommand(
+                    "mypy",
+                    ("uv", "run", "--frozen", "mypy", "src", "tools/lck", "tests"),
+                )
+            )
+    commands.append(ValidationCommand("git-diff-check", ("git", "diff", "--check")))
+
+    changed = _git_changed_files(runner, base_sha)
+    governance_changed = any(
+        path.startswith(".agents/skills/")
+        or path.startswith(".agents/policies/")
+        or path.startswith("tools/lck/")
+        for path in changed
+    )
+    if include_skill_validators or governance_changed:
+        if skill_validator is None:
+            limitations.append("Skill validator unavailable")
+        else:
+            for skill in SKILLS:
+                path = repo_root / ".agents" / "skills" / skill
+                if path.is_dir():
+                    commands.append(
+                        ValidationCommand(
+                            f"skill-{skill}",
+                            (sys.executable, str(skill_validator), str(path)),
+                        )
+                    )
+    return commands, limitations
+
+
+def _sanitize_log(value: str, repo_root: Path) -> str:
+    text = redact_machine_paths(redact_sensitive(value))
+    replacements = [
+        (str(repo_root.resolve()), "<repo>"),
+        (str(Path.home().resolve()), "<home>"),
+    ]
+    for original, replacement in replacements:
+        if original:
+            text = text.replace(original, replacement)
+            text = text.replace(original.replace("\\", "/"), replacement)
+    if len(text.encode("utf-8")) <= MAX_LOG_BYTES:
+        return text
+    raw = text.encode("utf-8")[:MAX_LOG_BYTES]
+    return raw.decode("utf-8", errors="ignore") + "\n<truncated>\n"
+
+
+def _summary(command_id: str, stdout: str, stderr: str, returncode: int) -> str:
+    combined = f"{stdout}\n{stderr}".strip()
+    if returncode != 0:
+        return stderr_tail(combined, limit=1200)
+    patterns = {
+        "pytest": r"(?m)^=+\s+([^\n]*passed[^\n]*)\s+=+$",
+        "mypy": r"(?m)^Success: no issues found[^\n]*$",
+        "ruff-check": r"(?m)^All checks passed!?$",
+        "ruff-format-check": r"(?m)^\d+ files? already formatted$",
+    }
+    pattern = patterns.get(command_id)
+    if pattern:
+        match = re.search(pattern, combined)
+        if match:
+            return (
+                safe_text(
+                    match.group(1) if match.lastindex else match.group(0), limit=240
+                )
+                or "pass"
+            )
+    lines = [line.strip() for line in combined.splitlines() if line.strip()]
+    if not lines:
+        return "pass"
+    return safe_text(lines[-1], limit=240) or "pass"
+
+
+def _run_validation(
+    args: argparse.Namespace, repo_root: Path
+) -> tuple[dict[str, Any], int]:
+    runner = CommandRunner(repo_root)
+    skill_validator = _discover_skill_validator(args.skill_validator)
+    plan, limitations = _build_plan(
+        repo_root,
+        runner,
+        include_skill_validators=args.include_skill_validators,
+        skill_validator=skill_validator,
+        base_sha=args.base_sha,
+    )
+    if args.require_skill_validator and skill_validator is None:
+        raise WorkflowToolError("Skill validator is required but unavailable")
+    if not plan:
+        raise WorkflowToolError("no validation commands were selected")
+
+    plan_identity = {
+        "phase": args.phase,
+        "base_sha": args.base_sha,
+        "commands": [
+            {
+                "command_id": item.command_id,
+                "argv": [
+                    Path(value).name if index == 0 else value
+                    for index, value in enumerate(item.argv)
+                ],
+            }
+            for item in plan
+        ],
+    }
+    run_id = f"val-{args.phase}-{sha256_json(plan_identity)[:12]}"
+    output_root = require_exact_ignored_directory(repo_root, OUTPUT_DIR)
+    run_dir = output_root / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    results: list[dict[str, Any]] = []
+    overall = True
+    progress = ProgressReporter("workflow-validation")
+    progress.started("validation")
+    for command in plan:
+        started = time.monotonic()
+        stage = f"command:{command.command_id}"
+        progress.running(stage, command_id=command.command_id)
+        result = runner.run(
+            command.argv,
+            command_id=command.command_id,
+            validation=True,
+            progress=lambda: progress.heartbeat(stage, command_id=command.command_id),
+        )
+        duration_ms = max(0, round((time.monotonic() - started) * 1000))
+        status = "pass" if result.returncode == 0 else "fail"
+        overall = overall and result.returncode == 0
+        if result.returncode == 0:
+            progress.completed(stage)
+        else:
+            progress.failed(stage)
+        log_text = _sanitize_log(
+            f"$ {' '.join(command.argv)}\n\n[stdout]\n{result.stdout}\n\n[stderr]\n{result.stderr}",
+            repo_root,
+        )
+        log_path = run_dir / f"{command.command_id}.log"
+        log_path.write_text(log_text, encoding="utf-8", newline="\n")
+        entry: dict[str, Any] = {
+            "command_id": command.command_id,
+            "status": status,
+            "exit_code": result.returncode,
+            "duration_ms": duration_ms,
+            "summary": _summary(
+                command.command_id,
+                result.stdout,
+                result.stderr,
+                result.returncode,
+            ),
+            "log_path": log_path.relative_to(repo_root).as_posix(),
+        }
+        if result.returncode != 0:
+            entry["diagnostic"] = stderr_tail(
+                f"{result.stdout}\n{result.stderr}",
+                limit=2000,
+            )
+        results.append(entry)
+
+    if overall:
+        progress.completed("validation")
+    else:
+        progress.failed("validation")
+
+    output: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "operation": "workflow-validation",
+        "run_id": run_id,
+        "phase": args.phase,
+        "base_sha": args.base_sha,
+        "status": "pass" if overall else "fail",
+        "command_count": len(results),
+        "passed": sum(item["status"] == "pass" for item in results),
+        "failed": sum(item["status"] == "fail" for item in results),
+        "commands": results,
+        "limitations": limitations,
+        "operations": runner.counters(),
+        "output_dir": run_dir.relative_to(repo_root).as_posix(),
+        "execution_identity": {
+            "path": "tools/lck/validation_runner.py",
+            "content_sha256": hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
+        },
+    }
+    return output, 0 if overall else 1
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run current CI-equivalent validation with compact JSON output."
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+    run = sub.add_parser("run", help="run selected validation commands")
+    run.add_argument("--repo-root", default=".")
+    run.add_argument(
+        "--phase",
+        choices=("delivery", "review", "closeout", "feature-audit"),
+        required=True,
+    )
+    run.add_argument("--skill-validator", help="path to quick_validate.py")
+    run.add_argument(
+        "--base-sha",
+        help="PR or Task base SHA used to detect changed validation scope",
+    )
+    run.add_argument(
+        "--include-skill-validators",
+        action="store_true",
+        help="run validators for all repository workflow Skills",
+    )
+    run.add_argument(
+        "--require-skill-validator",
+        action="store_true",
+        help="fail when no Skill validator can be found",
+    )
+    run.add_argument("--pretty", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    repo_root = Path(args.repo_root).resolve()
+    if (
+        args.command == "run"
+        and args.base_sha is not None
+        and not is_sha(args.base_sha)
+    ):
+        print(
+            "workflow validation error: --base-sha must be a full commit SHA",
+            file=sys.stderr,
+        )
+        return 2
+    try:
+        output, returncode = _run_validation(args, repo_root)
+        print_json(output, pretty=args.pretty)
+        return returncode
+    except WorkflowToolError as exc:
+        print(f"workflow validation error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lck/wsl2_validation_runner.py
+++ b/tools/lck/wsl2_validation_runner.py
@@ -1,0 +1,825 @@
+#!/usr/bin/env python3
+"""Fixed WSL2 validation runner with bounded, parseable results."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import signal
+import subprocess
+import sys
+import time
+import uuid
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Final
+
+if __package__ in {None, ""}:  # Support the documented direct-file fallback.
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+    __package__ = "tools.lck"
+
+from .common import build_workflow_env
+
+SCHEMA_VERSION: Final = 1
+RUNNER_VERSION: Final = "1.2.0"
+OUTPUT_ROOT: Final = ".agents/validation.local/wsl2-runs"
+SPEC_PATH: Final = "tools/lck/config/validation_profiles.json"
+RUNNER_PATH: Final = "tools/lck/wsl2_validation_runner.py"
+RULES_PATH: Final = ".codex/rules/tracequant-wsl-validation.rules"
+CI_WORKFLOW_PATH: Final = ".github/workflows/ci.yml"
+WORKFLOW_VALIDATION_PATH: Final = "tools/lck/validation_runner.py"
+COMMON_TOOL_PATH: Final = "tools/lck/common.py"
+STDIO_LIMIT_BYTES: Final = 4096
+SENSITIVE_PATTERNS: Final = (
+    re.compile(r"gh[pousr]_[A-Za-z0-9]{20,}"),
+    re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._~-]{16,}"),
+    re.compile(r"-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----"),
+    re.compile(
+        r"(?i)(authorization|cookie|api[_-]?key|token|password|secret)\s*[:=]\s*\S+"
+    ),
+)
+
+IDENTITY_PATHS: Final = (
+    RUNNER_PATH,
+    SPEC_PATH,
+    RULES_PATH,
+    WORKFLOW_VALIDATION_PATH,
+    COMMON_TOOL_PATH,
+)
+COMMAND_ID_PATTERN: Final = re.compile(r"[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?")
+SHA_PATTERN: Final = re.compile(r"^[0-9a-f]{40}$")
+CANONICAL_COMMANDS: Final[dict[str, tuple[str, ...]]] = {
+    "uv-lock-check": ("uv", "lock", "--check"),
+    "pytest": ("uv", "run", "--frozen", "pytest"),
+    "ruff-check": ("uv", "run", "--frozen", "ruff", "check", "."),
+    "ruff-format-check": (
+        "uv",
+        "run",
+        "--frozen",
+        "ruff",
+        "format",
+        "--check",
+        ".",
+    ),
+    "mypy": ("uv", "run", "--frozen", "mypy", "src", "tools/lck", "tests"),
+    "git-diff-check": ("git", "diff", "--check"),
+    "pytest-tools": ("uv", "run", "--frozen", "pytest", "tests/tools"),
+    "pytest-workflow": (
+        "uv",
+        "run",
+        "--frozen",
+        "pytest",
+        "tests/tools/lck/test_workflow_skills.py",
+        "tests/tools/lck/test_validation_runner.py",
+        "tests/tools/lck/test_feature_audit.py",
+        "tests/tools/lck/test_wsl2_validation_runner.py",
+        "tests/tools/lck/test_wsl2_validation_rules.py",
+        "tests/tools/lck/test_acceptance.py",
+    ),
+}
+CANONICAL_PROFILE_COMMAND_IDS: Final[dict[str, tuple[str, ...]]] = {
+    "current-ci-equivalent": (
+        "uv-lock-check",
+        "pytest",
+        "ruff-check",
+        "ruff-format-check",
+        "mypy",
+        "git-diff-check",
+    ),
+    "targeted": ("pytest-tools",),
+    "targeted:tools-tests": ("pytest-tools",),
+    "targeted:workflow-tests": ("pytest-workflow",),
+    "post-merge": (
+        "uv-lock-check",
+        "pytest",
+        "ruff-check",
+        "ruff-format-check",
+        "mypy",
+        "git-diff-check",
+    ),
+}
+CANONICAL_PROFILE_KINDS: Final[dict[str, str]] = {
+    "current-ci-equivalent": "ci-equivalent",
+    "targeted": "targeted",
+    "targeted:tools-tests": "targeted",
+    "targeted:workflow-tests": "targeted",
+    "post-merge": "post-merge",
+}
+CANONICAL_PROFILE_PRECONDITIONS: Final[dict[str, tuple[bool, bool, bool]]] = {
+    "current-ci-equivalent": (False, False, False),
+    "targeted": (False, False, False),
+    "targeted:tools-tests": (False, False, False),
+    "targeted:workflow-tests": (False, False, False),
+    "post-merge": (True, True, True),
+}
+CANONICAL_WORKFLOW_PROFILES: Final[dict[str, tuple[str, tuple[bool, bool, bool]]]] = {
+    "workflow-delivery": ("delivery", (True, False, False)),
+    "workflow-review": ("review", (True, False, False)),
+    "workflow-closeout": ("closeout", (True, True, True)),
+}
+ALL_PROFILES: Final = tuple(CANONICAL_PROFILE_COMMAND_IDS) + tuple(
+    CANONICAL_WORKFLOW_PROFILES
+)
+CANONICAL_CI_COMMANDS: Final[tuple[tuple[str, ...], ...]] = (
+    CANONICAL_COMMANDS["uv-lock-check"],
+    CANONICAL_COMMANDS["pytest"],
+    CANONICAL_COMMANDS["ruff-check"],
+    CANONICAL_COMMANDS["ruff-format-check"],
+    CANONICAL_COMMANDS["mypy"],
+)
+PROCESS_TERM_GRACE_SECONDS: Final = 2.0
+PROCESS_INTERRUPT_GRACE_SECONDS: Final = 5.0
+ALLOWED_ENV: Final = (
+    "PATH",
+    "HOME",
+    "UV_CACHE_DIR",
+    "PYTHONUTF8",
+    "PYTHONIOENCODING",
+    "NO_COLOR",
+    "CI",
+    "CODEX_SKILL_VALIDATOR",
+)
+
+
+class RunnerError(RuntimeError):
+    """Expected fail-closed runner error."""
+
+
+def _json_dumps(value: Any, *, pretty: bool = False) -> str:
+    if pretty:
+        return json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    return (
+        json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        + "\n"
+    )
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _sha256_file(path: Path) -> str:
+    return _sha256_bytes(path.read_bytes())
+
+
+def _redact(text: str) -> str:
+    value = text.replace("\x00", "")
+    for pattern in SENSITIVE_PATTERNS:
+        value = pattern.sub("<redacted>", value)
+    return value
+
+
+def _bounded(text: str) -> tuple[str, bool, str]:
+    sanitized = _redact(text)
+    digest = _sha256_bytes(sanitized.encode("utf-8", errors="replace"))
+    payload = sanitized.encode("utf-8", errors="replace")
+    if len(payload) <= STDIO_LIMIT_BYTES:
+        return sanitized, False, digest
+    truncated = payload[:STDIO_LIMIT_BYTES].decode("utf-8", errors="ignore")
+    return truncated + "\n<truncated>\n", True, digest
+
+
+def _atomic_write(path: Path, payload: bytes, *, mode: int = 0o600) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp = path.with_name(f".{path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
+    fd = os.open(temp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, mode)
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(payload)
+        os.replace(temp, path)
+    except BaseException:
+        try:
+            temp.unlink()
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def _load_json_bytes(payload: bytes, path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(payload.decode("utf-8"))
+    except UnicodeDecodeError as exc:
+        raise RunnerError(f"invalid UTF-8 in {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise RunnerError(f"invalid JSON in {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise RunnerError(f"invalid JSON object in {path}")
+    return value
+
+
+def _read_current_file(repo_root: Path, relative_path: str) -> bytes:
+    path = repo_root / relative_path
+    if path.is_symlink():
+        raise RunnerError(f"workflow file must not be a symlink: {relative_path}")
+    try:
+        return path.read_bytes()
+    except FileNotFoundError as exc:
+        raise RunnerError(
+            f"required workflow file is missing: {relative_path}"
+        ) from exc
+
+
+def _load_inputs(repo_root: Path) -> tuple[dict[str, Any], dict[str, str]]:
+    payloads = {
+        relative_path: _read_current_file(repo_root, relative_path)
+        for relative_path in IDENTITY_PATHS
+    }
+    spec_path = repo_root / SPEC_PATH
+    spec = _load_json_bytes(payloads[SPEC_PATH], spec_path)
+    hashes = {path: _sha256_bytes(payload) for path, payload in payloads.items()}
+    return spec, hashes
+
+
+ALLOWED_SKILL_ROOTS: Final = (".agents/skills/", ".claude/skills/")
+SKILL_FILENAME: Final = "SKILL.md"
+
+
+def _resolve_skill_identity(
+    repo_root: Path,
+    profile_name: str,
+    caller_skill_path: str | None,
+) -> dict[str, str] | None:
+    """Resolve the actual Skill identity for this Runner invocation.
+
+    When *caller_skill_path* is provided the Runner validates it, re-hashes the
+    content, and records the actual path and platform.  When absent the Runner
+    falls back to the ``.agents`` path for the profile.
+    """
+    mapping = {
+        "workflow-delivery": ".agents/skills/task-delivery-runner/SKILL.md",
+        "workflow-review": ".agents/skills/task-pr-review-runner/SKILL.md",
+        "workflow-closeout": ".agents/skills/task-closeout/SKILL.md",
+    }
+
+    if caller_skill_path is not None:
+        normalized = caller_skill_path.replace("\\", "/")
+        if not normalized.endswith(f"/{SKILL_FILENAME}"):
+            raise RunnerError(
+                f"--skill-path must end with SKILL.md, got: {caller_skill_path!r}"
+            )
+        if ".." in normalized or normalized.startswith("/"):
+            raise RunnerError(
+                f"--skill-path must be a repo-relative path: {caller_skill_path!r}"
+            )
+        if not any(normalized.startswith(root) for root in ALLOWED_SKILL_ROOTS):
+            raise RunnerError(
+                f"--skill-path must start with one of {ALLOWED_SKILL_ROOTS}: "
+                f"{caller_skill_path!r}"
+            )
+        payload = _read_current_file(repo_root, normalized)
+        return {"path": normalized, "sha256": _sha256_bytes(payload)}
+
+    relative_path = mapping.get(profile_name)
+    if relative_path is None:
+        return None
+    payload = _read_current_file(repo_root, relative_path)
+    return {"path": relative_path, "sha256": _sha256_bytes(payload)}
+
+
+def _run_quiet(
+    argv: Sequence[str], repo_root: Path
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(item) for item in argv],
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=_command_env(repo_root),
+    )
+
+
+def _command_env(repo_root: Path) -> dict[str, str]:
+    inherited = build_workflow_env(repo_root)
+    env: dict[str, str] = {
+        key: inherited[key] for key in ALLOWED_ENV if key in inherited
+    }
+    env.setdefault("PYTHONUTF8", "1")
+    env.setdefault("PYTHONIOENCODING", "utf-8")
+    env.setdefault("NO_COLOR", "1")
+    return env
+
+
+def _find_repo_root(script_path: Path) -> Path:
+    if script_path.is_symlink():
+        raise RunnerError("runner entry must not be invoked through a symlink")
+    repo_root = script_path.resolve().parents[2]
+    expected = repo_root / RUNNER_PATH
+    if script_path.resolve() != expected.resolve():
+        raise RunnerError("runner entry path is not the repository entry")
+    if Path.cwd().resolve() != repo_root.resolve():
+        raise RunnerError("runner must be started from the repository root")
+    if repo_root.resolve().as_posix().startswith("/mnt/"):
+        raise RunnerError("repository must be on the WSL2 Linux filesystem, not /mnt")
+    git_root = _run_quiet(["git", "rev-parse", "--show-toplevel"], repo_root)
+    if git_root.returncode != 0:
+        raise RunnerError("current directory is not a Git repository")
+    if Path(git_root.stdout.strip()).resolve() != repo_root.resolve():
+        raise RunnerError("Git repository root does not match runner repository")
+    return repo_root
+
+
+def _git_lines(repo_root: Path, *args: str) -> list[str]:
+    result = _run_quiet(["git", *args], repo_root)
+    if result.returncode != 0:
+        raise RunnerError(
+            f"git {' '.join(args)} failed: {_redact(result.stderr).strip()}"
+        )
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def _git_value(repo_root: Path, *args: str) -> str:
+    lines = _git_lines(repo_root, *args)
+    return lines[0] if lines else ""
+
+
+def _assert_output_root(repo_root: Path) -> Path:
+    ignore = repo_root / ".gitignore"
+    patterns = {
+        line.strip().removeprefix("./")
+        for line in ignore.read_text(encoding="utf-8-sig").splitlines()
+        if line.strip() and not line.lstrip().startswith(("#", "!"))
+    }
+    if ".agents/validation.local/" not in patterns:
+        raise RunnerError(".agents/validation.local/ must be exactly Git ignored")
+    output_root = repo_root / OUTPUT_ROOT
+    output_root.mkdir(parents=True, exist_ok=True)
+    output_root.chmod(0o700)
+    return output_root
+
+
+def _ci_run_commands(repo_root: Path, workflow: str) -> list[list[str]]:
+    path = repo_root / workflow
+    commands: list[list[str]] = []
+    current_step = ""
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("- name: "):
+            current_step = stripped.removeprefix("- name: ").strip()
+            continue
+        if not stripped.startswith("run: "):
+            continue
+        command = stripped.removeprefix("run: ").strip()
+        if current_step in {
+            "Validate lock file",
+            "Run tests",
+            "Run Ruff lint",
+            "Check Ruff formatting",
+            "Run mypy",
+        }:
+            commands.append(command.split())
+    return commands
+
+
+def _verify_drift(repo_root: Path, spec: Mapping[str, Any]) -> None:
+    expected = spec.get("ci_validation_commands")
+    workflow = spec.get("ci_workflow")
+    canonical = [list(argv) for argv in CANONICAL_CI_COMMANDS]
+    if not isinstance(expected, list) or not isinstance(workflow, str):
+        raise RunnerError("profile spec missing CI drift metadata")
+    if workflow != CI_WORKFLOW_PATH:
+        raise RunnerError("profile spec CI workflow path is not canonical")
+    if expected != canonical:
+        raise RunnerError(
+            "profile spec CI commands differ from the runner canonical set"
+        )
+    observed = _ci_run_commands(repo_root, workflow)
+    if observed != canonical:
+        raise RunnerError(
+            "CI validation commands drifted from the canonical WSL2 command set"
+        )
+
+
+def _validate_spec_identity(spec: Mapping[str, Any]) -> None:
+    if spec.get("schema_version") != SCHEMA_VERSION:
+        raise RunnerError("profile spec schema_version is unsupported")
+    if spec.get("runner_version") != RUNNER_VERSION:
+        raise RunnerError("profile spec runner_version does not match the runner")
+    profiles = spec.get("profiles")
+    if not isinstance(profiles, dict) or set(profiles) != set(ALL_PROFILES):
+        raise RunnerError("profile spec profile set differs from the canonical set")
+
+
+def _validated_workflow_profile(
+    repo_root: Path,
+    profile_name: str,
+    profile: Mapping[str, Any],
+    base_sha: str | None,
+) -> list[dict[str, Any]]:
+    canonical = CANONICAL_WORKFLOW_PROFILES.get(profile_name)
+    if canonical is None:
+        raise RunnerError("workflow profile is not canonical")
+    phase, expected_preconditions = canonical
+    if base_sha is None or SHA_PATTERN.fullmatch(base_sha) is None:
+        raise RunnerError("workflow profile requires a full --base-sha")
+    if profile.get("kind") != "workflow-phase":
+        raise RunnerError(
+            f"profile kind differs from canonical profile: {profile_name}"
+        )
+    if profile.get("phase") != phase:
+        raise RunnerError(
+            f"profile phase differs from canonical profile: {profile_name}"
+        )
+    if profile.get("requires_base_sha") is not True:
+        raise RunnerError(f"profile base-SHA contract drift: {profile_name}")
+    if profile.get("include_skill_validators") is not True:
+        raise RunnerError(f"profile Skill-validator contract drift: {profile_name}")
+    if profile.get("require_skill_validator") is not True:
+        raise RunnerError(f"profile Skill-validator requirement drift: {profile_name}")
+    observed_preconditions = _profile_preconditions(profile)
+    if observed_preconditions != expected_preconditions:
+        raise RunnerError(
+            f"profile preconditions differ from canonical profile: {profile_name}"
+        )
+    argv = [
+        sys.executable,
+        str(repo_root / WORKFLOW_VALIDATION_PATH),
+        "run",
+        "--repo-root",
+        ".",
+        "--phase",
+        phase,
+        "--base-sha",
+        base_sha,
+        "--include-skill-validators",
+        "--require-skill-validator",
+    ]
+    return [{"id": "workflow-validation", "argv": argv}]
+
+
+def _profile_preconditions(profile: Mapping[str, Any]) -> tuple[bool, bool, bool]:
+    values: list[bool] = []
+    for key in (
+        "requires_clean_worktree",
+        "requires_main_branch",
+        "requires_origin_main_identity",
+    ):
+        value = profile.get(key, False)
+        if type(value) is not bool:
+            raise RunnerError(f"profile precondition must be boolean: {key}")
+        values.append(value)
+    return tuple(values)  # type: ignore[return-value]
+
+
+def _validated_commands(
+    profile_name: str, profile: Mapping[str, Any]
+) -> list[dict[str, Any]]:
+    commands = profile.get("commands")
+    if not isinstance(commands, list) or not commands:
+        raise RunnerError("profile must define at least one command")
+    validated: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+    for command in commands:
+        if not isinstance(command, dict):
+            raise RunnerError("invalid profile command definition")
+        command_id = command.get("id")
+        argv = command.get("argv")
+        if (
+            not isinstance(command_id, str)
+            or COMMAND_ID_PATTERN.fullmatch(command_id) is None
+        ):
+            raise RunnerError("invalid profile command id")
+        if command_id in seen_ids:
+            raise RunnerError(f"duplicate profile command id: {command_id}")
+        seen_ids.add(command_id)
+        canonical = CANONICAL_COMMANDS.get(command_id)
+        if canonical is None:
+            raise RunnerError(f"profile command id is not allowed: {command_id}")
+        if not isinstance(argv, list) or tuple(argv) != canonical:
+            raise RunnerError(
+                f"profile command argv does not match canonical command: {command_id}"
+            )
+        validated.append({"id": command_id, "argv": list(canonical)})
+    observed_ids = tuple(item["id"] for item in validated)
+    if observed_ids != CANONICAL_PROFILE_COMMAND_IDS[profile_name]:
+        raise RunnerError(
+            f"profile command sequence differs from canonical profile: {profile_name}"
+        )
+    if profile.get("kind") != CANONICAL_PROFILE_KINDS[profile_name]:
+        raise RunnerError(
+            f"profile kind differs from canonical profile: {profile_name}"
+        )
+    observed_preconditions = _profile_preconditions(profile)
+    if observed_preconditions != CANONICAL_PROFILE_PRECONDITIONS[profile_name]:
+        raise RunnerError(
+            f"profile preconditions differ from canonical profile: {profile_name}"
+        )
+    return validated
+
+
+def _verify_profile_preconditions(
+    repo_root: Path, profile: Mapping[str, Any]
+) -> dict[str, Any]:
+    branch = _git_value(repo_root, "branch", "--show-current")
+    head = _git_value(repo_root, "rev-parse", "HEAD")
+    origin_main_result = _run_quiet(
+        ["git", "rev-parse", "--verify", "refs/remotes/origin/main"], repo_root
+    )
+    origin_main = (
+        origin_main_result.stdout.strip() if origin_main_result.returncode == 0 else ""
+    )
+    status = _git_lines(repo_root, "status", "--short", "--untracked-files=all")
+    if profile.get("requires_clean_worktree") and status:
+        raise RunnerError("profile requires a clean working tree")
+    if profile.get("requires_main_branch") and branch != "main":
+        raise RunnerError("profile requires branch main")
+    if profile.get("requires_origin_main_identity"):
+        if not origin_main:
+            raise RunnerError("profile requires refs/remotes/origin/main")
+        if branch != "main" or head != origin_main:
+            raise RunnerError("profile requires local main to equal origin/main")
+    return {
+        "branch": branch,
+        "head_sha": head,
+        "origin_main_sha": origin_main,
+        "clean": not status,
+    }
+
+
+def _signal_process_group(proc: subprocess.Popen[str], sig: int) -> None:
+    try:
+        os.killpg(proc.pid, sig)
+    except ProcessLookupError:
+        return
+
+
+def _terminate_process_group(
+    proc: subprocess.Popen[str],
+    *,
+    first_signal: int,
+    grace_seconds: float,
+) -> tuple[str, str]:
+    _signal_process_group(proc, first_signal)
+    try:
+        return proc.communicate(timeout=grace_seconds)
+    except subprocess.TimeoutExpired:
+        _signal_process_group(proc, signal.SIGKILL)
+        try:
+            return proc.communicate(timeout=PROCESS_TERM_GRACE_SECONDS)
+        except subprocess.TimeoutExpired as exc:
+            raise RunnerError(
+                "failed to terminate validation command process group"
+            ) from exc
+
+
+def _run_command(
+    command: Mapping[str, Any],
+    repo_root: Path,
+    run_dir: Path,
+    timeout_seconds: int,
+) -> dict[str, Any]:
+    command_id = command.get("id")
+    argv = command.get("argv")
+    if not isinstance(command_id, str) or not isinstance(argv, list):
+        raise RunnerError("invalid profile command definition")
+    if not all(isinstance(item, str) and item for item in argv):
+        raise RunnerError("invalid profile command argv")
+    started = time.monotonic()
+    proc = subprocess.Popen(
+        argv,
+        cwd=repo_root,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=_command_env(repo_root),
+        start_new_session=True,
+    )
+    timed_out = False
+    interrupted = False
+    try:
+        stdout, stderr = proc.communicate(timeout=timeout_seconds)
+    except subprocess.TimeoutExpired:
+        timed_out = True
+        stdout, stderr = _terminate_process_group(
+            proc,
+            first_signal=signal.SIGTERM,
+            grace_seconds=PROCESS_TERM_GRACE_SECONDS,
+        )
+    except KeyboardInterrupt:
+        interrupted = True
+        stdout, stderr = _terminate_process_group(
+            proc,
+            first_signal=signal.SIGINT,
+            grace_seconds=PROCESS_INTERRUPT_GRACE_SECONDS,
+        )
+    duration_ms = max(0, round((time.monotonic() - started) * 1000))
+    stdout_summary, stdout_truncated, stdout_digest = _bounded(stdout)
+    stderr_summary, stderr_truncated, stderr_digest = _bounded(stderr)
+    exit_code = 124 if timed_out else 130 if interrupted else int(proc.returncode)
+    log_path = run_dir / f"{command_id}.json"
+    log_payload = {
+        "id": command_id,
+        "argv": argv,
+        "exit_code": exit_code,
+        "duration_ms": duration_ms,
+        "timed_out": timed_out,
+        "interrupted": interrupted,
+        "stdout": _redact(stdout),
+        "stderr": _redact(stderr),
+    }
+    _atomic_write(log_path, _json_dumps(log_payload, pretty=True).encode("utf-8"))
+    return {
+        "id": command_id,
+        "argv": argv,
+        "exit_code": exit_code,
+        "duration_ms": duration_ms,
+        "stdout_digest": stdout_digest,
+        "stderr_digest": stderr_digest,
+        "stdout_truncated": stdout_truncated,
+        "stderr_truncated": stderr_truncated,
+        "timed_out": timed_out,
+        "interrupted": interrupted,
+        "log_path": log_path.relative_to(repo_root).as_posix(),
+        "stdout_summary": stdout_summary if exit_code != 0 else "",
+        "stderr_summary": stderr_summary if exit_code != 0 else "",
+    }
+
+
+def _run_profile(
+    profile_name: str, base_sha: str | None = None, skill_path: str | None = None
+) -> int:
+    script_path = Path(__file__)
+    repo_root = _find_repo_root(script_path)
+    spec, content_hashes = _load_inputs(repo_root)
+    _validate_spec_identity(spec)
+    profiles = spec.get("profiles")
+    if not isinstance(profiles, dict):
+        raise RunnerError("profile spec does not define profiles")
+    profile = profiles.get(profile_name)
+    if not isinstance(profile, dict):
+        raise RunnerError("unknown profile")
+    _verify_drift(repo_root, spec)
+    if profile_name in CANONICAL_WORKFLOW_PROFILES:
+        commands = _validated_workflow_profile(
+            repo_root, profile_name, profile, base_sha
+        )
+    else:
+        if base_sha is not None:
+            raise RunnerError("--base-sha is allowed only for workflow profiles")
+        commands = _validated_commands(profile_name, profile)
+    timeout_value = profile.get("timeout_seconds", 900)
+    if type(timeout_value) is not int:
+        raise RunnerError("profile timeout_seconds must be an integer")
+    timeout_seconds = timeout_value
+    if timeout_seconds <= 0 or timeout_seconds > 3600:
+        raise RunnerError("profile timeout_seconds is outside the allowed range")
+    repository_state = _verify_profile_preconditions(repo_root, profile)
+    output_root = _assert_output_root(repo_root)
+    run_id = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ") + "-" + uuid.uuid4().hex[:12]
+    run_dir = output_root / run_id
+    run_dir.mkdir(parents=True, exist_ok=False)
+    run_dir.chmod(0o700)
+    started_at = datetime.now(UTC)
+    results: list[dict[str, Any]] = []
+    status = "pass"
+    try:
+        for command in commands:
+            result = _run_command(command, repo_root, run_dir, timeout_seconds)
+            results.append(result)
+            if result["exit_code"] != 0:
+                status = "fail"
+                break
+        if len(results) != len(commands) and status == "pass":
+            status = "fail"
+    except KeyboardInterrupt:
+        status = "interrupted"
+    duration_ms = max(0, round((datetime.now(UTC) - started_at).total_seconds() * 1000))
+    result_document: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "runner_version": RUNNER_VERSION,
+        "profile": profile_name,
+        "profile_kind": profile.get("kind"),
+        "status": status,
+        "started_at": started_at.isoformat(),
+        "duration_ms": duration_ms,
+        "repository": {
+            "root": ".",
+            "state": repository_state,
+        },
+        "commands": results,
+        "expected_command_count": len(commands),
+        "artifacts": {
+            "run_id": run_id,
+            "run_dir": run_dir.relative_to(repo_root).as_posix(),
+            "result_json": (run_dir / "result.json").relative_to(repo_root).as_posix(),
+        },
+        "integrity": {
+            "verification": "current-worktree-content",
+            "repository_head_sha": repository_state["head_sha"],
+            "repository_clean": repository_state["clean"],
+            "runner_path": RUNNER_PATH,
+            "runner_sha256": content_hashes[RUNNER_PATH],
+            "profile_spec_path": SPEC_PATH,
+            "profile_spec_sha256": content_hashes[SPEC_PATH],
+            "rules_path": RULES_PATH,
+            "rules_sha256": content_hashes[RULES_PATH],
+            "workflow_validation_path": WORKFLOW_VALIDATION_PATH,
+            "workflow_validation_sha256": content_hashes[WORKFLOW_VALIDATION_PATH],
+            "skill": _resolve_skill_identity(repo_root, profile_name, skill_path),
+        },
+    }
+    result_path = run_dir / "result.json"
+    _atomic_write(
+        result_path, _json_dumps(result_document, pretty=True).encode("utf-8")
+    )
+    digest = {
+        "schema_version": SCHEMA_VERSION,
+        "runner_version": RUNNER_VERSION,
+        "profile": profile_name,
+        "status": status,
+        "command_count": len(results),
+        "expected_command_count": len(commands),
+        "duration_ms": duration_ms,
+        "result_path": result_document["artifacts"]["result_json"],
+        "result_sha256": _sha256_file(result_path),
+        "failed_command": next(
+            (item for item in results if item["exit_code"] != 0),
+            None,
+        ),
+    }
+    print(_json_dumps(digest), end="")
+    if status == "pass":
+        return 0
+    if status == "interrupted":
+        return 130
+    return 1
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run a fixed WSL2 validation profile.",
+        allow_abbrev=False,
+    )
+    parser.add_argument("profile", choices=ALL_PROFILES)
+    parser.add_argument("--base-sha", type=str)
+    parser.add_argument(
+        "--skill-path",
+        type=str,
+        default=None,
+        help="repo-relative path to the calling Skill's SKILL.md",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    raw_argv = list(sys.argv[1:] if argv is None else argv)
+    try:
+        args = parser.parse_args(raw_argv)
+        if args.profile in CANONICAL_WORKFLOW_PROFILES:
+            if len(raw_argv) < 3 or raw_argv[1] != "--base-sha":
+                parser.error(
+                    "workflow profiles require exactly: <profile> --base-sha <full-sha>"
+                )
+            normalized_base = str(args.base_sha or "").casefold()
+            if SHA_PATTERN.fullmatch(normalized_base) is None:
+                parser.error("--base-sha must be a full 40-character Git SHA")
+            return _run_profile(args.profile, normalized_base, args.skill_path)
+        # Count positional (non-option) arguments; allow --skill-path
+        positional = [
+            a for a in raw_argv if not a.startswith("-") and a not in ("--skill-path",)
+        ]
+        if len(positional) != 1:
+            parser.error(
+                "fixed profiles accept exactly one profile argument; "
+                "trailing arguments are not accepted"
+            )
+        return _run_profile(args.profile, skill_path=args.skill_path)
+    except KeyboardInterrupt:
+        print(
+            _json_dumps(
+                {
+                    "schema_version": SCHEMA_VERSION,
+                    "status": "interrupted",
+                    "error": "runner interrupted before completion",
+                }
+            ),
+            end="",
+            file=sys.stderr,
+        )
+        return 130
+    except (OSError, RunnerError) as exc:
+        print(
+            _json_dumps(
+                {
+                    "schema_version": SCHEMA_VERSION,
+                    "status": "blocked",
+                    "error": _redact(str(exc)),
+                }
+            ),
+            end="",
+            file=sys.stderr,
+        )
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -164,6 +164,24 @@ wheels = [
 ]
 
 [[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.22"
 source = { registry = "https://pypi.org/simple" }
@@ -200,7 +218,9 @@ dependencies = [
 dev = [
     { name = "mypy" },
     { name = "pytest" },
+    { name = "pyyaml" },
     { name = "ruff" },
+    { name = "types-pyyaml" },
 ]
 
 [package.metadata]
@@ -210,7 +230,18 @@ requires-dist = [{ name = "nautilus-trader", specifier = "==2.0.0rc4" }]
 dev = [
     { name = "mypy" },
     { name = "pytest" },
+    { name = "pyyaml" },
     { name = "ruff" },
+    { name = "types-pyyaml" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260906"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/6e/abec85b9013db5b934b0280a6dd104904d84f7bcbaab2e2f3def87ac7463/types_pyyaml-6.0.12.20260906.tar.gz", hash = "sha256:f59c1cc05010b833d2d72287bbaa72610106b28d42d89a907313117faba85212", size = 18649, upload-time = "2026-09-06T06:35:35.362Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/c0/fc0644b7ddcfb969e95845837143cb5173ddd6e06ee4ba5fc493cd9329b7/types_pyyaml-6.0.12.20260906-py3-none-any.whl", hash = "sha256:bca893ff0d51df5c9053137d5d0e6ccd36e939a196356f1d5c16372422f5137b", size = 21282, upload-time = "2026-09-06T06:35:34.372Z" },
 ]
 
 [[package]]

--- a/uv.toml
+++ b/uv.toml
@@ -1,1 +1,2 @@
+cache-dir = ".workflow.local/uv-cache"
 no-build-package = ["nautilus-trader"]


### PR DESCRIPTION
Closes #333

## Summary
Restore the final pre-removal LCK from Git objects into isolated tools, tests, documentation, and canonical agent asset roots; adapt the CLI, README, imports, validation, and guards to the v2 ownership boundary; preserve lifecycle behavior with migrated coverage.

## Validation
- Critical Outcome: pass
- Formal Delivery validation: pass

## Risks / limitations
No known semantic risks; LCK remains repository-only and excluded from product distribution.
